### PR TITLE
Changed default sound column volume to 100%.

### DIFF
--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -156,7 +156,7 @@ bool lessThan(const ColumnLevel *s1, const ColumnLevel *s2) {
 
 TXshSoundColumn::TXshSoundColumn()
     : m_player(0)
-    , m_volume(0.4)
+    , m_volume(1)
     , m_currentPlaySoundTrack(0)
     , m_isOldVersion(false) {
   m_timer.setInterval(500);


### PR DESCRIPTION
Change the default volume for new sound columns to 100% since this is usually where users want it.