### PR TITLE
Fix opencv in Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ after_build:
 
     copy /Y ..\..\thirdparty\libjpeg-turbo64\dist\turbojpeg.dll %CONFIGURATION%\Tahoma2D
 
-    copy /Y "C:\Tools\opencv\build\x64\vc14\bin\opencv_world412.dll" %CONFIGURATION%\Tahoma2D
+    copy /Y "C:\Tools\opencv\build\x64\vc14\bin\opencv_world451.dll" %CONFIGURATION%\Tahoma2D
 
     mkdir "%CONFIGURATION%\Tahoma2D\tahomastuff"
 


### PR DESCRIPTION
choco install of opencv now installs opencv 4.5.1.  Modifying script to account for this.

Side note: updated local build environments to use opencv 4.5.1. OT recently moved to 4.5.1 as well.