### PR TITLE
Update external app handling

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -48,6 +48,9 @@ jobs:
           export CC="ccache ${{ matrix.cc }}"
           export CXX="ccache ${{ matrix.cxx }}"
           ci-scripts/linux/tahoma-build.sh
+      - name: Get 3rd Party Apps
+        run: |
+          ci-scripts/linux/tahoma-get3rdpartyapps.sh
       - name: Create Package
         run: |
           ci-scripts/linux/tahoma-buildpkg.sh

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -27,7 +27,6 @@ jobs:
             /home/runner/.ccache
             /home/runner/work/tahoma2d/taoma2d/thirdparty/openh264
             /home/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg
-            /home/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg_shared
             /home/runner/work/tahoma2d/taoma2d/thirdparty/opencv
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           restore-keys: |

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -18,7 +18,6 @@ jobs:
             /Users/runner/.ccache
             /Users/runner/work/tahoma2d/taoma2d/thirdparty/aom
             /Users/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg
-            /Users/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg_shared
             /Users/runner/work/tahoma2d/taoma2d/thirdparty/opencv
           key: ${{ runner.os }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -34,6 +34,9 @@ jobs:
         run: |
           export PATH="/usr/local/opt/ccache/libexec:$PATH"
           ci-scripts/osx/tahoma-build.sh
+      - name: Get 3rd Party Apps
+        run: |
+          ci-scripts/osx/tahoma-get3rdpartyapps.sh
       - name: Create Package
         run: bash ./ci-scripts/osx/tahoma-buildpkg.sh
       - uses: actions/upload-artifact@v1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,26 @@ after_build:
 
     xcopy /Y /E ..\..\stuff "%CONFIGURATION%\Tahoma2D\tahomastuff"
     
+    curl -fsSL -o ffmpeg-4.3.1-win64-static-lgpl.zip https://github.com/tahoma2d/FFmpeg/releases/download/v4.3.1/ffmpeg-4.3.1-win64-static-lgpl.zip
+    
+    7z x ffmpeg-4.3.1-win64-static-lgpl.zip
+    
+    copy /Y ffmpeg-4.3.1-win64-static-lgpl\bin\ffmpeg.exe %CONFIGURATION%\Tahoma2D
+    
+    copy /Y ffmpeg-4.3.1-win64-static-lgpl\bin\ffprobe.exe %CONFIGURATION%\Tahoma2D
+
+    curl -fsSL -o rhubarb-lip-sync-tahoma2d-win.zip https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.2/rhubarb-lip-sync-tahoma2d-win.zip
+    
+    7z x rhubarb-lip-sync-tahoma2d-win.zip
+    
+    mkdir %CONFIGURATION%\Tahoma2D\rhubarb
+    
+    copy /Y rhubarb-lip-sync-tahoma2d-win\rhubarb.exe %CONFIGURATION%\Tahoma2D\rhubarb
+
+    mkdir %CONFIGURATION%\Tahoma2D\rhubarb\res
+    
+    xcopy /Y /E rhubarb-lip-sync-tahoma2d-win\res "%CONFIGURATION%\Tahoma2D\rhubarb\res"
+
 artifacts:
 - path: toonz\$(PLATFORM)\$(CONFIGURATION)
   name: Tahoma2D

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,9 +64,11 @@ after_build:
     
     7z x ffmpeg-4.3.1-win64-static-lgpl.zip
     
-    copy /Y ffmpeg-4.3.1-win64-static-lgpl\bin\ffmpeg.exe %CONFIGURATION%\Tahoma2D
+    mkdir %CONFIGURATION%\Tahoma2D\ffmpeg
+
+    copy /Y ffmpeg-4.3.1-win64-static-lgpl\bin\ffmpeg.exe %CONFIGURATION%\Tahoma2D\ffmpeg
     
-    copy /Y ffmpeg-4.3.1-win64-static-lgpl\bin\ffprobe.exe %CONFIGURATION%\Tahoma2D
+    copy /Y ffmpeg-4.3.1-win64-static-lgpl\bin\ffprobe.exe %CONFIGURATION%\Tahoma2D\ffmpeg
 
     curl -fsSL -o rhubarb-lip-sync-tahoma2d-win.zip https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.2/rhubarb-lip-sync-tahoma2d-win.zip
     

--- a/ci-scripts/linux/tahoma-buildffmpeg.sh
+++ b/ci-scripts/linux/tahoma-buildffmpeg.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 cd thirdparty
 
 echo ">>> Cloning openH264"
@@ -15,10 +16,9 @@ sudo make install
 cd ..
 
 echo ">>> Cloning ffmpeg"
-git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
-cp -R ffmpeg ffmpeg_shared
+git clone https://github.com/tahoma2d/ffmpeg ffmpeg
 
-cd ffmpeg_shared
+cd ffmpeg
 echo "*" >| .gitignore
 
 echo ">>> Configuring to build ffmpeg (shared)"
@@ -65,56 +65,3 @@ echo ">>> Installing ffmpeg (shared)"
 sudo make install
 
 sudo ldconfig
-
-echo ">>> Configuring to build ffmpeg (static)"
-cd ../ffmpeg
-echo "*" >| .gitignore
-
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-
-./configure  --prefix=/usr/local \
-      --cc="$CC" \
-      --cxx="$CXX" \
-      --pkg-config-flags="--static" \
-      --extra-cflags="-I/usr/local/include -static" \
-      --extra-ldflags="-L/usr/local/lib -static" \
-      --extra-ldexeflags="-static" \
-      --enable-static \
-      --enable-cross-compile \
-      --enable-pic \
-      --disable-shared \
-      --enable-libopenh264 \
-      --enable-pthreads \
-      --enable-version3 \
-      --enable-avresample \
-      --enable-libmp3lame \
-      --enable-libopus \
-      --enable-libsnappy \
-      --enable-libtheora \
-      --enable-libvorbis \
-      --enable-libvpx \
-      --enable-libwebp \
-      --enable-lzma \
-      --enable-libfreetype \
-      --enable-libopencore-amrnb \
-      --enable-libopencore-amrwb \
-      --enable-libspeex \
-      --disable-ffplay \
-      --disable-htmlpages \
-      --disable-manpages \
-      --disable-podpages \
-      --disable-txtpages \
-      --disable-libjack \
-      --disable-indev=jack
-
-echo ">>> Building ffmpeg (static)"
-make
-
-echo ">>> Installing to tahoma2d/thirdparty/ffmpeg/bin"
-if [ ! -d bin ]
-then
-   mkdir bin
-fi
-
-cp ffmpeg ffprobe bin/
-

--- a/ci-scripts/linux/tahoma-buildopencv.sh
+++ b/ci-scripts/linux/tahoma-buildopencv.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
 cd thirdparty
 
 echo ">>> Cloning opencv"
-git clone https://github.com/opencv/opencv.git
+git clone https://github.com/tahoma2d/opencv
 
 cd opencv
 echo "*" >| .gitignore

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -35,24 +35,26 @@ mv appdir/usr/share/tahoma2d/stuff Tahoma2D/tahomastuff
 chmod -R 777 Tahoma2D/tahomastuff
 rmdir appdir/usr/share/tahoma2d
 
-if [ -d ../../thirdparty/ffmpeg/bin ]
+if [ -d ../../thirdparty/apps/ffmpeg/bin ]
 then
    echo ">>> Copying FFmpeg to Tahoma2D/ffmpeg"
    if [ -d Tahoma2D/ffmpeg ]
    then
       rm -rf Tahoma2D/ffmpeg
    fi
-   cp -R ../../thirdparty/ffmpeg/bin Tahoma2D/ffmpeg
+   mkdir -p Tahoma2D/ffmpeg
+   cp -R ../../thirdparty/apps/ffmpeg/bin/ffmpeg ../../thirdparty/apps/ffmpeg/bin/ffprobe Tahoma2D/ffmpeg
 fi
 
-if [ -d ../../thirdparty/rhubarb ]
+if [ -d ../../thirdparty/apps/rhubarb ]
 then
    echo ">>> Copying Rhubarb Lip Sync to Tahoma2D/rhubarb"
    if [ -d Tahoma2D/rhubarb ]
    then
       rm -rf Tahoma2D/rhubarb
    fi
-   cp -R ../../thirdparty/rhubarb Tahoma2D/rhubarb
+   mkdir -p Tahoma2D/rhubarb
+   cp -R ../../thirdparty/apps/rhubarb/rhubarb ../../thirdparty/apps/rhubarb/res Tahoma2D/rhubarb
 fi
 
 echo ">>> Creating Tahoma2D/Tahoma2D.AppImage"

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -45,6 +45,16 @@ then
    cp -R ../../thirdparty/ffmpeg/bin Tahoma2D/ffmpeg
 fi
 
+if [ -d ../../thirdparty/rhubarb ]
+then
+   echo ">>> Copying Rhubarb Lip Sync to Tahoma2D/rhubarb"
+   if [ -d Tahoma2D/rhubarb ]
+   then
+      rm -rf Tahoma2D/rhubarb
+   fi
+   cp -R ../../thirdparty/rhubarb Tahoma2D/rhubarb
+fi
+
 echo ">>> Creating Tahoma2D/Tahoma2D.AppImage"
 
 if [ ! -f linuxdeployqt*.AppImage ]

--- a/ci-scripts/linux/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/linux/tahoma-get3rdpartyapps.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+cd thirdparty
+
+if [ ! -d apps ]
+then
+   mkdir apps
+fi
+cd apps
+echo "*" >| .gitignore
+
+echo ">>> Getting FFmpeg"
+if [ -d ffmpeg ]
+then
+   rm -rf ffmpeg
+fi
+wget https://github.com/tahoma2d/FFmpeg/releases/download/v4.3.1/ffmpeg-4.3.1-linux-static-lgpl.zip
+unzip ffmpeg-4.3.1-linux-static-lgpl.zip 
+mv ffmpeg-4.3.1-linux-static-lgpl ffmpeg
+
+
+echo ">>> Getting Rhubarb Lip Sync"
+if [ -d rhubarb ]
+then
+   rm -rf rhubarb ]
+fi
+wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.2/rhubarb-lip-sync-tahoma2d-linux.zip
+unzip rhubarb-lip-sync-tahoma2d-linux.zip -d rhubarb
+

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 sudo add-apt-repository --yes ppa:beineri/opt-qt597-xenial
 sudo add-apt-repository --yes ppa:achadwick/mypaint-testing
 sudo apt-get update

