### PR TITLE
Separate debug files from windows build

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -27,3 +27,7 @@ jobs:
         with:
           name: Tahoma2D-win.zip
           path: toonz\build\Tahoma2D-win.zip
+      - uses: actions/upload-artifact@v1
+        with:
+          name: debug-symbols.zip
+          path: toonz\build\debug-symbols.zip

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -10,6 +10,10 @@ echo ">>> Copy and configure Tahoma2D installation"
 
 copy /y RelWithDebInfo\*.* Tahoma2D
 
+REM Remove PDB and ILK files
+del Tahoma2D\*.pdb
+del Tahoma2D\*.ilk
+
 copy /Y ..\..\thirdparty\freeglut\bin\x64\freeglut.dll Tahoma2D
 copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll Tahoma2D
 copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll Tahoma2D
@@ -69,5 +73,22 @@ echo ">>> Creating Tahoma2D Windows package"
 
 IF EXIST Tahoma2D-win.zip del Tahoma2D-win.zip
 7z a Tahoma2D-win.zip Tahoma2D
+
+IF EXIST ..\..\..\tahoma2d_symbols (
+   echo ">>> Saving debugging symbols"
+   for /f "tokens=1-4 delims=/ " %%i in ("%date%") do (
+     set dow=%%i
+     set month=%%j
+     set day=%%k
+     set year=%%l
+   )
+   set DATEDIR="%year%-%month%-%day%"
+   mkdir ..\..\..\tahoma2d_symbols\%DATEDIR%
+   copy /y RelWithDebInfo\*.* ..\..\..\tahoma2d_symbols\%DATEDIR%
+) else (
+   echo ">>> Creating debugging symbols package"
+   IF EXIST debug-symbols.zip del debug-symbols.zip
+   7z a debug-symbols.zip RelWithDebInfo\*.*
+)
 
 cd ../..


### PR DESCRIPTION
This removes the PDB and ILK from windows build.  They are not needed on user's systems for crashrpt to work properly and will also reduce the size of the download.

The PDB files (and other release files) are saved separately at time of build because they are needed for reviewing crashrpt dmps.  In order to see where it crashed, you need to have the exact DLL/PDB files the EXE was created with.