### PR TITLE
Statusbar enhancements

### DIFF
--- a/toonz/sources/include/toonz/tapplication.h
+++ b/toonz/sources/include/toonz/tapplication.h
@@ -20,6 +20,7 @@ class TPaletteHandle;
 class TFxHandle;
 class PaletteController;
 class TColorStyle;
+class StatusBar;
 
 //====================================================
 
@@ -51,6 +52,7 @@ public:
   virtual int getCurrentLevelStyleIndex() const     = 0;
   virtual void setCurrentLevelStyleIndex(int index,
                                          bool forceUpdate = false) = 0;
+  virtual void refreshStatusBar()                                  = 0;
 };
 
 #endif  // TAPPLICATION_H

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -1172,6 +1172,7 @@ public:
       if (typeCode != m_typeCode) {
         m_typeCode = typeCode;
         changeType(typeCode);
+        TTool::getApplication()->refreshStatusBar();
       }
     } else if (propertyName == m_param.m_edgeCount.getName())
       GeometricEdgeCount = m_param.m_edgeCount.getValue();

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -15,7 +15,7 @@
 #include "toonz/tobjecthandle.h"
 #include "toonzqt/tselectionhandle.h"
 #include "toonzqt/selection.h"
-#include "toonz/tstageobjecttree.h"
+#include "toonzqt/gutil.h"
 
 #include "tools/tool.h"
 
@@ -32,7 +32,7 @@ StatusBar::StatusBar(QWidget* parent) : QStatusBar(parent) {
   m_infoLabel = new StatusLabel(tr("Info goes here."), this);
   m_infoLabel->setObjectName("MainWindowPlainLabel");
   m_infoLabel->setMinimumWidth(1);
-  addWidget(m_infoLabel, 0);
+  addWidget(m_infoLabel, 1);
   addPermanentWidget(m_currentFrameLabel, 0);
 
   TApp* app                    = TApp::instance();
@@ -125,108 +125,120 @@ void StatusBar::updateInfoText() {
     i++;
   }
 
+  m_infoLabel->setToolTip(text);
   m_infoLabel->setText(text);
 }
 
 //-----------------------------------------------------------------------------
