### PR TITLE
Fix saving degree symbol

### DIFF
--- a/toonz/sources/common/tparam/tdoublekeyframe.cpp
+++ b/toonz/sources/common/tparam/tdoublekeyframe.cpp
@@ -57,7 +57,7 @@ void TDoubleKeyframe::saveData(TOStream &os) const {
   // Dirty resolution. Because the degree sign is converted to unexpected
   // string...
   if (QString::fromStdWString(L"\u00b0").toStdString() == unitName)
-    unitName = "\\u00b0";
+    unitName = "degrees";
   switch (m_type) {
   case Constant:
   case Exponential:
@@ -157,6 +157,9 @@ void TDoubleKeyframe::loadData(TIStream &is) {
     break;
   }
   if (!is.matchEndTag()) throw TException(tagName + " : missing endtag");
-  if (m_unitName == "default") m_unitName = "";
-  m_isKeyframe                            = true;
+  if (m_unitName == "default")
+    m_unitName = "";
+  else if (m_unitName == "degrees")
+    m_unitName = "\u00b0";
+  m_isKeyframe = true;
 }


### PR DESCRIPTION
This PR fixes #536 

When trying to save Expression Units = ° (degree symbol), it would convert it to a modified unicode string. On Windows, it is not a problem but on macOS, it would fail to write it to the scene file and abort the save.

Modified to store the text "degrees" instead, then convert it back to the symbol when loading the scene.  

This change will not impact loading existing scenes that stored the unicode string and scenes saved with this change appear to open fine with prior versions.
