### PR TITLE
Fix loading files with multiple dots

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -814,8 +814,12 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
   int k = str.substr(0, j).rfind(L'.');
 
   bool hasValidFrameNum = false;
-  if (!isFfmpegType() && checkForSeqNum(type) && isNumbers(str, k, j))
-    hasValidFrameNum = true;
+  if (!isFfmpegType() && checkForSeqNum(type)) {
+    if (isNumbers(str, k, j))
+      hasValidFrameNum = true;
+    else
+      k = (int)std::wstring::npos;
+  }
   std::string frameString;
   if (frame.isNoFrame())
     frameString = "";


### PR DESCRIPTION
This PR fixes loading files with multiple dots in the name (i.e "abc def.ghi jkl.png") but are not sequenced files.
