### PR TITLE
Restore new version check

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -756,8 +756,8 @@ int main(int argc, char *argv[]) {
 
   a.setQuitOnLastWindowClosed(false);
   // a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
-//  if (Preferences::instance()->isLatestVersionCheckEnabled())
-//    w.checkForUpdates();
+  if (Preferences::instance()->isLatestVersionCheckEnabled())
+    w.checkForUpdates();
   DvDirModel::instance()->forceRefresh();
 
   // Disable the layout temporarily to avoid redistribution of panes that is


### PR DESCRIPTION
This PR indirectly addresses #702.

The original bug was in 1.1 but the link was since changed when I corrected all outdated links in a prior PR.  However I didn't think the update checker was working properly because it was throwing errors for me so I had disabled the new version check for 1.2.

Recently found out the check works for Linux, macOS and for some Windows users so reenabling it for 1.3