### PR TITLE
mac specific fixes from OT

### DIFF
--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -491,8 +491,9 @@ int main(int argc, char *argv[]) {
   // questo definisce la registry root e inizializza TEnv
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
+  TEnv::setApplicationFileName(argv[0]);
 
-  QCoreApplication::setOrganizationName("OpenToonz");
+  QCoreApplication::setOrganizationName("Tahoma2D");
   QCoreApplication::setOrganizationDomain("");
   QCoreApplication::setApplicationName(
       QString::fromStdString(TEnv::getApplicationName()));

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -663,6 +663,7 @@ int main(int argc, char *argv[]) {
   // questo definisce la registry root e inizializza TEnv
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
+  TEnv::setApplicationFileName(argv[0]);
 
   QCoreApplication::setOrganizationName("Tahoma2D");
   QCoreApplication::setOrganizationDomain("");

--- a/toonz/sources/tconverter/tconverter.cpp
+++ b/toonz/sources/tconverter/tconverter.cpp
@@ -177,7 +177,7 @@ void convertFromVI(const TLevelReaderP &lr, const TPaletteP &plt,
   }
   maxBbox = maxBbox.enlarge(2);
   if (width)  // calcolo l'affine
-    aff   = TScale((double)width / maxBbox.getLx());
+    aff = TScale((double)width / maxBbox.getLx());
   maxBbox = aff * maxBbox;
 
   for (i = 0; i < (int)images.size(); i++) {
@@ -365,6 +365,7 @@ int main(int argc, char *argv[]) {
 
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
+  TEnv::setApplicationFileName(argv[0]);
   TFilePath fp = TEnv::getStuffDir();
 
   string msg;

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -175,7 +175,11 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_probe->setSource(m_audioRecorder);
   QAudioEncoderSettings audioSettings;
   audioSettings.setCodec("audio/PCM");
-  audioSettings.setSampleRate(44100);
+#ifdef MACOSX
+   audioSettings.setSampleRate(-1);
+ #else
+   audioSettings.setSampleRate(44100);
+ #endif
   audioSettings.setChannelCount(1);
   audioSettings.setBitRate(16);
   audioSettings.setEncodingMode(QMultimedia::ConstantBitRateEncoding);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -779,21 +779,21 @@ void FilmstripFrames::drawFrameIcon(QPainter &p, const QRect &r, int index,
         p.setPen(Qt::black);
         p.drawLine(x0 - 1, y0, x0 - 1, y1);
 
-        QPixmap inbetweenPixmap(
-            svgToPixmap(":Resources/filmstrip_inbetween.svg"));
+          QRectF txtRect(y0 + 1, -x1, y1 - y0 - 1, x1 - x0 + 1);
+                 QFontMetricsF tmpFm(p.font());
+                 QRectF bbox = tmpFm.boundingRect(
+                     txtRect, Qt::AlignBottom | Qt::AlignHCenter, tr("INBETWEEN"));
+                 double ratio = std::min(1.0, txtRect.width() / bbox.width());
 
-        if (r.height() - 6 < inbetweenPixmap.height()) {
-          QSize rectSize(inbetweenPixmap.size());
-          rectSize.setHeight(r.height() - 6);
-          inbetweenPixmap = inbetweenPixmap.scaled(
-              rectSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-        }
-
-        p.drawPixmap(
-            x0 + 2,
-            y1 - inbetweenPixmap.height() / inbetweenPixmap.devicePixelRatio() -
-                3,
-            inbetweenPixmap);
+                 p.save();
+                 p.setRenderHint(QPainter::TextAntialiasing);
+                 p.rotate(90.0);
+                 p.scale(ratio, 1.0);
+                 p.drawText(QRectF(txtRect.left() / ratio, txtRect.top(),
+                                   txtRect.width() / ratio, txtRect.height()),
+                            tr("INBETWEEN"),
+                            QTextOption(Qt::AlignBottom | Qt::AlignHCenter));
+                 p.restore();
       } else {
         int x1 = r.right();
         int x0 = r.left();


### PR DESCRIPTION
By @shun-iwasawa https://github.com/opentoonz/opentoonz/pull/3763 - this fixes #158
https://github.com/opentoonz/opentoonz/pull/3767 - this fixes #97 
https://github.com/opentoonz/opentoonz/pull/3766 - this fixes #460 

For audio recording, we already have info.plist updated properly, so we just need the sample rate condition removed for macOS. This also makes Task rendering work and fixes the display of the Inbetween button.