### PR TITLE
Fix crash when quitting with floating levelstrip

### DIFF
--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -172,6 +172,7 @@ protected slots:
   void comboBoxToggled(bool);
   void navigatorToggled(bool);
   void levelSelected(int);
+  void disconnectViewer();
 
 private:
   // QSS Properties

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -852,6 +852,8 @@ SceneViewer::~SceneViewer() {
 
   int ret = l_contexts.erase(m_currentContext);
   if (ret) TGLDisplayListsManager::instance()->releaseContext(m_currentContext);
+
+  emit viewerDestructing();
 }
 
 //-------------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -484,7 +484,7 @@ public slots:
   void onContextAboutToBeDestroyed();
   void onNewStopMotionImageReady();
   void onStopMotionLiveViewStopped();
-  void onPreferenceChanged(const QString& prefName);
+  void onPreferenceChanged(const QString &prefName);
 
 signals:
 
@@ -498,6 +498,7 @@ signals:
   void refreshNavi();
   // for updating the titlebar
   void previewToggled();
+  void viewerDestructing();
 };
 
 // Functions


### PR DESCRIPTION
Despite earlier attempts (ok...hacks!) at fixing the issue where Tahoma crashes on quitting if you have a level strip pane floating, I was still getting random crashes because of it.

This should definitively fix the issue. When the scene viewer is being destructed, it will emit a signal the level strip will detect and immediately disconnect the viewer just before the scene viewer is finally destructed.  This way when the level strip is destructed, it won't try to disconnect a viewer that no longer exists.