+QString trModKey(QString key) {
+#ifdef MACOSX
+  // Convert Windows key modifier to macOS modifier
+  if (key == "Ctrl")  // Command
+    return QString::fromStdWString(L"\u2318");
+  else if (key == "Shift")
+    return QString::fromStdWString(L"\u21e7");
+  else if (key == "Alt")
+    return QString::fromStdWString(L"\u2325");
+//  else if (key == "???") // Control
+//    return QString::fromStdWString(L"\u2303");
+#endif
+
+  return key;
+}
 
 void StatusBar::makeMap() {
-  QString spacer = "                    ";
+  QString spacer = tr("                    ");
   // tools
-  m_infoMap.insert({"T_Hand", "<b>Hand Tool:</b> Pans the workspace (Space)"});
+  m_infoMap.insert({"T_Hand", tr("Hand Tool: Pans the workspace")});
   m_infoMap.insert(
       {"T_Selection",
-       "Selection Tool: Select parts of your image to transform it."});
-  m_infoMap.insert({"T_Edit",
-                    "Animate Tool: Modifies the position, rotation and size of "
-                    "the current column"});
-  m_infoMap.insert({"T_Brush", "Brush Tool: Draws in the work area freehand"});
+       tr("Selection Tool: Select parts of your image to transform it") +
+           spacer +
+           tr("%1 - Scale / Directional scale").arg(trModKey("Shift")) +
+           spacer + tr("%1 - Distort / Shear").arg(trModKey("Ctrl")) + spacer +
+           tr("%1 - Scale symmetrically from center point")
+               .arg(trModKey("Alt"))});
+  m_infoMap.insert({"T_Edit", tr("Animate Tool: Modifies the position, "
+                                 "rotation and size of the current column")});
   m_infoMap.insert(
-      {"T_BrushVector", "Brush Tool: Draws in the work area freehand" + spacer +
-                            "Shift - Straight Lines" + spacer +
-#ifdef MACOSX
-                            "Cmd - Straight Lines Snapped to Angles" + spacer +
-                            "Cmd + Opt - Add / Remove Vanishing Point" +
-                            spacer + "Opt - Draw to Vanishing Point" + spacer +
-                            "Hold Cmd + Shift - Toggle Snapping"});
-#else
-                            "Control - Straight Lines Snapped to Angles" +
-                            spacer +
-                            "Ctrl + Alt - Add / Remove Vanishing Point" +
-                            spacer + "Alt - Draw to Vanishing Point" + spacer +
-                            "Hold Ctrl + Shift - Toggle Snapping"});
-#endif
-  m_infoMap.insert({"T_BrushSmartRaster",
-                    "Brush Tool: Draws in the work area freehand" + spacer +
-                        "Shift - Straight Lines" + spacer +
-#ifdef MACOSX
-                        "Cmd - Straight Lines Snapped to Angles" + spacer +
-                        "Cmd + Opt - Add / Remove Vanishing Point" + spacer +
-                        "Opt - Draw to Vanishing Point"});
-#else
-                        "Control - Straight Lines Snapped to Angles" + spacer +
-                        "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
-                        "Alt - Draw to Vanishing Point"});
-#endif
+      {"T_Brush", tr("Brush Tool: Draws in the work area freehand")});
   m_infoMap.insert(
-      {"T_BrushRaster", "Brush Tool: Draws in the work area freehand" + spacer +
-                            "Shift - Straight Lines" + spacer +
-#ifdef MACOSX
-                            "Cmd - Straight Lines Snapped to Angles" + spacer +
-                            "Cmd + Opt - Add / Remove Vanishing Point" +
-                            spacer + "Opt - Draw to Vanishing Point"});
-#else
-                            "Control - Straight Lines Snapped to Angles" +
-                            spacer +
-                            "Ctrl + Alt - Add / Remove Vanishing Point" +
-                            spacer + "Alt - Draw to Vanishing Point"});
-#endif
-  m_infoMap.insert({"T_Geometric", "Geometry Tool: Draws geometric shapes"});
+      {"T_BrushVector",
+       tr("Brush Tool : Draws in the work area freehand") + spacer +
+           tr("%1 - Straight Lines").arg(trModKey("Shift")) + spacer +
+           tr("%1 - Straight Lines Snapped to Angles").arg(trModKey("Ctrl")) +
+           spacer +
+           tr("%1 - Add / Remove Vanishing Point")
+               .arg(trModKey("Ctrl") + "+" + trModKey("Alt")) +
+           spacer + tr("%1 - Draw to Vanishing Point").arg(trModKey("Alt")) +
+           spacer +
+           tr("Hold %1 - Toggle Snapping")
+               .arg(trModKey("Ctrl") + "+" + trModKey("Shift"))});
   m_infoMap.insert(
-      {"T_GeometricVector", "Geometry Tool: Draws geometric shapes" + spacer +
-#ifdef MACOSX
-                                "Hold Cmd + Shift - Toggle Snapping"});
-#else
-                                "Hold Ctrl + Shift - Toggle Snapping"});
-#endif
-  m_infoMap.insert({"T_Type", "Type Tool: Adds text"});
+      {"T_BrushSmartRaster",
+       tr("Brush Tool : Draws in the work area freehand") + spacer +
+           tr("%1 - Straight Lines").arg(trModKey("Shift")) + spacer +
+           tr("%1 - Straight Lines Snapped to Angles").arg(trModKey("Ctrl")) +
+           spacer +
+           tr("%1 - Add / Remove Vanishing Point")
+               .arg(trModKey("Ctrl") + "+" + trModKey("Alt")) +
+           spacer + tr("%1 - Draw to Vanishing Point").arg(trModKey("Alt"))});
+  m_infoMap.insert(
+      {"T_BrushRaster",
+       tr("Brush Tool : Draws in the work area freehand") + spacer +
+           tr("%1 - Straight Lines").arg(trModKey("Shift")) + spacer +
+           tr("%1 - Straight Lines Snapped to Angles").arg(trModKey("Ctrl")) +
+           spacer +
+           tr("%1 - Add / Remove Vanishing Point")
+               .arg(trModKey("Ctrl") + "+" + trModKey("Alt")) +
+           spacer + tr("%1 - Draw to Vanishing Point").arg(trModKey("Alt"))});
+  m_infoMap.insert(
+      {"T_Geometric", tr("Geometry Tool: Draws geometric shapes")});
+  m_infoMap.insert({"T_GeometricVector",
+                    tr("Geometry Tool: Draws geometric shapes") + spacer +
+                        tr("Hold %1 - Toggle Snapping")
+                            .arg(trModKey("Ctrl") + "+" + trModKey("Shift"))});
+  m_infoMap.insert({"T_Type", tr("Type Tool: Adds text")});
   m_infoMap.insert(
       {"T_PaintBrush",
-       "Smart Raster Painter: Paints areas in Smart Raster leves"});
+       tr("Smart Raster Painter: Paints areas in Smart Raster leves")});
   m_infoMap.insert(
-      {"T_Fill", "Fill Tool: Fills drawing areas with the current style"});
-  m_infoMap.insert({"T_Eraser", "Eraser: Erases lines and areas"});
+      {"T_Fill", tr("Fill Tool: Fills drawing areas with the current style")});
+  m_infoMap.insert({"T_Eraser", tr("Eraser: Erases lines and areas")});
   m_infoMap.insert(
-      {"T_Tape", "Tape Tool: Closes gaps in raster, joins edges in vector"});
+      {"T_Tape",
+       tr("Tape Tool: Closes gaps in raster, joins edges in vector")});
   m_infoMap.insert(
-      {"T_StylePicker", "Style Picker: Selects style on current drawing"});
+      {"T_StylePicker", tr("Style Picker: Selects style on current drawing")});
   m_infoMap.insert(
       {"T_RGBPicker",
-       "RGB Picker: Picks color on screen and applies to current style"});
-  m_infoMap.insert({"T_ControlPointEditor",
-                    "Control Point Editor: Modifies vector lines by editing "
-                    "its control points"});
-  m_infoMap.insert({"T_Pinch", "Pinch Tool: Pulls vector drawings"});
-  m_infoMap.insert({"T_Pump", "Pump Tool: Changes vector thickness"});
-  m_infoMap.insert({"T_Magnet", "Magnet Tool: Deforms vector lines"});
+       tr("RGB Picker: Picks color on screen and applies to current style")});
   m_infoMap.insert(
-      {"T_Bender", "Bend Tool: Bends vector shapes around the first click"});
-  m_infoMap.insert({"T_Iron", "Iron Tool: Smooths vector lines"});
-  m_infoMap.insert({"T_Cutter", "Cutter Tool: Splits vector lines"});
+      {"T_ControlPointEditor", tr("Control Point Editor: Modifies vector lines "
+                                  "by editing its control points")});
+  m_infoMap.insert({"T_Pinch", tr("Pinch Tool: Pulls vector drawings")});
+  m_infoMap.insert({"T_Pump", tr("Pump Tool: Changes vector thickness")});
+  m_infoMap.insert({"T_Magnet", tr("Magnet Tool: Deforms vector lines")});
+  m_infoMap.insert(
+      {"T_Bender",
+       tr("Bend Tool: Bends vector shapes around the first click")});
+  m_infoMap.insert({"T_Iron", tr("Iron Tool: Smooths vector lines")});
+  m_infoMap.insert({"T_Cutter", tr("Cutter Tool: Splits vector lines")});
   m_infoMap.insert({"T_Hook", ""});
