### PR TITLE
Disable version update check

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -756,8 +756,8 @@ int main(int argc, char *argv[]) {
 
   a.setQuitOnLastWindowClosed(false);
   // a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
-  if (Preferences::instance()->isLatestVersionCheckEnabled())
-    w.checkForUpdates();
+//  if (Preferences::instance()->isLatestVersionCheckEnabled())
+//    w.checkForUpdates();
   DvDirModel::instance()->forceRefresh();
 
   // Disable the layout temporarily to avoid redistribution of panes that is

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1437,7 +1437,7 @@ extern const char *applicationVersion;
 void MainWindow::checkForUpdates() {
   // Since there is only a single version of Tahoma, we can do a simple check
   // against a string
-  QString updateUrl("http://tahoma2d.org/files/tahoma-version.txt");
+  QString updateUrl("https://tahoma2d.org/files/tahoma-version.txt");
 
   m_updateChecker = new UpdateChecker(updateUrl);
   connect(m_updateChecker, SIGNAL(done(bool)), this,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1911,7 +1911,7 @@ QWidget* PreferencesPopup::createVersionControlPage() {
 
   insertUI(SVNEnabled, lay);
   insertUI(automaticSVNFolderRefreshEnabled, lay);
-  insertUI(latestVersionCheckEnabled, lay);
+//  insertUI(latestVersionCheckEnabled, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);


### PR DESCRIPTION
Sadly, I need to disable version update checking for the following reasons:

1. My current builds do not support establishing SSL connections which is why the HTTPS address to get the current version information wasn't working.  Changing it to HTTP came back with a redirect message and causes Tahoma to crash at startup.
2. The site that houses Tahoma's webpage and Github requires SSL connections so I cannot use either site for the purpose of maintaining a version file that I read only 1x at startup.
3. In order to support SSL, I need to find or compile SSL support into the QT version I am using for all 3 platforms which is something I am not doing at this time, and may not do.

With that, I have disabled the check and hidden the option to check in Preferences.  Not like it was working anyway.
