### PR TITLE
Move savebox fill limit preference to tool option

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -570,7 +570,8 @@ protected slots:
 class EraserToolOptionsBox final : public ToolOptionsBox {
   Q_OBJECT
 
-  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode;
+  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode,
+      *m_eraseOnlySavebox;
   ToolOptionCombo *m_toolType, *m_colorMode;
   QLabel *m_hardnessLabel, *m_colorModeLabel;
   ToolOptionSlider *m_hardnessField;

--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -28,6 +28,7 @@ public:
   TPoint m_p;
   TPalette *m_palette;
   bool m_prevailing;
+  bool m_fillOnlySavebox;
 
   FillParameters()
       : m_styleId(0)
@@ -39,7 +40,8 @@ public:
       , m_p()
       , m_shiftFill(false)
       , m_palette(0)
-      , m_prevailing(true) {}
+      , m_prevailing(true)
+      , m_fillOnlySavebox(false) {}
   FillParameters(const FillParameters &params)
       : m_styleId(params.m_styleId)
       , m_fillType(params.m_fillType)
@@ -50,7 +52,8 @@ public:
       , m_p(params.m_p)
       , m_shiftFill(params.m_shiftFill)
       , m_palette(params.m_palette)
-      , m_prevailing(params.m_prevailing) {}
+      , m_prevailing(params.m_prevailing)
+      , m_fillOnlySavebox(params.m_fillOnlySavebox) {}
 };
 
 //=============================================================================

