### PR TITLE
Configure test builds with Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,49 @@
+name: Tahoma2D Build
+
+on: [push, pull_request]
+
+jobs:
+  Linux:
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        compiler: [ clang ]
+        include:
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: bash ./ci-scripts/linux/tahoma-install.sh
+      - name: Build ffmpeg
+        run: bash ./ci-scripts/linux/tahoma-buildffmpeg.sh
+      - name: Build OpenCV
+        run: bash ./ci-scripts/linux/tahoma-buildopencv.sh
+      - name: Build Tahoma2D
+        run: bash ./ci-scripts/linux/tahoma-build.sh
+      - name: Create Package
+        run: bash ./ci-scripts/linux/tahoma-buildpkg.sh
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Tahoma2D-linux.tar.gz
+          path: toonz/build/Tahoma2D-linux.tar.gz
+
+  macOS:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: bash ./ci-scripts/osx/tahoma-install.sh
+      - name: Build ffmpeg
+        run: bash ./ci-scripts/osx/tahoma-buildffmpeg.sh
+      - name: Build OpenCV
+        run: bash ./ci-scripts/osx/tahoma-buildopencv.sh
+      - name: Build Tahoma2D
+        run: bash ./ci-scripts/osx/tahoma-build.sh
+      - name: Create Package
+        run: bash ./ci-scripts/osx/tahoma-buildpkg.sh
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Tahoma2D-osx.dmg
+          path: toonz/build/Tahoma2D-osx.dmg

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -2,7 +2,7 @@
 brew update
 # from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
 # so we start to use the latest version of Qt. (#1910)
-brew install qt clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm aom dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
+brew install boost qt clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm aom dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
 # delete older qt versions and make sure to have only the latest
 brew cleanup qt
 # temp workaround to brew installed glew cmake info overriding glew lib detection


### PR DESCRIPTION
Set up to use Github Actions to test Linux/macOS builds.

For now, artifacts will be made available. macOS artifacts will require 10.15 (Catalina) to test and won't be backwards compatible.