### PR TITLE
Allow ending underscore in output filename

### DIFF
--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -1002,7 +1002,9 @@ void OutputSettingsPopup::updateField() {
 
   if (!m_isPreviewSettings) {
     TFilePath path = prop->getPath();
-    QString name   = QString::fromStdWString(path.getWideName());
+    QString name   = path.withoutParentDir().getQString();
+    name           = QString::fromStdString(name.toStdString().substr(
+        0, name.length() - path.getDottedType().length()));
     if (name.isEmpty())
       name = QString::fromStdString(scene->getScenePath().getName());
     m_saveInFileFld->setPath(toQString(path.getParentDir()));
@@ -1204,7 +1206,7 @@ void OutputSettingsPopup::onNameChanged() {
 
   if (fp.getWideName() == wname) return;  // Already had the right name
 
-  fp = fp.withName(wname);
+  fp = fp.getParentDir() + TFilePath(wname).withType(fp.getType());
   prop->setPath(fp);
 
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);


### PR DESCRIPTION
This PR fixes an issue where if you enter an output filename that ends with an underscore ("_") in the Output Settings dialog, all filenames you change it to will have an underscore at the end, regardless if you added one or not.  In fact, if you entered with an underscore at the end, then closed and reopened the Output Settings dialog box, the filename no longer has the underscore, but internally it does.

It is doing this because internally it is treating the underscore as a sequenced filename format when it appends the extension to the full name and any change to the name doesn't remove the last underscore.

Modified the logic to allow underscores at the end of the filename as well as remove it properly when the user changes it.

Should be noted when rendering to a non-sequenced file type (i.e mp4, avi, etc.) the underscore is in the final output.  In the case of a sequenced file, the underscore becomes a part of the sequence format using "_." notation instead of using the ".." notation.