### PR TITLE
Add CrashRpt

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ assignees: ''
 ---
 
 <!-- Please search for existing issues to avoid creating duplicates. -->
-<!-- And please test using the latest nightly build to make sure your issue has not already been fixed: https://github.com/turtletooth/tahoma2d/releases/tag/nightly/ -->
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -19,8 +18,12 @@ List steps to reproduce the behavior.
 2.
 3.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Screenshots, short videos or logs**
+If applicable, add screenshots or links to short videos to help explain your problem or provide logs or dmp files if it's a crash.
+
+<!--Crash logs or dmp files may be found under the following:-->
+<!-- Windows crash dmp: C:\Users\yourusername\AppData\Local\Tahoma2D\Tahoma2D\cache\crashrpt\xxxx\crashdump.dmp -->
+<!-- macOS crash logs: Console App -> User Reports.  Look for Tahoma2D crash report -->
 
 **Device Information:**
  - OS: [e.g. Windows]

--- a/stuff/doc/LICENSE/LICENSE_crashrpt.txt
+++ b/stuff/doc/LICENSE/LICENSE_crashrpt.txt
@@ -1,0 +1,28 @@
+CrashRpt
+
+Copyright (c) 2003, The CrashRpt Project Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this 
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice, 
+      this list of conditions and the following disclaimer in the documentation 
+      and/or other materials provided with the distribution.
+
+    * Neither the name of the author nor the names of its contributors 
+      may be used to endorse or promote products derived from this software without 
+      specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
+SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/thirdparty/crashrpt/.gitignore
+++ b/thirdparty/crashrpt/.gitignore
@@ -1,0 +1,2 @@
+include/*
+*.lib

--- a/thirdparty/crashrpt/copy_crashrpt.txt
+++ b/thirdparty/crashrpt/copy_crashrpt.txt
@@ -1,0 +1,10 @@
+For Windows Builds Only!
+
+Copy the include folder from the CrashRpt source to here.
+Compile CrashRpt and copy the CrashRptXXXX.lib here also.
+
+When releasing with CrashRpt, include:
+	CrashRptXXXX.dll
+	CrashSenderXXXX.exe
+	crashrpt_lang.ini
+	dbghelp.dll (optional)

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -102,6 +102,7 @@ endif()
 option(WITH_SYSTEM_LZO "Use the system LZO library instead of 'thirdpary'" ${_init_SYSTEM_LZO})
 option(WITH_SYSTEM_SUPERLU "Use the system SuperLU library instead of 'thirdpary'" ${_init_SYSTEM_SUPERLU})
 option(WITH_CANON "Build with Canon DSLR support - Requires Canon SDK" OFF)
+option(WITH_CRASHRPT "Build CrashRpt support - Requires CrashRpt Library" OFF)
 
 # avoid using again
 option_defaults_clear()
@@ -277,6 +278,12 @@ if(BUILD_ENV_MSVC)
     add_definitions(
         -DGLUT_NO_LIB_PRAGMA
     )
+
+	if(WITH_CRASHRPT)
+		include_directories(
+			${SDKROOT}/crashrpt/include
+		)
+	endif()
 endif()
 
 if(BUILD_ENV_MSVC)
@@ -370,6 +377,10 @@ if(BUILD_ENV_MSVC)
     endif()
     set(MYPAINT_LIB_INCLUDE_DIRS ${SDKROOT}/libmypaint/dist/${PLATFORM}/include/libmypaint)
     set(MYPAINT_LIB_LDFLAGS ${SDKROOT}/libmypaint/dist/${PLATFORM}/libmypaint.lib)
+
+	if(WITH_CRASHRPT)
+		set(CRASHRPT_LIB ${SDKROOT}/crashrpt/CrashRpt1500.lib)
+	endif()
 elseif(BUILD_ENV_APPLE)
     find_library(GLUT_LIB GLUT)
     find_library(GL_LIB OpenGL)

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -421,6 +421,10 @@ if (WITH_CANON)
     add_definitions(-DWITH_CANON)
 endif()
 
+if (WITH_CRASHRPT)
+    add_definitions(-DWITH_CRASHRPT)
+endif()
+
 if(BUILD_ENV_APPLE)
     include_directories(
        ../../sources/mousedragfilter
@@ -438,38 +442,21 @@ if(BUILD_TARGET_WIN)
     endif()
 endif()
 
-if(BUILD_ENV_MSVC AND WITH_CANON)
-    target_link_libraries(Tahoma2D
-        Qt5::WinMain Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
-        Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort
-        ${GL_LIB} ${GLUT_LIB} 
-        ${CANON_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS} strmiids
-        tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm
-    )
-elseif(BUILD_ENV_MSVC)
-    target_link_libraries(Tahoma2D
-        Qt5::WinMain Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
-        Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort
-        ${GL_LIB} ${GLUT_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS} strmiids
-        tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm
-    )
-elseif(BUILD_ENV_APPLE AND WITH_CANON)
-    find_library(COCOA_LIB Cocoa)
+if(BUILD_ENV_MSVC)
+    if(WITH_CANON) 
+       set(EXTRA_LIBS ${EXTRA_LIBS} ${CANON_LIB})
+	endif()
 
-    _find_toonz_library(EXTRA_LIBS "tnzcore;tnzbase;toonzlib;colorfx;tnzext;image;sound;toonzqt;tnztools")
+	if(WITH_CRASHRPT)
+       set(EXTRA_LIBS ${EXTRA_LIBS} ${CRASHRPT_LIB})
+	endif()
 
-    # 変なところにライブラリ生成するカスども
-    set(EXTRA_LIBS ${EXTRA_LIBS} "$<TARGET_FILE:tnzstdfx>" "$<TARGET_FILE:tfarm>")
-
-    add_dependencies(Tahoma2D tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm)
-
-    target_link_libraries(Tahoma2D
-        Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
-        Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::MultimediaWidgets Qt5::SerialPort
-        ${GL_LIB} ${GLUT_LIB} ${CANON_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS}
-        ${COCOA_LIB} ${EXTRA_LIBS} mousedragfilter
-    )
-
+	target_link_libraries(Tahoma2D
+		Qt5::WinMain Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
+		Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort
+		${GL_LIB} ${GLUT_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS} ${EXTRA_LIBS} strmiids
+		tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm
+	)
 elseif(BUILD_ENV_APPLE)
     find_library(COCOA_LIB Cocoa)
 
@@ -477,6 +464,10 @@ elseif(BUILD_ENV_APPLE)
 
     # 変なところにライブラリ生成するカスども
     set(EXTRA_LIBS ${EXTRA_LIBS} "$<TARGET_FILE:tnzstdfx>" "$<TARGET_FILE:tfarm>")
+
+	if(WITH_CANON)
+	    set(EXTRA_LIBS ${EXTRA_LIBS} ${CANON_LIB})
+	endif()
 
     add_dependencies(Tahoma2D tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm)
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -1,4 +1,7 @@
 // Soli Deo gloria
+#ifdef WITH_CRASHRPT
+#include <tchar.h>
+#endif
 
 // Tnz6 includes
 #include "mainwindow.h"
@@ -62,6 +65,10 @@
 #include "tfont.h"
 
 #include "kis_tablet_support_win8.h"
+
+#ifdef WITH_CRASHRPT
+#include "CrashRpt.h"
+#endif
 
 #ifdef MACOSX
 #include "tipc.h"
@@ -242,6 +249,12 @@ static void script_output(int type, const QString &value) {
 }
 
 //-----------------------------------------------------------------------------
+#ifdef WITH_CRASHRPT
+LPCWSTR convertToLPCWSTR(std::string str) {
+  std::wstring stemp = std::wstring(str.begin(), str.end());
+  return stemp.c_str();
+}
+#endif
 
 int main(int argc, char *argv[]) {
 #ifdef Q_OS_WIN
@@ -313,6 +326,26 @@ int main(int argc, char *argv[]) {
 
     argc = 1;
   }
+
+  // Toonz environment
+  initToonzEnv(argumentPathValues);
+
+#ifdef WITH_CRASHRPT
+  CR_INSTALL_INFO pInfo;
+  memset(&pInfo, 0, sizeof(CR_INSTALL_INFO));
+  pInfo.cb            = sizeof(CR_INSTALL_INFO);
+  pInfo.pszAppName    = convertToLPCWSTR(TEnv::getApplicationName());
+  pInfo.pszAppVersion = convertToLPCWSTR(TEnv::getApplicationVersion());
+  TFilePath crashrptCache =
+      ToonzFolder::getCacheRootFolder() + TFilePath("crashrpt");
+  pInfo.pszErrorReportSaveDir =
+      convertToLPCWSTR(crashrptCache.getQString().toStdString());
+  // Install all available exception handlers.
+  // Don't send reports automaticall, store locally
+  pInfo.dwFlags |= CR_INST_ALL_POSSIBLE_HANDLERS | CR_INST_DONT_SEND_REPORT;
+
+  crInstall(&pInfo);
+#endif
 
 // Enables high-DPI scaling. This attribute must be set before QApplication is
 // constructed. Available from Qt 5.6.
@@ -480,9 +513,6 @@ int main(int argc, char *argv[]) {
   // Install run out of contiguous memory callback
   TBigMemoryManager::instance()->setRunOutOfContiguousMemoryHandler(
       &toonzRunOutOfContMemHandler);
-
-  // Toonz environment
-  initToonzEnv(argumentPathValues);
 
   // Initialize thread components
   TThread::init();
@@ -819,6 +849,10 @@ int main(int argc, char *argv[]) {
   if (consoleAttached) {
     ::FreeConsole();
   }
+#endif
+
+#ifdef WITH_CRASHRPT
+  crUninstall();
 #endif
 
   return ret;


### PR DESCRIPTION
This PR sets up integration for the open source CrashRpt (v1.5) system which will create a mini dump file whenever Tahoma2D crashes.

- CrashRpt In General
   - CrashRpt is only for Windows systems and is not available for macOS or Linux.
   - Source (for v1.5) can be found here: https://github.com/CrashRpt/crashrpt2
   - Documentation (for 1.4.3) can be found here: http://crashrpt.sourceforge.net/docs/html

- CrashRpt Intergration into Tahoma2D
   - CrashRpt will only be available in Windows pre-release and releases compiled locally. It will not be active for PRs.
   - Crash logs and mini dump files will be created in `C:\Users\yourusername\AppData\Local\Tahoma2D\Tahoma2D\cache\crashrpt\`
   - Since the CrashRpt output is created in Tahoma2D's cache folder, it will be cleared when the user select the Tahoma2D menu option `File -> Clear Cache Folder`