-  m_infoMap.insert({"T_Skeleton",
-                    "Skeleton Tool: Allows to build a skeleton and animate in "
-                    "a cut-out workflow"});
+  m_infoMap.insert(
+      {"T_Skeleton", tr("Skeleton Tool: Allows to build a skeleton and animate "
+                        "in a cut-out workflow")});
   m_infoMap.insert(
       {"T_Tracker",
-       "Tracker: Tracks specific regions in a sequence of images"});
-  m_infoMap.insert({"T_Plastic",
-                    "Plastic Tool: Builds a mesh that allows to deform and "
-                    "animate a level"});
-  m_infoMap.insert({"T_Zoom", "Zoom Tool: Zooms viewer"});
-  m_infoMap.insert({"T_Rotate", "Rotate Tool: Rotate the workspace"});
-  m_infoMap.insert({"T_Ruler", ""});
+       tr("Tracker: Tracks specific regions in a sequence of images")});
+  m_infoMap.insert({"T_Plastic", tr("Plastic Tool: Builds a mesh that allows "
+                                    "to deform and animate a level")});
+  m_infoMap.insert({"T_Zoom", tr("Zoom Tool: Zooms viewer")});
+  m_infoMap.insert({"T_Rotate", tr("Rotate Tool: Rotate the workspace")});
   m_infoMap.insert(
-      {"T_Finger", "Finger Tool: Smudges small areas to cover with line"});
-  m_infoMap.insert({"T_Dummy", "This tool doesn't work on this layer type."});
+      {"T_Ruler", tr("Ruler Tool: Measures distances on the canvas")});
+  m_infoMap.insert(
+      {"T_Finger", tr("Finger Tool: Smudges small areas to cover with line")});
+  m_infoMap.insert(
+      {"T_Dummy", tr("This tool doesn't work on this layer type.")});
 }

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -21,6 +21,8 @@
 
 #include "tools/toolhandle.h"
 
