### PR TITLE
word wrap to improve layout in preview prefs

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -911,7 +911,10 @@ void PreferencesPopup::insertUI(PreferencesItemId id, QGridLayout* layout,
     layout->addWidget(widget, layout->rowCount(), 0, 1, 2);
   else {  // insert labels for other types
     int row = layout->rowCount();
-    layout->addWidget(new QLabel(getUIString(id), this), row, 0,
+    QLabel *label = new QLabel(getUIString(id),this);
+    label->setWordWrap(true);
+
+    layout->addWidget(label, row, 0,
                       Qt::AlignRight | Qt::AlignVCenter);
     if (isFileField)
       layout->addWidget(widget, row, 1, 1, 2);


### PR DESCRIPTION
this adds word wrap to labels in the preferences UI window to aid in alignment
before
![image](https://user-images.githubusercontent.com/1405869/100041157-64a54e00-2dce-11eb-82b2-9eecf06158da.png)

after
![image](https://user-images.githubusercontent.com/1405869/100041085-36c00980-2dce-11eb-88a9-267625cfffd3.png)
