### PR TITLE
Fix console warning messages

### DIFF
--- a/toonz/sources/toonz/aboutpopup.cpp
+++ b/toonz/sources/toonz/aboutpopup.cpp
@@ -21,7 +21,7 @@ void AboutClickableLabel::mousePressEvent(QMouseEvent* event) {
 }
 
 AboutPopup::AboutPopup(QWidget* parent)
-    : DVGui::Dialog(parent, true, "About Tahoma2D") {
+    : DVGui::Dialog(parent, true, true, "About Tahoma2D") {
   setFixedWidth(360);
   setFixedHeight(350);
 

--- a/toonz/sources/toonz/aboutpopup.cpp
+++ b/toonz/sources/toonz/aboutpopup.cpp
@@ -31,7 +31,7 @@ AboutPopup::AboutPopup(QWidget* parent)
   TFilePath baseLicensePath   = TEnv::getStuffDir() + "doc/LICENSE";
   TFilePath tahomaLicensePath = baseLicensePath + "LICENSE.txt";
 
-  QVBoxLayout* mainLayout = new QVBoxLayout(this);
+  QVBoxLayout* mainLayout = new QVBoxLayout();
 
   QLabel* logo = new QLabel(this);
 

--- a/toonz/sources/toonz/antialiaspopup.cpp
+++ b/toonz/sources/toonz/antialiaspopup.cpp
@@ -138,7 +138,7 @@ AntialiasPopup::AntialiasPopup()
                                        QSizePolicy::MinimumExpanding));
   scrollArea->setWidget(topWidget);
 
-  QGridLayout *topLayout = new QGridLayout(this);
+  QGridLayout *topLayout = new QGridLayout();
   topWidget->setLayout(topLayout);
 
   //------------------------- Parameters --------------------------

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -129,7 +129,7 @@ AudioRecordingPopup::AudioRecordingPopup()
       recordGridLay->addWidget(new QLabel(tr(" ")), 1, 0, Qt::AlignCenter);
       recordGridLay->addWidget(m_audioLevelsDisplay, 2, 0, 1, 4,
                                Qt::AlignCenter);
-      QHBoxLayout *recordLay = new QHBoxLayout(this);
+      QHBoxLayout *recordLay = new QHBoxLayout();
       recordLay->setSpacing(4);
       recordLay->setContentsMargins(0, 0, 0, 0);
       {
@@ -140,7 +140,7 @@ AudioRecordingPopup::AudioRecordingPopup()
         recordLay->addStretch();
       }
       recordGridLay->addLayout(recordLay, 3, 0, 1, 4, Qt::AlignCenter);
