### PR TITLE
Fix pen not drawing after quick pan

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -917,6 +917,7 @@ void SceneViewer::onRelease(const TMouseEvent &event) {
     GLInvalidateAll();
     invalidateToolStatus();
 
+    m_buttonClicked = false;
     doQuit();
     return;
   }


### PR DESCRIPTION
This PR fixes an issue reported in the 1.2 alpha where the pen would sometimes stop drawing after quick panning. 

This could have occurred after quick zoom and quick rotations as well.

When releasing from quick panning, the internal state of the button pressed wasn't being cleared. Sometimes it would clear on it's own but if moving too quickly, it would impact the next stroke or 2 until it clears properly.