--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -26,9 +26,8 @@ cd ../..
 
 echo ">>> Cloning ffmpeg"
 git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
-cp -R ffmpeg ffmpeg_shared
 
-cd ffmpeg_shared
+cd ffmpeg
 echo "*" >| .gitignore
 
 echo ">>> Configuring to build ffmpeg (shared)"
@@ -73,37 +72,3 @@ make -j7 # runs 7 jobs in parallel
 echo ">>> Installing ffmpeg (shared)"
 sudo make install
 
-echo ">>> Configuring to build ffmpeg (static)"
-cd ../ffmpeg
-echo "*" >| .gitignore
-
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-export SDKROOT=`xcrun --show-sdk-path`
-./configure  --prefix=/usr/local \
-      --pkg-config-flags="--static" \
-      --enable-static \
-      --disable-shared \
-      --enable-pic \
-      --enable-pthreads \
-      --enable-version3 \
-      --enable-videotoolbox \
-      --enable-avresample \
-      --enable-libaom \
-      --enable-libxml2 \
-      --enable-libvpx \
-      --disable-ffplay \
-      --disable-sdl2 \
-      --disable-libjack \
-	  --disable-libxcb \
-      --disable-indev=jack
-
-echo ">>> Building ffmpeg (static)"
-make -j7 # runs 7 jobs in parallel
-
-echo ">>> Installing to tahoma2d/thirdparty/ffmpeg/bin"
-if [ ! -d bin ]
-then
-   mkdir bin
-fi
-
-cp ffmpeg ffprobe bin/

