### PR TITLE
Fix saving memos on macOS

### DIFF
--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -32,7 +32,7 @@ string escape(string v) {
     i = v.find_first_of("\\\"", i);
 #endif
     if (i == (int)string::npos) break;
-    string h = "\\" + v[i];
+//    string h = "\\" + v[i];
     v.insert(i, "\\");
     i = i + 2;
   }


### PR DESCRIPTION
This PR fixes an issue (originally reported in OT) where saving memos blocks a scene from being saved on macOS.

I determined it was because of this statement when trying to escape special characters:

> strings h = "\\\\" + v[i];

For whatever reason it is trying to append a char to a string.  In Windows, the result is garbage but doesn't cause a problem with the logic.  In macOS, it fails to append and throws an exception blocking the save of the scene.

Though I could fix it to append the char to the string properly, `h` is not used for anything so the concatenation appears pointless.

Commented it out and the problem was resolved.