-      QHBoxLayout *playLay = new QHBoxLayout(this);
+      QHBoxLayout *playLay = new QHBoxLayout();
       playLay->setSpacing(4);
       playLay->setContentsMargins(0, 0, 0, 0);
       {

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -65,6 +65,7 @@ void MyFileSystemWatcher::addPaths(const QStringList &paths, bool onlyNewPath) {
   if (paths.isEmpty()) return;
   for (int p = 0; p < paths.size(); p++) {
     QString path = paths.at(p);
+    if (path.isEmpty() || path.isNull()) continue;
     // if the path is not watched yet, try to start watching it
     if (!m_watchedPath.contains(path)) {
       // symlink path will not be watched

--- a/toonz/sources/toonz/exportscenepopup.cpp
+++ b/toonz/sources/toonz/exportscenepopup.cpp
@@ -501,7 +501,7 @@ ExportScenePopup::ExportScenePopup(std::vector<TFilePath> scenes)
 
   bool ret = true;
 
-  QVBoxLayout *layout = new QVBoxLayout(this);
+  QVBoxLayout *layout = new QVBoxLayout();
 
   //  m_command = new QLabel(this);
   //  layout->addWidget(m_command);

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -492,7 +492,7 @@ LevelSettingsPopup::LevelSettingsPopup()
     m_topLayout->addWidget(dpiBox);
     dpiBox->hide();
 
-    QHBoxLayout* resLayout = new QHBoxLayout(this);
+    QHBoxLayout* resLayout = new QHBoxLayout();
     resLayout->addWidget(imageResTitle);
     resLayout->addWidget(m_imageResLabel);
     resLayout->addStretch();

--- a/toonz/sources/toonz/linesfadepopup.cpp
+++ b/toonz/sources/toonz/linesfadepopup.cpp
@@ -161,7 +161,7 @@ LinesFadePopup::LinesFadePopup()
                                        QSizePolicy::MinimumExpanding));
   scrollArea->setWidget(topWidget);
 
-  QGridLayout *topLayout = new QGridLayout(this);
+  QGridLayout *topLayout = new QGridLayout();
   topWidget->setLayout(topLayout);
 
   //------------------------- Parameters --------------------------

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -244,7 +244,7 @@ LipSyncPopup::LipSyncPopup()
   m_playButton->setIcon(m_playIcon);
 
   m_columnLabel            = new QLabel(tr("Audio Source: "), this);
-  QHBoxLayout *soundLayout = new QHBoxLayout(this);
+  QHBoxLayout *soundLayout = new QHBoxLayout();
   soundLayout->addWidget(m_columnLabel);
   soundLayout->addWidget(m_soundLevels);
   soundLayout->addWidget(m_playButton);
@@ -267,7 +267,7 @@ LipSyncPopup::LipSyncPopup()
   m_scriptEdit->setFixedHeight(80);
   m_scriptEdit->setFixedWidth(840);
 
-  QGridLayout *rhubarbLayout = new QGridLayout(this);
+  QGridLayout *rhubarbLayout = new QGridLayout();
   rhubarbLayout->addLayout(soundLayout, 0, 0, 1, 5);
   rhubarbLayout->addWidget(m_audioFile, 1, 0, 1, 5);
   rhubarbLayout->addWidget(m_scriptLabel, 2, 0, 1, 3);
@@ -285,7 +285,7 @@ LipSyncPopup::LipSyncPopup()
   m_file->setFixedWidth(840);
   QLabel *pathLabel    = new QLabel(tr("Lip Sync Data File: "), this);
 
-  QGridLayout *fileLay = new QGridLayout(this);
+  QGridLayout *fileLay = new QGridLayout();
   fileLay->setSpacing(4);
   fileLay->setMargin(10);
   fileLay->addWidget(pathLabel, 0, 0, Qt::AlignLeft);
@@ -430,10 +430,10 @@ LipSyncPopup::LipSyncPopup()
     m_topLayout->addLayout(phonemeLay, 0);
   }
 
-  QHBoxLayout *optionsLay = new QHBoxLayout(this);
+  QHBoxLayout *optionsLay = new QHBoxLayout();
   optionsLay->setMargin(10);
   optionsLay->setSpacing(15);
-  QHBoxLayout *insertAtLay = new QHBoxLayout(this);
+  QHBoxLayout *insertAtLay = new QHBoxLayout();
   insertAtLay->setMargin(0);
   insertAtLay->setSpacing(4);
   m_insertAtLabel = new QLabel(tr("Insert at Frame: "));

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3807,8 +3807,8 @@ void MainWindow::makeTransparencyDialog() {
     toggleTransparency(true);
   });
 
-  QVBoxLayout *togglerLayout       = new QVBoxLayout(this);
-  QHBoxLayout *togglerSliderLayout = new QHBoxLayout(this);
+  QVBoxLayout *togglerLayout       = new QVBoxLayout();
+  QHBoxLayout *togglerSliderLayout = new QHBoxLayout();
   togglerSliderLayout->addWidget(new QLabel(tr("Amount: "), this));
   togglerSliderLayout->addWidget(m_transparencySlider);
   togglerLayout->addLayout(togglerSliderLayout);

