### PR TITLE
Stop switching columns on column button press

### DIFF
--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -40,6 +40,8 @@
 #include "toonz/preferences.h"
 #include "toonz/tstageobjectid.h"
 
+#include "../toonz/xsheetviewer.h"
+
 // TnzBase includes
 #include "tfx.h"
 #include "tfxattributes.h"
@@ -1396,10 +1398,11 @@ public:
   void execute() override {
     TColumnSelection *selection = dynamic_cast<TColumnSelection *>(
         TApp::instance()->getCurrentSelection()->getSelection());
-    TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
-    int cc             = TApp::instance()->getCurrentColumn()->getColumnIndex();
-    bool sound_changed = false;
-    TTool *tool        = TApp::instance()->getCurrentTool()->getTool();
+    TXsheet *xsh          = TApp::instance()->getCurrentXsheet()->getXsheet();
+    XsheetViewer *xviewer = TApp::instance()->getCurrentXsheetViewer();
+    int cc                = xviewer->getClickedColumn();
+    bool sound_changed    = false;
+    TTool *tool           = TApp::instance()->getCurrentTool()->getTool();
     TTool::Viewer *viewer = tool ? tool->getViewer() : nullptr;
     bool viewer_changed   = false;
 

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -358,6 +358,8 @@ public:
 
   QPixmap getColumnIcon(int columnIndex);
 
+  int getClickedColumn() { return m_col; }
+
   class Pixmaps {
   public:
     static const QPixmap &sound();

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -485,6 +485,14 @@ int XsheetViewer::getCurrentColumn() const {
 
 //-----------------------------------------------------------------------------
 
+int XsheetViewer::getClickedColumn() const {
+  if (!m_columnArea) return -1;
+
+  return m_columnArea->getClickedColumn();
+}
+
+//-----------------------------------------------------------------------------
+
 int XsheetViewer::getCurrentRow() const {
   return TApp::instance()->getCurrentFrame()->getFrame();
 }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -675,6 +675,7 @@ public:
 
   TXsheet *getXsheet() const;
   int getCurrentColumn() const;
+  int getClickedColumn() const;
   int getCurrentRow() const;
   //! Restituisce la \b objectId corrispondente alla colonna \b col
   TStageObjectId getObjectId(int col) const;


### PR DESCRIPTION
This PR stops the forced column switching that occurs when pressing on another column's button (preview, camera stand, lock or config) or using context menu for another column as you may need to change the column status of another column while still working on the current one.

Clicking anywhere else in the column will still cause a column switch.