--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 cd thirdparty
 
 echo ">>> Cloning aom"
@@ -25,7 +26,7 @@ sudo make install
 cd ../..
 
 echo ">>> Cloning ffmpeg"
-git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
+git clone https://github.com/tahoma2d/ffmpeg
 
 cd ffmpeg
 echo "*" >| .gitignore

--- a/ci-scripts/osx/tahoma-buildopencv.sh
+++ b/ci-scripts/osx/tahoma-buildopencv.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
 cd thirdparty
 
 echo ">>> Cloning opencv"
-git clone https://github.com/opencv/opencv.git
+git clone https://github.com/tahoma2d/opencv
 
 cd opencv
 echo "*" >| .gitignore

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -33,6 +33,17 @@ then
    cp -R thirdparty/ffmpeg/bin $TOONZDIR/Tahoma2D.app/ffmpeg
 fi
 
+if [ -d thirdparty/rhubarb ]
+then
+   echo ">>> Copying Rhubarb Lip Sync to $TOONZDIR/Tahoma2D.app/rhubarb"
+   if [ -d $TOONZDIR/Tahoma2D.app/rhubarb ]
+   then
+      # In case of prior builds, replace rhubarb folder
+      rm -rf $TOONZDIR/Tahoma2D.app/rhubarb
+   fi
+   cp -R thirdparty/rhubarb $TOONZDIR/Tahoma2D.app/rhubarb
+fi
+
 if [ -d thirdparty/canon/Framework ]
 then
    echo ">>> Copying canon framework to $TOONZDIR/Tahoma2D.app/Contents/Frameworks/EDSDK.Framework"

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -22,7 +22,7 @@ fi
 cp -R stuff $TOONZDIR/Tahoma2D.app/tahomastuff
 chmod -R 777 $TOONZDIR/Tahoma2D.app/tahomastuff
 
-if [ -d thirdparty/ffmpeg/bin ]
+if [ -d thirdparty/apps/ffmpeg/bin ]
 then
    echo ">>> Copying FFmpeg to $TOONZDIR/Tahoma2D.app/ffmpeg"
    if [ -d $TOONZDIR/Tahoma2D.app/ffmpeg ]
@@ -30,10 +30,11 @@ then
       # In case of prior builds, replace ffmpeg folder
       rm -rf $TOONZDIR/Tahoma2D.app/ffmpeg
    fi
-   cp -R thirdparty/ffmpeg/bin $TOONZDIR/Tahoma2D.app/ffmpeg
+   mkdir $TOONZDIR/Tahoma2D.app/ffmpeg
+   cp -R thirdparty/apps/ffmpeg/bin/ffmpeg thirdparty/apps/ffmpeg/bin/ffprobe $TOONZDIR/Tahoma2D.app/ffmpeg
 fi
 
-if [ -d thirdparty/rhubarb ]
+if [ -d thirdparty/apps/rhubarb ]
 then
    echo ">>> Copying Rhubarb Lip Sync to $TOONZDIR/Tahoma2D.app/rhubarb"
    if [ -d $TOONZDIR/Tahoma2D.app/rhubarb ]
@@ -41,7 +42,8 @@ then
       # In case of prior builds, replace rhubarb folder
       rm -rf $TOONZDIR/Tahoma2D.app/rhubarb
    fi
-   cp -R thirdparty/rhubarb $TOONZDIR/Tahoma2D.app/rhubarb
+   mkdir $TOONZDIR/Tahoma2D.app/rhubarb
+   cp -R thirdparty/apps/rhubarb/rhubarb thirdparty/apps/rhubarb/res $TOONZDIR/Tahoma2D.app/rhubarb
 fi
 
 if [ -d thirdparty/canon/Framework ]
@@ -88,3 +90,4 @@ echo ">>> Creating Tahoma2D-osx.dmg"
 $QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -dmg -verbose=0
 
 mv $TOONZDIR/Tahoma2D.dmg $TOONZDIR/../Tahoma2D-osx.dmg
+

--- a/ci-scripts/osx/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/osx/tahoma-get3rdpartyapps.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+cd thirdparty
+
+if [ ! -d apps ]
+then
+   mkdir apps
+fi
+cd apps
+echo "*" >| .gitignore
+
+echo ">>> Getting FFmpeg"
+wget https://github.com/tahoma2d/FFmpeg/releases/download/v4.3.1/ffmpeg-4.3.1-macos64-static-lgpl.zip
+unzip ffmpeg-4.3.1-macos64-static-lgpl.zip 
+mv ffmpeg-4.3.1-macos64-static-lgpl ffmpeg
+
+
+echo ">>> Getting Rhubarb Lip Sync"
+wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.2/rhubarb-lip-sync-tahoma2d-osx.zip
+unzip rhubarb-lip-sync-tahoma2d-osx.zip -d rhubarb
+

