### PR TITLE
Fix Lazy Nezumi Pro hooking incorrectly

### DIFF
--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -893,6 +893,10 @@ FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
   layout->setSpacing(0);
 
   setLayout(layout);
+
+#ifdef _WIN32
+  this->winId();
+#endif
 }
 
 //---------------------------------------------------------------------------------
@@ -1033,7 +1037,6 @@ bool FullScreenWidget::toggleFullScreen(
             this->window()->windowHandle()->setScreen(ptrScreenThisWindowIsOn);
 
             // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
-            this->winId();
             QWindowsWindowFunctions::setHasBorderInFullScreen(
                 this->windowHandle(), true);
 


### PR DESCRIPTION
This PR fixes the issue with Lazy Nezumi Pro incorrectly hooking to the main window instead of the canvas. 

This was due to OT patch opentoonz/opentoonz/3730 moving the call to `this->winId()` outside of the widget creation.  I *think* it's setting a windows system identifier specifically for the canvas that LNP could hook to directly. Without it, LNP would hook to the main window instead.  Putting it back where it was fixed the problem.

Thanks to Lazy Nezumi Pro for granting me a temporary license. Without it I wouldn't have been able to verify this was this issue and test to make sure it was fixed.