### PR TITLE
Fix outdated Tahoma2D links

### DIFF
--- a/toonz/sources/toonz/aboutpopup.cpp
+++ b/toonz/sources/toonz/aboutpopup.cpp
@@ -86,20 +86,23 @@ AboutPopup::AboutPopup(QWidget* parent)
   mainLayout->addWidget(
       new QLabel(tr("Tahoma2D is made possible with the help of "
                     "patrons.\nSpecial thanks to:")));
-  mainLayout->addWidget(new QLabel("Rodney Baker"));
-  mainLayout->addWidget(new QLabel("Hans Jacob Wagner"));
-  mainLayout->addWidget(new QLabel("Pierre Coffin"));
-  mainLayout->addWidget(new QLabel("Adam Earle"));
+  QLabel* patrons = new QLabel(
+      "<i>Rodney Baker, Hans Jacob Wagner, Pierre Coffin, Adam Earle</i>");
+  patrons->setTextFormat(Qt::TextFormat::RichText);
+  mainLayout->addWidget(patrons);
   mainLayout->addWidget(new QLabel("  "));
 
-  AboutClickableLabel* supportLink = new AboutClickableLabel(this);
-  supportLink->setText(tr("Please consider supporting Tahoma2D on Patreon."));
-  connect(supportLink, &AboutClickableLabel::clicked, [=]() {
-    QDesktopServices::openUrl(QUrl("https://patreon.com/jeremybullock"));
-    ;
-  });
-  supportLink->setToolTip("https://patreon.com/jeremybullock");
-  mainLayout->addWidget(supportLink);
+  //  AboutClickableLabel* supportLink = new AboutClickableLabel(this);
+  //  supportLink->setText(tr("Please consider supporting Tahoma2D on
+  //  Patreon."));
+  //  connect(supportLink, &AboutClickableLabel::clicked, [=]() {
+  //    QDesktopServices::openUrl(QUrl("https://patreon.com/jeremybullock"));
+  //    ;
+  //  });
+  //  supportLink->setToolTip("https://patreon.com/jeremybullock");
+  //  mainLayout->addWidget(supportLink);
+  mainLayout->addWidget(new QLabel(
+      tr("Please consider sponsoring Tahoma2D developers on GitHub.")));
   mainLayout->addStretch();
 
   QFrame* mainFrame = new QFrame(this);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -585,7 +585,8 @@ centralWidget->setLayout(centralWidgetLayout);*/
 
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_OpenOnlineManual, this, &MainWindow::onOpenOnlineManual);
-  setCommandHandler(MI_SupportTahoma2D, this, &MainWindow::onSupportTahoma2D);
+  //  setCommandHandler(MI_SupportTahoma2D, this,
+  //  &MainWindow::onSupportTahoma2D);
   setCommandHandler(MI_OpenWhatsNew, this, &MainWindow::onOpenWhatsNew);
   setCommandHandler(MI_OpenCommunityForum, this,
                     &MainWindow::onOpenCommunityForum);
@@ -1165,15 +1166,15 @@ void MainWindow::onOpenOnlineManual() {
 
 //-----------------------------------------------------------------------------
 
-void MainWindow::onSupportTahoma2D() {
-  QDesktopServices::openUrl(QUrl("http://patreon.com/jeremybullock"));
-}
+// void MainWindow::onSupportTahoma2D() {
+//  QDesktopServices::openUrl(QUrl("http://patreon.com/jeremybullock"));
+//}
 
 //-----------------------------------------------------------------------------
 
 void MainWindow::onOpenWhatsNew() {
   QDesktopServices::openUrl(
-      QUrl(tr("https://tahoma.readthedocs.io/en/latest/whats_new.html")));
+      QUrl(tr("https://tahoma2d.readthedocs.io/en/latest/whats_new.html")));
 }
 
 //-----------------------------------------------------------------------------
@@ -2385,8 +2386,9 @@ void MainWindow::defineActions() {
   createMenuHelpAction(MI_OpenReportABug, QT_TR_NOOP("&Report a Bug..."), "",
                        "web");
   createMenuHelpAction(MI_About, QT_TR_NOOP("&About Tahoma2D..."), "", "info");
-  createMenuHelpAction(MI_SupportTahoma2D, QT_TR_NOOP("&Support Tahoma2D..."), "",
-                       "web");
+  //  createMenuHelpAction(MI_SupportTahoma2D, QT_TR_NOOP("&Support
+  //  Tahoma2D..."), "",
+  //                       "web");
 
   // Fill
 

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -104,7 +104,7 @@ public:
   void onUpgradeTabPro();
   void onAbout();
   void onOpenOnlineManual();
-  void onSupportTahoma2D();
+  // void onSupportTahoma2D();
   void onOpenWhatsNew();
   void onOpenCommunityForum();
   void onOpenReportABug();

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -667,7 +667,7 @@ void TopBar::loadMenubar() {
   addMenuItem(helpMenu, MI_OpenWhatsNew);
   addMenuItem(helpMenu, MI_OpenCommunityForum);
   helpMenu->addSeparator();
-  addMenuItem(helpMenu, MI_SupportTahoma2D);
+  //  addMenuItem(helpMenu, MI_SupportTahoma2D);
   addMenuItem(helpMenu, MI_OpenReportABug);
   helpMenu->addSeparator();
   addMenuItem(helpMenu, MI_About);


### PR DESCRIPTION
This PR changes the following

- Corrected the URL for the `What's New...` page to point to https://tahoma2d.readthedocs.io
- Disabled the `Support Tahoma2D...` command as I don't have a Patreon account. 
  - We can reenable this if/when it is warranted to create a non-profit organization to accept donations.
- Replaced support Tahoma2D mesage/link in About window with a message to sponsor Tahoma2D developers on GitHub.
- Reformatted and italicized patrons in About window list to 1 line conserve some vertical space.

