### PR TITLE
Enhanced WAV support

### DIFF
--- a/toonz/sources/common/tsound/tsound.cpp
+++ b/toonz/sources/common/tsound/tsound.cpp
@@ -10,6 +10,8 @@
 #define TRK_S16 18
 #define TRK_M24 25
 #define TRK_S24 26
+#define TRK_M32 33
+#define TRK_S32 34
 
 //==============================================================================
 
@@ -111,6 +113,14 @@ TSoundTrackP TSoundTrack::create(TUINT32 sampleRate, int bitPerSample,
     st = new TSoundTrackStereo24(sampleRate, channelCount, sampleCount);
     break;
 
+  case TRK_M32:
+    st = new TSoundTrackMono32(sampleRate, channelCount, sampleCount);
+    break;
+
+  case TRK_S32:
+    st = new TSoundTrackStereo32(sampleRate, channelCount, sampleCount);
+    break;
+
   default:
     std::string s;
     s = "Type " + std::to_string(sampleRate) + " Hz " +
@@ -173,6 +183,16 @@ TSoundTrackP TSoundTrack::create(TUINT32 sampleRate, int bitPerSample,
   case TRK_S24:
     st = new TSoundTrackStereo24(sampleRate, channelCount, sampleCount,
                                  (TStereo24Sample *)buffer, 0);
+    break;
+
+  case TRK_M32:
+    st = new TSoundTrackMono32(sampleRate, channelCount, sampleCount,
+                               (TMono32Sample *)buffer, 0);
+    break;
+
+  case TRK_S32:
+    st = new TSoundTrackStereo32(sampleRate, channelCount, sampleCount,
+                                 (TStereo32Sample *)buffer, 0);
     break;
 
   default:

--- a/toonz/sources/common/tsound/tsound_nt.cpp
+++ b/toonz/sources/common/tsound/tsound_nt.cpp
@@ -490,7 +490,7 @@ TSoundOutputDeviceImp::~TSoundOutputDeviceImp() { delete m_whdrQueue; }
 
 bool TSoundOutputDeviceImp::doOpenDevice(const TSoundTrackFormat &format) {
   WAVEFORMATEX wf;
-  wf.wFormatTag      = WAVE_FORMAT_PCM;
+  wf.wFormatTag      = format.m_formatType;  // WAVE_FORMAT_PCM;
   wf.nChannels       = format.m_channelCount;
   wf.nSamplesPerSec  = format.m_sampleRate;
   wf.wBitsPerSample  = format.m_bitPerSample;
@@ -800,7 +800,8 @@ void TSoundOutputDevice::setLooping(bool loop) {
 
 TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(TUINT32 sampleRate,
                                                          int channelCount,
-                                                         int bitPerSample) {
+                                                         int bitPerSample,
+                                                         int formatType) {
   TSoundTrackFormat fmt;
 
   // avvvicinarsi al sample rate => dovrebbe esser OK avendo selezionato i piu'
@@ -840,6 +841,7 @@ TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(TUINT32 sampleRate,
   fmt.m_bitPerSample = bitPerSample;
   fmt.m_channelCount = channelCount;
   fmt.m_sampleRate   = sampleRate;
+  fmt.m_formatType   = formatType;
 
   return fmt;
 }
@@ -850,7 +852,7 @@ TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(
     const TSoundTrackFormat &format) {
   try {
     return getPreferredFormat(format.m_sampleRate, format.m_channelCount,
-                              format.m_bitPerSample);
+                              format.m_bitPerSample, format.m_formatType);
   } catch (TSoundDeviceException &e) {
     throw TSoundDeviceException(TSoundDeviceException::UnsupportedFormat,
                                 e.getMessage());
@@ -869,14 +871,14 @@ class WaveFormat final : public WAVEFORMATEX {
 public:
   WaveFormat(){};
   WaveFormat(unsigned char channelCount, TUINT32 sampleRate,
-             unsigned char bitPerSample);
+             unsigned char bitPerSample, WORD formatType);
 
   ~WaveFormat(){};
 };
 
 WaveFormat::WaveFormat(unsigned char channelCount, TUINT32 sampleRate,
-                       unsigned char bitPerSample) {
-  wFormatTag      = WAVE_FORMAT_PCM;
+                       unsigned char bitPerSample, WORD formatType) {
+  wFormatTag      = formatType;  // WAVE_FORMAT_PCM;
   nChannels       = channelCount;
   nSamplesPerSec  = sampleRate;
   wBitsPerSample  = bitPerSample;
@@ -1217,7 +1219,7 @@ throw TException("This format is not supported for recording");*/
 
   try {
     WaveFormat wf(m_imp->m_format.m_channelCount, m_imp->m_format.m_sampleRate,
-                  m_imp->m_format.m_bitPerSample);
+                  m_imp->m_format.m_bitPerSample, m_imp->m_format.m_formatType);
 
     m_imp->open(wf);
   } catch (TException &e) {
@@ -1289,7 +1291,7 @@ throw TException("This format is not supported for recording");*/
   m_imp->m_byteRecorded = 0;
   try {
     WaveFormat wf(m_imp->m_format.m_channelCount, m_imp->m_format.m_sampleRate,
-                  m_imp->m_format.m_bitPerSample);
+                  m_imp->m_format.m_bitPerSample, m_imp->m_format.m_formatType);
 
     m_imp->open(wf);
     m_imp->prepareHeader(
@@ -1700,7 +1702,8 @@ vicini
 */
 TSoundTrackFormat TSoundInputDevice::getPreferredFormat(TUINT32 sampleRate,
                                                         int channelCount,
-                                                        int bitPerSample) {
+                                                        int bitPerSample,
+                                                        int formatType) {
   TSoundTrackFormat fmt;
 
   // avvvicinarsi al sample rate => dovrebbe esser OK avendo selezionato i piu'
@@ -1740,6 +1743,7 @@ TSoundTrackFormat TSoundInputDevice::getPreferredFormat(TUINT32 sampleRate,
   fmt.m_bitPerSample = bitPerSample;
   fmt.m_channelCount = channelCount;
   fmt.m_sampleRate   = sampleRate;
+  fmt.m_formatType   = formatType;
 
   return fmt;
 }
@@ -1750,7 +1754,7 @@ TSoundTrackFormat TSoundInputDevice::getPreferredFormat(
     const TSoundTrackFormat &format) {
   try {
     return getPreferredFormat(format.m_sampleRate, format.m_channelCount,
-                              format.m_bitPerSample);
+                              format.m_bitPerSample, format.m_formatType);
   } catch (TSoundDeviceException &e) {
     throw TSoundDeviceException(TSoundDeviceException::UnsupportedFormat,
                                 e.getMessage());

--- a/toonz/sources/common/tsound/tsound_nt.cpp
+++ b/toonz/sources/common/tsound/tsound_nt.cpp
@@ -819,8 +819,12 @@ TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(TUINT32 sampleRate,
 
   if (bitPerSample <= 8)
     bitPerSample = 8;
-  else if ((bitPerSample > 8 && bitPerSample < 16) || bitPerSample >= 16)
+  else if (bitPerSample <= 16)
     bitPerSample = 16;
+  else if (bitPerSample <= 24)
+    bitPerSample = 24;
+  else
+    bitPerSample = 32;
 
   if (bitPerSample >= 16)
     fmt.m_signedSample = true;
@@ -1715,8 +1719,12 @@ TSoundTrackFormat TSoundInputDevice::getPreferredFormat(TUINT32 sampleRate,
 
   if (bitPerSample <= 8)
     bitPerSample = 8;
-  else if ((bitPerSample > 8 && bitPerSample < 16) || bitPerSample >= 16)
+  else if (bitPerSample <= 16)
     bitPerSample = 16;
+  else if (bitPerSample <= 24)
+    bitPerSample = 24;
+  else
+    bitPerSample = 32;
 
   if (bitPerSample >= 16)
     fmt.m_signedSample = true;

--- a/toonz/sources/common/tsound/tsound_qt.cpp
+++ b/toonz/sources/common/tsound/tsound_qt.cpp
@@ -313,8 +313,9 @@ void TSoundOutputDevice::setLooping(bool loop) { m_imp->setLooping(loop); }
 
 TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(TUINT32 sampleRate,
                                                          int channelCount,
-                                                         int bitPerSample) {
-  TSoundTrackFormat fmt(sampleRate, bitPerSample, channelCount, true);
+                                                         int bitPerSample,
+                                                         int formatType) {
+  TSoundTrackFormat fmt(sampleRate, bitPerSample, channelCount, true, formatType);
   return fmt;
 }
 
@@ -323,7 +324,7 @@ TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(TUINT32 sampleRate,
 TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(
     const TSoundTrackFormat &format) {
   return getPreferredFormat(format.m_sampleRate, format.m_channelCount,
-                            format.m_bitPerSample);
+                            format.m_bitPerSample, format.m_formatType);
 }
 
 //==============================================================================
@@ -435,7 +436,8 @@ bool TSoundInputDevice::supportsVolume() { return true; }
 
 TSoundTrackFormat TSoundInputDevice::getPreferredFormat(TUINT32 sampleRate,
                                                         int channelCount,
-                                                        int bitPerSample) {
+                                                        int bitPerSample,
+                                                        int formatType) {
   TSoundTrackFormat fmt;
   return fmt;
 }
@@ -448,7 +450,7 @@ TSoundTrackFormat TSoundInputDevice::getPreferredFormat(
 try {
 */
   return getPreferredFormat(format.m_sampleRate, format.m_channelCount,
-                            format.m_bitPerSample);
+                            format.m_bitPerSample, format.m_formatType);
   /*}
 
 catch (TSoundDeviceException &e) {

--- a/toonz/sources/include/tsound.h
+++ b/toonz/sources/include/tsound.h
@@ -53,13 +53,16 @@ public:
   int m_bitPerSample;    // numero di bit per campione
   int m_channelCount;    // numero di canali
   bool m_signedSample;
+  int m_formatType;
 
   TSoundTrackFormat(TUINT32 sampleRate = 0, int bitPerSample = 0,
-                    int channelCount = 0, bool signedSample = true)
+                    int channelCount = 0, bool signedSample = true,
+                    int formatType = WAVE_FORMAT_PCM)
       : m_sampleRate(sampleRate)
       , m_bitPerSample(bitPerSample)
       , m_channelCount(channelCount)
-      , m_signedSample(signedSample) {}
+      , m_signedSample(signedSample)
+      , m_formatType(formatType) {}
 
   ~TSoundTrackFormat() {}
 
@@ -84,6 +87,7 @@ protected:
   int m_bitPerSample;    // numero di bit per campione
   TINT32 m_sampleCount;  // numero di campioni
   int m_channelCount;    // numero di canali
+  int m_formatType;
 
   TSoundTrack *m_parent;  // nel caso di sotto-traccie
 
@@ -93,11 +97,12 @@ protected:
   TSoundTrack();
 
   TSoundTrack(TUINT32 sampleRate, int bitPerSample, int channelCount,
-              int sampleSize, TINT32 sampleCount, bool isSampleSigned);
+              int sampleSize, TINT32 sampleCount, bool isSampleSigned,
+              int formatType);
 
   TSoundTrack(TUINT32 sampleRate, int bitPerSample, int channelCount,
               int sampleSize, TINT32 sampleCount, UCHAR *buffer,
-              TSoundTrack *parent);
+              TSoundTrack *parent, int formatType);
 
 public:
   /*!
@@ -107,11 +112,13 @@ signedSample must be true for tracks whose samples are signed
 */
   static TSoundTrackP create(TUINT32 sampleRate, int bitPerSample,
                              int channelCount, TINT32 sampleCount,
-                             bool signedSample = true);
+                             bool signedSample = true,
+                             int formatType    = WAVE_FORMAT_PCM);
 
   static TSoundTrackP create(TUINT32 sampleRate, int bitPerSample,
                              int channelCount, TINT32 sampleCount, void *buffer,
-                             bool signedSample = true);
+                             bool signedSample = true,
+                             int formatType    = WAVE_FORMAT_PCM);
 
   /*!
 Create a new soundtrack according to the format and number of samples
@@ -136,6 +143,7 @@ specified as inputs
   int getChannelCount() const { return m_channelCount; }
   int getBitPerSample() const { return m_bitPerSample; }
   TINT32 getSampleCount() const { return m_sampleCount; }
+  int getFormatType() const { return m_formatType; }
 
   //! Returns the duration of the soundtrack in seconds.
   double getDuration() const;
@@ -297,7 +305,7 @@ Returns true if on the machine there is an audio card installed correctly
 
   //! Returns the best format supported near the given parameters
   TSoundTrackFormat getPreferredFormat(TUINT32 sampleRate, int channelCount,
-                                       int bitPerSample);
+                                       int bitPerSample, int formatType);
 
   //! Returns the best format supported near the given format
   TSoundTrackFormat getPreferredFormat(const TSoundTrackFormat &);
@@ -366,7 +374,7 @@ Returns true if on the machine there is an audio card installed correctly
 
   //! Returns the best format supported near the given parameters
   TSoundTrackFormat getPreferredFormat(TUINT32 sampleRate, int channelCount,
-                                       int bitPerSample);
+                                       int bitPerSample, int formatType);
 
   //! Returns the best format supported near the given format
   TSoundTrackFormat getPreferredFormat(const TSoundTrackFormat &);

--- a/toonz/sources/include/tsound.h
+++ b/toonz/sources/include/tsound.h
@@ -19,6 +19,10 @@
 #define DVVAR DV_IMPORT_VAR
 #endif
 
+#ifndef _WIN32
+#define WAVE_FORMAT_PCM 1
+#endif
+
 //=========================================================
 
 namespace TSound {

--- a/toonz/sources/include/tsound_t.h
+++ b/toonz/sources/include/tsound_t.h
@@ -351,6 +351,8 @@ template class DVAPI TSoundTrackT<TMono16Sample>;
 template class DVAPI TSoundTrackT<TStereo16Sample>;
 template class DVAPI TSoundTrackT<TMono24Sample>;
 template class DVAPI TSoundTrackT<TStereo24Sample>;
+template class DVAPI TSoundTrackT<TMono32Sample>;
+template class DVAPI TSoundTrackT<TStereo32Sample>;
 #endif
 
 typedef TSoundTrackT<TMono8SignedSample> TSoundTrackMono8Signed;
@@ -361,6 +363,8 @@ typedef TSoundTrackT<TMono16Sample> TSoundTrackMono16;
 typedef TSoundTrackT<TStereo16Sample> TSoundTrackStereo16;
 typedef TSoundTrackT<TMono24Sample> TSoundTrackMono24;
 typedef TSoundTrackT<TStereo24Sample> TSoundTrackStereo24;
+typedef TSoundTrackT<TMono32Sample> TSoundTrackMono32;
+typedef TSoundTrackT<TStereo32Sample> TSoundTrackStereo32;
 
 //==============================================================================
 
@@ -379,6 +383,8 @@ public:
   virtual TSoundTrackP compute(const TSoundTrackStereo16 &) { return 0; };
   virtual TSoundTrackP compute(const TSoundTrackMono24 &) { return 0; };
   virtual TSoundTrackP compute(const TSoundTrackStereo24 &) { return 0; };
+  virtual TSoundTrackP compute(const TSoundTrackMono32 &) { return 0; };
+  virtual TSoundTrackP compute(const TSoundTrackStereo32 &) { return 0; };
 };
 
 //==============================================================================

--- a/toonz/sources/include/tsound_t.h
+++ b/toonz/sources/include/tsound_t.h
@@ -24,17 +24,20 @@ public:
 
   //----------------------------------------------------------------------------
 
-  TSoundTrackT(TUINT32 sampleRate, int channelCount, TINT32 sampleCount)
+  TSoundTrackT(TUINT32 sampleRate, int channelCount, TINT32 sampleCount,
+               int formatType = WAVE_FORMAT_PCM)
       : TSoundTrack(sampleRate, T::getBitPerSample(), channelCount, sizeof(T),
-                    sampleCount, T::isSampleSigned()) {}
+                    sampleCount, T::isSampleSigned(), formatType) {}
 
   //----------------------------------------------------------------------------
 
   TSoundTrackT(TUINT32 sampleRate, int channelCount, TINT32 sampleCount,
-               T *buffer, TSoundTrackT<T> *parent)
+               T *buffer, TSoundTrackT<T> *parent,
+               int formatType = WAVE_FORMAT_PCM)
 
       : TSoundTrack(sampleRate, T::getBitPerSample(), channelCount, sizeof(T),
-                    sampleCount, reinterpret_cast<UCHAR *>(buffer), parent) {}
+                    sampleCount, reinterpret_cast<UCHAR *>(buffer), parent,
+                    formatType) {}
 
   //----------------------------------------------------------------------------
 
@@ -77,9 +80,10 @@ public:
     ss0 = tcrop<TINT32>(s0, (TINT32)0, getSampleCount() - 1);
     ss1 = tcrop<TINT32>(s1, (TINT32)0, getSampleCount() - 1);
 
-    return TSoundTrackP(new TSoundTrackT<T>(
-        getSampleRate(), getChannelCount(), ss1 - ss0 + 1,
-        (T *)(m_buffer + (long)(ss0 * getSampleSize())), this));
+    return TSoundTrackP(
+        new TSoundTrackT<T>(getSampleRate(), getChannelCount(), ss1 - ss0 + 1,
+                            (T *)(m_buffer + (long)(ss0 * getSampleSize())),
+                            this, getFormatType()));
   }
 
   //----------------------------------------------------------------------------
@@ -94,8 +98,8 @@ from which it's created.It hasn't reference to the object.
       return clone();
     else {
       typedef typename T::ChannelSampleType TCST;
-      TSoundTrackT<TCST> *dst =
-          new TSoundTrackT<TCST>(m_sampleRate, 1, getSampleCount());
+      TSoundTrackT<TCST> *dst = new TSoundTrackT<TCST>(
+          m_sampleRate, 1, getSampleCount(), getFormatType());
 
       const T *sample    = samples();
       const T *endSample = sample + getSampleCount();
@@ -353,6 +357,8 @@ template class DVAPI TSoundTrackT<TMono24Sample>;
 template class DVAPI TSoundTrackT<TStereo24Sample>;
 template class DVAPI TSoundTrackT<TMono32Sample>;
 template class DVAPI TSoundTrackT<TStereo32Sample>;
+template class DVAPI TSoundTrackT<TMono32floatSample>;
+template class DVAPI TSoundTrackT<TStereo32floatSample>;
 #endif
 
 typedef TSoundTrackT<TMono8SignedSample> TSoundTrackMono8Signed;
@@ -365,6 +371,8 @@ typedef TSoundTrackT<TMono24Sample> TSoundTrackMono24;
 typedef TSoundTrackT<TStereo24Sample> TSoundTrackStereo24;
 typedef TSoundTrackT<TMono32Sample> TSoundTrackMono32;
 typedef TSoundTrackT<TStereo32Sample> TSoundTrackStereo32;
+typedef TSoundTrackT<TMono32floatSample> TSoundTrackMono32float;
+typedef TSoundTrackT<TStereo32floatSample> TSoundTrackStereo32float;
 
 //==============================================================================
 
@@ -385,6 +393,8 @@ public:
   virtual TSoundTrackP compute(const TSoundTrackStereo24 &) { return 0; };
   virtual TSoundTrackP compute(const TSoundTrackMono32 &) { return 0; };
   virtual TSoundTrackP compute(const TSoundTrackStereo32 &) { return 0; };
+  virtual TSoundTrackP compute(const TSoundTrackMono32float &) { return 0; };
+  virtual TSoundTrackP compute(const TSoundTrackStereo32float &) { return 0; };
 };
 
 //==============================================================================

--- a/toonz/sources/include/tsoundsample.h
+++ b/toonz/sources/include/tsoundsample.h
@@ -26,6 +26,8 @@ class TMono24Sample;
 class TStereo24Sample;
 class TMono32Sample;
 class TStereo32Sample;
+class TMono32floatSample;
+class TStereo32floatSample;
 
 //==============================================================================
 
@@ -80,6 +82,8 @@ public:
   static inline TMono8SignedSample from(const TStereo24Sample &sample);
   static inline TMono8SignedSample from(const TMono32Sample &sample);
   static inline TMono8SignedSample from(const TStereo32Sample &sample);
+  static inline TMono8SignedSample from(const TMono32floatSample &sample);
+  static inline TMono8SignedSample from(const TStereo32floatSample &sample);
 };
 
 inline TMono8SignedSample operator+(const TMono8SignedSample &s1,
@@ -142,6 +146,8 @@ public:
   static inline TMono8UnsignedSample from(const TStereo24Sample &sample);
   static inline TMono8UnsignedSample from(const TMono32Sample &sample);
   static inline TMono8UnsignedSample from(const TStereo32Sample &sample);
+  static inline TMono8UnsignedSample from(const TMono32floatSample &sample);
+  static inline TMono8UnsignedSample from(const TStereo32floatSample &sample);
 };
 
 inline TMono8UnsignedSample operator+(const TMono8UnsignedSample &s1,
@@ -225,6 +231,8 @@ public:
   static inline TStereo8SignedSample from(const TStereo24Sample &sample);
   static inline TStereo8SignedSample from(const TMono32Sample &sample);
   static inline TStereo8SignedSample from(const TStereo32Sample &sample);
+  static inline TStereo8SignedSample from(const TMono32floatSample &sample);
+  static inline TStereo8SignedSample from(const TStereo32floatSample &sample);
 };
 
 inline TStereo8SignedSample operator+(const TStereo8SignedSample &s1,
@@ -313,6 +321,8 @@ public:
   static inline TStereo8UnsignedSample from(const TStereo24Sample &sample);
   static inline TStereo8UnsignedSample from(const TMono32Sample &sample);
   static inline TStereo8UnsignedSample from(const TStereo32Sample &sample);
+  static inline TStereo8UnsignedSample from(const TMono32floatSample &sample);
+  static inline TStereo8UnsignedSample from(const TStereo32floatSample &sample);
 };
 
 inline TStereo8UnsignedSample operator+(const TStereo8UnsignedSample &s1,
@@ -374,6 +384,8 @@ public:
   static inline TMono16Sample from(const TStereo24Sample &sample);
   static inline TMono16Sample from(const TMono32Sample &sample);
   static inline TMono16Sample from(const TStereo32Sample &sample);
+  static inline TMono16Sample from(const TMono32floatSample &sample);
+  static inline TMono16Sample from(const TStereo32floatSample &sample);
 };
 
 inline TMono16Sample operator+(const TMono16Sample &s1,
@@ -457,6 +469,8 @@ public:
   static inline TStereo16Sample from(const TStereo24Sample &sample);
   static inline TStereo16Sample from(const TMono32Sample &sample);
   static inline TStereo16Sample from(const TStereo32Sample &sample);
+  static inline TStereo16Sample from(const TMono32floatSample &sample);
+  static inline TStereo16Sample from(const TStereo32floatSample &sample);
 };
 
 inline TStereo16Sample operator+(const TStereo16Sample &s1,
@@ -521,6 +535,8 @@ public:
   static inline TMono24Sample from(const TStereo24Sample &sample);
   static inline TMono24Sample from(const TMono32Sample &sample);
   static inline TMono24Sample from(const TStereo32Sample &sample);
+  static inline TMono24Sample from(const TMono32floatSample &sample);
+  static inline TMono24Sample from(const TStereo32floatSample &sample);
 };
 
 inline TMono24Sample operator+(const TMono24Sample &s1,
@@ -601,6 +617,8 @@ public:
   static inline TStereo24Sample from(const TStereo24Sample &sample);
   static inline TStereo24Sample from(const TMono32Sample &sample);
   static inline TStereo24Sample from(const TStereo32Sample &sample);
+  static inline TStereo24Sample from(const TMono32floatSample &sample);
+  static inline TStereo24Sample from(const TStereo32floatSample &sample);
 };
 
 inline TStereo24Sample operator+(const TStereo24Sample &s1,
@@ -665,6 +683,8 @@ public:
   static inline TMono32Sample from(const TStereo24Sample &sample);
   static inline TMono32Sample from(const TMono32Sample &sample);
   static inline TMono32Sample from(const TStereo32Sample &sample);
+  static inline TMono32Sample from(const TMono32floatSample &sample);
+  static inline TMono32Sample from(const TStereo32floatSample &sample);
 };
 
 inline TMono32Sample operator+(const TMono32Sample &s1,
@@ -745,11 +765,160 @@ public:
   static inline TStereo32Sample from(const TStereo24Sample &sample);
   static inline TStereo32Sample from(const TMono32Sample &sample);
   static inline TStereo32Sample from(const TStereo32Sample &sample);
+  static inline TStereo32Sample from(const TMono32floatSample &sample);
+  static inline TStereo32Sample from(const TStereo32floatSample &sample);
 };
 
 inline TStereo32Sample operator+(const TStereo32Sample &s1,
                                  const TStereo32Sample &s2) {
   TStereo32Sample s = s1;
+  return s += s2;
+}
+
+//=========================================================
+
+class DVAPI TMono32floatSample {
+  float value;
+
+public:
+  typedef float ChannelValueType;
+  typedef TMono32floatSample ChannelSampleType;
+
+  TMono32floatSample(float v = 0.0) : value(tcrop<float>(v, -1.0, 1.0)) {}
+  ~TMono32floatSample(){};
+
+  static bool isSampleSigned() { return true; }
+  static int getBitPerSample() { return 32; }
+
+  inline float getValue(TSound::Channel) const { return value; }
+
+  inline void setValue(TSound::Channel /*chan*/, float v) {
+    value = tcrop<float>(v, -1.0, 1.0);
+  }
+
+  inline double getPressure(TSound::Channel chan) const {
+    return (getValue(chan));
+  }
+
+  inline TMono32floatSample &operator+=(const TMono32floatSample &s) {
+    float fVal = value + s.value;
+    value      = tcrop<float>(fVal, -1.0, 1.0);
+    return *this;
+  }
+
+  inline TMono32floatSample &operator*=(double a) {
+    float fVal = (value * a);
+    value      = tcrop<float>(fVal, -1.0, 1.0);
+    return *this;
+  }
+
+  inline TMono32floatSample operator*(double a) {
+    return TMono32floatSample(*this) *= a;
+  }
+
+  static TMono32floatSample mix(const TMono32floatSample &s1, double a1,
+                                const TMono32floatSample &s2, double a2) {
+    return TMono32floatSample(
+        tcrop<float>((s1.value * a1 + s2.value * a2), -1.0, 1.0));
+  }
+
+  static inline TMono32floatSample from(const TMono8UnsignedSample &sample);
+  static inline TMono32floatSample from(const TMono8SignedSample &sample);
+  static inline TMono32floatSample from(const TStereo8SignedSample &sample);
+  static inline TMono32floatSample from(const TStereo8UnsignedSample &sample);
+  static inline TMono32floatSample from(const TMono16Sample &sample);
+  static inline TMono32floatSample from(const TStereo16Sample &sample);
+  static inline TMono32floatSample from(const TMono24Sample &sample);
+  static inline TMono32floatSample from(const TStereo24Sample &sample);
+  static inline TMono32floatSample from(const TMono32Sample &sample);
+  static inline TMono32floatSample from(const TStereo32Sample &sample);
+  static inline TMono32floatSample from(const TMono32floatSample &sample);
+  static inline TMono32floatSample from(const TStereo32floatSample &sample);
+};
+
+inline TMono32floatSample operator+(const TMono32floatSample &s1,
+                                    const TMono32floatSample &s2) {
+  TMono32floatSample s = s1;
+  return s += s2;
+}
+
+//=========================================================
+
+class DVAPI TStereo32floatSample {
+  float channel[2];  // l'ordine dei canali e' left,right
+
+public:
+  typedef float ChannelValueType;
+  typedef TMono32floatSample ChannelSampleType;
+
+  TStereo32floatSample(float lchan = 0.0, float rchan = 0.0) {
+    channel[0] = tcrop<float>(lchan, -1.0, 1.0);
+    channel[1] = tcrop<float>(rchan, -1.0, 1.0);
+  }
+
+  ~TStereo32floatSample(){};
+
+  static bool isSampleSigned() { return true; }
+  static int getBitPerSample() { return 32; }
+
+  inline float getValue(TSound::Channel chan) const {
+    assert(chan <= 1);
+    return channel[chan];
+  }
+
+  inline void setValue(TSound::Channel chan, float v) {
+    assert(chan <= 1);
+    channel[chan] = tcrop<float>(v, -1.0, 1.0);
+  }
+
+  inline double getPressure(TSound::Channel chan) const {
+    return (getValue(chan));
+  }
+
+  inline TStereo32floatSample &operator+=(const TStereo32floatSample &s) {
+    float fLeftVal  = channel[0] + s.channel[0];
+    float fRightVal = channel[1] + s.channel[1];
+    channel[0]      = tcrop<float>(fLeftVal, -1.0, 1.0);
+    channel[1]      = tcrop<float>(fRightVal, -1.0, 1.0);
+    return *this;
+  }
+
+  inline TStereo32floatSample &operator*=(double a) {
+    float fLeftVal  = (a * channel[0]);
+    float fRightVal = (a * channel[1]);
+    channel[0]      = tcrop<float>(fLeftVal, -1.0, 1.0);
+    channel[1]      = tcrop<float>(fRightVal, -1.0, 1.0);
+    return *this;
+  }
+
+  inline TStereo32floatSample operator*(double a) {
+    return TStereo32floatSample(*this) *= a;
+  }
+
+  static TStereo32floatSample mix(const TStereo32floatSample &s1, double a1,
+                                  const TStereo32floatSample &s2, double a2) {
+    return TStereo32floatSample(
+        tcrop<float>((s1.channel[0] * a1 + s2.channel[0] * a2), -1.0, 1.0),
+        tcrop<float>((s1.channel[1] * a1 + s2.channel[1] * a2), -1.0, 1.0));
+  }
+
+  static inline TStereo32floatSample from(const TMono8UnsignedSample &sample);
+  static inline TStereo32floatSample from(const TMono8SignedSample &sample);
+  static inline TStereo32floatSample from(const TStereo8SignedSample &sample);
+  static inline TStereo32floatSample from(const TStereo8UnsignedSample &sample);
+  static inline TStereo32floatSample from(const TMono16Sample &sample);
+  static inline TStereo32floatSample from(const TStereo16Sample &sample);
+  static inline TStereo32floatSample from(const TMono24Sample &sample);
+  static inline TStereo32floatSample from(const TStereo24Sample &sample);
+  static inline TStereo32floatSample from(const TMono32Sample &sample);
+  static inline TStereo32floatSample from(const TStereo32Sample &sample);
+  static inline TStereo32floatSample from(const TMono32floatSample &sample);
+  static inline TStereo32floatSample from(const TStereo32floatSample &sample);
+};
+
+inline TStereo32floatSample operator+(const TStereo32floatSample &s1,
+                                      const TStereo32floatSample &s2) {
+  TStereo32floatSample s = s1;
   return s += s2;
 }
 
@@ -831,6 +1000,25 @@ inline TMono8SignedSample TMono8SignedSample::from(
     const TStereo32Sample &sample) {
   int val =
       (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 25;
+  return TMono8SignedSample(val);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono8SignedSample TMono8SignedSample::from(
+    const TMono32floatSample &sample) {
+  float val = (TINT32)(sample.getValue(TSound::LEFT) * 2147483648) >> 24;
+  return TMono8SignedSample(val);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono8SignedSample TMono8SignedSample::from(
+    const TStereo32floatSample &sample) {
+  float val = (TINT32)((sample.getValue(TSound::LEFT) +
+                        sample.getValue(TSound::RIGHT)) *
+                       2147483648) >>
+              25;
   return TMono8SignedSample(val);
 }
 
@@ -918,6 +1106,28 @@ inline TMono8UnsignedSample TMono8UnsignedSample::from(
       128);
 }
 
+//------------------------------------------------------------------------------
+
+inline TMono8UnsignedSample TMono8UnsignedSample::from(
+    const TMono32floatSample &sample) {
+  return TMono8UnsignedSample(
+      (unsigned char)((TINT32)(sample.getValue(TSound::MONO) * 2147483648) >>
+                      24) +
+      128);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono8UnsignedSample TMono8UnsignedSample::from(
+    const TStereo32floatSample &sample) {
+  return TMono8UnsignedSample(
+      (unsigned char)((TINT32)((sample.getValue(TSound::LEFT) +
+                                sample.getValue(TSound::RIGHT)) *
+                               2147483648) >>
+                      25) +
+      128);
+}
+
 //==============================================================================
 
 inline TStereo8SignedSample TStereo8SignedSample::from(
@@ -999,6 +1209,25 @@ inline TStereo8SignedSample TStereo8SignedSample::from(
     const TStereo32Sample &sample) {
   int srcval =
       (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 25;
+  return TStereo8SignedSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo8SignedSample TStereo8SignedSample::from(
+    const TMono32floatSample &sample) {
+  int srcval = (TINT32)(sample.getValue(TSound::LEFT) * 2147483648) >> 24;
+  return TStereo8SignedSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo8SignedSample TStereo8SignedSample::from(
+    const TStereo32floatSample &sample) {
+  int srcval = (TINT32)((sample.getValue(TSound::LEFT) +
+                         sample.getValue(TSound::RIGHT)) *
+                        2147483648) >>
+               25;
   return TStereo8SignedSample(srcval, srcval);
 }
 
@@ -1091,6 +1320,27 @@ inline TStereo8UnsignedSample TStereo8UnsignedSample::from(
   return TStereo8UnsignedSample(srcval, srcval);
 }
 
+//------------------------------------------------------------------------------
+
+inline TStereo8UnsignedSample TStereo8UnsignedSample::from(
+    const TMono32floatSample &sample) {
+  int srcval =
+      ((TINT32)(sample.getValue(TSound::LEFT) * 2147483648) >> 24) + 128;
+  return TStereo8UnsignedSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo8UnsignedSample TStereo8UnsignedSample::from(
+    const TStereo32floatSample &sample) {
+  int srcval = ((TINT32)((sample.getValue(TSound::LEFT) +
+                          sample.getValue(TSound::RIGHT)) *
+                         2147483648) >>
+                25) +
+               128;
+  return TStereo8UnsignedSample(srcval, srcval);
+}
+
 //==============================================================================
 
 inline TMono16Sample TMono16Sample::from(const TMono8UnsignedSample &sample) {
@@ -1158,6 +1408,23 @@ inline TMono16Sample TMono16Sample::from(const TMono32Sample &sample) {
 inline TMono16Sample TMono16Sample::from(const TStereo32Sample &sample) {
   int srcval =
       ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 17);
+  return TMono16Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono16Sample TMono16Sample::from(const TMono32floatSample &sample) {
+  int srcval = (TINT32)(sample.getValue(TSound::LEFT) * 2147483648) >> 16;
+  return TMono16Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono16Sample TMono16Sample::from(const TStereo32floatSample &sample) {
+  int srcval = (TINT32)((sample.getValue(TSound::LEFT) +
+                         sample.getValue(TSound::RIGHT)) *
+                        2147483648) >>
+               17;
   return TMono16Sample(srcval);
 }
 
@@ -1238,6 +1505,24 @@ inline TStereo16Sample TStereo16Sample::from(const TStereo32Sample &sample) {
   return TStereo16Sample(srcval, srcval);
 }
 
+//------------------------------------------------------------------------------
+
+inline TStereo16Sample TStereo16Sample::from(const TMono32floatSample &sample) {
+  int srcval = (TINT32)(sample.getValue(TSound::LEFT) * 2147483648) >> 16;
+  return TStereo16Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo16Sample TStereo16Sample::from(
+    const TStereo32floatSample &sample) {
+  int srcval = (TINT32)((sample.getValue(TSound::LEFT) +
+                         sample.getValue(TSound::RIGHT)) *
+                        2147483648) >>
+               17;
+  return TStereo16Sample(srcval, srcval);
+}
+
 //==============================================================================
 
 inline TMono24Sample TMono24Sample::from(const TMono8UnsignedSample &sample) {
@@ -1310,6 +1595,23 @@ inline TMono24Sample TMono24Sample::from(const TMono32Sample &sample) {
 inline TMono24Sample TMono24Sample::from(const TStereo32Sample &sample) {
   int srcval =
       ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 9);
+  return TMono24Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono24Sample TMono24Sample::from(const TMono32floatSample &sample) {
+  int srcval = (TINT32)(sample.getValue(TSound::LEFT) * 2147483648) >> 8;
+  return TMono24Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono24Sample TMono24Sample::from(const TStereo32floatSample &sample) {
+  int srcval = (TINT32)((sample.getValue(TSound::LEFT) +
+                         sample.getValue(TSound::RIGHT)) *
+                        2147483648) >>
+               9;
   return TMono24Sample(srcval);
 }
 
@@ -1390,6 +1692,24 @@ inline TStereo24Sample TStereo24Sample::from(const TStereo32Sample &sample) {
   return TStereo24Sample(srcval, srcval);
 }
 
+//------------------------------------------------------------------------------
+
+inline TStereo24Sample TStereo24Sample::from(const TMono32floatSample &sample) {
+  int srcval = (TINT32)(sample.getValue(TSound::LEFT) * 2147483648) >> 8;
+  return TStereo24Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo24Sample TStereo24Sample::from(
+    const TStereo32floatSample &sample) {
+  int srcval = (TINT32)((sample.getValue(TSound::LEFT) +
+                         sample.getValue(TSound::RIGHT)) *
+                        2147483648) >>
+               9;
+  return TStereo24Sample(srcval, srcval);
+}
+
 //==============================================================================
 
 inline TMono32Sample TMono32Sample::from(const TMono8UnsignedSample &sample) {
@@ -1446,7 +1766,8 @@ inline TMono32Sample TMono32Sample::from(const TMono24Sample &sample) {
 //------------------------------------------------------------------------------
 
 inline TMono32Sample TMono32Sample::from(const TStereo24Sample &sample) {
-  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 7;
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT))
+               << 7;
   return TMono32Sample(srcval);
 }
 
@@ -1461,6 +1782,20 @@ inline TMono32Sample TMono32Sample::from(const TMono32Sample &sample) {
 inline TMono32Sample TMono32Sample::from(const TStereo32Sample &sample) {
   return TMono32Sample(
       (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 1);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TMono32floatSample &sample) {
+  return TMono32Sample(sample.getValue(TSound::LEFT) * 2147483648);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TStereo32floatSample &sample) {
+  return TMono32Sample(
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) *
+      2147483648);
 }
 
 //==============================================================================
@@ -1522,7 +1857,8 @@ inline TStereo32Sample TStereo32Sample::from(const TMono24Sample &sample) {
 //------------------------------------------------------------------------------
 
 inline TStereo32Sample TStereo32Sample::from(const TStereo24Sample &sample) {
-  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 7;
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT))
+               << 7;
   return TStereo32Sample(srcval, srcval);
 }
 
@@ -1536,6 +1872,235 @@ inline TStereo32Sample TStereo32Sample::from(const TMono32Sample &sample) {
 //------------------------------------------------------------------------------
 
 inline TStereo32Sample TStereo32Sample::from(const TStereo32Sample &sample) {
+  return sample;
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TMono32floatSample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) * 2147483648;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(
+    const TStereo32floatSample &sample) {
+  int srcval =
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) *
+      2147483648;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//==============================================================================
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TMono8UnsignedSample &sample) {
+  float srcval = ((sample.getValue(TSound::LEFT) - 128) << 24) / 2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TMono8SignedSample &sample) {
+  float srcval = (sample.getValue(TSound::LEFT) << 24) / 2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TStereo8SignedSample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 23) /
+      2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TStereo8UnsignedSample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT) - 256)
+       << 23) /
+      2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TMono16Sample &sample) {
+  float srcval = (sample.getValue(TSound::LEFT) << 16) / 2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TStereo16Sample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 15) /
+      2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TMono24Sample &sample) {
+  float srcval = (sample.getValue(TSound::LEFT) << 8) / 2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TStereo24Sample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 7) /
+      2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TMono32Sample &sample) {
+  float srcval = sample.getValue(TSound::LEFT) / 2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TStereo32Sample &sample) {
+  float srcval =
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) /
+      2147483648;
+  return TMono32floatSample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TMono32floatSample &sample) {
+  return sample;
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32floatSample TMono32floatSample::from(
+    const TStereo32floatSample &sample) {
+  return TMono32floatSample(
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)));
+}
+
+//==============================================================================
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TMono8UnsignedSample &sample) {
+  float srcval = ((sample.getValue(TSound::LEFT) - 128) << 24) / 2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TMono8SignedSample &sample) {
+  float srcval = (sample.getValue(TSound::LEFT) << 24) / 2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TStereo8SignedSample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 23) /
+      2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TStereo8UnsignedSample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT) - 256)
+       << 23) /
+      2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TMono16Sample &sample) {
+  float srcval = (sample.getValue(TSound::LEFT) << 16) / 2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TStereo16Sample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 15) /
+      2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TMono24Sample &sample) {
+  float srcval = (sample.getValue(TSound::LEFT) << 8) / 2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TStereo24Sample &sample) {
+  float srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 7) /
+      2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TMono32Sample &sample) {
+  float srcval = sample.getValue(TSound::LEFT) / 2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TStereo32Sample &sample) {
+  float srcval =
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::LEFT)) /
+      2147483648;
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TMono32floatSample &sample) {
+  float srcval = sample.getValue(TSound::LEFT);
+  return TStereo32floatSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32floatSample TStereo32floatSample::from(
+    const TStereo32floatSample &sample) {
   return sample;
 }
 

--- a/toonz/sources/include/tsoundsample.h
+++ b/toonz/sources/include/tsoundsample.h
@@ -24,6 +24,8 @@ class TMono16Sample;
 class TStereo16Sample;
 class TMono24Sample;
 class TStereo24Sample;
+class TMono32Sample;
+class TStereo32Sample;
 
 //==============================================================================
 
@@ -76,6 +78,8 @@ public:
   static inline TMono8SignedSample from(const TStereo16Sample &sample);
   static inline TMono8SignedSample from(const TMono24Sample &sample);
   static inline TMono8SignedSample from(const TStereo24Sample &sample);
+  static inline TMono8SignedSample from(const TMono32Sample &sample);
+  static inline TMono8SignedSample from(const TStereo32Sample &sample);
 };
 
 inline TMono8SignedSample operator+(const TMono8SignedSample &s1,
@@ -136,6 +140,8 @@ public:
   static inline TMono8UnsignedSample from(const TStereo16Sample &sample);
   static inline TMono8UnsignedSample from(const TMono24Sample &sample);
   static inline TMono8UnsignedSample from(const TStereo24Sample &sample);
+  static inline TMono8UnsignedSample from(const TMono32Sample &sample);
+  static inline TMono8UnsignedSample from(const TStereo32Sample &sample);
 };
 
 inline TMono8UnsignedSample operator+(const TMono8UnsignedSample &s1,
@@ -217,6 +223,8 @@ public:
   static inline TStereo8SignedSample from(const TStereo16Sample &sample);
   static inline TStereo8SignedSample from(const TMono24Sample &sample);
   static inline TStereo8SignedSample from(const TStereo24Sample &sample);
+  static inline TStereo8SignedSample from(const TMono32Sample &sample);
+  static inline TStereo8SignedSample from(const TStereo32Sample &sample);
 };
 
 inline TStereo8SignedSample operator+(const TStereo8SignedSample &s1,
@@ -303,6 +311,8 @@ public:
   static inline TStereo8UnsignedSample from(const TStereo16Sample &sample);
   static inline TStereo8UnsignedSample from(const TMono24Sample &sample);
   static inline TStereo8UnsignedSample from(const TStereo24Sample &sample);
+  static inline TStereo8UnsignedSample from(const TMono32Sample &sample);
+  static inline TStereo8UnsignedSample from(const TStereo32Sample &sample);
 };
 
 inline TStereo8UnsignedSample operator+(const TStereo8UnsignedSample &s1,
@@ -362,6 +372,8 @@ public:
   static inline TMono16Sample from(const TStereo16Sample &sample);
   static inline TMono16Sample from(const TMono24Sample &sample);
   static inline TMono16Sample from(const TStereo24Sample &sample);
+  static inline TMono16Sample from(const TMono32Sample &sample);
+  static inline TMono16Sample from(const TStereo32Sample &sample);
 };
 
 inline TMono16Sample operator+(const TMono16Sample &s1,
@@ -443,6 +455,8 @@ public:
   static inline TStereo16Sample from(const TStereo16Sample &sample);
   static inline TStereo16Sample from(const TMono24Sample &sample);
   static inline TStereo16Sample from(const TStereo24Sample &sample);
+  static inline TStereo16Sample from(const TMono32Sample &sample);
+  static inline TStereo16Sample from(const TStereo32Sample &sample);
 };
 
 inline TStereo16Sample operator+(const TStereo16Sample &s1,
@@ -504,6 +518,8 @@ public:
   static inline TMono24Sample from(const TStereo16Sample &sample);
   static inline TMono24Sample from(const TMono24Sample &sample);
   static inline TMono24Sample from(const TStereo24Sample &sample);
+  static inline TMono24Sample from(const TMono32Sample &sample);
+  static inline TMono24Sample from(const TStereo32Sample &sample);
 };
 
 inline TMono24Sample operator+(const TMono24Sample &s1,
@@ -581,11 +597,157 @@ public:
   static inline TStereo24Sample from(const TStereo16Sample &sample);
   static inline TStereo24Sample from(const TMono24Sample &sample);
   static inline TStereo24Sample from(const TStereo24Sample &sample);
+  static inline TStereo24Sample from(const TMono32Sample &sample);
+  static inline TStereo24Sample from(const TStereo32Sample &sample);
 };
 
 inline TStereo24Sample operator+(const TStereo24Sample &s1,
                                  const TStereo24Sample &s2) {
   TStereo24Sample s = s1;
+  return s += s2;
+}
+
+//=========================================================
+
+class DVAPI TMono32Sample {
+  TINT32 value;
+
+public:
+  typedef TINT32 ChannelValueType;
+  typedef TMono32Sample ChannelSampleType;
+
+  TMono32Sample(TINT32 v = 0)
+      : value(tcrop<TINT32>(v, -2147483648, 2147483647)) {}
+  ~TMono32Sample(){};
+
+  static bool isSampleSigned() { return true; }
+  static int getBitPerSample() { return 32; }
+
+  inline TINT32 getValue(TSound::Channel) const { return value; }
+
+  inline void setValue(TSound::Channel /*chan*/, TINT32 v) {
+    value = tcrop<TINT32>(v, -2147483648, 2147483647);
+  }
+
+  inline double getPressure(TSound::Channel chan) const {
+    return (getValue(chan));
+  }
+
+  inline TMono32Sample &operator+=(const TMono32Sample &s) {
+    int iVal = value + s.value;
+    value    = tcrop<TINT32>(iVal, -2147483648, 2147483647);
+    return *this;
+  }
+
+  inline TMono32Sample &operator*=(double a) {
+    int iVal = (int)(value * a);
+    value    = tcrop<TINT32>(iVal, -2147483648, 2147483647);
+    return *this;
+  }
+
+  inline TMono32Sample operator*(double a) { return TMono32Sample(*this) *= a; }
+
+  static TMono32Sample mix(const TMono32Sample &s1, double a1,
+                           const TMono32Sample &s2, double a2) {
+    return TMono32Sample(tcrop<TINT32>((int)(s1.value * a1 + s2.value * a2),
+                                       -2147483648, 2147483647));
+  }
+
+  static inline TMono32Sample from(const TMono8UnsignedSample &sample);
+  static inline TMono32Sample from(const TMono8SignedSample &sample);
+  static inline TMono32Sample from(const TStereo8SignedSample &sample);
+  static inline TMono32Sample from(const TStereo8UnsignedSample &sample);
+  static inline TMono32Sample from(const TMono16Sample &sample);
+  static inline TMono32Sample from(const TStereo16Sample &sample);
+  static inline TMono32Sample from(const TMono24Sample &sample);
+  static inline TMono32Sample from(const TStereo24Sample &sample);
+  static inline TMono32Sample from(const TMono32Sample &sample);
+  static inline TMono32Sample from(const TStereo32Sample &sample);
+};
+
+inline TMono32Sample operator+(const TMono32Sample &s1,
+                               const TMono32Sample &s2) {
+  TMono32Sample s = s1;
+  return s += s2;
+}
+
+//=========================================================
+
+class DVAPI TStereo32Sample {
+  TINT32 channel[2];  // l'ordine dei canali e' left,right
+
+public:
+  typedef TINT32 ChannelValueType;
+  typedef TMono32Sample ChannelSampleType;
+
+  TStereo32Sample(TINT32 lchan = 0, TINT32 rchan = 0) {
+    channel[0] = tcrop<TINT32>(lchan, -2147483648, 2147483647);
+    channel[1] = tcrop<TINT32>(rchan, -2147483648, 2147483647);
+  }
+
+  ~TStereo32Sample(){};
+
+  static bool isSampleSigned() { return true; }
+  static int getBitPerSample() { return 32; }
+
+  inline TINT32 getValue(TSound::Channel chan) const {
+    assert(chan <= 1);
+    return channel[chan];
+  }
+
+  inline void setValue(TSound::Channel chan, TINT32 v) {
+    assert(chan <= 1);
+    channel[chan] = tcrop<TINT32>(v, -2147483648, 2147483647);
+  }
+
+  inline double getPressure(TSound::Channel chan) const {
+    return (getValue(chan));
+  }
+
+  inline TStereo32Sample &operator+=(const TStereo32Sample &s) {
+    int iLeftVal  = channel[0] + s.channel[0];
+    int iRightVal = channel[1] + s.channel[1];
+    channel[0]    = tcrop<TINT32>(iLeftVal, -2147483648, 2147483647);
+    channel[1]    = tcrop<TINT32>(iRightVal, -2147483648, 2147483647);
+    return *this;
+  }
+
+  inline TStereo32Sample &operator*=(double a) {
+    int iLeftVal  = (int)(a * channel[0]);
+    int iRightVal = (int)(a * channel[1]);
+    channel[0]    = tcrop<TINT32>(iLeftVal, -2147483648, 2147483647);
+    channel[1]    = tcrop<TINT32>(iRightVal, -2147483648, 2147483647);
+    return *this;
+  }
+
+  inline TStereo32Sample operator*(double a) {
+    return TStereo32Sample(*this) *= a;
+  }
+
+  static TStereo32Sample mix(const TStereo32Sample &s1, double a1,
+                             const TStereo32Sample &s2, double a2) {
+    return TStereo32Sample(
+        tcrop<TINT32>((int)(s1.channel[0] * a1 + s2.channel[0] * a2),
+                      -2147483648, 2147483647),
+        tcrop<TINT32>((int)(s1.channel[1] * a1 + s2.channel[1] * a2),
+                      -2147483648, 2147483647));
+  }
+
+  static inline TStereo32Sample from(const TMono8UnsignedSample &sample);
+  static inline TStereo32Sample from(const TMono8SignedSample &sample);
+  static inline TStereo32Sample from(const TStereo8SignedSample &sample);
+  static inline TStereo32Sample from(const TStereo8UnsignedSample &sample);
+  static inline TStereo32Sample from(const TMono16Sample &sample);
+  static inline TStereo32Sample from(const TStereo16Sample &sample);
+  static inline TStereo32Sample from(const TMono24Sample &sample);
+  static inline TStereo32Sample from(const TStereo24Sample &sample);
+  static inline TStereo32Sample from(const TMono32Sample &sample);
+  static inline TStereo32Sample from(const TStereo32Sample &sample);
+};
+
+inline TStereo32Sample operator+(const TStereo32Sample &s1,
+                                 const TStereo32Sample &s2) {
+  TStereo32Sample s = s1;
   return s += s2;
 }
 
@@ -650,6 +812,23 @@ inline TMono8SignedSample TMono8SignedSample::from(
     const TStereo24Sample &sample) {
   int val =
       (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 17;
+  return TMono8SignedSample(val);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono8SignedSample TMono8SignedSample::from(
+    const TMono32Sample &sample) {
+  int val = (sample.getValue(TSound::LEFT) >> 24);
+  return TMono8SignedSample(val);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono8SignedSample TMono8SignedSample::from(
+    const TStereo32Sample &sample) {
+  int val =
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 25;
   return TMono8SignedSample(val);
 }
 
@@ -718,6 +897,25 @@ inline TMono8UnsignedSample TMono8UnsignedSample::from(
       128);
 }
 
+//------------------------------------------------------------------------------
+
+inline TMono8UnsignedSample TMono8UnsignedSample::from(
+    const TMono32Sample &sample) {
+  return TMono8UnsignedSample(
+      (unsigned char)(sample.getValue(TSound::MONO) >> 24) + 128);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono8UnsignedSample TMono8UnsignedSample::from(
+    const TStereo32Sample &sample) {
+  return TMono8UnsignedSample(
+      (unsigned char)((sample.getValue(TSound::LEFT) +
+                       sample.getValue(TSound::RIGHT)) >>
+                      25) +
+      128);
+}
+
 //==============================================================================
 
 inline TStereo8SignedSample TStereo8SignedSample::from(
@@ -782,6 +980,23 @@ inline TStereo8SignedSample TStereo8SignedSample::from(
     const TStereo24Sample &sample) {
   int srcval =
       (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 17;
+  return TStereo8SignedSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo8SignedSample TStereo8SignedSample::from(
+    const TMono32Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) >> 24;
+  return TStereo8SignedSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo8SignedSample TStereo8SignedSample::from(
+    const TStereo32Sample &sample) {
+  int srcval =
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 25;
   return TStereo8SignedSample(srcval, srcval);
 }
 
@@ -856,6 +1071,24 @@ inline TStereo8UnsignedSample TStereo8UnsignedSample::from(
   return TStereo8UnsignedSample(srcval, srcval);
 }
 
+//------------------------------------------------------------------------------
+
+inline TStereo8UnsignedSample TStereo8UnsignedSample::from(
+    const TMono32Sample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) >> 24) + 128;
+  return TStereo8UnsignedSample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo8UnsignedSample TStereo8UnsignedSample::from(
+    const TStereo32Sample &sample) {
+  int srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 25) +
+      128;
+  return TStereo8UnsignedSample(srcval, srcval);
+}
+
 //==============================================================================
 
 inline TMono16Sample TMono16Sample::from(const TMono8UnsignedSample &sample) {
@@ -908,6 +1141,21 @@ inline TMono16Sample TMono16Sample::from(const TMono24Sample &sample) {
 inline TMono16Sample TMono16Sample::from(const TStereo24Sample &sample) {
   int srcval =
       ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 9);
+  return TMono16Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono16Sample TMono16Sample::from(const TMono32Sample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) >> 16);
+  return TMono16Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono16Sample TMono16Sample::from(const TStereo32Sample &sample) {
+  int srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 17);
   return TMono16Sample(srcval);
 }
 
@@ -973,6 +1221,21 @@ inline TStereo16Sample TStereo16Sample::from(const TStereo24Sample &sample) {
   return TStereo16Sample(srcval, srcval);
 }
 
+//------------------------------------------------------------------------------
+
+inline TStereo16Sample TStereo16Sample::from(const TMono32Sample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) >> 16);
+  return TStereo16Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo16Sample TStereo16Sample::from(const TStereo32Sample &sample) {
+  int srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 17);
+  return TStereo16Sample(srcval, srcval);
+}
+
 //==============================================================================
 
 inline TMono24Sample TMono24Sample::from(const TMono8UnsignedSample &sample) {
@@ -1030,6 +1293,21 @@ inline TMono24Sample TMono24Sample::from(const TMono24Sample &sample) {
 inline TMono24Sample TMono24Sample::from(const TStereo24Sample &sample) {
   int srcval =
       (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 1;
+  return TMono24Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono24Sample TMono24Sample::from(const TMono32Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) >> 8;
+  return TMono24Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono24Sample TMono24Sample::from(const TStereo32Sample &sample) {
+  int srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 9);
   return TMono24Sample(srcval);
 }
 
@@ -1092,6 +1370,170 @@ inline TStereo24Sample TStereo24Sample::from(const TMono24Sample &sample) {
 //------------------------------------------------------------------------------
 
 inline TStereo24Sample TStereo24Sample::from(const TStereo24Sample &sample) {
+  return sample;
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo24Sample TStereo24Sample::from(const TMono32Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) >> 8;
+  return TStereo24Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo24Sample TStereo24Sample::from(const TStereo32Sample &sample) {
+  int srcval =
+      ((sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 9);
+  return TStereo24Sample(srcval, srcval);
+}
+
+//==============================================================================
+
+inline TMono32Sample TMono32Sample::from(const TMono8UnsignedSample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) - 128) << 24;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TMono8SignedSample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) << 24;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TStereo8SignedSample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT))
+               << 23;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TStereo8UnsignedSample &sample) {
+  int srcval =
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT) - 256)
+      << 23;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TMono16Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) << 16;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TStereo16Sample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT))
+               << 15;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TMono24Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) << 8;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TStereo24Sample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 7;
+  return TMono32Sample(srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TMono32Sample &sample) {
+  return sample;
+}
+
+//------------------------------------------------------------------------------
+
+inline TMono32Sample TMono32Sample::from(const TStereo32Sample &sample) {
+  return TMono32Sample(
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) >> 1);
+}
+
+//==============================================================================
+
+inline TStereo32Sample TStereo32Sample::from(
+    const TMono8UnsignedSample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) - 128) << 24;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TMono8SignedSample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) << 24;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(
+    const TStereo8SignedSample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT))
+               << 23;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(
+    const TStereo8UnsignedSample &sample) {
+  int srcval =
+      (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT) - 256)
+      << 23;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TMono16Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) << 16;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TStereo16Sample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT))
+               << 15;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TMono24Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT) << 8;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TStereo24Sample &sample) {
+  int srcval = (sample.getValue(TSound::LEFT) + sample.getValue(TSound::RIGHT)) << 7;
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TMono32Sample &sample) {
+  int srcval = sample.getValue(TSound::LEFT);
+  return TStereo32Sample(srcval, srcval);
+}
+
+//------------------------------------------------------------------------------
+
+inline TStereo32Sample TStereo32Sample::from(const TStereo32Sample &sample) {
   return sample;
 }
 

