### PR TITLE
Fix LNP generating tails

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -989,8 +989,7 @@ void SceneViewer::onRelease(const TMouseEvent &event) {
   tool->setViewer(this);
 
   {
-    TPointD pos = tool->getMatrix().inv() *
-                  winToWorld(event.mousePos() * getDevPixRatio());
+    TPointD pos = tool->getMatrix().inv() * winToWorld(m_lastMousePos);
 
     TObjectHandle *objHandle = TApp::instance()->getCurrentObject();
     if (tool->getToolType() & TTool::LevelTool && !objHandle->isSpline()) {


### PR DESCRIPTION
This PR fixes an issue with LNP that occurs when you lift the pen causing the stroke to generate a tail between the desired end stroke position and the position of the pen.

When the pen is lifted, the releases event tells the tool to complete operation using the position of the pen on the canvas instead of where the last drawn position was resulting in the stroke catching up to the pen position.

Changed to complete tool operation using the last known drawn position.

Regression testing: I have tested this without using LNP on Windows and Linux (via VM) and did not encounter any particular issues. 

I am unable to test this change on macOS VM.  My VM doesn't quite recognize my tablet correctly and treats all events as Mouse events. Would be appreciated if someone could test this on macOS using a pen.
