### PR TITLE
Support MOV formats through ffmpeg

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -709,7 +709,7 @@ TFrameId TFilePath::getFrame() const {
 
 bool TFilePath::isFfmpegType() const {
   QString type = QString::fromStdString(getType()).toLower();
-  if (type == "gif" || type == "mp4" || type == "webm")
+  if (type == "gif" || type == "mp4" || type == "webm" || type == "mov")
     return true;
   else
     return false;

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HEADERS
     ffmpeg/tiio_gif.h
     ffmpeg/tiio_webm.h
     ffmpeg/tiio_mp4.h
+    ffmpeg/tiio_mov.h
     ffmpeg/tiio_ffmpeg.h
     sprite/tiio_sprite.h
     mesh/tiio_mesh.h
@@ -50,6 +51,7 @@ set(SOURCES
     ffmpeg/tiio_gif.cpp
     ffmpeg/tiio_webm.cpp
     ffmpeg/tiio_mp4.cpp
+    ffmpeg/tiio_mov.cpp
     ffmpeg/tiio_ffmpeg.cpp
     sprite/tiio_sprite.cpp
     mesh/tiio_mesh.cpp

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -474,6 +474,11 @@ void Ffmpeg::getFramesFromMovie(int frame) {
     // frameArgs << "-accurate_seek";
     // frameArgs << "-ss";
     // frameArgs << "0" + QString::number(frameIndex / m_info->m_frameRate);
+    if (m_path.getType() == "webm") {
+      // To load in webm transparency
+      preIFrameArgs << "-vcodec";
+      preIFrameArgs << "libvpx";
+    }
     preIFrameArgs << "-i";
     preIFrameArgs << m_path.getQString();
     postIFrameArgs << "-y";

--- a/toonz/sources/image/ffmpeg/tiio_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mov.cpp
@@ -85,7 +85,9 @@ TLevelWriterMov::~TLevelWriterMov() {
   preIArgs << QString::number(m_frameRate);
 
   postIArgs << "-pix_fmt";
-  postIArgs << "yuv420p";
+  postIArgs << "rgb24";
+  postIArgs << "-c:v";
+  postIArgs << "png";
   postIArgs << "-s";
   postIArgs << QString::number(outLx) + "x" + QString::number(outLy);
   postIArgs << "-b";

--- a/toonz/sources/image/ffmpeg/tiio_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mov.cpp
@@ -84,8 +84,8 @@ TLevelWriterMov::~TLevelWriterMov() {
   preIArgs << "-framerate";
   preIArgs << QString::number(m_frameRate);
 
-  postIArgs << "-pix_fmt";
-  postIArgs << "rgba";
+//  postIArgs << "-pix_fmt";
+//  postIArgs << "rgba";
   postIArgs << "-c:v";
   postIArgs << "png";
   postIArgs << "-s";

--- a/toonz/sources/image/ffmpeg/tiio_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mov.cpp
@@ -1,0 +1,239 @@
+
+#include "tsystem.h"
+#include "tiio_mov.h"
+#include "trasterimage.h"
+#include "timageinfo.h"
+#include "tsound.h"
+#include "toonz/stage.h"
+#include <QStringList>
+
+//===========================================================
+//
+//  TImageWriterMov
+//
+//===========================================================
+
+class TImageWriterMov : public TImageWriter {
+public:
+  int m_frameIndex;
+
+  TImageWriterMov(const TFilePath &path, int frameIndex, TLevelWriterMov *lwg)
+      : TImageWriter(path), m_frameIndex(frameIndex), m_lwg(lwg) {
+    m_lwg->addRef();
+  }
+  ~TImageWriterMov() { m_lwg->release(); }
+
+  bool is64bitOutputSupported() override { return false; }
+  void save(const TImageP &img) override { m_lwg->save(img, m_frameIndex); }
+
+private:
+  TLevelWriterMov *m_lwg;
+};
+
+//===========================================================
+//
+//  TLevelWriterMov;
+//
+//===========================================================
+
+TLevelWriterMov::TLevelWriterMov(const TFilePath &path, TPropertyGroup *winfo)
+    : TLevelWriter(path, winfo) {
+  if (!m_properties) m_properties = new Tiio::MovWriterProperties();
+  if (m_properties->getPropertyCount() == 0) {
+    m_scale      = 100;
+    m_vidQuality = 100;
+  } else {
+    std::string scale = m_properties->getProperty("Scale")->getValueAsString();
+    m_scale           = QString::fromStdString(scale).toInt();
+    std::string quality =
+        m_properties->getProperty("Quality")->getValueAsString();
+    m_vidQuality = QString::fromStdString(quality).toInt();
+  }
+  ffmpegWriter = new Ffmpeg();
+  ffmpegWriter->setPath(m_path);
+  if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
+}
+
+//-----------------------------------------------------------
+
+TLevelWriterMov::~TLevelWriterMov() {
+  // QProcess createMov;
+  QStringList preIArgs;
+  QStringList postIArgs;
+
+  int outLx = m_lx;
+  int outLy = m_ly;
+
+  // set scaling
+  if (m_scale != 0) {
+    outLx = m_lx * m_scale / 100;
+    outLy = m_ly * m_scale / 100;
+  }
+  // ffmpeg doesn't like resolutions that aren't divisible by 2.
+  if (outLx % 2 != 0) outLx++;
+  if (outLy % 2 != 0) outLy++;
+
+  // calculate quality (bitrate)
+  int pixelCount   = m_lx * m_ly;
+  int bitRate      = pixelCount / 150;  // crude but gets decent values
+  double quality   = m_vidQuality / 100.0;
+  double tempRate  = (double)bitRate * quality;
+  int finalBitrate = (int)tempRate;
+  int crf          = 51 - (m_vidQuality * 51 / 100);
+
+  preIArgs << "-framerate";
+  preIArgs << QString::number(m_frameRate);
+
+  postIArgs << "-pix_fmt";
+  postIArgs << "yuv420p";
+  postIArgs << "-s";
+  postIArgs << QString::number(outLx) + "x" + QString::number(outLy);
+  postIArgs << "-b";
+  postIArgs << QString::number(finalBitrate) + "k";
+
+  ffmpegWriter->runFfmpeg(preIArgs, postIArgs, false, false, true);
+  ffmpegWriter->cleanUpFiles();
+}
+
+//-----------------------------------------------------------
+
+TImageWriterP TLevelWriterMov::getFrameWriter(TFrameId fid) {
+  // if (IOError != 0)
+  //	throw TImageException(m_path, buildMovExceptionString(IOError));
+  if (fid.getLetter() != 0) return TImageWriterP(0);
+  int index            = fid.getNumber();
+  TImageWriterMov *iwg = new TImageWriterMov(m_path, index, this);
+  return TImageWriterP(iwg);
+}
+
+//-----------------------------------------------------------
+void TLevelWriterMov::setFrameRate(double fps) {
+  m_frameRate = fps;
+  ffmpegWriter->setFrameRate(fps);
+}
+
+void TLevelWriterMov::saveSoundTrack(TSoundTrack *st) {
+  ffmpegWriter->saveSoundTrack(st);
+}
+
+//-----------------------------------------------------------
+
+void TLevelWriterMov::save(const TImageP &img, int frameIndex) {
+  TRasterImageP image(img);
+  m_lx = image->getRaster()->getLx();
+  m_ly = image->getRaster()->getLy();
+  ffmpegWriter->createIntermediateImage(img, frameIndex);
+}
+
+//===========================================================
+//
+//  TImageReaderMov
+//
+//===========================================================
+
+class TImageReaderMov final : public TImageReader {
+public:
+  int m_frameIndex;
+
+  TImageReaderMov(const TFilePath &path, int index, TLevelReaderMov *lra,
+                  TImageInfo *info)
+      : TImageReader(path), m_lra(lra), m_frameIndex(index), m_info(info) {
+    m_lra->addRef();
+  }
+  ~TImageReaderMov() { m_lra->release(); }
+
+  TImageP load() override { return m_lra->load(m_frameIndex); }
+  TDimension getSize() const { return m_lra->getSize(); }
+  TRect getBBox() const { return TRect(); }
+  const TImageInfo *getImageInfo() const override { return m_info; }
+
+private:
+  TLevelReaderMov *m_lra;
+  TImageInfo *m_info;
+
+  // not implemented
+  TImageReaderMov(const TImageReaderMov &);
+  TImageReaderMov &operator=(const TImageReaderMov &src);
+};
+
+//===========================================================
+//
+//  TLevelReaderMov
+//
+//===========================================================
+
+TLevelReaderMov::TLevelReaderMov(const TFilePath &path) : TLevelReader(path) {
+  ffmpegReader = new Ffmpeg();
+  ffmpegReader->setPath(m_path);
+  ffmpegReader->disablePrecompute();
+  ffmpegFileInfo tempInfo = ffmpegReader->getInfo();
+  double fps              = tempInfo.m_frameRate;
+  m_frameCount            = tempInfo.m_frameCount;
+  m_size                  = TDimension(tempInfo.m_lx, tempInfo.m_ly);
+  m_lx                    = m_size.lx;
+  m_ly                    = m_size.ly;
+
+  // set values
+  m_info                   = new TImageInfo();
+  m_info->m_frameRate      = fps;
+  m_info->m_lx             = m_lx;
+  m_info->m_ly             = m_ly;
+  m_info->m_bitsPerSample  = 8;
+  m_info->m_samplePerPixel = 4;
+  m_info->m_dpix           = Stage::standardDpi;
+  m_info->m_dpiy           = Stage::standardDpi;
+}
+//-----------------------------------------------------------
+
+TLevelReaderMov::~TLevelReaderMov() {
+  // ffmpegReader->cleanUpFiles();
+}
+
+//-----------------------------------------------------------
+
+TLevelP TLevelReaderMov::loadInfo() {
+  if (m_frameCount == -1) return TLevelP();
+  TLevelP level;
+  for (int i = 1; i <= m_frameCount; i++) level->setFrame(i, TImageP());
+  return level;
+}
+
+//-----------------------------------------------------------
+
+TImageReaderP TLevelReaderMov::getFrameReader(TFrameId fid) {
+  // if (IOError != 0)
+  //	throw TImageException(m_path, buildAVIExceptionString(IOError));
+  if (fid.getLetter() != 0) return TImageReaderP(0);
+  int index = fid.getNumber();
+
+  TImageReaderMov *irm = new TImageReaderMov(m_path, index, this, m_info);
+  return TImageReaderP(irm);
+}
+
+//------------------------------------------------------------------------------
+
+TDimension TLevelReaderMov::getSize() { return m_size; }
+
+//------------------------------------------------
+
+TImageP TLevelReaderMov::load(int frameIndex) {
+  if (!ffmpegFramesCreated) {
+    ffmpegReader->getFramesFromMovie();
+    ffmpegFramesCreated = true;
+  }
+  return ffmpegReader->getImage(frameIndex);
+}
+
+Tiio::MovWriterProperties::MovWriterProperties()
+    : m_vidQuality("Quality", 1, 100, 90), m_scale("Scale", 1, 100, 100) {
+  bind(m_vidQuality);
+  bind(m_scale);
+}
+
+void Tiio::MovWriterProperties::updateTranslation() {
+  m_vidQuality.setQStringName(tr("Quality"));
+  m_scale.setQStringName(tr("Scale"));
+}
+
+// Tiio::Reader* Tiio::makeMovReader(){ return nullptr; }
+// Tiio::Writer* Tiio::makeMovWriter(){ return nullptr; }

--- a/toonz/sources/image/ffmpeg/tiio_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mov.cpp
@@ -85,7 +85,7 @@ TLevelWriterMov::~TLevelWriterMov() {
   preIArgs << QString::number(m_frameRate);
 
   postIArgs << "-pix_fmt";
-  postIArgs << "rgb24";
+  postIArgs << "rgba";
   postIArgs << "-c:v";
   postIArgs << "png";
   postIArgs << "-s";

--- a/toonz/sources/image/ffmpeg/tiio_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mov.cpp
@@ -84,10 +84,12 @@ TLevelWriterMov::~TLevelWriterMov() {
   preIArgs << "-framerate";
   preIArgs << QString::number(m_frameRate);
 
-//  postIArgs << "-pix_fmt";
-//  postIArgs << "rgba";
+  postIArgs << "-pix_fmt";
+  postIArgs << "yuva444p10le";
   postIArgs << "-c:v";
-  postIArgs << "png";
+  postIArgs << "prores_ks";
+  postIArgs << "-profile";
+  postIArgs << "4444";
   postIArgs << "-s";
   postIArgs << QString::number(outLx) + "x" + QString::number(outLy);
   postIArgs << "-b";

--- a/toonz/sources/image/ffmpeg/tiio_mov.h
+++ b/toonz/sources/image/ffmpeg/tiio_mov.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#ifndef TTIO_MOV_INCLUDED
+#define TTIO_MOV_INCLUDED
+
+#include "tproperty.h"
+#include "tlevel_io.h"
+#include "tiio_ffmpeg.h"
+
+#include <QCoreApplication>
+
+//===========================================================
+//
+//  TLevelWriterMov
+//
+//===========================================================
+
+class TLevelWriterMov : public TLevelWriter {
+public:
+  TLevelWriterMov(const TFilePath &path, TPropertyGroup *winfo);
+  ~TLevelWriterMov();
+  void setFrameRate(double fps) override;
+
+  TImageWriterP getFrameWriter(TFrameId fid) override;
+  void save(const TImageP &image, int frameIndex);
+
+  void saveSoundTrack(TSoundTrack *st) override;
+
+  static TLevelWriter *create(const TFilePath &path, TPropertyGroup *winfo) {
+    return new TLevelWriterMov(path, winfo);
+  }
+
+private:
+  Ffmpeg *ffmpegWriter;
+  int m_lx, m_ly;
+  int m_scale;
+  int m_vidQuality;
+  // void *m_buffer;
+};
+
+//===========================================================
+//
+//  TLevelReaderMov
+//
+//===========================================================
+
+class TLevelReaderMov final : public TLevelReader {
+public:
+  TLevelReaderMov(const TFilePath &path);
+  ~TLevelReaderMov();
+  TImageReaderP getFrameReader(TFrameId fid) override;
+
+  static TLevelReader *create(const TFilePath &f) {
+    return new TLevelReaderMov(f);
+  }
+
+  TLevelP loadInfo() override;
+  TImageP load(int frameIndex);
+  TDimension getSize();
+  // TThread::Mutex m_mutex;
+  // void *m_decompressedBuffer;
+private:
+  Ffmpeg *ffmpegReader;
+  bool ffmpegFramesCreated = false;
+  TDimension m_size;
+  int m_frameCount, m_lx, m_ly;
+};
+
+//===========================================================================
+
+namespace Tiio {
+
+//===========================================================================
+
+class MovWriterProperties : public TPropertyGroup {
+  Q_DECLARE_TR_FUNCTIONS(MovWriterProperties)
+public:
+  // TEnumProperty m_pixelSize;
+  // TBoolProperty m_matte;
+  TIntProperty m_vidQuality;
+  TIntProperty m_scale;
+  MovWriterProperties();
+  void updateTranslation() override;
+};
+
+//===========================================================================
+
+// Tiio::Reader *makeMovReader();
+// Tiio::Writer *makeMovWriter();
+
+}  // namespace
+
+#endif

--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -163,7 +163,7 @@ void initImageIo(bool lightVersion) {
       Tiio::defineWriterProperties("mp4", new Tiio::Mp4WriterProperties());
     }
     if (Ffmpeg::checkFormat("mov")) {
-      TLevelWriter::define("mov", TLevelWriterMp4::create, true);
+      TLevelWriter::define("mov", TLevelWriterMov::create, true);
       if (ffprobe) TLevelReader::define("mov", TLevelReaderMov::create);
       TFileType::declare("mov", TFileType::RASTER_LEVEL);
       Tiio::defineWriterProperties("mov", new Tiio::MovWriterProperties());

--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -53,6 +53,7 @@
 #include "./ffmpeg/tiio_gif.h"
 #include "./ffmpeg/tiio_webm.h"
 #include "./ffmpeg/tiio_mp4.h"
+#include "./ffmpeg/tiio_mov.h"
 #include "./mesh/tiio_mesh.h"
 #include "./sprite/tiio_sprite.h"
 
@@ -160,6 +161,12 @@ void initImageIo(bool lightVersion) {
       if (ffprobe) TLevelReader::define("mp4", TLevelReaderMp4::create);
       TFileType::declare("mp4", TFileType::RASTER_LEVEL);
       Tiio::defineWriterProperties("mp4", new Tiio::Mp4WriterProperties());
+    }
+    if (Ffmpeg::checkFormat("mov")) {
+      TLevelWriter::define("mov", TLevelWriterMp4::create, true);
+      if (ffprobe) TLevelReader::define("mov", TLevelReaderMov::create);
+      TFileType::declare("mov", TFileType::RASTER_LEVEL);
+      Tiio::defineWriterProperties("mov", new Tiio::MovWriterProperties());
     }
   }
 #endif

--- a/toonz/sources/include/tlevel_io.h
+++ b/toonz/sources/include/tlevel_io.h
@@ -227,7 +227,7 @@ public:
 
 inline bool isMovieType(std::string type) {
   return (type == "avi" || type == "webm" ||
-          type == "mp4");
+          type == "mp4" || type == "mov");
 }
 
 //-----------------------------------------------------------

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1071,6 +1071,7 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
           sl->getPath().getType() == "gif" ||
           sl->getPath().getType() == "mp4" ||
           sl->getPath().getType() == "webm" ||
+          sl->getPath().getType() == "mov" ||
           sl->is16BitChannelLevel() ||  // Inherited by previous
                                         // implementation.
                                         // Could be fixed?

--- a/toonz/sources/toonz/batches.cpp
+++ b/toonz/sources/toonz/batches.cpp
@@ -288,7 +288,7 @@ void BatchesController::setTasksTree(TaskTreeModel *tree) {
 
 //------------------------------------------------------------------------------
 
-inline bool isMovieType(std::string type) { return (type == "avi"); }
+inline bool isMovieType(std::string type) { return (type == "avi" || type == "mp4" || type == "webm" || type == "mov"); }
 
 //------------------------------------------------------------------------------
 

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -477,7 +477,8 @@ bool pasteStrokesInCellWithoutUndo(
     sl = cell.getSimpleLevel();
     if (sl->getType() == OVL_XSHLEVEL &&
         (sl->getPath().getType() == "psd" || sl->getPath().getType() == "gif" ||
-         sl->getPath().getType() == "mp4" || sl->getPath().getType() == "webm"))
+         sl->getPath().getType() == "mp4" || sl->getPath().getType() == "webm" ||
+         sl->getPath().getType() == "mov"))
       return false;
     fid = cell.getFrameId();
     if (!vi) {
@@ -1691,7 +1692,8 @@ static void pasteRasterImageInCell(int row, int col,
       if (sl->getType() == OVL_XSHLEVEL && (sl->getPath().getType() == "psd" ||
                                             sl->getPath().getType() == "gif" ||
                                             sl->getPath().getType() == "mp4" ||
-                                            sl->getPath().getType() == "webm"))
+                                            sl->getPath().getType() == "webm" ||
+                                            sl->getPath().getType() == "mov"))
         return;
       oldPalette = sl->getPalette();
     }

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1534,7 +1534,8 @@ void CloneLevelUndo::cloneLevels() const {
       if (srcSl->getPath().getType() == "psd" ||
           srcSl->getPath().getType() == "gif" ||
           srcSl->getPath().getType() == "mp4" ||
-          srcSl->getPath().getType() == "webm")
+          srcSl->getPath().getType() == "webm" ||
+          srcSl->getPath().getType() == "mov")
         continue;
 
       const TFilePath &srcPath = srcSl->getPath();

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -252,6 +252,7 @@ static bool canMergeColumns(int column, int mColumn, bool forMatchlines) {
            level->getPath().getType() == "gif" ||
            level->getPath().getType() == "mp4" ||
            level->getPath().getType() == "webm" ||
+           level->getPath().getType() == "mov" ||
            level->is16BitChannelLevel() ||            // 16bpc images.
            level->getProperties()->getBpp() == 1)) {  // Black & White images.
         return false;

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -171,7 +171,7 @@ bool RenderController::addScene(MovieGenerator &g, ToonzScene *scene) {
   }
   if (r1 < r0) return false;
   TPixel color = scene->getProperties()->getBgColor();
-  if (m_movieExt == "mp4" || m_movieExt == "webm") color.m = 255;
+  if (m_movieExt == "mp4" || m_movieExt == "webm" || m_movieExt == "mov") color.m = 255;
   g.setBackgroundColor(color);
   g.addScene(*scene, r0, r1);
   return true;

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -171,7 +171,7 @@ bool RenderController::addScene(MovieGenerator &g, ToonzScene *scene) {
   }
   if (r1 < r0) return false;
   TPixel color = scene->getProperties()->getBgColor();
-  if (m_movieExt == "mp4" || m_movieExt == "webm" || m_movieExt == "mov") color.m = 255;
+  if (isMovieType(m_movieExt) && m_movieExt != "mov" && m_movieExt != "webm") color.m = 255;
   g.setBackgroundColor(color);
   g.addScene(*scene, r0, r1);
   return true;

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -146,7 +146,7 @@ QMutex levelFileMutex;
 
 inline bool isMultipleFrameType(std::string type) {
   return (type == "tlv" || type == "tzl" || type == "pli" || type == "avi" ||
-          type == "gif" || type == "mp4" || type == "webm");
+          type == "gif" || type == "mp4" || type == "webm" || type == "mov");
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1293,7 +1293,8 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   if (sl &&
       (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL ||
        (sl->getType() == OVL_XSHLEVEL && sl->getPath().getType() != "gif" &&
-        sl->getPath().getType() != "mp4" && sl->getPath().getType() != "webm")))
+        sl->getPath().getType() != "mp4" && sl->getPath().getType() != "webm" &&
+        sl->getPath().getType() != "mov")))
     menu->addAction(cm->getAction(MI_RevertToLastSaved));
   menu->addSeparator();
   createSelectLevelMenu(menu);

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -59,7 +59,7 @@ void TFilmstripSelection::enableCommands() {
       (type == PLI_XSHLEVEL || type == TZP_XSHLEVEL || type == MESH_XSHLEVEL ||
        (type == OVL_XSHLEVEL && path.getType() != "psd" &&
         path.getType() != "gif" && path.getType() != "mp4" &&
-        path.getType() != "webm"));
+        path.getType() != "webm" && path.getType() != "mov"));
 
   TRasterImageP ri = (TRasterImageP)sl->getSimpleLevel()->getFrame(
       sl->getSimpleLevel()->getFirstFid(), false);

--- a/toonz/sources/toonz/matchlinecommand.cpp
+++ b/toonz/sources/toonz/matchlinecommand.cpp
@@ -339,7 +339,8 @@ void doCloneLevelNoSave(const TCellSelection::Range &range,
           cell.getSimpleLevel()->getPath().getType() == "psd" ||
           cell.getSimpleLevel()->getPath().getType() == "gif" ||
           cell.getSimpleLevel()->getPath().getType() == "mp4" ||
-          cell.getSimpleLevel()->getPath().getType() == "webm")
+          cell.getSimpleLevel()->getPath().getType() == "webm" ||
+          cell.getSimpleLevel()->getPath().getType() == "mov")
         continue;
 
       std::map<TXshSimpleLevel *, TXshLevelP>::iterator it =

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -1220,7 +1220,7 @@ void OutputSettingsPopup::onNameChanged() {
 void OutputSettingsPopup::onFormatChanged(const QString &str) {
   auto isMultiRenderInvalid = [](std::string ext) -> bool {
     return ext == "mp4" || ext == "gif" || ext == "webm" ||
-           ext == "spritesheet";
+           ext == "spritesheet" || ext == "mov";
   };
 
   TOutputProperties *prop    = getProperties();

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -439,7 +439,7 @@ void RenderCommand::rasterRender(bool isPreview) {
   // depth). I tried to make OT to detect the mov settings and adaptively switch
   // the behavior, but ended in vain :-(
   // So I just omitted every mov from applying solid background as a quick fix.
-  if (isMovieType(ext)) {
+  if (isMovieType(ext) && ext != "mov" && ext != "webm") {
     scene->getProperties()->setBgColor(currBgColor);
   }
   // for non alpha-enabled images (like jpg), background color will be inserted

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -89,7 +89,8 @@ public:
       if (!isPreview && (Preferences::instance()->isDefaultViewerEnabled()) &&
           (m_fp.getType() == "avi" ||
            m_fp.getType() == "mp4" ||
-           m_fp.getType() == "gif" || m_fp.getType() == "webm")) {
+           m_fp.getType() == "gif" || m_fp.getType() == "webm" ||
+           m_fp.getType() == "mov")) {
         QString name = QString::fromStdString(m_fp.getName());
         int index;
         if ((index = name.indexOf("#RENDERID")) != -1)  //! quite ugly I
@@ -132,7 +133,8 @@ public:
             app->getCurrentXsheet()->getXsheet()->makeSound(prop);
         // keeps ffmpeg files from being previewed until import is fixed
         if (m_fp.getType() != "mp4" && m_fp.getType() != "webm" &&
-            m_fp.getType() != "gif" && m_fp.getType() != "spritesheet") {
+            m_fp.getType() != "gif" && m_fp.getType() != "spritesheet" &&
+            m_fp.getType() != "mov") {
           if (outputSettings.getRenderSettings().m_stereoscopic) {
             assert(!isPreview);
             ::viewFile(m_fp.withName(m_fp.getName() + "_l"), r0 + 1, r1 + 1,

--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -37,7 +37,7 @@ using namespace DVGui;
 namespace {
 bool isMovieType(std::string type) {
   return (type == "avi" || type == "mp4" ||
-          type == "webm");
+          type == "webm" || type == "mov");
 }
 };  // namespace
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -119,7 +119,8 @@ bool isAreadOnlyLevel(const TFilePath &path) {
       (path.getDots() == ".." &&
        (path.getType() == "tlv" || path.getType() == "tpl"))) {
     if (path.getType() == "psd" || path.getType() == "gif" ||
-        path.getType() == "mp4" || path.getType() == "webm")
+        path.getType() == "mp4" || path.getType() == "webm" ||
+        path.getType() == "mov")
       return true;
     if (!TSystem::doesExistFileOrLevel(path)) return false;
     TFileStatus fs(path);
@@ -2466,7 +2467,7 @@ bool TXshSimpleLevel::isFrameReadOnly(TFrameId fid) {
     TFilePath fullPath   = getScene()->decodeFilePath(m_path);
     std::string fileType = fullPath.getType();
     if (fileType == "psd" || fileType == "gif" || fileType == "mp4" ||
-        fileType == "webm")
+        fileType == "webm" || fileType == "mov")
       return true;
     TFilePath path =
         fullPath.getDots() == ".." ? fullPath.withFrame(fid) : fullPath;


### PR DESCRIPTION
This PR provides support for importing and rendering MOV formats using ffmpeg.

As a test I imported an 1920x1080 30fps 900 frame MOV file and rendering it back out at 24fps. Quality wise, from a quick review, it looked the same or extremely close, but perhaps someone with a better eye for it can see differences and determine if it's ok or not.

I made it so MOV will render with a transparent background.

For rendering MOV, it currently uses the same ffmpeg command line settings as MP4, which isn't much (-pix_fmt yuv420p).  If someone feels this isn't good enough and can give me better ffmpeg parameters for rendering from PNG to MOV, let me know.

Even though 1.2 is in BETA mode, as MOV is still a popular format, I'm willing to include this in 1.2 if the output is good enough or can be improved by May 1st.
