### PR TITLE
Add View Check indicators to Viewer

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -235,8 +235,8 @@ public:
   void setColorCalibrationLutPath(QString monitorName, QString path);
   QString getColorCalibrationLutPath(QString &monitorName) const;
 
-  bool isCheckIndicatorEnabled() const {
-    return getBoolValue(checkIndicatorEnabled);
+  bool isViewerIndicatorEnabled() const {
+    return getBoolValue(viewerIndicatorEnabled);
   }
 
   // Visualization  tab

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -235,6 +235,10 @@ public:
   void setColorCalibrationLutPath(QString monitorName, QString path);
   QString getColorCalibrationLutPath(QString &monitorName) const;
 
+  bool isCheckIndicatorEnabled() const {
+    return getBoolValue(checkIndicatorEnabled);
+  }
+
   // Visualization  tab
   bool getShow0ThickLines() const { return getBoolValue(show0ThickLines); }
   bool getRegionAntialias() const { return getBoolValue(regionAntialias); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -46,7 +46,7 @@ enum PreferencesItemId {
   interfaceFontStyle,
   colorCalibrationEnabled,
   colorCalibrationLutPaths,
-  checkIndicatorEnabled,
+  viewerIndicatorEnabled,
 
   //----------
   // Visualization

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -46,6 +46,7 @@ enum PreferencesItemId {
   interfaceFontStyle,
   colorCalibrationEnabled,
   colorCalibrationLutPaths,
+  checkIndicatorEnabled,
 
   //----------
   // Visualization

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2475,8 +2475,8 @@ void MainWindow::defineActions() {
                Preferences::instance()->isAutoStretchEnabled(),
                MiscCommandType, "auto_stretch",
                tr("Toggles the auto-stretch of a frame to the next frame"));
-  createToggle(MI_CheckIndicator, QT_TR_NOOP("Toggle Check Indicators"), "",
-               Preferences::instance()->isCheckIndicatorEnabled(),
+  createToggle(MI_ViewerIndicator, QT_TR_NOOP("Toggle Viewer Indicators"), "",
+               Preferences::instance()->isViewerIndicatorEnabled(),
                RightClickMenuCommandType);
 
   // Tools

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2475,6 +2475,9 @@ void MainWindow::defineActions() {
                Preferences::instance()->isAutoStretchEnabled(),
                MiscCommandType, "auto_stretch",
                tr("Toggles the auto-stretch of a frame to the next frame"));
+  createToggle(MI_CheckIndicator, QT_TR_NOOP("Toggle Check Indicators"), "",
+               Preferences::instance()->isCheckIndicatorEnabled(),
+               RightClickMenuCommandType);
 
   // Tools
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -244,7 +244,7 @@
 #define MI_OnionSkin "MI_OnionSkin"
 #define MI_ZeroThick "MI_ZeroThick"
 #define MI_CursorOutline "MI_CursorOutline"
-#define MI_CheckIndicator "MI_CheckIndicator"
+#define MI_ViewerIndicator "MI_ViewerIndicator"
 
 //#define MI_LoadResourceFile       "MI_LoadResourceFile"
 #define MI_DuplicateFile "MI_DuplicateFile"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -244,6 +244,7 @@
 #define MI_OnionSkin "MI_OnionSkin"
 #define MI_ZeroThick "MI_ZeroThick"
 #define MI_CursorOutline "MI_CursorOutline"
+#define MI_CheckIndicator "MI_CheckIndicator"
 
 //#define MI_LoadResourceFile       "MI_LoadResourceFile"
 #define MI_DuplicateFile "MI_DuplicateFile"

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1019,6 +1019,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {colorCalibrationLutPaths,
        tr("3DLUT File for [%1]:")
            .arg(LutManager::instance()->getMonitorName())},
+      {checkIndicatorEnabled, tr("Show Check Indicators")},
 
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
@@ -1462,6 +1463,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   insertUI(moveCurrentFrameByClickCellArea, lay);
   insertUI(actualPixelViewOnSceneEditingMode, lay);
   // insertUI(levelNameOnEachMarkerEnabled, lay);
+  insertUI(checkIndicatorEnabled, lay);
   insertUI(showRasterImagesDarkenBlendedInViewer, lay);
   // insertUI(showFrameNumberWithLetters, lay);
   insertUI(iconSize, lay);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1019,7 +1019,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {colorCalibrationLutPaths,
        tr("3DLUT File for [%1]:")
            .arg(LutManager::instance()->getMonitorName())},
-      {checkIndicatorEnabled, tr("Show Check Indicators")},
+      {viewerIndicatorEnabled, tr("Show Viewer Indicators")},
 
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
@@ -1463,7 +1463,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   insertUI(moveCurrentFrameByClickCellArea, lay);
   insertUI(actualPixelViewOnSceneEditingMode, lay);
   // insertUI(levelNameOnEachMarkerEnabled, lay);
-  insertUI(checkIndicatorEnabled, lay);
+  insertUI(viewerIndicatorEnabled, lay);
   insertUI(showRasterImagesDarkenBlendedInViewer, lay);
   // insertUI(showFrameNumberWithLetters, lay);
   insertUI(iconSize, lay);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1851,6 +1851,47 @@ void SceneViewer::drawOverlay() {
 
 //-----------------------------------------------------------------------------
 
+void SceneViewer::drawCheckNotices() {
+  if (m_previewMode) return;
+
+  ToonzCheck *tc = ToonzCheck::instance();
+  int mask       = tc->getChecks();
+
+  if (!mask) return;
+
+  QStringList checkTexts;
+
+  if (mask & ToonzCheck::eTransparency)
+    checkTexts.append(tr("Transparency Check ENABLED"));
+  if (mask & ToonzCheck::eInk) checkTexts.append(tr("Ink Check ENABLED"));
+  if (mask & ToonzCheck::eInk1) checkTexts.append(tr("Ink#1 Check ENABLED"));
+  if (mask & ToonzCheck::ePaint) checkTexts.append(tr("Paint Check ENABLED"));
+  if (mask & ToonzCheck::eInksOnly)
+    checkTexts.append(tr("Inks Only Check ENABLED"));
+  if (mask & ToonzCheck::eBlackBg)
+    checkTexts.append(tr("Black BG Check ENABLED"));
+  if (mask & ToonzCheck::eGap) checkTexts.append(tr("Fill Check ENABLED"));
+  if (mask & ToonzCheck::eAutoclose) checkTexts.append(tr("Gap Check ENABLED"));
+
+  if (!checkTexts.size()) return;
+
+  int x0, x1, y0, y1;
+  rect().getCoords(&x0, &y0, &x1, &y1);
+  x0 = (-(x1 / 2)) + 15;
+  y0 = ((y1 / 2)) - 25;
+
+  glPushMatrix();
+  glScaled(2, 2, 2);
+  glColor3d(1.0, 0.0, 0.0);
+  for (int i = 0; i < checkTexts.size(); i++) {
+    int y = (y0 / 2) - (i * 10);
+    tglDrawText(TPointD((x0 / 2), y), checkTexts[i].toStdString());
+  }
+  glPopMatrix();
+}
+
+//-----------------------------------------------------------------------------
+
 static void drawFpsGraph(int t0, int t1) {
   glDisable(GL_BLEND);
   static std::deque<std::pair<int, int>> times;
@@ -1974,6 +2015,8 @@ void SceneViewer::paintGL() {
   drawOverlay();
 
   drawDisableScissor();
+
+  drawCheckNotices();
 
   // Il freezed e' attivo ed e' in stato "update": faccio il grab del viewer.
   if (m_freezedStatus == UPDATE_FREEZED) {

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1634,22 +1634,9 @@ void SceneViewer::drawOverlay() {
 
     TXsheet *xsh         = TApp::instance()->getCurrentXsheet()->getXsheet();
     TStageObjectId objId = app->getCurrentObject()->getObjectId();
-    bool isMotionPath    = false;
-
-    if (objId == xsh->getStageObjectTree()->getMotionPathViewerId() &&
-        app->getCurrentObject()->isSpline()) {
-      isMotionPath = true;
-      int x0, x1, y0, y1;
-      rect().getCoords(&x0, &y0, &x1, &y1);
-      x0 = (-(x1 / 2)) + 15;
-      y0 = ((y1 / 2)) - 25;
-      glPushMatrix();
-      glScaled(3, 3, 3);
-      glColor3d(1.0, 0.0, 0.0);
-      tglDrawText(TPointD(x0 / 3, y0 / 3),
-                  tr("Motion Path Selected").toStdWString());
-      glPopMatrix();
-    }
+    bool isMotionPath =
+        (objId == xsh->getStageObjectTree()->getMotionPathViewerId() &&
+         app->getCurrentObject()->isSpline());
 
     // draw camera
     if (!isMotionPath && viewCameraToggle.getStatus() &&
@@ -1735,10 +1722,6 @@ void SceneViewer::drawOverlay() {
     else
       m_FPS = 0;
 
-    if (m_freezedStatus != NO_FREEZED) {
-      tglColor(TPixel32::Red);
-      tglDrawText(TPointD(0, 0), "FROZEN");
-    }
     assert(glGetError() == GL_NO_ERROR);
 
   }  //! cameraTest
@@ -1851,27 +1834,36 @@ void SceneViewer::drawOverlay() {
 
 //-----------------------------------------------------------------------------
 
-void SceneViewer::drawCheckNotices() {
-  if (m_previewMode) return;
-
-  if (!Preferences::instance()->isCheckIndicatorEnabled()) return;
-
-  ToonzCheck *tc = ToonzCheck::instance();
-  int mask       = tc->getChecks();
-
-  if (!mask) return;
+void SceneViewer::drawViewerIndicators() {
+  if (!Preferences::instance()->isViewerIndicatorEnabled()) return;
 
   QStringList checkTexts;
 
-  if (mask & ToonzCheck::eTransparency)
-    checkTexts.append(tr("*Transparency Check*"));
-  if (mask & ToonzCheck::eInk) checkTexts.append(tr("*Ink Check*"));
-  if (mask & ToonzCheck::eInk1) checkTexts.append(tr("*Ink#1 Check*"));
-  if (mask & ToonzCheck::ePaint) checkTexts.append(tr("*Paint Check*"));
-  if (mask & ToonzCheck::eInksOnly) checkTexts.append(tr("*Inks Only Check*"));
-  if (mask & ToonzCheck::eBlackBg) checkTexts.append(tr("*Black BG Check*"));
-  if (mask & ToonzCheck::eGap) checkTexts.append(tr("*Fill Check*"));
-  if (mask & ToonzCheck::eAutoclose) checkTexts.append(tr("*Gap Check*"));
+  // Frozen Viewer Indicator
+  if (m_freezedStatus) checkTexts.append(tr("FROZEN"));
+
+  // Motion Path Indicator
+  TApp *app            = TApp::instance();
+  TStageObjectId objId = app->getCurrentObject()->getObjectId();
+  TXsheet *xsh         = app->getCurrentXsheet()->getXsheet();
+  if (objId == xsh->getStageObjectTree()->getMotionPathViewerId() &&
+      app->getCurrentObject()->isSpline())
+    checkTexts.append(tr("Motion Path Selected"));
+
+  // Check Indicators (disabled in Preview mode)
+  ToonzCheck *tc = ToonzCheck::instance();
+  int mask       = tc->getChecks();
+  if (!m_previewMode && mask) {
+    if (mask & ToonzCheck::eTransparency)
+      checkTexts.append(tr("Transparency Check"));
+    if (mask & ToonzCheck::eInk) checkTexts.append(tr("Ink Check"));
+    if (mask & ToonzCheck::eInk1) checkTexts.append(tr("Ink#1 Check"));
+    if (mask & ToonzCheck::ePaint) checkTexts.append(tr("Paint Check"));
+    if (mask & ToonzCheck::eInksOnly) checkTexts.append(tr("Inks Only Check"));
+    if (mask & ToonzCheck::eBlackBg) checkTexts.append(tr("Black BG Check"));
+    if (mask & ToonzCheck::eGap) checkTexts.append(tr("Fill Check"));
+    if (mask & ToonzCheck::eAutoclose) checkTexts.append(tr("Gap Check"));
+  }
 
   if (!checkTexts.size()) return;
 
@@ -1995,6 +1987,8 @@ void SceneViewer::paintGL() {
     if (!m_isPicking && m_lutCalibrator && m_lutCalibrator->isValid())
       m_lutCalibrator->onEndDraw(m_fbo);
 
+    drawViewerIndicators();
+
     return;
   }
 
@@ -2016,7 +2010,7 @@ void SceneViewer::paintGL() {
 
   drawDisableScissor();
 
-  drawCheckNotices();
+  drawViewerIndicators();
 
   // Il freezed e' attivo ed e' in stato "update": faccio il grab del viewer.
   if (m_freezedStatus == UPDATE_FREEZED) {

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1854,6 +1854,8 @@ void SceneViewer::drawOverlay() {
 void SceneViewer::drawCheckNotices() {
   if (m_previewMode) return;
 
+  if (!Preferences::instance()->isCheckIndicatorEnabled()) return;
+
   ToonzCheck *tc = ToonzCheck::instance();
   int mask       = tc->getChecks();
 

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1862,16 +1862,14 @@ void SceneViewer::drawCheckNotices() {
   QStringList checkTexts;
 
   if (mask & ToonzCheck::eTransparency)
-    checkTexts.append(tr("Transparency Check ENABLED"));
-  if (mask & ToonzCheck::eInk) checkTexts.append(tr("Ink Check ENABLED"));
-  if (mask & ToonzCheck::eInk1) checkTexts.append(tr("Ink#1 Check ENABLED"));
-  if (mask & ToonzCheck::ePaint) checkTexts.append(tr("Paint Check ENABLED"));
-  if (mask & ToonzCheck::eInksOnly)
-    checkTexts.append(tr("Inks Only Check ENABLED"));
-  if (mask & ToonzCheck::eBlackBg)
-    checkTexts.append(tr("Black BG Check ENABLED"));
-  if (mask & ToonzCheck::eGap) checkTexts.append(tr("Fill Check ENABLED"));
-  if (mask & ToonzCheck::eAutoclose) checkTexts.append(tr("Gap Check ENABLED"));
+    checkTexts.append(tr("*Transparency Check*"));
+  if (mask & ToonzCheck::eInk) checkTexts.append(tr("*Ink Check*"));
+  if (mask & ToonzCheck::eInk1) checkTexts.append(tr("*Ink#1 Check*"));
+  if (mask & ToonzCheck::ePaint) checkTexts.append(tr("*Paint Check*"));
+  if (mask & ToonzCheck::eInksOnly) checkTexts.append(tr("*Inks Only Check*"));
+  if (mask & ToonzCheck::eBlackBg) checkTexts.append(tr("*Black BG Check*"));
+  if (mask & ToonzCheck::eGap) checkTexts.append(tr("*Fill Check*"));
+  if (mask & ToonzCheck::eAutoclose) checkTexts.append(tr("*Gap Check*"));
 
   if (!checkTexts.size()) return;
 

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -168,7 +168,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
 
   bool m_isPicking;
   bool m_canShowPerspectiveGrids = false;
-  bool m_showCheckIndicators     = true;
+  bool m_showViewerIndicators    = true;
 
   TRaster32P m_3DSideL;
   TRaster32P m_3DSideR;
@@ -351,7 +351,7 @@ protected:
   void drawCameraStand();
   void drawPreview();
   void drawOverlay();
-  void drawCheckNotices();
+  void drawViewerIndicators();
 
   void drawScene();
   void drawToolGadgets();

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -168,6 +168,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
 
   bool m_isPicking;
   bool m_canShowPerspectiveGrids = false;
+  bool m_showCheckIndicators     = true;
 
   TRaster32P m_3DSideL;
   TRaster32P m_3DSideR;

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -350,6 +350,7 @@ protected:
   void drawCameraStand();
   void drawPreview();
   void drawOverlay();
+  void drawCheckNotices();
 
   void drawScene();
   void drawToolGadgets();

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -226,7 +226,7 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
   // Brush size outline
   CursorOutlineToggleGui::addCursorOutlineCommand(this);
 
-  CheckIndicatorToggleGui::addCheckIndicatorCommand(this);
+  ViewerIndicatorToggleGui::addViewerIndicatorCommand(this);
 
   // preview
   if (parent->isPreviewEnabled()) {
@@ -550,40 +550,40 @@ void CursorOutlineToggleGui::CursorOutlineToggleHandler::deactivate() {
   CursorOutlineToggle::enableCursorOutline(false);
 }
 
-class CheckIndicatorToggle : public MenuItemHandler {
+class ViewerIndicatorToggle : public MenuItemHandler {
 public:
-  CheckIndicatorToggle() : MenuItemHandler(MI_CheckIndicator) {}
+  ViewerIndicatorToggle() : MenuItemHandler(MI_ViewerIndicator) {}
   void execute() {
-    QAction *action = CommandManager::instance()->getAction(MI_CheckIndicator);
+    QAction *action = CommandManager::instance()->getAction(MI_ViewerIndicator);
     if (!action) return;
     bool checked = action->isChecked();
-    enableCheckIndicator(checked);
+    enableViewerIndicator(checked);
   }
 
-  static void enableCheckIndicator(bool enable = true) {
-    Preferences::instance()->setValue(checkIndicatorEnabled, enable);
+  static void enableViewerIndicator(bool enable = true) {
+    Preferences::instance()->setValue(viewerIndicatorEnabled, enable);
   }
-} CheckIndicatorToggle;
+} ViewerIndicatorToggle;
 
-void CheckIndicatorToggleGui::addCheckIndicatorCommand(QMenu *menu) {
-  static CheckIndicatorToggleHandler switcher;
-  if (Preferences::instance()->isCheckIndicatorEnabled()) {
-    QAction *hideCheckIndicator =
-        menu->addAction(QString(QObject::tr("Hide Check Indicators")));
-    menu->connect(hideCheckIndicator, SIGNAL(triggered()), &switcher,
+void ViewerIndicatorToggleGui::addViewerIndicatorCommand(QMenu *menu) {
+  static ViewerIndicatorToggleHandler switcher;
+  if (Preferences::instance()->isViewerIndicatorEnabled()) {
+    QAction *hideViewerIndicator =
+        menu->addAction(QString(QObject::tr("Hide Viewer Indicators")));
+    menu->connect(hideViewerIndicator, SIGNAL(triggered()), &switcher,
                   SLOT(deactivate()));
   } else {
-    QAction *showCheckIndicator =
-        menu->addAction(QString(QObject::tr("Show Check Indicators")));
-    menu->connect(showCheckIndicator, SIGNAL(triggered()), &switcher,
+    QAction *showViewerIndicator =
+        menu->addAction(QString(QObject::tr("Show Viewer Indicators")));
+    menu->connect(showViewerIndicator, SIGNAL(triggered()), &switcher,
                   SLOT(activate()));
   }
 }
 
-void CheckIndicatorToggleGui::CheckIndicatorToggleHandler::activate() {
-  CheckIndicatorToggle::enableCheckIndicator(true);
+void ViewerIndicatorToggleGui::ViewerIndicatorToggleHandler::activate() {
+  ViewerIndicatorToggle::enableViewerIndicator(true);
 }
 
-void CheckIndicatorToggleGui::CheckIndicatorToggleHandler::deactivate() {
-  CheckIndicatorToggle::enableCheckIndicator(false);
+void ViewerIndicatorToggleGui::ViewerIndicatorToggleHandler::deactivate() {
+  ViewerIndicatorToggle::enableViewerIndicator(false);
 }

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -226,6 +226,8 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
   // Brush size outline
   CursorOutlineToggleGui::addCursorOutlineCommand(this);
 
+  CheckIndicatorToggleGui::addCheckIndicatorCommand(this);
+
   // preview
   if (parent->isPreviewEnabled()) {
     addSeparator();
@@ -546,4 +548,42 @@ void CursorOutlineToggleGui::CursorOutlineToggleHandler::activate() {
 
 void CursorOutlineToggleGui::CursorOutlineToggleHandler::deactivate() {
   CursorOutlineToggle::enableCursorOutline(false);
+}
+
+class CheckIndicatorToggle : public MenuItemHandler {
+public:
+  CheckIndicatorToggle() : MenuItemHandler(MI_CheckIndicator) {}
+  void execute() {
+    QAction *action = CommandManager::instance()->getAction(MI_CheckIndicator);
+    if (!action) return;
+    bool checked = action->isChecked();
+    enableCheckIndicator(checked);
+  }
+
+  static void enableCheckIndicator(bool enable = true) {
+    Preferences::instance()->setValue(checkIndicatorEnabled, enable);
+  }
+} CheckIndicatorToggle;
+
+void CheckIndicatorToggleGui::addCheckIndicatorCommand(QMenu *menu) {
+  static CheckIndicatorToggleHandler switcher;
+  if (Preferences::instance()->isCheckIndicatorEnabled()) {
+    QAction *hideCheckIndicator =
+        menu->addAction(QString(QObject::tr("Hide Check Indicators")));
+    menu->connect(hideCheckIndicator, SIGNAL(triggered()), &switcher,
+                  SLOT(deactivate()));
+  } else {
+    QAction *showCheckIndicator =
+        menu->addAction(QString(QObject::tr("Show Check Indicators")));
+    menu->connect(showCheckIndicator, SIGNAL(triggered()), &switcher,
+                  SLOT(activate()));
+  }
+}
+
+void CheckIndicatorToggleGui::CheckIndicatorToggleHandler::activate() {
+  CheckIndicatorToggle::enableCheckIndicator(true);
+}
+
+void CheckIndicatorToggleGui::CheckIndicatorToggleHandler::deactivate() {
+  CheckIndicatorToggle::enableCheckIndicator(false);
 }

--- a/toonz/sources/toonz/sceneviewercontextmenu.h
+++ b/toonz/sources/toonz/sceneviewercontextmenu.h
@@ -65,4 +65,17 @@ public slots:
 
 }  // Namespace CursorOutlineToggleGui
 
+namespace CheckIndicatorToggleGui {
+void addCheckIndicatorCommand(QMenu *menu);
+
+class CheckIndicatorToggleHandler : public QObject {
+  Q_OBJECT
+
+public slots:
+  void activate();
+  void deactivate();
+};
+
+}  // Namespace CheckIndicatorToggleGui
+
 #endif

--- a/toonz/sources/toonz/sceneviewercontextmenu.h
+++ b/toonz/sources/toonz/sceneviewercontextmenu.h
@@ -65,10 +65,10 @@ public slots:
 
 }  // Namespace CursorOutlineToggleGui
 
-namespace CheckIndicatorToggleGui {
-void addCheckIndicatorCommand(QMenu *menu);
+namespace ViewerIndicatorToggleGui {
+void addViewerIndicatorCommand(QMenu *menu);
 
-class CheckIndicatorToggleHandler : public QObject {
+class ViewerIndicatorToggleHandler : public QObject {
   Q_OBJECT
 
 public slots:
@@ -76,6 +76,6 @@ public slots:
   void deactivate();
 };
 
-}  // Namespace CheckIndicatorToggleGui
+}  // Namespace ViewerIndicatorToggleGui
 
 #endif

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -441,6 +441,8 @@ void Preferences::definePreferenceItems() {
   setCallBack(linearUnits, &Preferences::setUnits);
   setCallBack(cameraUnits, &Preferences::setCameraUnits);
 
+  define(checkIndicatorEnabled, "checkIndicatorEnabled", QMetaType::Bool, true);
+
   // Visualization
   define(show0ThickLines, "show0ThickLines", QMetaType::Bool, true);
   define(regionAntialias, "regionAntialias", QMetaType::Bool, false);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -441,7 +441,8 @@ void Preferences::definePreferenceItems() {
   setCallBack(linearUnits, &Preferences::setUnits);
   setCallBack(cameraUnits, &Preferences::setCameraUnits);
 
-  define(checkIndicatorEnabled, "checkIndicatorEnabled", QMetaType::Bool, true);
+  define(viewerIndicatorEnabled, "viewerIndicatorEnabled", QMetaType::Bool,
+         true);
 
   // Visualization
   define(show0ThickLines, "show0ThickLines", QMetaType::Bool, true);


### PR DESCRIPTION
This PR makes it obvious that 1 or more View -> check menu options are enabled by putting indicators (text) in the upper left corner of the viewer when selected:

![image](https://user-images.githubusercontent.com/19245851/130365855-d69ea8bd-de08-4159-8ebf-ab7895d309b4.png)

Updates:
Added Viewer right-click menu option to Hide/Show Check Indicators
![image](https://user-images.githubusercontent.com/19245851/130365934-2f6f7c61-ff12-431b-917e-c170a12986c8.png)

Option controls Preference setting: `Interface` -> `Show Check Indicators` (Default is ON):

Command button/Shortcut is available for this setting as `Toggle Check Indicators`.