### PR TITLE
Fix libmypaint version for Linux builds

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -44,6 +44,8 @@ jobs:
           ci-scripts/linux/tahoma-buildopencv.sh
       - name: Build libmypaint
         run: |
+          export CC="ccache ${{ matrix.cc }}"
+          export CXX="ccache ${{ matrix.cxx }}"
           ci-scripts/linux/tahoma-buildlibmypaint.sh
       - name: Build Tahoma2D
         run: |

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -42,6 +42,9 @@ jobs:
           export CC="ccache ${{ matrix.cc }}"
           export CXX="ccache ${{ matrix.cxx }}"
           ci-scripts/linux/tahoma-buildopencv.sh
+      - name: Build libmypaint
+        run: |
+          ci-scripts/linux/tahoma-buildlibmypaint.sh
       - name: Build Tahoma2D
         run: |
           export CC="ccache ${{ matrix.cc }}"

--- a/ci-scripts/linux/tahoma-buildlibmypaint.sh
+++ b/ci-scripts/linux/tahoma-buildlibmypaint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+cd thirdparty/libmypaint
+
+echo ">>> Cloning libmypaint"
+git clone https://github.com/tahoma2d/libmypaint src
+
+cd src
+echo "*" >| .gitignore
+
+export CFLAGS='-Ofast -ftree-vectorize -fopt-info-vec-optimized -march=native -mtune=native -funsafe-math-optimizations -funsafe-loop-optimizations'
+
+echo ">>> Generating libmypaint environment"
+./autogen.sh
+
+echo ">>> Configuring libmypaint build"
+./configure
+
+echo ">>> Building libmypaint"
+sudo make
+
+echo ">>> Installing libmypaint"
+sudo make install
+
+sudo ldconfig

--- a/ci-scripts/linux/tahoma-buildlibmypaint.sh
+++ b/ci-scripts/linux/tahoma-buildlibmypaint.sh
@@ -13,7 +13,7 @@ echo ">>> Generating libmypaint environment"
 ./autogen.sh
 
 echo ">>> Configuring libmypaint build"
-./configure
+sudo ./configure
 
 echo ">>> Building libmypaint"
 sudo make

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 sudo add-apt-repository --yes ppa:beineri/opt-qt597-xenial
-sudo add-apt-repository --yes ppa:achadwick/mypaint-testing
 sudo apt-get update
-sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt59script libsuperlu-dev qt59svg qt59tools qt59multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libmypaint-dev libjpeg-turbo8-dev libglib2.0-dev qt59serialport
+sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt59script libsuperlu-dev qt59svg qt59tools qt59multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg-turbo8-dev libglib2.0-dev qt59serialport
 sudo apt-get install -y nasm yasm libgnutls-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libfreetype6-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenjpeg-dev libspeex-dev libsoxr-dev libopenjp2-7-dev
 sudo apt-get install -y python3-pip
+sudo apt install -y build-essential libgirepository1.0-dev autotools-dev intltool gettext libtool
 
 pip3 install --upgrade pip
 pip3 install numpy

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -502,7 +502,7 @@ elseif(BUILD_ENV_UNIXLIKE)
         pkg_check_modules(FREETYPE REQUIRED freetype2)
     endif()
     # Can be 'libmypaint' or 'libmypaint-1.x'
-    pkg_search_module(MYPAINT_LIB REQUIRED libmypaint libmypaint-1.3>=1.3)
+    pkg_search_module(MYPAINT_LIB REQUIRED libmypaint)
 
     find_library(TURBOJPEG_LIB turbojpeg)
     message("**************** turbojpeg lib:" ${TURBOJPEG_LIB})


### PR DESCRIPTION
This PR fixes #572 

The current Linux build environment is Ubuntu 16.04 and apt repositories only have libmypaint 1.3, but Tahoma2D requires 1.4 or later otherwise Tahoma crashes when opening the Raster tab if brushes with new 1.4 parameters are encountered.

This update will download and compile the source for libmypaint v1.6.1  (latest release) for building.