### PR TITLE
Fix missing tooloption bar icons

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -436,7 +436,7 @@ int main(int argc, char *argv[]) {
   // qDebug() << "All icon theme search paths:" << QIcon::themeSearchPaths();
 
   // Set show icons in menus flag (use iconVisibleInMenu to disable selectively)
-  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
+  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, false);
 
   TEnv::setApplicationFileName(argv[0]);
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1550,6 +1550,7 @@ QAction *MainWindow::createAction(const char *id, const char *name,
     // do nothing for other platforms
   } else
     action->setIcon(createQIcon(iconSVGName));
+  action->setIconVisibleInMenu(false);
   addAction(action);
 #ifdef MACOSX
   // To prevent the wrong menu items (due to MacOS menu naming conventions),


### PR DESCRIPTION
This PR fixes #652 an issue reported in 1.2 Alpha where the cap/join icons are missing.

Restored the original method that hid menu icons since the way I chose disabled icons in dropdowns that only showed icons and no text.