### PR TITLE
Fix loading scenes from Story Planner

### DIFF
--- a/toonz/sources/common/timage_io/tlevel_io.cpp
+++ b/toonz/sources/common/timage_io/tlevel_io.cpp
@@ -35,7 +35,8 @@ TLevelReader::TLevelReader(const TFilePath &path)
     , m_info(0)
     , m_path(path)
     , m_contentHistory(0)
-    , m_frameFormat(TFrameId::FOUR_ZEROS) {}
+    , m_frameFormat(TFrameId::FOUR_ZEROS)
+    , m_useExactPath(false) {}
 
 //-----------------------------------------------------------
 
@@ -102,6 +103,9 @@ const TImageInfo *TLevelReader::getImageInfo() {
 TLevelP TLevelReader::loadInfo() {
   TFilePath parentDir = m_path.getParentDir();
   TFilePath levelName(m_path.getLevelName());
+  // For scene loading, use what was stored in the file instead
+  // of auto converting to a level name.
+  if (useExactPath()) levelName = m_path.withoutParentDir();
   //  cout << "Parent dir = '" << parentDir << "'" << endl;
   //  cout << "Level name = '" << levelName << "'" << endl;
   TFilePathSet files;
@@ -115,9 +119,13 @@ TLevelP TLevelReader::loadInfo() {
   for (TFilePathSet::iterator it = files.begin(); it != files.end(); it++) {
     TFilePath ln(it->getLevelName());
     // cout << "try " << *it << "  " << it->getLevelName() <<  endl;
-    if (levelName == TFilePath(it->getLevelName())) {
+    if (levelName == TFilePath(it->getLevelName()) ||
+        levelName == it->withoutParentDir()) {
       try {
-        level->setFrame(it->getFrame(), TImageP());
+        if (levelName == it->withoutParentDir())
+          level->setFrame(TFrameId::NO_FRAME, TImageP());
+        else
+          level->setFrame(it->getFrame(), TImageP());
         data.push_back(*it);
       } catch (TMalformedFrameException tmfe) {
         // skip frame named incorrectly warning to the user in the message
@@ -163,6 +171,7 @@ TLevelP TLevelReader::loadInfo() {
 //-----------------------------------------------------------
 
 TImageReaderP TLevelReader::getFrameReader(TFrameId fid) {
+  if (fid.isNoFrame()) return m_path;
   return TImageReaderP(m_path.withFrame(fid, m_frameFormat));
 }
 

--- a/toonz/sources/common/timage_io/tlevel_io.cpp
+++ b/toonz/sources/common/timage_io/tlevel_io.cpp
@@ -171,7 +171,7 @@ TLevelP TLevelReader::loadInfo() {
 //-----------------------------------------------------------
 
 TImageReaderP TLevelReader::getFrameReader(TFrameId fid) {
-  if (fid.isNoFrame()) return m_path;
+  if (fid.isNoFrame()) return TImageReaderP(m_path);
   return TImageReaderP(m_path.withFrame(fid, m_frameFormat));
 }
 

--- a/toonz/sources/include/tlevel_io.h
+++ b/toonz/sources/include/tlevel_io.h
@@ -49,6 +49,8 @@ protected:
   TFilePath m_path;
   TContentHistory *m_contentHistory;
 
+  bool m_useExactPath;
+
 public:
   TLevelReader(const TFilePath &path);
   virtual ~TLevelReader();
@@ -94,6 +96,9 @@ public:
 
   //! TLevelReader keeps the ownership of TContentHistory. Don't delete it
   const TContentHistory *getContentHistory() const { return m_contentHistory; }
+
+  void setUseExactPath(bool useExactPath) { m_useExactPath = useExactPath; }
+  bool useExactPath() { return m_useExactPath; }
 
 private:
   TFrameId::FrameFormat m_frameFormat;

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1220,6 +1220,8 @@ void TXshSimpleLevel::load() {
     TLevelReaderP lr(path);  // May throw
     assert(lr);
 
+    lr->setUseExactPath(getScene()->isLoading());
+
     TLevelP level = lr->loadInfo();
     if (level->getFrameCount() > 0) {
       const TImageInfo *info = lr->getImageInfo(level->begin()->first);


### PR DESCRIPTION
This PR was primarily created to fix an issue when trying to load a scene generated by Digital Video's Story Planner.

When Story Planner generates a scene for OT/Tahoma...

1. It generates image files with the naming convention Scene_<scene#>\_<panel#>\_<layer#>.png (i.e. Scene_001_001_0.png).
2. It generates a scene file storing the full name of the image file but uses it as a single image file.

Unfortunately, when Tahoma reads the scene file, the image filenames are treated as sequenced filenames, regardless of how it is used. This causes it to have trouble finding the file because it isn't expecting a sequenced filename to be used as a single image file.

Added logic when loading a level, if we are currently loading a scene, use the path stored in the file as is instead of auto-converting to level name convention.  Treat all exact file name matches, in this case, as Single Image files (no frames), regardless if the file has the sequence file naming convention.  In all other cases of loading, auto-convert to level naming convention and look for files matching the sequenced file name.