--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -124,7 +124,7 @@ else if \b fillInks is false fill only paint delimited by ink;
 else fill ink and paint in region contained in spline.
 */
   void strokeFill(TStroke *s, int color, bool onlyUnfilled, bool fillPaints,
-                  bool fillInks);
+                  bool fillInks, const TRect &saveRect);
 };
 
 class DVAPI FullColorAreaFiller {

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2464,8 +2464,8 @@ void FillTool::draw() {
     if (ti) {
       TRectD bbox =
           ToonzImageUtils::convertRasterToWorld(convert(ti->getBBox()), ti);
-      drawRect(bbox.enlarge(0.5) * ti->getSubsampling(), TPixel32::Black,
-               0x5555, true);
+      drawRect(bbox.enlarge(0.5) * ti->getSubsampling(),
+               TPixel32(210, 210, 210), 0xF0F0, true);
     }
   }
   if (m_fillType.getValue() != NORMALFILL) {

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -57,6 +57,7 @@ private:
   bool m_onion;
   bool m_isLeftButtonPressed;
   bool m_autopaintLines;
+  bool m_fillOnlySavebox;
 
 public:
   AreaFillTool(TTool *Parent);
@@ -72,7 +73,8 @@ public:
                     bool closeGaps, int closeStyleIndex);
   void onImageChanged();
   bool onPropertyChanged(bool multi, bool onlyUnfilled, bool onion, Type type,
-                         std::wstring colorType, bool autopaintLines);
+                         std::wstring colorType, bool autopaintLines,
+                         bool fillOnlySavebox);
   void onActivate();
   void onEnter();
 };

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -112,6 +112,7 @@ class FillTool final : public QObject, public TTool {
   // For the raster fill tool, autopaint lines is optional and can be temporary
   // disabled
   TBoolProperty m_autopaintLines;
+  TBoolProperty m_fillOnlySavebox;
 
 public:
   FillTool(int targetType);

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -832,8 +832,8 @@ void EraserTool::draw() {
     if (ti) {
       TRectD bbox =
           ToonzImageUtils::convertRasterToWorld(convert(ti->getBBox()), ti);
-      drawRect(bbox.enlarge(0.5) * ti->getSubsampling(), TPixel32::Black,
-               0x5555, true);
+      drawRect(bbox.enlarge(0.5) * ti->getSubsampling(),
+               TPixel32(210, 210, 210), 0xF0F0, true);
     }
   }
 

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -824,6 +824,16 @@ TPointD EraserTool::fixMousePos(TPointD pos, bool precise) {
 //------------------------------------------------------------------------
 
 void EraserTool::draw() {
+  if (m_eraseType.getValue() == SEGMENTERASE && m_eraseOnlySavebox.getValue()) {
+    TToonzImageP ti = (TToonzImageP)getImage(false);
+    if (ti) {
+      TRectD bbox =
+          ToonzImageUtils::convertRasterToWorld(convert(ti->getBBox()), ti);
+      drawRect(bbox.enlarge(0.5) * ti->getSubsampling(), TPixel32::Black,
+               0x5555, true);
+    }
+  }
+
   /*-- MouseLeave時に赤点が描かれるのを防ぐ --*/
   if (m_pointSize == -1 && m_cleanerSize == 0) return;
 

--- a/toonz/sources/tnztools/setsaveboxtool.cpp
+++ b/toonz/sources/tnztools/setsaveboxtool.cpp
@@ -221,9 +221,6 @@ void SetSaveboxTool::draw() {
   else
     bbox = m_modifiedRect;
 
-  drawRect(bbox * image->getSubsampling(), TPixel32::Black, 0x5555, true);
-  tglColor(TPixel32(90, 90, 90));
-
   double pixelSize = m_tool->getPixelSize();
   TPointD p00      = bbox.getP00();
   TPointD p11      = bbox.getP11();
@@ -233,13 +230,50 @@ void SetSaveboxTool::draw() {
   TPointD p11_10   = (bbox.getP11() + bbox.getP10()) * 0.5;
   TPointD p00_01   = (bbox.getP00() + bbox.getP01()) * 0.5;
   TPointD p00_10   = (bbox.getP00() + bbox.getP10()) * 0.5;
-  TPointD size(pixelSize * 4, pixelSize * 4);
-  tglDrawRect(TRectD(p00 - size, p00 + size));
-  tglDrawRect(TRectD(p11 - size, p11 + size));
-  tglDrawRect(TRectD(p01 - size, p01 + size));
-  tglDrawRect(TRectD(p10 - size, p10 + size));
-  tglDrawRect(TRectD(p11_01 - size, p11_01 + size));
-  tglDrawRect(TRectD(p11_10 - size, p11_10 + size));
-  tglDrawRect(TRectD(p00_01 - size, p00_01 + size));
-  tglDrawRect(TRectD(p00_10 - size, p00_10 + size));
+
+  TPixel32 frameColor(210, 210, 210);
+  TPixel32 frameColor2(0, 0, 0);
+
+  // Draw bounding box
+  drawRect(bbox, frameColor, 0xF0F0, true);
+
+  // Top left control box
+  TPointD tl(p01.x - pixelSize, p01.y + pixelSize);
+  drawSquare(tl, pixelSize * 4, frameColor);
+  drawSquare(p01, pixelSize * 4, frameColor2);
+
+  // Middle left control box
+  TPointD ml(p00_01.x - pixelSize, p00_01.y + pixelSize);
+  drawSquare(ml, pixelSize * 4, frameColor);
+  drawSquare(p00_01, pixelSize * 4, frameColor2);
+
+  // Bottom left control box
+  TPointD bl(p00.x - pixelSize, p00.y + pixelSize);
+  drawSquare(bl, pixelSize * 4, frameColor);
+  drawSquare(p00, pixelSize * 4, frameColor2);
+
+  // Top right control box
+  TPointD tr(p11.x - pixelSize, p11.y + pixelSize);
+  drawSquare(tr, pixelSize * 4, frameColor);
+  drawSquare(p11, pixelSize * 4, frameColor2);
+
+  // Middle right control box
+  TPointD mr(p11_10.x - pixelSize, p11_10.y + pixelSize);
+  drawSquare(mr, pixelSize * 4, frameColor);
+  drawSquare(p11_10, pixelSize * 4, frameColor2);
+
+  // Bottom right control box
+  TPointD br(p10.x - pixelSize, p10.y + pixelSize);
+  drawSquare(br, pixelSize * 4, frameColor);
+  drawSquare(p10, pixelSize * 4, frameColor2);
+
+  // Middle top control box
+  TPointD mt(p11_01.x - pixelSize, p11_01.y + pixelSize);
+  drawSquare(mt, pixelSize * 4, frameColor);
+  drawSquare(p11_01, pixelSize * 4, frameColor2);
+
+  // Middle bottom control box
+  TPointD mb(p00_10.x - pixelSize, p00_10.y + pixelSize);
+  drawSquare(mb, pixelSize * 4, frameColor);
+  drawSquare(p00_10, pixelSize * 4, frameColor2);
 }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2032,6 +2032,8 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Frame Range"));
   m_pencilMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Pencil Mode"));
+  m_eraseOnlySavebox =
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Savebox"));
 
   bool ret = true;
   if (m_pencilMode) {
@@ -2061,6 +2063,13 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
           m_colorModeLabel->setEnabled(false);
       }
       m_invertMode->setEnabled(false);
+  }
+
+  if (m_eraseOnlySavebox) {
+    if (m_toolType->getProperty()->getValue() == L"Segment")
+      m_eraseOnlySavebox->setEnabled(true);
+    else
+      m_eraseOnlySavebox->setEnabled(false);
   }
 
   if (m_colorMode && m_colorMode->getProperty()->getValue() == L"Areas") {
@@ -2100,6 +2109,7 @@ void EraserToolOptionsBox::onToolTypeChanged(int index) {
       m_colorModeLabel->setDisabled(isSegment);
   }
   m_invertMode->setEnabled(!isSegment && value);
+  if (m_eraseOnlySavebox) m_eraseOnlySavebox->setEnabled(isSegment);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1076,7 +1076,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
 
       // Tools
       // {dropdownShortcutsCycleOptions, tr("Dropdown Shortcuts:")}, // removed
-      {FillOnlysavebox, tr("Use the TLV Savebox to Limit Filling Operations")},
+      // {FillOnlysavebox, tr("Use the TLV Savebox to Limit Filling Operations")}, // Moved to tools that need it
       {multiLayerStylePickerEnabled,
        tr("Multi Layer Style Picker: Switch Levels by Picking")},
       {cursorBrushType, tr("Basic Cursor Type:")},
@@ -1707,7 +1707,7 @@ QWidget* PreferencesPopup::createToolsPage() {
 
   // insertUI(dropdownShortcutsCycleOptions, lay,
   //         getComboItemList(dropdownShortcutsCycleOptions));
-  insertUI(FillOnlysavebox, lay);
+  // insertUI(FillOnlysavebox, lay);
   insertUI(multiLayerStylePickerEnabled, lay);
   QGridLayout* cursorOptionsLay = insertGroupBox(tr("Cursor Options"), lay);
   {
@@ -1725,8 +1725,8 @@ QWidget* PreferencesPopup::createToolsPage() {
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);
 
-  m_onEditedFuncMap.insert(FillOnlysavebox,
-                           &PreferencesPopup::notifySceneChanged);
+  //  m_onEditedFuncMap.insert(FillOnlysavebox,
+  //                           &PreferencesPopup::notifySceneChanged);
   m_onEditedFuncMap.insert(levelBasedToolsDisplay,
                            &PreferencesPopup::onLevelBasedToolsDisplayChanged);
 


### PR DESCRIPTION
This PR removes the Preference `Use TLV Savebox to Limit Filling Operations` and adds a ![image](https://user-images.githubusercontent.com/19245851/128029899-322f8fcc-4093-4752-bfe5-87b00103efef.png) toolbar option to the following Smart Raster tools as well as fix a few issues encountered while testing the savebox option:

- Fill Tool
  - Adds `Savebox` to toolbar option for all Fill types
  - Corrects issue with how non-`Normal` fill modes was interacting (or not) with the savebox
  - Fixes `Normal` fill Redo action not correctly redoing the savebox fill
  - Improve savebox visibility

- Eraser Tool
  - Adds `Savebox` to toolbar option for `Segment` eraser mode only (was not configured for other modes)
  - Display savebox when enabled
  - Stop updating savebox if segment eraser did not erase anything
  - Fixes `Segment` erase Redo action not correctly redoing the savebox erase

- Additionally updated the Selection Tool to improve savebox visibility.


Future plans:  Add savebox to other Eraser tool modes, Paint Brush tool, Raster versions of Fill, Eraser and Paint Brush tools.