### PR TITLE
Fix nightly build commit info

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -91,6 +91,7 @@ jobs:
           artifacts: toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz
           artifactContentType: "raw"
           body: ${{ github.event.head_commit.message }}
+          commit: ${{ github.sha }}
           name: ${{ env.NIGHTLYDATETIME }}
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -85,6 +85,7 @@ jobs:
           artifacts: toonz/build/Tahoma2D-osx.dmg
           artifactContentType: "raw"
           body: ${{ github.event.head_commit.message }}
+          commit: ${{ github.sha }}
           name: ${{ env.NIGHTLYDATETIME }}
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -68,6 +68,7 @@ jobs:
           artifacts: toonz\build\Tahoma2D-win.zip,toonz\build\debug-symbols.zip
           artifactContentType: "raw"
           body: ${{ github.event.head_commit.message }}
+          commit: ${{ github.sha }}
           name: ${{ env.NIGHTLYDATETIME }}
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true


### PR DESCRIPTION
This PR fixes the commit key on nightly builds.

Currently it uses the last commit key from the tahoma2d_nightlies.  This should use now set the commit key based on the commit that was merged from this repo

As this only impacts the nightly builds, I will merge as soon as the checks are complete with this PR to verify it works correctly.