### PR TITLE
Block saving scene outside current project

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -252,6 +252,17 @@ void FileBrowserPopup::onOkPressed() {
         return;
       }
     } else {
+      if (m_forSaving && m_browser->getFilterTypes().contains("tnz")) {
+        TProjectManager *pm = TProjectManager::instance();
+        TFilePath currentPrjDir =
+            pm->getCurrentProject()->getProjectPath().getParentDir();
+        if (!currentPrjDir.isAncestorOf(*pt)) {
+          DVGui::warning(QObject::tr(
+              "You cannot save a scene outside of the current project's folder."));
+          return;
+        }
+      }
+
       if (!m_isDirectoryOnly)
         pathSet.insert(*pt);
       else {


### PR DESCRIPTION
This PR should address issue #605, by preventing users from saving a scene (new scene or Save Scene As) outside of the current project.

It is necessary to do this because newly created assets would be saved in the current project folders, but it is not reflected in the scene file saved elsewhere. When you try to open/load the scene file from another project, the project-less scene defaults to sandbox and will either load the wrong asset or no asset if not found there.