--- a/toonz/sources/sound/wav/tsio_wav.cpp
+++ b/toonz/sources/sound/wav/tsio_wav.cpp
@@ -272,6 +272,7 @@ TSoundTrackP TSoundTrackReaderWav::load() {
         //#endif
         break;
       case 24:
+        // NOTE: This effectively changes from 24bit to 32bit bitPerSample
         if (!TNZ_LITTLE_ENDIAN) {
           UCHAR *begin = (UCHAR *)track->getRawData();
           for (int i = 0; i < (int)(sampleCount * fmtChunk->m_chans); ++i) {

--- a/toonz/sources/sound/wav/tsio_wav.cpp
+++ b/toonz/sources/sound/wav/tsio_wav.cpp
@@ -4,6 +4,7 @@
 #include "tsio_wav.h"
 #include "tsystem.h"
 #include "tfilepath_io.h"
+#include "tsop.h"
 
 using namespace std;
 
@@ -302,6 +303,15 @@ TSoundTrackP TSoundTrackReaderWav::load() {
                  sampleCount * fmtChunk->m_bytesPerSample);
         }
         break;
+      }
+
+      // Convert all WAV to 32bit PCM
+      if (fmtChunk->m_bitPerSample != 32 || fmtChunk->m_encodingType != WAVE_FORMAT_PCM) {
+        TSoundTrackP origTrack = track;
+        TSoundTrackFormat fmt = track->getFormat();
+        fmt.m_bitPerSample = 32;
+        fmt.m_formatType = WAVE_FORMAT_PCM;
+        track = TSop::convert(origTrack, fmt);
       }
     }
 

