### PR TITLE
Fix keyframe icon positions

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2433,18 +2433,18 @@ void CellArea::drawKeyframe(QPainter &p, const QRect toBeUpdated) {
           int handleRow0, handleRow1;
           if (getEaseHandles(segmentRow0, segmentRow1, ease0, ease1, handleRow0,
                              handleRow1)) {
+            QRect easeRect = tmpKeyRect;
+            if (o->isVerticalTimeline()) easeRect.adjust(-2, 0, -2, 0);
             QPoint topLeft =
                 m_viewer->positionToXY(CellPosition(handleRow0, col));
-            m_viewer->drawPredefinedPath(
-                p, PredefinedPath::BEGIN_EASE_TRIANGLE,
-                tmpKeyRect.translated(topLeft).center(), keyFrameColor,
-                outline);
+            m_viewer->drawPredefinedPath(p, PredefinedPath::BEGIN_EASE_TRIANGLE,
+                                         easeRect.translated(topLeft).center(),
+                                         keyFrameColor, outline);
 
             topLeft = m_viewer->positionToXY(CellPosition(handleRow1, col));
-            m_viewer->drawPredefinedPath(
-                p, PredefinedPath::END_EASE_TRIANGLE,
-                tmpKeyRect.translated(topLeft).center(), keyFrameColor,
-                outline);
+            m_viewer->drawPredefinedPath(p, PredefinedPath::END_EASE_TRIANGLE,
+                                         easeRect.translated(topLeft).center(),
+                                         keyFrameColor, outline);
           }
         }
         // skip to next segment

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1707,11 +1707,17 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
                             ->rect(PredefinedRect::FRAME_MARKER_AREA)
                             .translated(xy)
                             .translated(-frameAdj / 2);
-  if (isKeyFrame)
+  if (isKeyFrame) {
+    if (isCamera && !m_viewer->orientation()->isVerticalTimeline() &&
+        m_viewer->getFrameZoomFactor() <=
+            m_viewer->orientation()->dimension(
+                PredefinedDimension::SCALE_THRESHOLD))
+      dotRect.adjust(0, -3, 0, -3);
+
     m_viewer->drawPredefinedPath(p, PredefinedPath::FRAME_MARKER_DIAMOND,
                                  dotRect.adjusted(1, 1, 1, 1).center(), color,
                                  outlineColor);
-  else {
+  } else {
     // move to column center
     if (m_viewer->orientation()->isVerticalTimeline()) {
       PredefinedLine which =

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -995,6 +995,8 @@ void ColumnArea::DrawHeader::drawColumnNumber() const {
 
   int valign = o->isVerticalTimeline() ? Qt::AlignVCenter : Qt::AlignBottom;
 
+  if (!o->isVerticalTimeline()) pos.adjust(0, -1, 0, -1);
+
   p.drawText(pos, Qt::AlignHCenter | valign | Qt::TextSingleLine,
              QString::number(col + 1));
 }
@@ -1072,7 +1074,11 @@ void ColumnArea::DrawHeader::drawColumnName() const {
     return;
   }
 
-  p.drawText(columnName.adjusted(leftadj, 0, rightadj, 0),
+  int vertAdj = 0;
+
+  if (!o->isVerticalTimeline()) vertAdj = col < 0 || isEmpty ? -4 : -1;
+
+  p.drawText(columnName.adjusted(leftadj, vertAdj, rightadj, vertAdj),
              Qt::AlignLeft | valign | Qt::TextSingleLine,
              QString(name.c_str()));
 }

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -985,11 +985,11 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(PredefinedRect::DRAG_HANDLE_CORNER,
           QRect(0, 0, CELL_WIDTH, CELL_DRAG_HEIGHT));
   QRect keyRect((CELL_WIDTH - KEY_ICON_WIDTH) / 2,
-                CELL_HEIGHT - KEY_ICON_HEIGHT - 2, KEY_ICON_WIDTH,
+                CELL_HEIGHT - KEY_ICON_HEIGHT - 3, KEY_ICON_WIDTH,
                 KEY_ICON_HEIGHT);
   addRect(PredefinedRect::KEY_ICON, keyRect);
-  addRect(PredefinedRect::CAMERA_KEY_ICON, keyRect.adjusted(0, -4, 0, -4));
-  QRect nameRect = cellRect.adjusted(4, 4, -6, 0);
+  addRect(PredefinedRect::CAMERA_KEY_ICON, keyRect.adjusted(0, -3, 0, -3));
+  QRect nameRect = cellRect.adjusted(4, 3, -6, -1);
   addRect(PredefinedRect::CELL_NAME, nameRect);
   addRect(PredefinedRect::CELL_NAME_WITH_KEYFRAME, nameRect);
   addRect(PredefinedRect::END_EXTENDER,

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -988,7 +988,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
                 CELL_HEIGHT - KEY_ICON_HEIGHT - 2, KEY_ICON_WIDTH,
                 KEY_ICON_HEIGHT);
   addRect(PredefinedRect::KEY_ICON, keyRect);
-  addRect(PredefinedRect::CAMERA_KEY_ICON, keyRect);
+  addRect(PredefinedRect::CAMERA_KEY_ICON, keyRect.adjusted(0, -4, 0, -4));
   QRect nameRect = cellRect.adjusted(4, 4, -6, 0);
   addRect(PredefinedRect::CELL_NAME, nameRect);
   addRect(PredefinedRect::CELL_NAME_WITH_KEYFRAME, nameRect);


### PR DESCRIPTION
This PR fixes the keyframe icons as follows

- Corrects the position of the Ease In/Out handles on the Xsheet
- Vertically centers all the Camera keyframe icons on the Timeline