### PR TITLE
Fix macOS crash on startup

### DIFF
--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -446,20 +446,20 @@ endif()
 
 if(BUILD_ENV_MSVC)
     if(WITH_CANON) 
-       set(EXTRA_LIBS ${EXTRA_LIBS} ${CANON_LIB})
-	endif()
+        set(EXTRA_LIBS ${EXTRA_LIBS} ${CANON_LIB})
+    endif()
 
-	if(WITH_CRASHRPT)
-       set(EXTRA_LIBS ${EXTRA_LIBS} ${CRASHRPT_LIB})
-	endif()
+    if(WITH_CRASHRPT)
+        set(EXTRA_LIBS ${EXTRA_LIBS} ${CRASHRPT_LIB})
+    endif()
 
-	target_link_libraries(Tahoma2D
-		Qt5::WinMain Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
-		Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort
-		${GL_LIB} ${GLUT_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS} ${EXTRA_LIBS} strmiids
-		tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm
-	)
-elseif(BUILD_ENV_APPLE)
+    target_link_libraries(Tahoma2D
+        Qt5::WinMain Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
+        Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort
+        ${GL_LIB} ${GLUT_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS} ${EXTRA_LIBS} strmiids
+        tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm
+    )
+elseif(BUILD_ENV_APPLE AND WITH_CANON)
     find_library(COCOA_LIB Cocoa)
 
     _find_toonz_library(EXTRA_LIBS "tnzcore;tnzbase;toonzlib;colorfx;tnzext;image;sound;toonzqt;tnztools")
@@ -467,9 +467,22 @@ elseif(BUILD_ENV_APPLE)
     # 変なところにライブラリ生成するカスども
     set(EXTRA_LIBS ${EXTRA_LIBS} "$<TARGET_FILE:tnzstdfx>" "$<TARGET_FILE:tfarm>")
 
-	if(WITH_CANON)
-	    set(EXTRA_LIBS ${EXTRA_LIBS} ${CANON_LIB})
-	endif()
+    add_dependencies(Tahoma2D tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm)
+
+    target_link_libraries(Tahoma2D
+        Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
+        Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::MultimediaWidgets Qt5::SerialPort
+        ${GL_LIB} ${GLUT_LIB} ${CANON_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS}
+        ${COCOA_LIB} ${EXTRA_LIBS} mousedragfilter
+    )
+
+elseif(BUILD_ENV_APPLE)
+    find_library(COCOA_LIB Cocoa)
+
+    _find_toonz_library(EXTRA_LIBS "tnzcore;tnzbase;toonzlib;colorfx;tnzext;image;sound;toonzqt;tnztools")
+
+    # 変なところにライブラリ生成するカスども
+    set(EXTRA_LIBS ${EXTRA_LIBS} "$<TARGET_FILE:tnzstdfx>" "$<TARGET_FILE:tfarm>")
 
     add_dependencies(Tahoma2D tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm)
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -328,28 +328,8 @@ int main(int argc, char *argv[]) {
     argc = 1;
   }
 
-  // Toonz environment
-  initToonzEnv(argumentPathValues);
-
-#ifdef WITH_CRASHRPT
-  CR_INSTALL_INFO pInfo;
-  memset(&pInfo, 0, sizeof(CR_INSTALL_INFO));
-  pInfo.cb            = sizeof(CR_INSTALL_INFO);
-  pInfo.pszAppName    = convertToLPCWSTR(TEnv::getApplicationName());
-  pInfo.pszAppVersion = convertToLPCWSTR(TEnv::getApplicationVersion());
-  TFilePath crashrptCache =
-      ToonzFolder::getCacheRootFolder() + TFilePath("crashrpt");
-  pInfo.pszErrorReportSaveDir =
-      convertToLPCWSTR(crashrptCache.getQString().toStdString());
-  // Install all available exception handlers.
-  // Don't send reports automaticall, store locally
-  pInfo.dwFlags |= CR_INST_ALL_POSSIBLE_HANDLERS | CR_INST_DONT_SEND_REPORT;
-
-  crInstall(&pInfo);
-#endif
-
-// Enables high-DPI scaling. This attribute must be set before QApplication is
-// constructed. Available from Qt 5.6.
+  // Enables high-DPI scaling. This attribute must be set before QApplication is
+  // constructed. Available from Qt 5.6.
 #if QT_VERSION >= 0x050600
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
@@ -510,6 +490,26 @@ int main(int argc, char *argv[]) {
   // Install run out of contiguous memory callback
   TBigMemoryManager::instance()->setRunOutOfContiguousMemoryHandler(
       &toonzRunOutOfContMemHandler);
+
+  // Toonz environment
+  initToonzEnv(argumentPathValues);
+
+#ifdef WITH_CRASHRPT
+  CR_INSTALL_INFO pInfo;
+  memset(&pInfo, 0, sizeof(CR_INSTALL_INFO));
+  pInfo.cb = sizeof(CR_INSTALL_INFO);
+  pInfo.pszAppName = convertToLPCWSTR(TEnv::getApplicationName());
+  pInfo.pszAppVersion = convertToLPCWSTR(TEnv::getApplicationVersion());
+  TFilePath crashrptCache =
+    ToonzFolder::getCacheRootFolder() + TFilePath("crashrpt");
+  pInfo.pszErrorReportSaveDir =
+    convertToLPCWSTR(crashrptCache.getQString().toStdString());
+  // Install all available exception handlers.
+  // Don't send reports automaticall, store locally
+  pInfo.dwFlags |= CR_INST_ALL_POSSIBLE_HANDLERS | CR_INST_DONT_SEND_REPORT;
+
+  crInstall(&pInfo);
+#endif
 
   // Initialize thread components
   TThread::init();


### PR DESCRIPTION
This PR fixes #590

I inadvertently broke macOS builds when I moved `initToonzEnv()`  up in the startup sequence for #578. For whatever reason, moving it up prevented the application from reading/configuring something correctly and resulted in immediate crash.

Moved it back to its original location and moved the CrashRpt changes that used the information to run afterwards.

Edit: Was also having problems with local macOS builds building with Canon support due to the changes I made to `CMakeLists.txt`.  I reverted those changes as well.