--- a/toonz/sources/sound/wav/tsio_wav.cpp
+++ b/toonz/sources/sound/wav/tsio_wav.cpp
@@ -290,6 +290,17 @@ TSoundTrackP TSoundTrackReaderWav::load() {
         }
         //#endif
         break;
+      case 32:
+        if (!TNZ_LITTLE_ENDIAN) {
+          swapAndCopySamples((short *)dataChunk->m_samples.get(),
+                             (short *)track->getRawData(),
+                             sampleCount * fmtChunk->m_chans);
+        } else {
+          memcpy((void *)track->getRawData(),
+                 (void *)(dataChunk->m_samples.get()),
+                 sampleCount * fmtChunk->m_bytesPerSample);
+        }
+        break;
       }
     }
 

--- a/toonz/sources/sound/wav/tsio_wav.cpp
+++ b/toonz/sources/sound/wav/tsio_wav.cpp
@@ -249,9 +249,9 @@ TSoundTrackP TSoundTrackReaderWav::load() {
     TINT32 sampleCount = dataChunk->m_length / fmtChunk->m_bytesPerSample;
     bool signedSample  = (fmtChunk->m_bitPerSample != 8);
 
-    track = TSoundTrack::create((int)fmtChunk->m_sampleRate,
-                                fmtChunk->m_bitPerSample, fmtChunk->m_chans,
-                                sampleCount, signedSample);
+    track = TSoundTrack::create(
+        (int)fmtChunk->m_sampleRate, fmtChunk->m_bitPerSample,
+        fmtChunk->m_chans, sampleCount, signedSample, fmtChunk->m_encodingType);
 
     if (track) {
       switch (fmtChunk->m_bitPerSample) {

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -1116,7 +1116,8 @@ TSoundTrackP TXshSoundColumn::mixingTogether(
 
   // Per ora perche mov vuole solo 16 bit
   TSoundTrackFormat fmt                            = mix->getFormat();
-  if (fmt.m_bitPerSample != 16) fmt.m_bitPerSample = 16;
+  if (fmt.m_bitPerSample != 32) fmt.m_bitPerSample = 32;
+  if (fmt.m_formatType != WAVE_FORMAT_PCM) fmt.m_formatType = WAVE_FORMAT_PCM;
   mix                                              = TSop::convert(mix, fmt);
   return mix;
 }

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -970,7 +970,7 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
   }
 
 #ifdef _WIN32
-  if (format.m_sampleRate > 44100) format.m_sampleRate = 44100;
+  if (format.m_sampleRate > 48000) format.m_sampleRate = 48000;
 #else
   QAudioDeviceInfo info(QAudioDeviceInfo::defaultOutputDevice());
   if (info.deviceName().length() == 0) throw TSoundDeviceException(TSoundDeviceException::NoDevice,

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -949,6 +949,7 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
         format.m_signedSample = f.m_signedSample;
         format.m_bitPerSample = f.m_bitPerSample;
         bitsPerSample         = f.m_bitPerSample;
+        format.m_formatType   = f.m_formatType;
       }
       if (f.m_channelCount > channels) {
         format.m_channelCount = f.m_channelCount;
@@ -958,6 +959,8 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
         format.m_bitPerSample = f.m_bitPerSample;
         bitsPerSample         = f.m_bitPerSample;
       }
+      if (format.m_formatType > f.m_formatType)
+        format.m_formatType = f.m_formatType;
     }
   }
 
