### PR TITLE
Fix shortcut viewer crash on macOS

### DIFF
--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -87,7 +87,7 @@ ShortcutViewer::~ShortcutViewer() {}
 
 void ShortcutViewer::setAction(QAction *action) {
   m_action = action;
-  setKeySequence(m_action->shortcut());
+  setKeySequence(m_action ? m_action->shortcut() : 0);
   setFocus();
 }
 


### PR DESCRIPTION
This PR fixes #695 caused by a bug introduced with OT Patch #3930 (Fix Shortcut Input).
