### PR TITLE
Enable single click expansion on Quicktoolbar categories

### DIFF
--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -332,6 +332,9 @@ CommandBarListTree::CommandBarListTree(QWidget* parent) : QTreeWidget(parent) {
   CommandBarSeparatorItem* sep = new CommandBarSeparatorItem(0);
   sep->setToolTip(0, QObject::tr("[Drag&Drop] to copy separator to toolbar"));
   addTopLevelItem(sep);
+
+  connect(this, SIGNAL(clicked(const QModelIndex&)), this,
+          SLOT(onItemClicked(const QModelIndex&)));
 }
 
 //-----------------------------------------------------------------------------
@@ -455,6 +458,12 @@ void CommandBarListTree::searchItems(const QString& searchWord) {
   }
 
   update();
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBarListTree::onItemClicked(const QModelIndex& index) {
+  isExpanded(index) ? collapse(index) : expand(index);
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/commandbarpopup.h
+++ b/toonz/sources/toonz/commandbarpopup.h
@@ -52,6 +52,9 @@ public:
 
   void searchItems(const QString& searchWord = QString());
 
+public slots:
+  void onItemClicked(const QModelIndex&);
+
 private:
   void displayAll(QTreeWidgetItem* item);
   void hideAll(QTreeWidgetItem* item);


### PR DESCRIPTION
Because I liked what Shun-iwasawa did by enabling single-click expansion/collapse of Shortcut categories in the Configure Shortcut popup, I've enabled the same thing for Command categories in the Customize Quick toolbar/Command bar popup.