### PR TITLE
Fix macOS Github Action build issue

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -1,4 +1,4 @@
-name: Tahoma2D Build
+name: Tahoma2D Linux Build
 
 on: [push, pull_request]
 
@@ -28,22 +28,3 @@ jobs:
         with:
           name: Tahoma2D-linux.tar.gz
           path: toonz/build/Tahoma2D-linux.tar.gz
-
-  macOS:
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: bash ./ci-scripts/osx/tahoma-install.sh
-      - name: Build ffmpeg
-        run: bash ./ci-scripts/osx/tahoma-buildffmpeg.sh
-      - name: Build OpenCV
-        run: bash ./ci-scripts/osx/tahoma-buildopencv.sh
-      - name: Build Tahoma2D
-        run: bash ./ci-scripts/osx/tahoma-build.sh
-      - name: Create Package
-        run: bash ./ci-scripts/osx/tahoma-buildpkg.sh
-      - uses: actions/upload-artifact@v1
-        with:
-          name: Tahoma2D-osx.dmg
-          path: toonz/build/Tahoma2D-osx.dmg

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -1,0 +1,23 @@
+name: Tahoma2D macOS Build
+
+on: [push, pull_request]
+
+jobs:
+  macOS:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: bash ./ci-scripts/osx/tahoma-install.sh
+      - name: Build ffmpeg
+        run: bash ./ci-scripts/osx/tahoma-buildffmpeg.sh
+      - name: Build OpenCV
+        run: bash ./ci-scripts/osx/tahoma-buildopencv.sh
+      - name: Build Tahoma2D
+        run: bash ./ci-scripts/osx/tahoma-build.sh
+      - name: Create Package
+        run: bash ./ci-scripts/osx/tahoma-buildpkg.sh
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Tahoma2D-osx.dmg
+          path: toonz/build/Tahoma2D-osx.dmg

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 brew update
-# from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
-# so we start to use the latest version of Qt. (#1910)
-brew unlink python@2
+# Remove symlink to bin/2to3 in order for latest python to install
+rm -f '/usr/local/bin/2to3'
 brew install boost qt clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm aom dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
 # delete older qt versions and make sure to have only the latest
 brew cleanup qt

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -2,6 +2,7 @@
 brew update
 # from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
 # so we start to use the latest version of Qt. (#1910)
+brew unlink python@2
 brew install boost qt clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm aom dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
 # delete older qt versions and make sure to have only the latest
 brew cleanup qt


### PR DESCRIPTION
This PR fixes a macOS build issue in Github Actions. 

Homebrew is trying to replace an existing symbolic link for python in order to switch from python2 to 3 and failing. It was suggested to perform a brew unlink of python2 prior to brew installing python3.

Also separates the builds into separate scripts by platform.