+#include "tproperty.h"
+
 #include <QLayout>
 #include <QLabel>
 
@@ -97,32 +99,46 @@ void StatusBar::updateInfoText() {
   if (level) {
     type = level->getType();
   }
-  bool isRaster        = false;
-  bool isVector        = false;
-  bool isSmartRaster   = false;
-  std::string namePlus = "";
+  bool isRaster         = false;
+  bool isVector         = false;
+  bool isSmartRaster    = false;
+  std::string nameLevel = "";
+  std::string nameMode  = "";
   if (type >= 0) {
     if (type == TXshLevelType::PLI_XSHLEVEL) {
-      isVector = true;
-      namePlus = "Vector";
+      isVector  = true;
+      nameLevel = "Vector";
     } else if (type == TXshLevelType::TZP_XSHLEVEL) {
       isSmartRaster = true;
-      namePlus      = "SmartRaster";
+      nameLevel     = "SmartRaster";
     } else if (type == TXshLevelType::OVL_XSHLEVEL) {
-      isRaster = true;
-      namePlus = "Raster";
+      isRaster  = true;
+      nameLevel = "Raster";
     }
   }
 
+  if (name == "T_Geometric") {
+    TPropertyGroup* props = tool->getProperties(0);
+    nameMode              = props->getProperty("Shape:")->getValueAsString();
+  }
+
   QString text = "";
-  if (m_infoMap.find(name + namePlus) != m_infoMap.end())
-    text += m_infoMap[name + namePlus];
+  if (m_infoMap.find(name + nameLevel + nameMode) != m_infoMap.end())
+    text += m_infoMap[name + nameLevel + nameMode];
+  else if (m_infoMap.find(name + nameLevel) != m_infoMap.end())
+    text += m_infoMap[name + nameLevel];
+  else if (m_infoMap.find(name + nameMode) != m_infoMap.end())
+    text += m_infoMap[name + nameMode];
   else if (m_infoMap.find(name) != m_infoMap.end())
     text += m_infoMap[name];
 
   QString hintText = "";
-  if (m_hintMap.find(name + namePlus) != m_hintMap.end())
-    hintText += m_hintMap[name + namePlus];
+  if (m_hintMap.find(name + nameLevel + nameMode) != m_hintMap.end())
+    hintText += m_hintMap[name + nameLevel + nameMode];
+  else if (m_hintMap.find(name + nameLevel) != m_hintMap.end())
+    hintText += m_hintMap[name + nameLevel];
+  else if (m_hintMap.find(name + nameMode) != m_hintMap.end())
+    hintText += m_hintMap[name + nameMode];
   else if (m_hintMap.find(name) != m_hintMap.end())
     hintText += m_hintMap[name];
 
@@ -232,11 +248,83 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                        .arg(trModKey("Alt"))
                        .arg(cmd2TextSeparator)});
   lMap.insert({"T_Geometric", tr("Geometry Tool: Draws geometric shapes")});
