### PR TITLE
Fix crash adding Fx while on Camera column

### DIFF
--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -936,6 +936,8 @@ void TFxCommand::addFx(TFx *newFx, const QList<TFxP> &fxs, TApplication *app,
                        int col, int row) {
   if (!newFx) return;
 
+  if (col < 0) col = 0;
+
   std::unique_ptr<FxCommandUndo> undo(
       new InsertFxUndo(newFx, row, col, fxs, QList<Link>(), app, false));
   if (!undo->isConsistent()) return;

--- a/toonz/sources/toonzqt/addfxcontextmenu.cpp
+++ b/toonz/sources/toonzqt/addfxcontextmenu.cpp
@@ -564,9 +564,9 @@ void AddFxContextMenu::onAddFx(QAction *action) {
     if (fx->isZerary() &&
         fx->getAttributes()->getDagNodePos() != TConst::nowhere) {
       TXsheet *xsh = m_app->getCurrentXsheet()->getXsheet();
-      TXshZeraryFxColumn *column =
-          xsh->getColumn(m_app->getCurrentColumn()->getColumnIndex())
-              ->getZeraryFxColumn();
+      int col      = m_app->getCurrentColumn()->getColumnIndex();
+      if (col < 0) col = 0;
+      TXshZeraryFxColumn *column = xsh->getColumn(col)->getZeraryFxColumn();
       if (column)
         column->getZeraryColumnFx()->getAttributes()->setDagNodePos(
             fx->getAttributes()->getDagNodePos());


### PR DESCRIPTION
This PR fixes #747 

When adding a Zerary Fx like CheckboardFx or ColorCardFx, it adds a new column to the timeline/xsheet. It will to move everything from the current column to make way for the new column, but crashes when trying to move the camera column.

Added logic to assume you are on Column 1, instead of the Camera column when adding a Zerary Fx.