### PR TITLE
Add start Short Play from Live View

### DIFF
--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -4,6 +4,7 @@
 #include "menubarcommandids.h"
 #include "tapp.h"
 #include "sceneviewer.h"
+#include "stopmotion.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -143,6 +144,10 @@ public:
         TApp::instance()->getCurrentXsheet()->getXsheet()->getFrameCount();
 
     int stopFrame = std::min(currentFrame, maxFrame);
+
+    StopMotion *stopMotion = StopMotion::instance();
+    if (stopMotion->getPlaceOnXSheet() && stopMotion->m_liveViewStatus > 0)
+      stopFrame = StopMotion::instance()->getXSheetFrameNumber() - 1;
 
     int startFrame = std::max(0, stopFrame - shortPlayFrameCount);
 


### PR DESCRIPTION
This PR forces Short Play to always play relative to the Live View frame when turned on, which is better for Stop Motion than playing relative to Current Frame which is more ideal for regular animation