### PR TITLE
Fix static macOS ffmpeg builds

### DIFF
--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -1,5 +1,29 @@
 cd thirdparty
 
+echo ">>> Cloning aom"
+mkdir aom
+cd aom
+echo "*" >| .gitignore
+
+git clone https://aomedia.googlesource.com/aom
+
+if [ ! -d build ]
+then
+   mkdir build
+fi
+cd build
+
+echo ">>> CMaking aom"
+cmake ../aom
+
+echo ">>> Making aom"
+make
+
+echo ">>> Installing aom"
+sudo make install
+
+cd ../..
+
 echo ">>> Cloning ffmpeg"
 git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 

--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -58,7 +58,6 @@ export SDKROOT=`xcrun --show-sdk-path`
       --enable-static \
       --disable-shared \
       --enable-pic \
-      --disable-shared \
       --enable-pthreads \
       --enable-version3 \
       --enable-videotoolbox \
@@ -69,6 +68,7 @@ export SDKROOT=`xcrun --show-sdk-path`
       --disable-ffplay \
       --disable-sdl2 \
       --disable-libjack \
+	  --disable-libxcb \
       --disable-indev=jack
 
 echo ">>> Building ffmpeg (static)"

--- a/ci-scripts/osx/tahoma-buildopencv.sh
+++ b/ci-scripts/osx/tahoma-buildopencv.sh
@@ -12,7 +12,7 @@ then
 fi
 cd build
 
-echo ">>> Cmaking openv"
+echo ">>> Cmaking opencv"
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_JASPER=OFF \
       -DBUILD_JPEG=OFF \

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -2,4 +2,4 @@
 brew update
 # Remove symlink to bin/2to3 in order for latest python to install
 rm -f '/usr/local/bin/2to3'
-brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm aom dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
+brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz


### PR DESCRIPTION
This PR fixes #617 by disabling libxcb library inclusion when building the static ffmpeg version for macOS.

Additionally, Homebrew of aom generates a shared library which isn't good for the static ffmpeg build.  Now building static aom from source for use in both static and shared ffmpeg builds