@@ -967,6 +970,7 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
     format.m_bitPerSample = 16;
     format.m_channelCount = 1;
     format.m_signedSample = true;
+    format.m_formatType   = WAVE_FORMAT_PCM;
   }
 
 #ifdef _WIN32
@@ -1051,15 +1055,14 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
 
     if (s1 > 0 && s1 >= s0) {
       soundTrack = soundTrack->extract(s0, s1);
-
-      // Copy the sound track
-      overallSoundTrack->copy(
-          soundTrack,
-          int((levelStartFrame - fromFrame) *
-              samplePerFrame));  // The int cast is IMPORTANT, since
-    }                            // there are 2 overloads (int & double)
-  }                              // with DIFFERENT SCALES. We mean the
-                                 // SAMPLES-BASED one.
+      if (format.m_formatType == WAVE_FORMAT_PCM)
+        overallSoundTrack->copy(
+            soundTrack, int((levelStartFrame - fromFrame) * samplePerFrame));
+      else
+        overallSoundTrack->copy(
+            soundTrack, double((levelStartFrame - fromFrame) * samplePerFrame));
+    }
+  }
   return overallSoundTrack;
 }
 


### PR DESCRIPTION
This PR natively enhances WAV support as follows:

- Added support for 32bit fixed and float WAV formats
- Fixes playback quality when loading 24bit fixed WAV formats
- Internally converts 8bit, 16bit, 24bit and 32bit float WAV files to 32bit fixed format
- Processes sound files as 32bit fixed PCM format where applicable.

Caveats:
- I was only able to test on Windows and Linux.  My macOS VM won't recognize my audio.
- I loaded an MP3 for regression testing and didn't have any apparent issues.  I didn't verify with AIF/AIFF or RAW files.
- Sound clipping is still an issue if the audio is still too loud
- Not 100% sure of my fixed <-> float conversions for lower bit formats, but shouldn't be an issue since everything is converted to 32bit fixed. (I didn't have issues converting 32bit float to 16 bit fixed so I think it's ok)