### PR TITLE
Paint Brush Tool enhancements

### DIFF
--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -490,6 +490,12 @@ void PaintBrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
         int styleIdUnderCursor              = getStyleUnderCursor(m_mousePos);
         if (styleIdUnderCursor > 0) styleId = styleIdUnderCursor;
         m_task                              = FINGER;
+      } else if (e.isShiftPressed()) {
+        int styleIdUnderCursor = getStyleUnderCursor(m_mousePos);
+        if (styleIdUnderCursor > 0) {
+          styleId = styleIdUnderCursor;
+          getApplication()->setCurrentLevelStyleIndex(styleId);
+        }
       }
 
       TTileSetCM32 *tileSet = new TTileSetCM32(ras->getSize());

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -327,7 +327,11 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                .arg(cmdTextSeparator)});
   lMap.insert({"T_Type", tr("Type Tool: Adds text")});
   lMap.insert({"T_PaintBrush",
-               tr("Smart Raster Painter: Paints areas in Smart Raster leves")});
+               tr("Smart Raster Painter: Paints areas in Smart Raster leves") +
+                   spacer +
+                   tr("%1%2Fix small fill gaps with click+dragged style")
+                       .arg(trModKey("Ctrl"))
+                       .arg(cmdTextSeparator)});
   lMap.insert(
       {"T_Fill", tr("Fill Tool: Fills drawing areas with the current style")});
   lMap.insert({"T_Eraser", tr("Eraser: Erases lines and areas")});

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -327,7 +327,7 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                .arg(cmdTextSeparator)});
   lMap.insert({"T_Type", tr("Type Tool: Adds text")});
   lMap.insert({"T_PaintBrush",
-               tr("Smart Raster Painter: Paints areas in Smart Raster leves") +
+               tr("Smart Raster Painter: Paints areas in Smart Raster levels") +
                    spacer +
                    tr("%1%2Fix small fill gaps with click+dragged style")
                        .arg(trModKey("Ctrl"))

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -331,6 +331,10 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                    spacer +
                    tr("%1%2Fix small fill gaps with click+dragged style")
                        .arg(trModKey("Ctrl"))
+                       .arg(cmdTextSeparator) +
+                   spacer +
+                   tr("%1%2Selects style on current drawing")
+                       .arg(trModKey("Shift"))
                        .arg(cmdTextSeparator)});
   lMap.insert(
       {"T_Fill", tr("Fill Tool: Fills drawing areas with the current style")});


### PR DESCRIPTION
This PR enhances the Paint Brush Tool as follows:

- Adds Pressure Sensitivity and min/max brush size (fixes #708)
![image](https://user-images.githubusercontent.com/19245851/120550831-5b232100-c3c3-11eb-9eb3-f82b5d9f646e.png)
  - When using a mouse or if Pressure Sensitivity is off, the max brush size is used.

- Replicates the behavior of the old `Finger Tool` by holding `CTRL`, click on style in the drawing and dragging
  - This will pick and use the style you clicked on regardless if the style was used for AREA or LINE.
  - If you click in an empty area, the current style is used.
  - If you release `CTRL` while still dragging, the stroke will be ended and a new normal stroke using the currently style will be started

- Switch style by using `SHIFT` + click a style on the drawing

- Updates Status bar information with the `CTRL` and `SHIFT` options
![image](https://user-images.githubusercontent.com/19245851/120551254-cf5dc480-c3c3-11eb-9b2f-cdd345b81dc3.png)