+  lMap.insert({"T_GeometricRectangle",
+               tr("Geometry Tool: Draws geometric shapes") + spacer +
+                   tr("%1%2Proportion Lock")
+                       .arg(trModKey("Shift"))
+                       .arg(cmdTextSeparator) +
+                   spacer +
+                   tr("%1%2Create From Center")
+                       .arg(trModKey("Alt"))
+                       .arg(cmdTextSeparator)});
+  lMap.insert({"T_GeometricEllipse",
+               tr("Geometry Tool: Draws geometric shapes") + spacer +
+                   tr("%1%2Proportion Lock")
+                       .arg(trModKey("Shift"))
+                       .arg(cmdTextSeparator) +
+                   spacer +
+                   tr("%1%2Create From Center")
+                       .arg(trModKey("Alt"))
+                       .arg(cmdTextSeparator)});
+  lMap.insert(
+      {"T_GeometricPolyline",
+       tr("Geometry Tool: Draws geometric shapes") + spacer +
+           tr("%1%2Create Curve").arg(tr("Click+Drag")).arg(cmdTextSeparator) +
+           spacer +
+           tr("%1%2Return to Straight Line")
+               .arg(trModKey("Ctrl"))
+               .arg(cmd2TextSeparator) +
+           spacer +
+           tr("%1%2Snap to Angle")
+               .arg(trModKey("Shift"))
+               .arg(cmd2TextSeparator)});
   lMap.insert({"T_GeometricVector",
                tr("Geometry Tool: Draws geometric shapes") + spacer +
                    tr("%1%2Allow or Disallow Snapping")
                        .arg(trModKey("Ctrl") + "+" + trModKey("Shift"))
                        .arg(cmdTextSeparator)});