--- a/ci-scripts/osx/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/osx/tahoma-get3rdpartyapps.sh
@@ -9,12 +9,20 @@ cd apps
 echo "*" >| .gitignore
 
 echo ">>> Getting FFmpeg"
+if [ -d ffmpeg ]
+then
+   rm -rf ffmpeg
+fi
 wget https://github.com/tahoma2d/FFmpeg/releases/download/v4.3.1/ffmpeg-4.3.1-macos64-static-lgpl.zip
 unzip ffmpeg-4.3.1-macos64-static-lgpl.zip 
 mv ffmpeg-4.3.1-macos64-static-lgpl ffmpeg
 
 
 echo ">>> Getting Rhubarb Lip Sync"
+if [ -d rhubarb ]
+then
+   rm -rf rhubarb
+fi
 wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.2/rhubarb-lip-sync-tahoma2d-osx.zip
 unzip rhubarb-lip-sync-tahoma2d-osx.zip -d rhubarb
 

--- a/stuff/doc/LICENSE/LICENSE_rhubarb.txt
+++ b/stuff/doc/LICENSE/LICENSE_rhubarb.txt
@@ -1,0 +1,9 @@
+Rhubarb Lip Sync is released under the MIT License (MIT).
+
+Copyright (c) 2015-2016 Daniel Wolf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/stuff/doc/LICENSE/LICENSE_rhubarb_info.txt
+++ b/stuff/doc/LICENSE/LICENSE_rhubarb_info.txt
@@ -1,0 +1,7 @@
+Tahoma2D ships with Rhubarb Lip Sync, and uses Rhubarb Lip Sync through command line commands.
+Tahoma2D does not directly use Rhubarb Lip Sync libraries or code.
+
+Rhubarb Lip Sync source code can be found at:
+https://github.com/tahoma2d/rhubarb-lip-sync
+or 
+https://github.com/DanielSWolf/rhubarb-lip-sync

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -1044,6 +1044,18 @@ bool TSystem::showDocument(const TFilePath &path) {
 #endif
 }
 
+QString TSystem::findFileLocation(QStringList folderList, QString fileName) {
+  if (folderList.isEmpty()) return "";
+
+  QStringList::iterator it;
+  for (it = folderList.begin(); it != folderList.end(); it++) {
+    QString path = *it + "/" + fileName;
+    if (TSystem::doesExistFileOrLevel(TFilePath(path))) return *it;
+  }
+
+  return "";
+}
+
 #else
 
 #include <windows.h>

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -1050,7 +1050,9 @@ QString TSystem::findFileLocation(QStringList folderList, QString fileName) {
   QStringList::iterator it;
   for (it = folderList.begin(); it != folderList.end(); it++) {
     QString path = *it + "/" + fileName;
-    if (TSystem::doesExistFileOrLevel(TFilePath(path))) return *it;
+    TFilePath fp(path);
+    if (TSystem::doesExistFileOrLevel(fp) && !TFileStatus(fp).isDirectory())
+      return *it;
   }
 
   return "";

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -13,8 +13,9 @@
 #include "tmsgcore.h"
 
 Ffmpeg::Ffmpeg() {
-  m_ffmpegPath         = Preferences::instance()->getFfmpegPath();
-  m_ffmpegTimeout      = Preferences::instance()->getFfmpegTimeout() * 1000;
+  m_ffmpegPath    = Preferences::instance()->getFfmpegPath();
+  m_ffmpegTimeout = Preferences::instance()->getFfmpegTimeout();
+  if (m_ffmpegTimeout > 0) m_ffmpegTimeout * 1000;
   std::string strPath  = m_ffmpegPath.toStdString();
   m_intermediateFormat = "png";
 }

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -15,7 +15,10 @@
 Ffmpeg::Ffmpeg() {
   m_ffmpegPath    = Preferences::instance()->getFfmpegPath();
   m_ffmpegTimeout = Preferences::instance()->getFfmpegTimeout();
-  if (m_ffmpegTimeout > 0) m_ffmpegTimeout * 1000;
+  if (m_ffmpegTimeout > 0)
+    m_ffmpegTimeout * 1000;
+  else
+    m_ffmpegTimeout    = -1;
   std::string strPath  = m_ffmpegPath.toStdString();
   m_intermediateFormat = "png";
 }

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -21,87 +21,76 @@ Ffmpeg::Ffmpeg() {
 Ffmpeg::~Ffmpeg() {}
 
 bool Ffmpeg::checkFfmpeg() {
-  // check the user defined path in preferences first
-  QString path = Preferences::instance()->getFfmpegPath() + "/ffmpeg";
+  QString exe = "ffmpeg";
 #if defined(_WIN32)
-  path = path + ".exe";
+  exe = exe + ".exe";
 #endif
+
+  // check the user defined path in preferences first
+  QString path = Preferences::instance()->getFfmpegPath() + "/" + exe;
   if (TSystem::doesExistFileOrLevel(TFilePath(path))) return true;
 
-  // check the Tahoma root directory next
-  path = QDir::currentPath() + "/ffmpeg";
-#if defined(_WIN32)
-  path = path + ".exe";
-#endif
-  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-    Preferences::instance()->setValue(ffmpegPath, QDir::currentPath());
-    return true;
-  }
+  // Let's try and autodetect the exe included with release
+  QStringList folderList;
+
+  folderList.append(".");
+  folderList.append("./ffmpeg");  // ffmpeg folder
 
 #ifdef MACOSX
-  path = QDir::currentPath() + "/" +
-         QString::fromStdString(TEnv::getApplicationFileName()) +
-         ".app/ffmpeg/ffmpeg";
-  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-    Preferences::instance()->setValue(
-        ffmpegPath, QDir::currentPath() + "/" +
-                        QString::fromStdString(TEnv::getApplicationFileName()) +
-                        ".app/ffmpeg/");
-    return true;
-  }
+  // Look inside app
+  folderList.append("./" +
+                    QString::fromStdString(TEnv::getApplicationFileName()) +
+                    ".app/ffmpeg");  // ffmpeg folder
+#elif defined LINUX
+  // Need to account for symbolic links
+  folderList.append(TEnv::getWorkingDirectory().getQString() +
+                    "/ffmpeg");  // ffmpeg folder
 #endif
 
-#ifdef LINUX
-  QString currentPath = TEnv::getWorkingDirectory().getQString();
-  path                = currentPath + "/ffmpeg/ffmpeg";
-  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-    Preferences::instance()->setValue(ffmpegPath, currentPath + "/ffmpeg/");
+  QString exePath = TSystem::findFileLocation(folderList, exe);
+
+  if (!exePath.isEmpty()) {
+    Preferences::instance()->setValue(ffmpegPath, exePath);
     return true;
   }
-#endif
+
   // give up
   return false;
 }
 
 bool Ffmpeg::checkFfprobe() {
-  // check the user defined path in preferences first
-  QString path = Preferences::instance()->getFfmpegPath() + "/ffprobe";
+  QString exe = "ffprobe";
 #if defined(_WIN32)
-  path = path + ".exe";
+  exe = exe + ".exe";
 #endif
+
+  // check the user defined path in preferences first
+  QString path = Preferences::instance()->getFfmpegPath() + "/" + exe;
   if (TSystem::doesExistFileOrLevel(TFilePath(path))) return true;
 
-  // check the Tahoma root directory next
-  path = QDir::currentPath() + "/ffprobe";
-#if defined(_WIN32)
-  path = path + ".exe";
-#endif
-  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-    Preferences::instance()->setValue(ffmpegPath, QDir::currentPath());
-    return true;
-  }
+  // Let's try and autodetect the exe included with release
+  QStringList folderList;
+
+  folderList.append(".");
+  folderList.append("./ffmpeg");  // ffmpeg folder
 
 #ifdef MACOSX
