### PR TITLE
Fix crashing on exit with floating level strip

### DIFF
--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -488,9 +488,8 @@ void FilmstripFrames::hideEvent(QHideEvent *) {
 
   // if the level strip is floating during shutting down Tahoma2D
   // it can cause a crash disconnecting from the viewer which was already
-  // destroyed.  Checking the fps is a janky way to ensure the viewer is 
-  // stil relevant.
-  if (m_viewer && m_viewer->getFPS() > -100) { 
+  // destroyed.
+  if (m_viewer && m_viewer->isValid()) {
     disconnect(m_viewer, SIGNAL(onZoomChanged()), this, SLOT(update()));
     disconnect(m_viewer, SIGNAL(refreshNavi()), this, SLOT(update()));
     m_viewer = nullptr;


### PR DESCRIPTION
This PR corrects the initial attempt to fix the crash caused by having a floating level strip when exiting.

The original fix used a viewer's FPS value to determine if the viewer had already been destructed, however there is no guarantee the value would change to something invalid when destructed.

Found using isValid() a better choice to check to see if the viewer still existed.