### PR TITLE
Change shortcut usage and navigation while renaming cell

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -26,6 +26,7 @@ class RenameCellField final : public QLineEdit {
   int m_row;
   int m_col;
   XsheetViewer *m_viewer;
+  bool m_isRenamingCell;
 
 public:
   RenameCellField(QWidget *parent, XsheetViewer *viewer);
@@ -34,6 +35,8 @@ public:
   void showInRowCol(int row, int col, bool multiColumnSelected = false);
 
   bool isLocatedAt(int row, int col) { return row == m_row && col == m_col; }
+
+  bool isRenamingCell() { return m_isRenamingCell; }
 
 protected:
   void focusOutEvent(QFocusEvent *) override;
@@ -45,6 +48,10 @@ protected:
 
   void renameCell();
   void renameSoundTextColumn(TXshSoundTextColumn *sndTextCol, const QString &s);
+
+  void moveCellSelection(int direction);
+  void onTabPressed();
+  void onBacktabPressed();
 
 protected slots:
   void onReturnPressed();
@@ -134,6 +141,9 @@ public:
     m_renameCell->showInRowCol(row, col, multiColumnSelected);
   }
   void hideRenameField() { m_renameCell->hide(); }
+  bool isRenamingCell() {
+    return m_renameCell && m_renameCell->isRenamingCell();
+  }
 
 protected:
   void paintEvent(QPaintEvent *) override;


### PR DESCRIPTION
This PR fixes #484 

I've modified how shortcuts and navigation is handled while renaming cells as follows:

1. If the column is a Note column or when `Enable Tahoma2D Commands' Shortcut Keys While Renaming Cells` is OFF (default), no Tahoma configured shortcuts will work.
   - If not a Note column and settings is ON, Tahoma shortcuts apply except line editing standard commands: Copy, Cut, Paste, Undo, Redo, Clear
  
2.  LEFT/RIGHT navigation arrows within a rename edit box will move between characters.
   - If you move LEFT past the 1st character, you will move to the cell to the left without renaming cell.
   - If you move RIGHT past the last character, you will move to the cell to the right without renaming cell

3. Added TAB and BACKTAB (Shift+TAB) navigation to move down and up the column, respectively without renaming cell.