-  path = QDir::currentPath() + "/" +
-         QString::fromStdString(TEnv::getApplicationFileName()) +
-         ".app/ffmpeg/ffprobe";
-  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-    Preferences::instance()->setValue(
-        ffmpegPath, QDir::currentPath() + "/" +
-                        QString::fromStdString(TEnv::getApplicationFileName()) +
-                        ".app/ffmpeg/");
-    return true;
-  }
+  // Look inside app
+  folderList.append("./" +
+                    QString::fromStdString(TEnv::getApplicationFileName()) +
+                    ".app/ffmpeg");  // ffmpeg folder
+#elif defined LINUX
+  // Need to account for symbolic links
+  folderList.append(TEnv::getWorkingDirectory().getQString() +
+                    "/ffmpeg");  // ffmpeg folder
 #endif
 
-#ifdef LINUX
-  QString currentPath = TEnv::getWorkingDirectory().getQString();
-  path                = currentPath + "/ffmpeg/ffprobe";
-  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-    Preferences::instance()->setValue(ffmpegPath, currentPath + "/ffmpeg/");
+  QString exePath = TSystem::findFileLocation(folderList, exe);
+
+  if (!exePath.isEmpty()) {
+    Preferences::instance()->setValue(ffmpegPath, exePath);
     return true;
   }
-#endif
 
   // give up
   return false;

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -46,7 +46,7 @@ public:
 private:
   QString m_intermediateFormat, m_ffmpegPath, m_audioPath, m_audioFormat;
   int m_frameCount    = 0, m_lx, m_ly, m_bpp, m_bitsPerSample, m_channelCount,
-      m_ffmpegTimeout = 30000, m_frameNumberOffset = -1;
+      m_ffmpegTimeout = -1, m_frameNumberOffset = -1;
   double m_frameRate  = 24.0;
   bool m_ffmpegExists = false, m_ffprobeExists = false, m_hasSoundTrack = false;
   TFilePath m_path;

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -282,6 +282,7 @@ public:
   QString getFfmpegPath() const { return getStringValue(ffmpegPath); }
   int getFfmpegTimeout() { return getIntValue(ffmpegTimeout); }
   QString getFastRenderPath() const { return getStringValue(fastRenderPath); }
+  QString getRhubarbPath() const { return getStringValue(rhubarbPath); }
 
   // Drawing  tab
   QString getScanLevelType() const { return getStringValue(scanLevelType); }

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -283,6 +283,7 @@ public:
   int getFfmpegTimeout() { return getIntValue(ffmpegTimeout); }
   QString getFastRenderPath() const { return getStringValue(fastRenderPath); }
   QString getRhubarbPath() const { return getStringValue(rhubarbPath); }
