### PR TITLE
Fix timeline column lock indicator refresh

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2621,7 +2621,8 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
                                     m_doOnRelease == ToggleAllTransparency ||
                                     m_doOnRelease == OpenSettings)) ||
         m_doOnRelease == TogglePreviewVisible ||
-        m_doOnRelease == ToggleAllPreviewVisible)
+        m_doOnRelease == ToggleAllPreviewVisible ||
+        m_doOnRelease == ToggleLock || m_doOnRelease == ToggleAllLock)
       app->getCurrentXsheet()->notifyXsheetChanged();
     update();
     m_doOnRelease = 0;


### PR DESCRIPTION
This PR fixes a minor issue where the column lock indicator on cells isn't refreshed when using the column's Lock button.

Now whenever a column lock button is pressed, the timeline/xsheet refresh is forced.