+  lMap.insert({"T_GeometricVectorRectangle",
+               tr("Geometry Tool: Draws geometric shapes") + spacer +
+                   tr("%1%2Proportion Lock")
+                       .arg(trModKey("Shift"))
+                       .arg(cmd2TextSeparator) +
+                   spacer +
+                   tr("%1%2Create From Center")
+                       .arg(trModKey("Alt"))
+                       .arg(cmd2TextSeparator) +
+                   spacer +
+                   tr("%1%2Allow or Disallow Snapping")
+                       .arg(trModKey("Ctrl") + "+" + trModKey("Shift"))
+                       .arg(cmdTextSeparator)});
+  lMap.insert({"T_GeometricVectorEllipse",
+               tr("Geometry Tool: Draws geometric shapes") + spacer +
+                   tr("%1%2Proportion Lock")
+                       .arg(trModKey("Shift"))
+                       .arg(cmd2TextSeparator) +
+                   spacer +
+                   tr("%1%2Create From Center")
+                       .arg(trModKey("Alt"))
+                       .arg(cmd2TextSeparator) +
+                   spacer +
+                   tr("%1%2Allow or Disallow Snapping")
+                       .arg(trModKey("Ctrl") + "+" + trModKey("Shift"))
+                       .arg(cmdTextSeparator)});
+  lMap.insert(
+      {"T_GeometricVectorPolyline",
+       tr("Geometry Tool: Draws geometric shapes") + spacer +
+           tr("%1%2Create Curve").arg(tr("Click+Drag")).arg(cmdTextSeparator) +
+           spacer +
+           tr("%1%2Return to Straight Line")
+               .arg(trModKey("Ctrl"))
+               .arg(cmd2TextSeparator) +
+           spacer +
+           tr("%1%2Snap to Angle")
+               .arg(trModKey("Shift"))
+               .arg(cmd2TextSeparator) +
+           spacer +
+           tr("%1%2Allow or Disallow Snapping")
+               .arg(trModKey("Ctrl") + "+" + trModKey("Shift"))
+               .arg(cmdTextSeparator)});
   lMap.insert({"T_Type", tr("Type Tool: Adds text")});
   lMap.insert({"T_PaintBrush",
                tr("Smart Raster Painter: Paints areas in Smart Raster leves")});

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -56,7 +56,7 @@ StatusBar::StatusBar(QWidget* parent) : QStatusBar(parent) {
   assert(ret);
 
   m_infoMap = makeMap(tr("              "), tr(" - "), tr(" - "));
-  m_hintMap = makeMap(tr("\n    "), tr("\t- "), tr("\t\t-"));
+  m_hintMap = makeMap(tr("\n    "), tr("\t- "), tr("\t\t- "));
   updateInfoText();
 }
 

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -180,14 +180,18 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
            spacer +
            tr("%1%2Scale / Directional scale")
                .arg(trModKey("Shift"))
-               .arg(cmdTextSeparator) +
+               .arg(cmd2TextSeparator) +
            spacer +
            tr("%1%2Distort / Shear")
                .arg(trModKey("Ctrl"))
-               .arg(cmdTextSeparator) +
+               .arg(cmd2TextSeparator) +
            spacer +
-           tr("%1%2Scale symmetrically from center point")
+           tr("%1%2Scale Symmetrically from Center")
                .arg(trModKey("Alt"))
+               .arg(cmd2TextSeparator) +
+           spacer +
+           tr("%1%2Scale Symmetrically from Center w/ Proportion Lock")
+               .arg(trModKey("Shift") + "+" + trModKey("Alt"))
                .arg(cmdTextSeparator)});
   lMap.insert({"T_Edit", tr("Animate Tool: Modifies the position, "
                             "rotation and size of the current column")});

--- a/toonz/sources/toonz/statusbar.h
+++ b/toonz/sources/toonz/statusbar.h
@@ -3,7 +3,7 @@
 #ifndef STATUSBAR_H
 #define STATUSBAR_H
 
-#include <QStatusBar>;
+#include <QStatusBar>
 #include <unordered_map>
 #include <QLabel>
 

--- a/toonz/sources/toonz/statusbar.h
+++ b/toonz/sources/toonz/statusbar.h
@@ -35,8 +35,11 @@ public:
 protected:
   StatusLabel *m_currentFrameLabel, *m_infoLabel;
   std::unordered_map<std::string, QString> m_infoMap;
+  std::unordered_map<std::string, QString> m_hintMap;
   void showEvent(QShowEvent*) override;
-  void makeMap();
+  std::unordered_map<std::string, QString> makeMap(QString spacer,
+                                                   QString cmdTextSeparator,
+                                                   QString cmd2TextSeparator);
 
 protected slots:
   void updateInfoText();

--- a/toonz/sources/toonz/statusbar.h
+++ b/toonz/sources/toonz/statusbar.h
@@ -32,6 +32,8 @@ public:
 
   void updateFrameText(QString text);
 