+  int getRhubarbTimeout() { return getIntValue(rhubarbTimeout); }
 
   // Drawing  tab
   QString getScanLevelType() const { return getStringValue(scanLevelType); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -74,6 +74,7 @@ enum PreferencesItemId {
   ffmpegPath,
   ffmpegTimeout,
   fastRenderPath,
+  rhubarbPath,
 
   //----------
   // Drawing

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -75,6 +75,7 @@ enum PreferencesItemId {
   ffmpegTimeout,
   fastRenderPath,
   rhubarbPath,
+  rhubarbTimeout,
 
   //----------
   // Drawing

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -263,6 +263,8 @@ DVAPI TFilePath toLocalPath(const TFilePath &fp);
 
 DVAPI bool showDocument(const TFilePath &fp);
 
+DVAPI QString findFileLocation(QStringList folderList, QString fileName);
+
 #ifndef TNZCORE_LIGHT
 DVAPI QDateTime getFileTime(const TFilePath &path);
 DVAPI QString getHostName();

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -835,7 +835,10 @@ void LipSyncPopup::onApplyButton() {
     }
     runRhubarb();
     int rhubarbTimeout = Preferences::instance()->getRhubarbTimeout();
-    if (rhubarbTimeout > 0) rhubarbTimeout * 1000;
+    if (rhubarbTimeout > 0)
+      rhubarbTimeout * 1000;
+    else
+      rhubarbTimeout = -1;
     m_rhubarb->waitForFinished(rhubarbTimeout);
     m_progressDialog->hide();
     QString results = m_rhubarb->readAllStandardError();

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -834,7 +834,9 @@ void LipSyncPopup::onApplyButton() {
       return;
     }
     runRhubarb();
-    m_rhubarb->waitForFinished();
+    int rhubarbTimeout = Preferences::instance()->getRhubarbTimeout();
+    if (rhubarbTimeout > 0) rhubarbTimeout * 1000;
+    m_rhubarb->waitForFinished(rhubarbTimeout);
     m_progressDialog->hide();
     QString results = m_rhubarb->readAllStandardError();
     results += m_rhubarb->readAllStandardOutput();

--- a/toonz/sources/toonz/lipsyncpopup.h
+++ b/toonz/sources/toonz/lipsyncpopup.h
@@ -78,6 +78,7 @@ class LipSyncPopup final : public DVGui::Dialog {
   bool m_deleteFile = false;
   DVGui::ProgressDialog *m_progressDialog;
   QProcess *m_rhubarb;
+  QString m_rhubarbPath;
   QFrame *m_audioFrame;
   QFrame *m_dataFrame;
   QStackedWidget *m_stackedChooser;
@@ -93,7 +94,7 @@ protected:
   void refreshSoundLevels();
   void saveAudio();
   void runRhubarb();
-  QString findRhubarb();
+  bool checkRhubarb();
 
 public slots:
   void onApplyButton();

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1605,6 +1605,8 @@ QWidget* PreferencesPopup::createSavingPage() {
   insertUI(resetUndoOnSavingLevel, lay);
   insertUI(doNotShowPopupSaveScene, lay);
 
+  insertUI(fastRenderPath, lay);
+
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);
   return widget;
@@ -1629,8 +1631,6 @@ QWidget* PreferencesPopup::createImportExportPage() {
   {
     insertUI(ffmpegPath, ffmpegOptionsLay);
     insertUI(ffmpegTimeout, ffmpegOptionsLay);
-
-    insertUI(fastRenderPath, ffmpegOptionsLay);
   }
 
   QGridLayout* rhubarbOptionsLay = insertGroupBox(tr("Rhubarb Lip Sync"), lay);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1271,7 +1271,7 @@ PreferencesPopup::PreferencesPopup()
   m_categoryList = new QListWidget(this);
   QStringList categories;
   categories << tr("General") << tr("Interface") << tr("Visualization")
-             << tr("Loading") << tr("Saving") << tr("Import/Export")
+             << tr("Loading") << tr("Saving") << tr("3rd Party Apps")
              << tr("Drawing") << tr("Tools") << tr("Scene") << tr("Animation")
              << tr("Preview") << tr("Onion Skin") << tr("Colors")
              << tr("Version Control") << tr("Touch/Tablet Settings");

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1043,7 +1043,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
 
       // Import / Export
       {ffmpegPath, tr("Executable Directory:")},
-      {ffmpegTimeout, tr("Process Timeout:")},
+      {ffmpegTimeout, tr("Import/Export Timeout (sec; -1 = no timeout):")},
       {fastRenderPath, tr("Fast Render Output Directory:")},
       {rhubarbPath, tr("Executable Directory:")},
       {rhubarbTimeout, tr("Analyze Audio Timeout (sec; -1 = no timeout):") },
@@ -1628,14 +1628,6 @@ QWidget* PreferencesPopup::createImportExportPage() {
   QGridLayout* ffmpegOptionsLay = insertGroupBox(tr("FFmpeg"), lay);
   {
     insertUI(ffmpegPath, ffmpegOptionsLay);
-
-    putLabel(
-        tr("Number of seconds to wait for FFmpeg to complete processing the "
-           "output:"),
-        ffmpegOptionsLay);
-    putLabel(
-        tr("Note: FFmpeg begins working once all images have been processed."),
-        ffmpegOptionsLay);
     insertUI(ffmpegTimeout, ffmpegOptionsLay);
 
     insertUI(fastRenderPath, ffmpegOptionsLay);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1042,9 +1042,10 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {defaultProjectPath, tr("Default Project Path:")},
 
       // Import / Export
-      {ffmpegPath, tr("FFmpeg Path:")},
-      {ffmpegTimeout, tr("FFmpeg Timeout:")},
-      {fastRenderPath, tr("Fast Render Path:")},
+      {ffmpegPath, tr("Executable Directory:")},
+      {ffmpegTimeout, tr("Process Timeout:")},
+      {fastRenderPath, tr("Fast Render Output Directory:")},
+      {rhubarbPath, tr("Executable Directory:")},
 
       // Drawing
       {scanLevelType, tr("Scan File Format:")},
@@ -1619,26 +1620,28 @@ QWidget* PreferencesPopup::createImportExportPage() {
   QWidget* widget  = new QWidget(this);
   QGridLayout* lay = new QGridLayout();
   setupLayout(lay);
-
-  putLabel(
-      tr("Tahoma2D can use FFmpeg for additional file formats.\n") +
-          tr("FFmpeg is bundled with Tahoma2D,\n") +
-          tr("but you can provide the path to a different ffmpeg location."),
-      lay);
-  insertUI(ffmpegPath, lay);
-
-  putLabel(tr("Number of seconds to wait for FFmpeg to complete processing the "
-              "output:"),
+  putLabel(tr("External applications used by Tahoma2D.\nThese come bundled "
+              "with Tahoma2D, but you can set path to a different version."),
            lay);
-  putLabel(
-      tr("Note: FFmpeg begins working once all images have been processed."),
-      lay);
-  insertUI(ffmpegTimeout, lay);
 
-  putLabel(tr("Please indicate where you would like exports from Fast "
-              "Render (MP4) to go."),
-           lay);
-  insertUI(fastRenderPath, lay);
+  QGridLayout* ffmpegOptionsLay = insertGroupBox(tr("FFmpeg"), lay);
+  {
+    insertUI(ffmpegPath, ffmpegOptionsLay);
+
+    putLabel(
+        tr("Number of seconds to wait for FFmpeg to complete processing the "
+           "output:"),
+        ffmpegOptionsLay);
+    putLabel(
+        tr("Note: FFmpeg begins working once all images have been processed."),
+        ffmpegOptionsLay);
+    insertUI(ffmpegTimeout, ffmpegOptionsLay);
+
+    insertUI(fastRenderPath, ffmpegOptionsLay);
+  }
+
+  QGridLayout* rhubarbOptionsLay = insertGroupBox(tr("Rhubarb"), lay);
+  { insertUI(rhubarbPath, rhubarbOptionsLay); }
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);
@@ -2134,7 +2137,8 @@ void PreferencesPopup::onImport() {
       DVGui::warning("Failed to process Settings.\nCould not find " +
                      srcDir.getQString());
     else {
-      QString origFfmpegPath = Preferences::instance()->getFfmpegPath();
+      QString origFfmpegPath  = Preferences::instance()->getFfmpegPath();
+      QString origRhubarbPath = Preferences::instance()->getRhubarbPath();
 
       QFileInfoList fil = QDir(toQString(srcDir)).entryInfoList();
       int i;
@@ -2155,6 +2159,7 @@ void PreferencesPopup::onImport() {
       // it to find it again otherwise it will point to old location
       Preferences::instance()->load();
       Preferences::instance()->setValue(ffmpegPath, origFfmpegPath);
+      Preferences::instance()->setValue(rhubarbPath, origRhubarbPath);
     }
 
     if (useLegacy) {

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1043,10 +1043,10 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
 
       // Import / Export
       {ffmpegPath, tr("Executable Directory:")},
-      {ffmpegTimeout, tr("Import/Export Timeout (sec; -1 = no timeout):")},
+      {ffmpegTimeout, tr("Import/Export Timeout (seconds):")},
       {fastRenderPath, tr("Fast Render Output Directory:")},
       {rhubarbPath, tr("Executable Directory:")},
-      {rhubarbTimeout, tr("Analyze Audio Timeout (sec; -1 = no timeout):") },
+      {rhubarbTimeout, tr("Analyze Audio Timeout (seconds):")},
 
       // Drawing
       {scanLevelType, tr("Scan File Format:")},
@@ -1635,7 +1635,7 @@ QWidget* PreferencesPopup::createImportExportPage() {
 
   QGridLayout* rhubarbOptionsLay = insertGroupBox(tr("Rhubarb Lip Sync"), lay);
   {
-    insertUI(rhubarbPath, rhubarbOptionsLay); 
+    insertUI(rhubarbPath, rhubarbOptionsLay);
     insertUI(rhubarbTimeout, rhubarbOptionsLay);
   }
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1271,9 +1271,9 @@ PreferencesPopup::PreferencesPopup()
   m_categoryList = new QListWidget(this);
   QStringList categories;
   categories << tr("General") << tr("Interface") << tr("Visualization")
-             << tr("Loading") << tr("Saving") << tr("3rd Party Apps")
-             << tr("Drawing") << tr("Tools") << tr("Scene") << tr("Animation")
-             << tr("Preview") << tr("Onion Skin") << tr("Colors")
+             << tr("Loading") << tr("Saving") << tr("Drawing") << tr("Tools")
+             << tr("Scene") << tr("Animation") << tr("Preview")
+             << tr("Onion Skin") << tr("Colors") << tr("3rd Party Apps")
              << tr("Version Control") << tr("Touch/Tablet Settings");
   m_categoryList->addItems(categories);
   m_categoryList->setFixedWidth(160);
@@ -1286,7 +1286,6 @@ PreferencesPopup::PreferencesPopup()
   m_stackedWidget->addWidget(createVisualizationPage());
   m_stackedWidget->addWidget(createLoadingPage());
   m_stackedWidget->addWidget(createSavingPage());
-  m_stackedWidget->addWidget(createImportExportPage());
   m_stackedWidget->addWidget(createDrawingPage());
   m_stackedWidget->addWidget(createToolsPage());
   m_stackedWidget->addWidget(createXsheetPage());
@@ -1294,6 +1293,7 @@ PreferencesPopup::PreferencesPopup()
   m_stackedWidget->addWidget(createPreviewPage());
   m_stackedWidget->addWidget(createOnionSkinPage());
   m_stackedWidget->addWidget(createColorsPage());
+  m_stackedWidget->addWidget(createImportExportPage());
   m_stackedWidget->addWidget(createVersionControlPage());
   m_stackedWidget->addWidget(createTouchTabletPage());
   // createImportPrefsPage() must always be last

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1640,7 +1640,7 @@ QWidget* PreferencesPopup::createImportExportPage() {
     insertUI(fastRenderPath, ffmpegOptionsLay);
   }
 
-  QGridLayout* rhubarbOptionsLay = insertGroupBox(tr("Rhubarb"), lay);
+  QGridLayout* rhubarbOptionsLay = insertGroupBox(tr("Rhubarb Lip Sync"), lay);
   { insertUI(rhubarbPath, rhubarbOptionsLay); }
 
   lay->setRowStretch(lay->rowCount(), 1);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1046,6 +1046,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {ffmpegTimeout, tr("Process Timeout:")},
       {fastRenderPath, tr("Fast Render Output Directory:")},
       {rhubarbPath, tr("Executable Directory:")},
+      {rhubarbTimeout, tr("Analyze Audio Timeout (sec; -1 = no timeout):") },
 
       // Drawing
       {scanLevelType, tr("Scan File Format:")},
@@ -1641,7 +1642,10 @@ QWidget* PreferencesPopup::createImportExportPage() {
   }
 
   QGridLayout* rhubarbOptionsLay = insertGroupBox(tr("Rhubarb Lip Sync"), lay);
-  { insertUI(rhubarbPath, rhubarbOptionsLay); }
+  {
+    insertUI(rhubarbPath, rhubarbOptionsLay); 
+    insertUI(rhubarbTimeout, rhubarbOptionsLay);
+  }
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -446,7 +446,7 @@ void Preferences::definePreferenceItems() {
 
   // Import / Export
   define(ffmpegPath, "ffmpegPath", QMetaType::QString, "");
-  define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, 600, 1,
+  define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, -1, -1,
          std::numeric_limits<int>::max());
   define(fastRenderPath, "fastRenderPath", QMetaType::QString, "desktop");
   define(rhubarbPath, "rhubarbPath", QMetaType::QString, "");

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -450,6 +450,8 @@ void Preferences::definePreferenceItems() {
          std::numeric_limits<int>::max());
   define(fastRenderPath, "fastRenderPath", QMetaType::QString, "desktop");
   define(rhubarbPath, "rhubarbPath", QMetaType::QString, "");
+  define(rhubarbTimeout, "rhubarbTimeout", QMetaType::Int, -1, -1,
+    std::numeric_limits<int>::max());
 
   // Drawing
   define(scanLevelType, "scanLevelType", QMetaType::QString, "tif");

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -449,6 +449,7 @@ void Preferences::definePreferenceItems() {
   define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, 600, 1,
          std::numeric_limits<int>::max());
   define(fastRenderPath, "fastRenderPath", QMetaType::QString, "desktop");
+  define(rhubarbPath, "rhubarbPath", QMetaType::QString, "");
 
   // Drawing
   define(scanLevelType, "scanLevelType", QMetaType::QString, "tif");

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -446,12 +446,12 @@ void Preferences::definePreferenceItems() {
 
   // Import / Export
   define(ffmpegPath, "ffmpegPath", QMetaType::QString, "");
-  define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, -1, -1,
+  define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, 0, 0,
          std::numeric_limits<int>::max());
   define(fastRenderPath, "fastRenderPath", QMetaType::QString, "desktop");
   define(rhubarbPath, "rhubarbPath", QMetaType::QString, "");
-  define(rhubarbTimeout, "rhubarbTimeout", QMetaType::Int, -1, -1,
-    std::numeric_limits<int>::max());
+  define(rhubarbTimeout, "rhubarbTimeout", QMetaType::Int, 0, 0,
+         std::numeric_limits<int>::max());
 
   // Drawing
   define(scanLevelType, "scanLevelType", QMetaType::QString, "tif");


### PR DESCRIPTION
The following changes are included in this PR:

- Rhubarb Lip Sync
  - Added Rhubarb directory and processing timeout settings to Preferences
  - Improved autodetection of rhubarb executable path. Stores as relative path.
  - Allow `0` timeout value = no timeout (default). Means it waits until rhubarb finishes or errors out. 
  - Display rhubarb processing errors in a popup
  - Added Rhubarb Lip Sync license
  - Updated packaging scripts to include Rhubarb executable from https://github.com/tahoma2d/rhubarb-lip-sync repo
  - NOTE: Tahoma2D uses a modified version of the official Rhubarb application.

- Ffmpeg
  - Improved autodetection of ffmpeg executable path. Stores as relative path.
  - Allow `0` timeout value = no timeout (default). Means it waits until ffmpeg finishes or errors out. 
  - Updated packaging scripts to include ffmpeg executable from https://github.com/tahoma2d/ffmpeg repo

- Preferences
  - Moved `Fast Render Path` to `Savings` page
  - Renamed `Preferences` -> `Import/Export` to `3rd Party Apps`
  - Updated/Simplified wording for ffmpeg and rhubarb preferences

![image](https://user-images.githubusercontent.com/19245851/112027541-a4c2d600-8b0d-11eb-8e8f-218bcb8caf80.png)
