### PR TITLE
Block new frames in Single Frame levels

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -350,6 +350,13 @@ TImage *TTool::touchImage() {
   TXshSimpleLevel *sl = cell.getSimpleLevel();
 
   if (sl) {
+    // For Single Frame levels, don't create anything
+    std::vector<TFrameId> fids;
+    sl->getFids(fids);
+    if (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
+                             fids[0].getNumber() == TFrameId::NO_FRAME))
+      return 0;
+
     // If for some reason there is no palette, try and set a default one now.
     if (!sl->getPalette() &&
         (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL)) {
@@ -1072,6 +1079,20 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
 
         return (enable(false),
                 QObject::tr("The current level is not editable."));
+
+      // For Single Frame raster levels, don't allow new levels to be created
+      if (levelType == OVL_XSHLEVEL && !filmstrip) {
+        std::vector<TFrameId> fids;
+        sl->getFids(fids);
+        if (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
+                                 fids[0].getNumber() == TFrameId::NO_FRAME)) {
+          TXshCell cell = xsh->getCell(rowIndex, columnIndex);
+          if (cell.isEmpty())
+            return (enable(false),
+                    QObject::tr("The current tool cannot be used on empty "
+                                "frames of a Single Frame level."));
+        }
+      }
     }
   }
 

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2706,6 +2706,19 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
         DVGui::warning(QObject::tr("The current level is not editable"));
       return;
     }
+
+    // Do not duplicate frames on Single Frame levels
+    if (level->getSimpleLevel()) {
+      std::vector<TFrameId> fids;
+      level->getSimpleLevel()->getFids(fids);
+      if (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
+                               fids[0].getNumber() == TFrameId::NO_FRAME)) {
+        if (!multiple)
+          DVGui::warning(QObject::tr(
+              "Unable to create a blank drawing on a Single Frame level"));
+        return;
+      }
+    }
   }
 
   ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
@@ -2866,6 +2879,19 @@ void TCellSelection::duplicateFrame(int row, int col, bool multiple) {
 
   TXshSimpleLevel *sl = prevCell.getSimpleLevel();
   if (!sl || sl->isSubsequence() || sl->isReadOnly()) return;
+
+  // Do not duplicate frames on Single Frame levels
+  if (sl) {
+    std::vector<TFrameId> fids;
+    sl->getFids(fids);
+    if (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
+                             fids[0].getNumber() == TFrameId::NO_FRAME)) {
+      if (!multiple)
+        DVGui::warning(QObject::tr(
+            "Unable to duplicate a drawing on a Single Frame level"));
+      return;
+    }
+  }
 
   ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
 

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -850,6 +850,18 @@ void FilmstripFrames::mousePressEvent(QMouseEvent *event) {
   TFrameId fid = index2fid(index);
 
   TXshSimpleLevel *sl = getLevel();
+
+  // If accessed after 1st frame on a Single Frame level
+  // Block movement so we can't create new images
+  if (index > 0) {
+    std::vector<TFrameId> fids;
+    sl->getFids(fids);
+    if (fids.empty() ||
+        (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
+                              fids[0].getNumber() == TFrameId::NO_FRAME)))
+      return;
+  }
+
   int frameHeight = m_iconSize.height() + fs_frameSpacing + fs_iconMarginTop +
                     fs_iconMarginBottom;
   int frameWidth = m_iconSize.width() + fs_frameSpacing + fs_iconMarginLR +
@@ -1130,6 +1142,11 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
   std::vector<TFrameId> fids;
   level->getFids(fids);
   if (fids.empty()) return;
+  // Do not allow movement on Single Frame levels
+  if (fids.empty() ||
+      (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
+                            fids[0].getNumber() == TFrameId::NO_FRAME)))
+    return;
 
   // If on a level frame pass the frame id after the last frame to allow
   // creating a new frame with the down arrow key


### PR DESCRIPTION
This change will prevent the creation of new frames on Single Frame Levels.

"Single Frame" levels are raster files that contain only 1 image and whose filename is not in a sequenced file format.  Because of this, a frame number is never assigned to the image. For example ABC.png would be considered a Single Frame Level and noted as such in the Level Strip.

We need to block the creation of new frames on these types of levels because when it saves, the file is not renamed to account for multiple frames. What usually winds up happening is only 1 image is saved to the original file name and the rest are discarded, resulting in loss of drawings.

I've modified the following when it comes to Single Frame levels:
- Level Strip: Prevent any navigation to the blank areas where you would normally click to create a new frame.
- Duplicate Drawing command: Blocked the command and give warning
- Create Blank Frame command: Blocked the command and give warning
- Tools: Blocks the automatic creation of new frames. Warns when attempting to us a tool on empty frames that could normally cause new frames to be created. Updated cursor to show a tool cannot be used when on an empty frame.