+  void refreshStatusBar() { updateInfoText(); }
+
 protected:
   StatusLabel *m_currentFrameLabel, *m_infoLabel;
   std::unordered_map<std::string, QString> m_infoMap;

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -864,6 +864,12 @@ void TApp::showMessage(QString message) {
 
 //-----------------------------------------------------------------------------
 
+void TApp::refreshStatusBar() {
+  if (m_statusBar) m_statusBar->refreshStatusBar();
+}
+
+//-----------------------------------------------------------------------------
+
 QString TApp::getCurrentRoomName() const {
   Room *currentRoom = dynamic_cast<Room *>(getCurrentRoom());
   if (!currentRoom) return QString();

--- a/toonz/sources/toonz/tapp.h
+++ b/toonz/sources/toonz/tapp.h
@@ -216,6 +216,8 @@ public:
   void setStatusBar(StatusBar *statusBar);
   void setStatusBarFrameInfo(QString text);
 
+  void refreshStatusBar() override;
+
 protected:
   bool eventFilter(QObject *obj, QEvent *event) override;
   bool m_showTitleBars    = true;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1668,8 +1668,8 @@ void XsheetViewer::changeWindowTitle() {
   QString sceneName = QString::fromStdWString(scene->getSceneName());
   if (sceneName.isEmpty()) sceneName = tr("Untitled");
   if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-  QString name      = tr("Scene: ") + sceneName;
   QString separator = "   |   ";
+  QString name      = tr("Scene: ") + sceneName;
   int frameCount    = scene->getFrameCount();
   name = name + separator + tr(std::to_string(frameCount).c_str()) +
          (frameCount == 1 ? tr(" Frame") : tr(" Frames"));
@@ -1683,7 +1683,7 @@ void XsheetViewer::changeWindowTitle() {
   TXshLevel *level = app->getCurrentLevel()->getLevel();
   if (level) {
     QString levelName = QString::fromStdWString(level->getName());
-    name += separator + tr("  Level: ") + levelName;
+    name += separator + tr("Level: ") + levelName;
   }
   // cell selection range
   if ((TSelection *)getCellSelection() ==
@@ -1691,12 +1691,12 @@ void XsheetViewer::changeWindowTitle() {
       !getCellSelection()->isEmpty()) {
     int r0, r1, c0, c1;
     getCellSelection()->getSelectedCells(r0, c0, r1, c1);
-    name += separator + tr("   Selected: ") + QString::number(r1 - r0 + 1) +
+    name += separator + tr("Selected: ") + QString::number(r1 - r0 + 1) +
             ((r1 - r0 + 1 == 1) ? tr(" frame : ") : tr(" frames * ")) +
             QString::number(c1 - c0 + 1) +
             ((c1 - c0 + 1 == 1) ? tr(" column") : tr(" columns"));
   }
-  TApp::instance()->setStatusBarFrameInfo(name);
+  TApp::instance()->setStatusBarFrameInfo("|   " + name);
   parentWidget()->setWindowTitle(name);
 }
 


### PR DESCRIPTION
This PR enhances the statusbar as follows

1. Added Hover Hint displaying the same text as the status in case text doesn't fully display on smaller screens.

2. Added modifier key information for Selection tool.
![image](https://user-images.githubusercontent.com/19245851/107988615-6aaa6580-6f9e-11eb-9cc6-130fa29ac385.png)

3. Added logic to display macOS modifier key symbols instead of the text.
![image](https://user-images.githubusercontent.com/19245851/107989115-806c5a80-6f9f-11eb-83cb-e502a039468a.png)

4. Cleaned up unecessary spacing in scene section + added separator '|' between command and scene sections
![image](https://user-images.githubusercontent.com/19245851/107988920-089e3000-6f9f-11eb-8be4-d3adbe8a465f.png)

5. Command info text converted to translatable strings.

Having issues eliding (cutting and adding "...") text that doesn't fit into status bar completely.  Will submit that separately, but probably won't make upcoming release.