--- a/toonz/sources/toonz/motionpathpanel.cpp
+++ b/toonz/sources/toonz/motionpathpanel.cpp
@@ -52,15 +52,15 @@ double distanceSquared(QPoint p1, QPoint p2) {
 
 MotionPathPanel::MotionPathPanel(QWidget* parent)
     : QWidget(parent), m_currentSpline(0), m_playbackExecutor() {
-  m_outsideLayout = new QVBoxLayout(this);
+  m_outsideLayout = new QVBoxLayout();
   m_outsideLayout->setMargin(0);
   m_outsideLayout->setSpacing(0);
 
-  m_insideLayout = new QVBoxLayout(this);
+  m_insideLayout = new QVBoxLayout();
   m_insideLayout->setMargin(0);
   m_insideLayout->setSpacing(0);
 
-  m_pathsLayout = new QGridLayout(this);
+  m_pathsLayout = new QGridLayout();
   m_pathsLayout->setContentsMargins(0, 3, 2, 3);
   m_pathsLayout->setSpacing(2);
 
@@ -75,10 +75,10 @@ MotionPathPanel::MotionPathPanel(QWidget* parent)
   QSizePolicy policy(QSizePolicy::Expanding, QSizePolicy::Maximum);
   pathFrame->setSizePolicy(policy);
 
-  m_mainControlsPage = new QFrame(this);
+  m_mainControlsPage = new QFrame();
   m_mainControlsPage->setLayout(m_insideLayout);
 
-  m_graphArea = new GraphWidget(this);
+  m_graphArea = new GraphWidget();
   m_graphArea->setMaxXValue(1000);
   m_graphArea->setMaxYValue(1000);
 
@@ -101,7 +101,7 @@ MotionPathPanel::MotionPathPanel(QWidget* parent)
   m_toolbar->addAction(CommandManager::instance()->getAction("T_Geometric"));
   m_toolbar->setFixedHeight(18);
   m_toolbar->setIconSize(QSize(16, 16));
-  m_toolLayout = new QHBoxLayout(this);
+  m_toolLayout = new QHBoxLayout();
   m_toolLayout->setSpacing(2);
   m_toolLayout->setMargin(2);
   m_toolLayout->addWidget(m_toolbar);
@@ -134,11 +134,11 @@ MotionPathPanel::MotionPathPanel(QWidget* parent)
   container->setObjectName("MotionPathToolbar");
   container->setLayout(m_toolLayout);
 
-  m_controlsLayout = new QVBoxLayout(this);
+  m_controlsLayout = new QVBoxLayout();
   m_controlsLayout->setMargin(10);
   m_controlsLayout->setSpacing(3);
 
-  QHBoxLayout* graphLayout = new QHBoxLayout(this);
+  QHBoxLayout* graphLayout = new QHBoxLayout();
   graphLayout->setMargin(0);
   graphLayout->setSpacing(0);
   graphLayout->addWidget(m_graphArea);
@@ -294,7 +294,7 @@ void MotionPathPanel::createControl(TStageObjectSpline* spline, int number) {
   QComboBox* colorCombo = new QComboBox(this);
   fillCombo(colorCombo, spline);
 
-  QHBoxLayout* nameLayout = new QHBoxLayout(this);
+  QHBoxLayout* nameLayout = new QHBoxLayout();
   nameLayout->addWidget(nameLabel);
   nameLayout->addWidget(nameEdit);
   nameEdit->hide();

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -255,7 +255,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
 
     m_topLayout->addSpacing(5);
 
-    QHBoxLayout *renderButtonLayout = new QHBoxLayout(this);
+    QHBoxLayout *renderButtonLayout = new QHBoxLayout();
     renderButtonLayout->addWidget(renderButton);
     if (!isPreview)
       renderButtonLayout->addWidget(saveAndRenderButton);

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -441,7 +441,7 @@ TPanelTitleBarButtonForGrids::TPanelTitleBarButtonForGrids(
 
   QWidgetAction *gridsAction = new QWidgetAction(this);
   QWidget *gridWidget        = new QWidget(this);
-  QGridLayout *gridLayout    = new QGridLayout(this);
+  QGridLayout *gridLayout    = new QGridLayout();
 
   QCheckBox *thirdsCheckbox = new QCheckBox(tr("Rule of Thirds"), this);
   thirdsCheckbox->setChecked(ShowRuleOfThirds != 0);

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -60,7 +60,7 @@ ProjectPopup::ProjectPopup(bool isModal)
   m_prjNameLabel        = new QLabel(tr("Project Name:"), this);
   m_pathFieldLabel      = new QLabel(tr("Create Project In:"), this);
   m_nameFld             = new LineEdit();
-  m_recentProjectLayout = new QGridLayout(this);
+  m_recentProjectLayout = new QGridLayout();
   m_recentProjectLayout->setSpacing(2);
   m_recentProjectLayout->setMargin(4);
   m_projectLocationFld =

--- a/toonz/sources/toonz/timestretchpopup.cpp
+++ b/toonz/sources/toonz/timestretchpopup.cpp
@@ -221,7 +221,7 @@ TimeStretchPopup::TimeStretchPopup()
           SLOT(setCurrentStretchType(int)));
   addWidget(tr("Stretch:"), m_stretchType);
 
-  QHBoxLayout *rangeLayout = new QHBoxLayout(this);
+  QHBoxLayout *rangeLayout = new QHBoxLayout();
   m_oldRange               = new QLabel("0", this);
   m_oldRange->setFixedSize(43, DVGui::WidgetHeight);
   rangeLayout->addWidget(m_oldRange);

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -62,7 +62,7 @@ NotePopup::NotePopup(XsheetViewer *viewer, int noteIndex)
 
   beginVLayout();
 
-  QGridLayout *layout = new QGridLayout(this);
+  QGridLayout *layout = new QGridLayout();
   layout->setMargin(1);
   layout->setColumnStretch(7, 10);
   layout->setColumnStretch(8, 10);

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -376,12 +376,14 @@ void Dialog::hideEvent(QHideEvent *event) {
   if (y < screen.top()) y         = screen.top();
   move(QPoint(x, y));
   resize(size());
-  QRect r = geometry();
-  QSettings settings(settingsPath, QSettings::IniFormat);
-  settings.setValue(m_name, QString::number(r.left()) + " " +
-                                QString::number(r.top()) + " " +
-                                QString::number(r.width()) + " " +
-                                QString::number(r.height()));
+  if (m_name != QString()) {
+    QRect r = geometry();
+    QSettings settings(settingsPath, QSettings::IniFormat);
+    settings.setValue(m_name, QString::number(r.left()) + " " +
+      QString::number(r.top()) + " " +
+      QString::number(r.width()) + " " +
+      QString::number(r.height()));
+  }
   emit dialogClosed();
 }
 


### PR DESCRIPTION
This PR fixes the issues that causes certain console warnings to be generated when running from command line.

The following console warnings were addressed

- `QLayout: Attempting to add QLayout "" to xxxx "", which already has a layout`

Generated by: Main window at startup as well as the following popups: About, Antialias, Record Audio, Export Scene, Level Settings, Color Fade, Apply Lip Sync to Column, Stop Motion Control, Output Settings, Time Stretch, New/Switch Project,  Timeline Note Viewer

Caused by trying to see parent layout with QHBoxLayout(this) or QVBoxLayout(this) when the parent widget already has a layout.

Cleared `this` from these Layout constructors for the impacted popup.

- `QLayout: Attempting to add QLayout "" to TPanelTitleBarButtonForGrids "", which already has a layout`

Generated by: Anything with buttons in the panel's title bar, like the Viewer, ComboViewer

Caused by trying to see parent layout with QGridLayout when the parent widget already has a layout.

Cleared `this` from the Layout constructors for this object.

- `QSettings::setValue: Empty key passed`

Generated by: About popup. 

Caused by improper setup of DVGui:Dialog for the About popup as well as the DVGui:Dialog not checking to see if the key is empty before saving when hiding the popup.

Corrected About popup constructor to pass the proper parameters as well as skip saving QSettings if they key was not populated.

- `QFileSystemWatcher::addPath: path is empty` and `QFileSystemWatcher::removePath: path is empty`

Generated by: Browser room

Caused by trying to set a file watcher on an empty path when expanding/collapsing the file tree view.  Was triggered when a folder name started with a +.

Added logic to skip paths that are empty or null, in case it finds any.