### PR TITLE
Fix blurred brush crash after canvas resize

### DIFF
--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2555,6 +2555,13 @@ bool ToonzRasterBrushTool::isPencilModeActive() {
   return getTargetType() == TTool::ToonzImage && m_pencil.getValue();
 }
 
+//---------------------------------------------------------------------------------------------------
+
+void ToonzRasterBrushTool::onCanvasSizeChanged() {
+  onDeactivate();
+  setWorkAndBackupImages();
+}
+
 //------------------------------------------------------------------
 
 void ToonzRasterBrushTool::onColorStyleChanged() {
@@ -2608,6 +2615,11 @@ ToonzRasterBrushToolNotifier::ToonzRasterBrushToolNotifier(
     ToonzRasterBrushTool *tool)
     : m_tool(tool) {
   if (TTool::Application *app = m_tool->getApplication()) {
+    if (TXshLevelHandle *levelHandle = app->getCurrentLevel()) {
+      bool ret = connect(levelHandle, SIGNAL(xshCanvasSizeChanged()), this,
+                         SLOT(onCanvasSizeChanged()));
+      assert(ret);
+    }
     if (TPaletteHandle *paletteHandle = app->getCurrentPalette()) {
       bool ret;
       ret = connect(paletteHandle, SIGNAL(colorStyleChanged(bool)), this,

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -165,6 +165,7 @@ public:
   // Tools.
   bool isPencilModeActive() override;
 
+  void onCanvasSizeChanged();
   void onColorStyleChanged();
   bool askRead(const TRect &rect) override;
   bool askWrite(const TRect &rect) override;
@@ -259,7 +260,7 @@ public:
   ToonzRasterBrushToolNotifier(ToonzRasterBrushTool *tool);
 
 protected slots:
-  // void onCanvasSizeChanged() { m_tool->onCanvasSizeChanged(); }
+  void onCanvasSizeChanged() { m_tool->onCanvasSizeChanged(); }
   void onColorStyleChanged() { m_tool->onColorStyleChanged(); }
 };
 


### PR DESCRIPTION
This PR fixes #742 

Blurred brushes (Hardness < 100) on Smart Raster levels internally use work/backup raster images.  On a canvas resize, these raster images were not being resized.

Copied logic from standard Raster levels to reset work/backup raster images whenever a canvas resize was performed.