### PR TITLE
Disable menu icons

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -309,7 +309,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 40;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -309,7 +309,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 40;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -309,7 +309,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 40;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #a0c1dd;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -309,7 +309,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 40;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Medium/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Medium/less/layouts/mainwindow.less
@@ -139,7 +139,7 @@ QMenu {
   padding: 2 0;
   &::item {
     border: 0;
-    padding: 3 28 3 40;
+    padding: 3 28;
     &:selected {
       background-color: @menu-item-bg-color-selected;
       color: @menu-item-text-color-selected;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -309,7 +309,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 40;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #8FA0B2;

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -436,7 +436,7 @@ int main(int argc, char *argv[]) {
   // qDebug() << "All icon theme search paths:" << QIcon::themeSearchPaths();
 
   // Set show icons in menus flag (use iconVisibleInMenu to disable selectively)
-  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, false);
+  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
 
   TEnv::setApplicationFileName(argv[0]);
 


### PR DESCRIPTION
Decided to disable menu icons for the following reasons

1. Menu icons have been hidden since the beginning. Users are probably used to it. I don't think anyone misses them.
2. Menus look cleaner without them in my opinion
3. Menus are easier to read since it is not as busy with every item having an icon
4. Won't have to deal with icon alignment issues.
