### PR TITLE
Fix multiple levels using the same file

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -316,7 +316,11 @@ bool TFilePath::operator==(const TFilePath &fp) const {
 #ifdef _WIN32
   return _wcsicmp(m_path.c_str(), fp.m_path.c_str()) == 0;
 #else
-  return m_path == fp.m_path;
+  // On case insensitive systems like OSX, we need to
+  // compare using all the same case to confirm it is unique
+  // We'll force this for Linux as well since the project might
+  // be shared on other platforms.
+  return toLower(m_path) == toLower(fp.m_path);
 #endif
 }
 

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -805,6 +805,18 @@ bool TSystem::doesExistFileOrLevel(const TFilePath &fp) {
     TFilePathSet::iterator it, end = files.end();
     for (it = files.begin(); it != end; ++it) {
       if (it->getLevelNameW() == fp.getLevelNameW()) return true;
+// On case insensitive systems like Windows/OSX, we need to
+// compare using all the same case to confirm it is unique
+// We'll force this for Linux as well since the project might
+// be shared on other platforms.
+#ifdef _WIN32
+      if (_wcsicmp(it->getLevelNameW().c_str(), fp.getLevelNameW().c_str()) ==
+          0)
+        return true;
+#else
+      if (toLower(it->getLevelNameW()) == toLower(fp.getLevelNameW()))
+        return true;
+#endif
     }
   } else if (fp.getType() == "psd") {
     QString name(QString::fromStdWString(fp.getWideName()));

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -482,10 +482,27 @@ bool LevelCreatePopup::apply() {
       scene->getDefaultLevelPath(lType, levelName).withParentDir(parentDir);
 
   TFilePath actualFp = scene->decodeFilePath(fp);
-  if (TSystem::doesExistFileOrLevel(actualFp)) {
+  bool fileExists    = TSystem::doesExistFileOrLevel(actualFp);
+  if (!fileExists) {
+    // File may not have been written yet. Let's scan all existing levels
+    // and check files
+    TLevelSet *levelSet = scene->getLevelSet();
+    for (int i = 0; i < levelSet->getLevelCount(); i++) {
+      TXshLevel *tmpLvl = levelSet->getLevel(i);
+      if (!tmpLvl) continue;
+      TXshSimpleLevelP tmpSl = tmpLvl->getSimpleLevel();
+      if (!tmpSl) continue;
+      TFilePath tmpPath = scene->decodeFilePath(tmpSl->getPath());
+      if (tmpPath == actualFp) {
+        fileExists = true;
+        break;
+      }
+    }
+  }
+  if (fileExists) {
     error(
-        tr("The level name specified is already used: please choose a "
-           "different level name"));
+        tr("The level name specified is already used as a file by another "
+           "level: please choose a different level name"));
     m_nameFld->selectAll();
     return false;
   }
@@ -512,7 +529,7 @@ bool LevelCreatePopup::apply() {
       scene->createNewLevel(lType, levelName, TDimension(), 0, fp);
   TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(level);
   assert(sl);
-  sl->setPath(fp, true);
+  //  sl->setPath(fp, true);
   if (lType == TZP_XSHLEVEL || lType == OVL_XSHLEVEL) {
     sl->getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
     sl->getProperties()->setDpi(dpi);
@@ -579,10 +596,10 @@ bool LevelCreatePopup::apply() {
     for (j = 0; j < step; j++) xsh->setCell(row++, col, cell);
   }
 
-  if (lType == TZP_XSHLEVEL || lType == OVL_XSHLEVEL) {
-    sl->save(fp);
-    DvDirModel::instance()->refreshFolder(fp.getParentDir());
-  }
+  //  if (lType == TZP_XSHLEVEL || lType == OVL_XSHLEVEL) {
+  //  sl->save(fp);
+  //  DvDirModel::instance()->refreshFolder(fp.getParentDir());
+  //  }
 
   undo->onAdd(sl);
 

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -948,7 +948,7 @@ void LevelSettingsPopup::onNameChanged() {
   QString text = m_nameFld->text();
   if (text.length() == 0) {
     error("The name " + text +
-          " you entered for the level is not valid.\n Please enter a different "
+          " you entered for the level is not valid.\nPlease enter a different "
           "name.");
     m_nameFld->setFocus();
     return;
@@ -1038,13 +1038,36 @@ void LevelSettingsPopup::onPathChanged() {
     }
   }
   if (lvlWithSamePath) {
+    /*
+        QString question;
+
+        question = "The path you entered for the level " +
+                   QString(::to_string(lvlWithSamePath->getName()).c_str()) +
+                   "is already used: this may generate some conflicts in the
+       file "
+                   "management.\nAre you sure you want to assign the same path
+       to "
+                   "two different levels?";
+        int ret = DVGui::MsgBox(question, QObject::tr("Yes"),
+       QObject::tr("No"));
+        if (ret == 0 || ret == 2) {
+          m_pathFld->setPath(toQString(oldPath));
+          return;
+        }
+    */
+    error(
+        tr("The file you entered is already used by another level.\nPlease "
+           "choose a different file"));
+    m_pathFld->setPath(toQString(oldPath));
+    return;
+  }
+
+  if (sl && sl->getDirtyFlag()) {
     QString question;
 
-    question = "The path you entered for the level " +
-               QString(::to_string(lvlWithSamePath->getName()).c_str()) +
-               "is already used: this may generate some conflicts in the file "
-               "management.\nAre you sure you want to assign the same path to "
-               "two different levels?";
+    question =
+        "The level has unsaved changes that will be lost when you change the "
+        "path.\nAre you sure you want to change the path?";
     int ret = DVGui::MsgBox(question, QObject::tr("Yes"), QObject::tr("No"));
     if (ret == 0 || ret == 2) {
       m_pathFld->setPath(toQString(oldPath));


### PR DESCRIPTION
This PR fixes #562 

Level names as file names is a problem on systems where OS file names are case insensitive. Certain checks in Tahoma don't consider when doing file name comparisons. This can result in multiple levels writing to the same file name overwriting each other.

Modified the following changes which also apply to Linux in case the project is shared with Windows/OSX users:

1. General change
   - When performing TFilePath comparisons, a lowercase string comparison is used for OSX/Linux. It was already doing this for Windows.
   - When checking for files on the system, if the exact case filename is not found, it switches to lowercase matching.

2. Create New Level
   - Enhanced logic to force lowercase file name comparisons using the new level name to see if any other level uses a filename with the same name.
   - Modified to no longer automatically create files on the system when creating new Raster and Smart Raster levels. 
 
3. Level Settings
   - Removed logic that gave the option to use the same path as another level. It now blocks it instead.
   - Added warning that unsaved changes on the level will be lost when changing the path. 
