### PR TITLE
Add temp tool hold switch time as preference

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -342,6 +342,9 @@ public:
   bool useCtrlAltToResizeBrushEnabled() const {
     return getBoolValue(useCtrlAltToResizeBrush);
   }
+  int getTempToolSwitchtimer() const {
+    return getIntValue(temptoolswitchtimer);
+  }
 
   // Xsheet  tab
   QString getXsheetLayoutPreference() const {

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -107,6 +107,7 @@ enum PreferencesItemId {
   cursorOutlineEnabled,
   levelBasedToolsDisplay,
   useCtrlAltToResizeBrush,
+  temptoolswitchtimer,
 
   //----------
   // Xsheet

--- a/toonz/sources/tnztools/toolhandle.cpp
+++ b/toonz/sources/tnztools/toolhandle.cpp
@@ -7,6 +7,7 @@
 #include "timage.h"
 //#include "tapp.h"
 #include "toonzqt/menubarcommand.h"
+#include "toonz/preferences.h"
 #include <QAction>
 #include <QMap>
 #include <QDebug>
@@ -70,9 +71,10 @@ void ToolHandle::storeTool() {
 //-----------------------------------------------------------------------------
 
 void ToolHandle::restoreTool() {
-  // qDebug() << m_storedToolTime.elapsed();
+  //qDebug() << m_storedToolTime.elapsed();
   if (m_storedToolName != m_toolName && m_storedToolName != "" &&
-      m_storedToolTime.elapsed() > 500) {
+      m_storedToolTime.elapsed() >
+          Preferences::instance()->getTempToolSwitchtimer()) {
     setTool(m_storedToolName);
   }
 }

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1082,6 +1082,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {cursorOutlineEnabled, tr("Show Cursor Size Outlines")},
       {levelBasedToolsDisplay, tr("Toolbar Display Behaviour:")},
       {useCtrlAltToResizeBrush, tr("Use Ctrl+Alt to Resize Brush")},
+      {temptoolswitchtimer,
+       tr("Temporary Tool Switch Shortcut Hold Time (ms):")},
 
       // Xsheet
       {xsheetLayoutPreference, tr("Column Header Layout*:")},
@@ -1716,6 +1718,7 @@ QWidget* PreferencesPopup::createToolsPage() {
   insertUI(levelBasedToolsDisplay, lay,
            getComboItemList(levelBasedToolsDisplay));
   // insertUI(useCtrlAltToResizeBrush, lay);
+  insertUI(temptoolswitchtimer, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -498,6 +498,8 @@ void Preferences::definePreferenceItems() {
          0);  // Default
   define(useCtrlAltToResizeBrush, "useCtrlAltToResizeBrush", QMetaType::Bool,
          true);
+  define(temptoolswitchtimer, "temptoolswitchtimer", QMetaType::Int, 500, 1,
+         std::numeric_limits<int>::max());
 
   // Xsheet
   define(xsheetLayoutPreference, "xsheetLayoutPreference", QMetaType::QString,


### PR DESCRIPTION
This PR addresses the issue with temporary tool switching where it usually requires a user to hold the shortcut for 500 ms (1/2 second) in order to switch back to the original tool.

There is now a new Tools Preference setting allowing you to change that value from 500 to whatever you want it to be.

![image](https://user-images.githubusercontent.com/19245851/107814549-1609af00-6d40-11eb-9a36-7a963562f058.png)
