### PR TITLE
Fix Canvas Size availability

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1585,7 +1585,6 @@ void TCellSelection::selectCell(int row, int col) {
 
 void TCellSelection::selectNone() {
   m_range = Range();
-  CommandManager::instance()->enable(MI_CanvasSize, false);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -82,8 +82,14 @@ bool containsOnlyOneRasterLevel(int r0, int c0, int r1, int c1) {
       if (xsh->getCell(r, c).m_level.getPointer() != xl.getPointer())
         return false;
   }
-  return xl && (xl->getType() == TZP_XSHLEVEL ||
-                xl->getType() == OVL_XSHLEVEL || xl->getType() == TZI_XSHLEVEL);
+  if (!xl) return false;
+  if (xl->getType() == OVL_XSHLEVEL &&
+      (xl->getPath().getType() == "psd" || xl->getPath().getType() == "gif" ||
+       xl->getPath().getType() == "mp4" || xl->getPath().getType() == "webm" ||
+       xl->getPath().getType() == "mov"))
+    return false;
+  return (xl->getType() == TZP_XSHLEVEL || xl->getType() == OVL_XSHLEVEL ||
+          xl->getType() == TZI_XSHLEVEL);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -855,7 +855,14 @@ void FilmstripFrames::mousePressEvent(QMouseEvent *event) {
 
   TXshSimpleLevel *sl = getLevel();
 
+  CommandManager::instance()->enable(MI_CanvasSize, false);
+
   if (!sl) return;
+
+  bool isRasterLevel =
+      (sl->getType() == TZP_XSHLEVEL || sl->getType() == OVL_XSHLEVEL ||
+       sl->getType() == TZI_XSHLEVEL);
+  CommandManager::instance()->enable(MI_CanvasSize, isRasterLevel);
 
   // If accessed after 1st frame on a Single Frame level
   // Block movement so we can't create new images

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -146,11 +146,6 @@ void TFilmstripSelection::select(const TFrameId &fid, bool selected) {
   if (tool) tool->setSelectedFrames(m_selectedFrames);
 
   TXshSimpleLevel *sl = app->getCurrentLevel()->getSimpleLevel();
-  bool rasterLevel    = sl->getType() == TZP_XSHLEVEL ||
-                     sl->getType() == OVL_XSHLEVEL ||
-                     sl->getType() == TZI_XSHLEVEL;
-
-  CommandManager::instance()->enable(MI_CanvasSize, rasterLevel);
 }
 
 //-----------------------------------------------------------------------------
@@ -165,7 +160,6 @@ void TFilmstripSelection::selectNone() {
   m_selectedFrames.clear();
   updateInbetweenRange();
   TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
-  CommandManager::instance()->enable(MI_CanvasSize, false);
 }
 
 //-----------------------------------------------------------------------------
@@ -180,10 +174,6 @@ void TFilmstripSelection::selectAll() {
   updateInbetweenRange();
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   tool->setSelectedFrames(m_selectedFrames);
-  bool rasterLevel = sl->getType() == TZP_XSHLEVEL ||
-                     sl->getType() == OVL_XSHLEVEL ||
-                     sl->getType() == TZI_XSHLEVEL;
-  CommandManager::instance()->enable(MI_CanvasSize, rasterLevel);
   notifyView();
 }
 
@@ -204,9 +194,6 @@ void TFilmstripSelection::invertSelection() {
   updateInbetweenRange();
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   tool->setSelectedFrames(m_selectedFrames);
-  if (sl->getType() == TZP_XSHLEVEL || sl->getType() == OVL_XSHLEVEL ||
-      sl->getType() == TZI_XSHLEVEL)
-    CommandManager::instance()->enable(MI_CanvasSize, true);
   notifyView();
 }
 

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -586,6 +586,12 @@ void TApp::onXshLevelSwitched(TXshLevel *) {
       bool isRasterLevel = (simpleLevel->getType() == TZP_XSHLEVEL ||
                             simpleLevel->getType() == OVL_XSHLEVEL ||
                             simpleLevel->getType() == TZI_XSHLEVEL);
+      if (isRasterLevel && (simpleLevel->getPath().getType() == "psd" ||
+                            simpleLevel->getPath().getType() == "gif" ||
+                            simpleLevel->getPath().getType() == "mp4" ||
+                            simpleLevel->getPath().getType() == "webm" ||
+                            simpleLevel->getPath().getType() == "mov"))
+        isRasterLevel = false;
       CommandManager::instance()->enable(MI_CanvasSize, isRasterLevel);
 
       return;

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -11,6 +11,7 @@
 #include "cellselection.h"
 #include "sceneviewer.h"
 #include "statusbar.h"
+#include "menubarcommandids.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -566,6 +567,7 @@ void TApp::onColumnIndexSwitched() {
 
 void TApp::onXshLevelSwitched(TXshLevel *) {
   TXshLevel *level = m_currentLevel->getLevel();
+  CommandManager::instance()->enable(MI_CanvasSize, false);
   if (level) {
     TXshSimpleLevel *simpleLevel = level->getSimpleLevel();
 
@@ -580,6 +582,11 @@ void TApp::onXshLevelSwitched(TXshLevel *) {
       if (simpleLevel->getType() == OVL_XSHLEVEL && currentPalette &&
           currentPalette->isCleanupPalette())
         m_paletteController->editCleanupPalette();
+
+      bool isRasterLevel = (simpleLevel->getType() == TZP_XSHLEVEL ||
+                            simpleLevel->getType() == OVL_XSHLEVEL ||
+                            simpleLevel->getType() == TZI_XSHLEVEL);
+      CommandManager::instance()->enable(MI_CanvasSize, isRasterLevel);
 
       return;
     }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3479,6 +3479,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell) {
 
     if (selectionContainRasterImage(m_viewer->getCellSelection(),
                                     m_viewer->getXsheet())) {
+      menu.addAction(cmdManager->getAction(MI_CanvasSize));
       QMenu *editImageMenu = new QMenu(tr("Edit Image"), this);
       {
         editImageMenu->addAction(cmdManager->getAction(MI_AdjustLevels));
@@ -3486,7 +3487,6 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell) {
         editImageMenu->addAction(
             cmdManager->getAction(MI_BrightnessAndContrast));
         editImageMenu->addAction(cmdManager->getAction(MI_Antialias));
-        editImageMenu->addAction(cmdManager->getAction(MI_CanvasSize));
       }
       menu.addMenu(editImageMenu);
 


### PR DESCRIPTION
This PR does the following in relation to `Canvas Size` availability

- Fixes the issue with the `Canvas Size` option for Smart Raster/Raster levels not being activated right away.
- Disabled `Canvas Size` for levels that cannot be edited (i.e pdf, gif, webm, etc).
- Moved `Canvas Size` option in Raster cell context menu out of the `Edit Image` submenu to the same position as Smart Raster level for consistency of location