### PR TITLE
Fix paintbrush modifier actions

### DIFF
--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -558,7 +558,8 @@ void PaintBrushTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
       // If we were using FINGER mode before, but stopped mid drag, end previous
       // stroke and switch
       if (m_task == FINGER && !e.isCtrlPressed()) {
-        finishBrush(thickness);
+        double pressure = m_pressure.getValue() && e.isTablet() ? e.m_pressure : 0.5;
+        finishBrush(pressure);
         leftButtonDown(pos, e);
       }
 
@@ -630,7 +631,7 @@ void PaintBrushTool::onActivate() { onEnter(); }
 
 void PaintBrushTool::onDeactivate() {
   /*--マウスドラッグ中(m_selecting=true)にツールが切り替わったときに描画の終了処理を行う---*/
-  if (m_selecting) finishBrush(1);
+  if (m_selecting) finishBrush(1.0);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -520,6 +520,8 @@ void PaintBrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
           styleId = styleIdUnderCursor;
           getApplication()->setCurrentLevelStyleIndex(styleId);
         }
+        m_selecting = false;
+        return;
       }
 
       TTileSetCM32 *tileSet = new TTileSetCM32(ras->getSize());


### PR DESCRIPTION
This PR does the following:

1. Fixes #711 where crash occurred when using `Finger Tool` mode and lifting CTRL while still dragging
  - I think this was caused by passing an incorrect value to the `finishBrush` procedure. I was passing line thickness instead of pressure and if the value was large enough, it could cause a crash.
 
2. Fixes issue reported in #709 where using the style selector mode would leave marks