### PR TITLE
Fix loading plugins on Linux

### DIFF
--- a/toonz/sources/toonzqt/pluginhost.cpp
+++ b/toonz/sources/toonzqt/pluginhost.cpp
@@ -1365,8 +1365,13 @@ void Loader::doLoad(const QString &file) {
   HMODULE handle = LoadLibraryA(file.toLocal8Bit().data());
   printf("doLoad handle:%p path:%s\n", handle, file.toLocal8Bit().data());
 #else
+#if defined(LINUX)
+  void *handle = dlopen(file.toUtf8().data(), RTLD_NOW | RTLD_LOCAL);
+#else
   void *handle = dlopen(file.toUtf8().data(), RTLD_LOCAL);
+#endif
   printf("doLoad handle:%p path:%s\n", handle, file.toUtf8().data());
+  if(!handle) printf("dlerror()=%s\n", dlerror());
 #endif
   PluginInformation *pi = new PluginInformation;
   if (handle) {


### PR DESCRIPTION
This PR fixes loading Dwango and WolfInABowl plugins on Linux systems.

Currently, even if you manage to build the plugins on a Linux system (in progress!), it will no load because the code is not passing the appropriate parameters to `dlopen()`  on linux environments.  Corrected the parameters and was able to load the plugins.
