### PR TITLE
Fix selection tool for motion path editing

### DIFF
--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -774,8 +774,9 @@ bool StrokeSelection::isEditable() {
   }
 
   if (!filmstrip) {
-    int colIndex = app->getCurrentTool()->getTool()->getColumnIndex();
-    if (colIndex < 0) return false;
+    int colIndex  = app->getCurrentTool()->getTool()->getColumnIndex();
+    bool isSpline = app->getCurrentObject()->isSpline();
+    if (colIndex < 0 && !isSpline) return false;
     int rowIndex = frame->getFrame();
     if (app->getCurrentTool()->getTool()->isColumnLocked(colIndex))
       return false;

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -946,7 +946,8 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
     return (enable(true), QString());
 
   // Check against camera column
-  if (!filmstrip && columnIndex < 0 && (targetType & TTool::EmptyTarget) &&
+  if (!filmstrip && !spline && columnIndex < 0 &&
+      (targetType & TTool::EmptyTarget) &&
       (m_name == T_Type || m_name == T_Geometric || m_name == T_Brush))
     return (enable(false), QString());
 

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -891,7 +891,16 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
       }
   }
 
-  if (Preferences::instance()->isAutoCreateEnabled()) {
+  bool spline = m_application->getCurrentObject()->isSpline();
+
+  if (spline) {
+    // If editing a motion path, find vector version of the current tool
+    if (!(targetType & VectorImage)) {
+      TTool *tool = this;
+      tool        = TTool::getTool(m_name, VectorImage);
+      if (tool && tool != this) return tool->updateEnabled();
+    }
+  } else if (Preferences::instance()->isAutoCreateEnabled()) {
     // If not in Level editor, let's use our current cell from the xsheet to
     // find the nearest level before it
     if (levelType == NO_XSHLEVEL &&
@@ -928,8 +937,6 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
         return tool->updateEnabled();
     }
   }
-
-  bool spline = m_application->getCurrentObject()->isSpline();
 
   bool filmstrip = m_application->getCurrentFrame()->isEditingLevel();
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1515,6 +1515,7 @@ public:
 
   void initialize(TPanel *panel) override {
     MotionPathPanel *motionPathPanel = new MotionPathPanel(panel);
+    panel->setMinimumSize(300, 400);
     panel->setWidget(motionPathPanel);
     panel->setWindowTitle(QObject::tr("Motion Paths"));
     panel->setIsMaximizable(false);


### PR DESCRIPTION
This PR reenables the Selection Tool for Motion Path editing which was accidentally disabled, somehow, since 1.0.

This also makes Motion path enabled tools usable despite what cell you are in on the timeline/xsheet because it was reading the level type of the level you were in and wouldn't allow you to use the tool on a Motion Path unless you were on a blank frame or on a Vector Level to begin with