### PR TITLE
Update scene sounds on save.

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1685,6 +1685,8 @@ bool IoCmd::saveAll() {
   result = result && resources.save(scene->getScenePath());
   resources.updatePaths();
 
+  TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
+
   // for update title bar
   app->getCurrentLevel()->notifyLevelTitleChange();
   app->getCurrentPalette()->notifyPaletteTitleChanged();

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1687,8 +1687,6 @@ bool IoCmd::saveAll() {
   result = result && resources.save(scene->getScenePath());
   resources.updatePaths();
 
-  
-
   // for update title bar
   app->getCurrentLevel()->notifyLevelTitleChange();
   app->getCurrentPalette()->notifyPaletteTitleChanged();

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1487,6 +1487,8 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
 
   app->getCurrentScene()->setDirtyFlag(false);
 
+  app->getCurrentXsheet()->notifyXsheetSoundChanged();
+
   History::instance()->addItem(scenePath);
   RecentFiles::instance()->addFilePath(
       toQString(scenePath), RecentFiles::Scene,
@@ -1685,7 +1687,7 @@ bool IoCmd::saveAll() {
   result = result && resources.save(scene->getScenePath());
   resources.updatePaths();
 
-  TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
+  
 
   // for update title bar
   app->getCurrentLevel()->notifyLevelTitleChange();


### PR DESCRIPTION
Trigger a refresh of scene sounds when the user saves. This is a work around for sounds not being updated after some actions. Triggering an update after these actions would cause the application to lag too much, especially when there is a lot of audio.

I've been using this for about a year and have found it very helpful.