### PR TITLE
Fix checking for version update

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1437,7 +1437,7 @@ extern const char *applicationVersion;
 void MainWindow::checkForUpdates() {
   // Since there is only a single version of Tahoma, we can do a simple check
   // against a string
-  QString updateUrl("https://tahoma2d.org/files/tahoma-version.txt");
+  QString updateUrl("http://tahoma2d.org/files/tahoma-version.txt");
 
   m_updateChecker = new UpdateChecker(updateUrl);
   connect(m_updateChecker, SIGNAL(done(bool)), this,


### PR DESCRIPTION
This fixes Tahoma's ability to check for newer versions.  

Not sure why, but didn't like connecting to tahoma2d.org using HTTPS and had to drop it to HTTP.

Sadly it won't notify people when version 1.2 becomes official, but should work going forward.