### PR TITLE
Hide global set keys when no skeleton created

### DIFF
--- a/toonz/sources/tnztools/plastictool_animate.cpp
+++ b/toonz/sources/tnztools/plastictool_animate.cpp
@@ -188,6 +188,8 @@ void PlasticTool::leftButtonUp_animate(const TPointD &pos,
 void PlasticTool::addContextMenuActions_animate(QMenu *menu) {
   bool ret = true;
 
+  if (m_sd.getPointer() == nullptr) return;
+
   if (!m_svSel.isEmpty()) {
     QAction *setKey = menu->addAction(tr("Set Key"));
     ret = ret && connect(setKey, SIGNAL(triggered()), &l_plasticTool,


### PR DESCRIPTION
This PR fixes #552 

The `Set Global Key` and `Set Global Rest Key`  can be used when a skeleton vertices are not selected, but does require a skeleton to work or it causes a crash.  Options are now hidden if a skeleton does not exist to prevent usage and the crash.
