### PR TITLE
Fix converting timeout from sec to msec

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -16,7 +16,7 @@ Ffmpeg::Ffmpeg() {
   m_ffmpegPath    = Preferences::instance()->getFfmpegPath();
   m_ffmpegTimeout = Preferences::instance()->getFfmpegTimeout();
   if (m_ffmpegTimeout > 0)
-    m_ffmpegTimeout * 1000;
+    m_ffmpegTimeout *= 1000;
   else
     m_ffmpegTimeout    = -1;
   std::string strPath  = m_ffmpegPath.toStdString();

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -836,7 +836,7 @@ void LipSyncPopup::onApplyButton() {
     runRhubarb();
     int rhubarbTimeout = Preferences::instance()->getRhubarbTimeout();
     if (rhubarbTimeout > 0)
-      rhubarbTimeout * 1000;
+      rhubarbTimeout *= 1000;
     else
       rhubarbTimeout = -1;
     m_rhubarb->waitForFinished(rhubarbTimeout);


### PR DESCRIPTION
This fixes an issue with converting ffmpeg and rhubarb timeout calculations from sec to msec.