### PR TITLE
Update build environments + relevant OT patches

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Linux:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         compiler: [ gcc, clang ]

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Windows:
-    runs-on: windows-2016
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
         with:

--- a/ci-scripts/linux/tahoma-build.sh
+++ b/ci-scripts/linux/tahoma-build.sh
@@ -11,7 +11,7 @@ then
 fi
 cd build
 
-source /opt/qt59/bin/qt59-env.sh
+source /opt/qt515/bin/qt515-env.sh
 
 cmake ../sources \
     -DWITH_SYSTEM_SUPERLU:BOOL=OFF

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/qt59/bin/qt59-env.sh
+source /opt/qt515/bin/qt515-env.sh
 
 echo ">>> Temporary install of Tahoma2D"
 export BUILDDIR=$(pwd)/toonz/build

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-sudo add-apt-repository --yes ppa:beineri/opt-qt597-xenial
+sudo add-apt-repository --yes ppa:beineri/opt-qt-5.15.2-bionic
 sudo apt-get update
-sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt59script libsuperlu-dev qt59svg qt59tools qt59multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg-turbo8-dev libglib2.0-dev qt59serialport
-sudo apt-get install -y nasm yasm libgnutls-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libfreetype6-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenjpeg-dev libspeex-dev libsoxr-dev libopenjp2-7-dev
+sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt515script libsuperlu-dev qt515svg qt515tools qt515multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg-turbo8-dev libturbojpeg0-dev libglib2.0-dev qt515serialport
+# Removed: libopenjpeg-dev 
+sudo apt-get install -y nasm yasm libgnutls28-dev libunistring-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libfreetype6-dev libopencore-amrnb-dev libopencore-amrwb-dev libspeex-dev libsoxr-dev libopenjp2-7-dev
 sudo apt-get install -y python3-pip
 sudo apt install -y build-essential libgirepository1.0-dev autotools-dev intltool gettext libtool
 
@@ -13,17 +14,17 @@ pip3 install numpy
 cd ..
 
 # someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
-if [ ! -f liblz4.deb ]
-then
-   wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb
-fi
-
-if [ ! -f liblz4-dev.db ]
-then
-   wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-dev_0.0~r131-2ubuntu2_amd64.deb -O liblz4-dev.deb
-fi
-
-sudo dpkg -i liblz4.deb liblz4-dev.deb
+#if [ ! -f liblz4.deb ]
+#then
+#   wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb
+#fi
+#
+#if [ ! -f liblz4-dev.db ]
+#then
+#   wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-dev_0.0~r131-2ubuntu2_amd64.deb -O liblz4-dev.deb
+#fi
+#
+#sudo dpkg -i liblz4.deb liblz4-dev.deb
 
 # Remove this as the version that is there is old and causes issues compiling opencv
 sudo apt-get remove libprotobuf-dev

--- a/ci-scripts/windows/tahoma-build.bat
+++ b/ci-scripts/windows/tahoma-build.bat
@@ -10,17 +10,16 @@ IF NOT EXIST build mkdir build
 cd build
 
 REM Setup for local builds
-set MSVCVERSION="Visual Studio 14 2015"
-set BOOST_ROOT=C:\boost\boost_1_61_0
+set MSVCVERSION="Visual Studio 16 2019"
+set BOOST_ROOT=C:\boost\boost_1_74_0
 set OPENCV_DIR=C:\opencv\451\build
-set QT_PATH=C:\Qt\5.9.7\msvc2015_64
+set QT_PATH=C:\Qt\5.15.2\msvc2019_64
 
 REM These are effective when running from Actions
 IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
 IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64 (
-	set MSVCVERSION="Visual Studio 15 2017"
-	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64 (
+	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64
 )
 
 set WITH_CANON=N

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -62,10 +62,10 @@ IF EXIST ..\..\thirdparty\apps\rhubarb (
 echo ">>> Configuring Tahoma2D.exe for deployment"
 
 REM Setup for local builds
-set QT_PATH=C:\Qt\5.9.7\msvc2015_64
+set QT_PATH=C:\Qt\5.15.2\msvc2019_64
 
 REM These are effective when running from Actions/Appveyor
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64
 
 %QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe
 

--- a/ci-scripts/windows/tahoma-install.bat
+++ b/ci-scripts/windows/tahoma-install.bat
@@ -1,9 +1,9 @@
 choco install opencv --version=4.5.1
-choco install boost-msvc-14.1
+choco install boost-msvc-14.2
 
-REM Install Qt 5.9
-curl -fsSL -o Qt5.9.7_msvc2017_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.9.7/Qt5.9.7_msvc2017_64.zip
-7z x Qt5.9.7_msvc2017_64.zip
-rename Qt5.9.7_msvc2017_64 5.9
+REM Install Qt 5.15
+curl -fsSL -o Qt5.15.2_msvc2019_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.15.2/Qt5.15.2_msvc2019_64.zip
+7z x Qt5.15.2_msvc2019_64.zip
+rename Qt5.15.2_msvc2019_64 5.15
 mkdir thirdparty\qt
-move 5.9 thirdparty\qt
+move 5.15 thirdparty\qt

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 5;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 5;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 5;
 }
 QMenu::item:selected {
   background-color: #a0c1dd;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 5;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Medium/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Medium/less/layouts/mainwindow.less
@@ -140,7 +140,7 @@ QMenu {
   padding: 2 0;
   &::item {
     border: 0;
-    padding: 3 28;
+    padding: 3 28 3 5;
     &:selected {
       background-color: @menu-item-bg-color-selected;
       color: @menu-item-text-color-selected;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 5;
 }
 QMenu::item:selected {
   background-color: #8FA0B2;

--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -97,6 +97,7 @@ public:
   QPointF m_mousePos;  // mouse position obtained with QMouseEvent::pos() or
                        // QTabletEvent::pos()
   bool m_isTablet;
+  bool m_isHighFrequent;
 
 public:
   TMouseEvent()
@@ -104,7 +105,8 @@ public:
       , m_modifiersMask(NO_KEY)
       , m_buttons(Qt::NoButton)
       , m_button(Qt::NoButton)
-      , m_isTablet(false) {}
+      , m_isTablet(false)
+      , m_isHighFrequent(false) {}
 
   bool isShiftPressed() const { return (m_modifiersMask & SHIFT_KEY); }
   bool isAltPressed() const { return (m_modifiersMask & ALT_KEY); }
@@ -115,6 +117,7 @@ public:
   Qt::MouseButton button() const { return m_button; }
   QPointF mousePos() const { return m_mousePos; }
   bool isTablet() const { return m_isTablet; }
+  bool isHighFrequent() const { return m_isHighFrequent; }
 
   void setModifiers(bool shiftPressed, bool altPressed, bool ctrlPressed) {
     m_modifiersMask = ModifierMask((shiftPressed << SHIFT_BITSHIFT) |

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -46,6 +46,7 @@ enum PreferencesItemId {
   interfaceFontStyle,
   colorCalibrationEnabled,
   colorCalibrationLutPaths,
+  showIconsInMenu,
   viewerIndicatorEnabled,
 
   //----------

--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -116,7 +116,8 @@ QPixmap DVAPI recolorPixmap(
     QPixmap pixmap, QColor color = Preferences::instance()->getIconTheme()
                                        ? Qt::black
                                        : Qt::white);
-QIcon DVAPI createQIcon(const char *iconSVGName, bool useFullOpacity = false);
+QIcon DVAPI createQIcon(const char *iconSVGName, bool useFullOpacity = false,
+                        bool isForMenuItem = false);
 QIcon DVAPI createQIconPNG(const char *iconPNGName);
 QIcon DVAPI createQIconOnOffPNG(const char *iconPNGName, bool withOver = true);
 QIcon DVAPI createTemporaryIconFromName(const char *commandName);

--- a/toonz/sources/tnztools/rasterselectiontool.h
+++ b/toonz/sources/tnztools/rasterselectiontool.h
@@ -108,7 +108,7 @@ protected:
   //! It's true when use RasterFreeDeformer
   bool m_isFreeDeformer;
 
-  void applyTransform(FourPoints bbox) override;
+  void applyTransform(FourPoints bbox, bool onFastDragging = false) override;
   void applyTransform(TAffine aff, bool modifyCenter);
   void addTransformUndo() override;
 
@@ -143,6 +143,7 @@ class RasterFreeDeformTool final : public RasterDeformTool {
 public:
   RasterFreeDeformTool(RasterSelectionTool *tool);
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
+  void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override;
 };
 
 //=============================================================================
@@ -169,9 +170,11 @@ class RasterScaleTool final : public RasterDeformTool {
 public:
   RasterScaleTool(RasterSelectionTool *tool, ScaleType type);
   /*! Return scale value. */
-  TPointD transform(int index, TPointD newPos) override;
+  TPointD transform(int index, TPointD newPos,
+                    bool onFastDragging = false) override;
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
+  void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override;
 };
 
 }  // namespace DragSelectionTool

--- a/toonz/sources/tnztools/selectiontool.h
+++ b/toonz/sources/tnztools/selectiontool.h
@@ -48,7 +48,7 @@ public:
   /*! Helper function. */
   virtual void setPoints(const TPointD &p0, const TPointD &p1,
                          const TPointD &p2, const TPointD &p3) = 0;
-  virtual void deformImage() = 0;
+  virtual void deformImage()                                   = 0;
 };
 
 //=============================================================================
@@ -152,15 +152,18 @@ public:
 
   SelectionTool *getTool() const { return m_tool; }
 
-  virtual void transform(TAffine aff, double angle){}
-  virtual void transform(TAffine aff){}
-  virtual TPointD transform(int index, TPointD newPos) { return TPointD(); }
-  virtual void addTransformUndo(){}
+  virtual void transform(TAffine aff, double angle) {}
+  virtual void transform(TAffine aff) {}
+  virtual TPointD transform(int index, TPointD newPos,
+                            bool onFastDragging = false) {
+    return TPointD();
+  }
+  virtual void addTransformUndo() {}
 
   virtual void leftButtonDown(const TPointD &pos, const TMouseEvent &) = 0;
   virtual void leftButtonDrag(const TPointD &pos, const TMouseEvent &) = 0;
   virtual void leftButtonUp(const TPointD &pos, const TMouseEvent &)   = 0;
-  virtual void draw() = 0;
+  virtual void draw()                                                  = 0;
 };
 
 //=============================================================================
@@ -177,7 +180,7 @@ protected:
 public:
   DeformTool(SelectionTool *tool);
 
-  virtual void applyTransform(FourPoints bbox) = 0;
+  virtual void applyTransform(FourPoints bbox, bool onFastDragging = false) = 0;
   virtual void applyTransform(TAffine aff){};
 
   void addTransformUndo() override = 0;
@@ -234,6 +237,7 @@ class FreeDeform {
 public:
   FreeDeform(DeformTool *deformTool);
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e);
+  void leftButtonUp();
 };
 
 //=============================================================================
@@ -254,11 +258,7 @@ public:
 // Scale
 //-----------------------------------------------------------------------------
 
-enum class ScaleType {
-  GLOBAL = 0,
-  HORIZONTAL,
-  VERTICAL
-};
+enum class ScaleType { GLOBAL = 0, HORIZONTAL, VERTICAL };
 
 class Scale {
   TPointD m_startCenter;
@@ -270,7 +270,6 @@ class Scale {
   DeformTool *m_deformTool;
 
 public:
-
   ScaleType m_type;
   Scale(DeformTool *deformTool, ScaleType type);
 
@@ -301,12 +300,13 @@ compute scaleValue. */
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e);
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e);
+  void leftButtonUp();
 
   std::vector<FourPoints> getStartBboxs() const { return m_startBboxs; }
   TPointD getStartCenter() const { return m_startCenter; }
   bool scaleInCenter() const { return m_scaleInCenter; }
 };
-};
+};  // namespace DragSelectionTool
 
 //=============================================================================
 // Utility
@@ -315,7 +315,8 @@ compute scaleValue. */
 DragSelectionTool::DragTool *createNewMoveSelectionTool(SelectionTool *st);
 DragSelectionTool::DragTool *createNewRotationTool(SelectionTool *st);
 DragSelectionTool::DragTool *createNewFreeDeformTool(SelectionTool *st);
-DragSelectionTool::DragTool *createNewScaleTool(SelectionTool *st, DragSelectionTool::ScaleType type);
+DragSelectionTool::DragTool *createNewScaleTool(
+    SelectionTool *st, DragSelectionTool::ScaleType type);
 
 //=============================================================================
 // SelectionTool
@@ -420,7 +421,7 @@ public:
                        int index = 0);
 
   FreeDeformer *getFreeDeformer(int index = 0) const;
-  virtual void setNewFreeDeformer()       = 0;
+  virtual void setNewFreeDeformer() = 0;
   void clearDeformers();
 
   int getSelectedPoint() const { return m_selectedPoint; }

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -579,7 +579,8 @@ DragSelectionTool::VectorDeformTool::~VectorDeformTool() {
 
 //-----------------------------------------------------------------------------
 
-void DragSelectionTool::VectorDeformTool::applyTransform(FourPoints bbox) {
+void DragSelectionTool::VectorDeformTool::applyTransform(FourPoints bbox,
+                                                         bool onFastDragging) {
   SelectionTool *tool = getTool();
 
   std::unique_ptr<VFDScopedBlock> localVfdScopedBlock;
@@ -852,8 +853,8 @@ DragSelectionTool::VectorScaleTool::VectorScaleTool(VectorSelectionTool *tool,
 
 //-----------------------------------------------------------------------------
 
-TPointD DragSelectionTool::VectorScaleTool::transform(int index,
-                                                      TPointD newPos) {
+TPointD DragSelectionTool::VectorScaleTool::transform(int index, TPointD newPos,
+                                                      bool onFastDragging) {
   SelectionTool *tool = getTool();
   TPointD scaleValue  = tool->m_deformValues.m_scaleValue;
 

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -150,7 +150,7 @@ public:
   VectorDeformTool(VectorSelectionTool *tool);
   ~VectorDeformTool();
 
-  void applyTransform(FourPoints bbox) override;
+  void applyTransform(FourPoints bbox, bool onFastDragging = false) override;
   void addTransformUndo() override;
 
   /*! Transform whole level and add undo. */
@@ -225,8 +225,8 @@ class VectorScaleTool final : public VectorDeformTool {
 public:
   VectorScaleTool(VectorSelectionTool *tool, ScaleType type);
 
-  TPointD transform(int index,
-                    TPointD newPos) override;  //!< Returns scale value.
+  TPointD transform(int index, TPointD newPos, bool onFastDragging = false)
+      override;  //!< Returns scale value.
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -418,7 +418,17 @@ int main(int argc, char *argv[]) {
   a.setAttribute(Qt::AA_CompressHighFrequencyEvents);
   a.setAttribute(Qt::AA_CompressTabletEvents);
 #endif
-  // Set the app's locale for numeric stuff to standard C. This is important for
+
+#ifdef _WIN32
+  // This attribute is set to make menubar icon to be always (16 x devPixRatio).
+  // Without this attribute the menu bar icon size becomes the same as tool bar
+  // when Windows scale is in 125%. Currently hiding the menu bar icon is done
+  // by setting transparent pixmap only in menu bar icon size. So the size must
+  // be different between for menu bar and for tool bar.
+  a.setAttribute(Qt::AA_Use96Dpi);
+#endif
+
+ // Set the app's locale for numeric stuff to standard C. This is important for
   // atof() and similar
   // calls that are locale-dependent.
   setlocale(LC_NUMERIC, "C");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1415,7 +1415,7 @@ QAction *MainWindow::createAction(const char *id, const char *name,
   QAction *action = new DVAction(tr(name), this);
 
 #if !defined(_WIN32)
-  bool visible = Preferences::instance()->getBoolValue(showIconsInMenu);
+  bool visible = false; //Preferences::instance()->getBoolValue(showIconsInMenu);
   action->setIconVisibleInMenu(visible);
 #endif
 
@@ -1435,7 +1435,6 @@ QAction *MainWindow::createAction(const char *id, const char *name,
     // do nothing for other platforms
   } else
     action->setIcon(createQIcon(iconSVGName, false, true));
-  action->setIconVisibleInMenu(false);
   addAction(action);
 #ifdef MACOSX
   // To prevent the wrong menu items (due to MacOS menu naming conventions),
@@ -1681,7 +1680,7 @@ QAction *MainWindow::createToggle(const char *id, const char *name,
   if (!iconSVGName || !*iconSVGName) action->setIcon(QIcon());
 #if defined(_WIN32)
   else {
-    bool visible = Preferences::instance()->getBoolValue(showIconsInMenu);
+    bool visible = false; //Preferences::instance()->getBoolValue(showIconsInMenu);
     action->setIconVisibleInMenu(visible);
   }
 #endif

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1434,7 +1434,7 @@ QAction *MainWindow::createAction(const char *id, const char *name,
 #endif
     // do nothing for other platforms
   } else
-    action->setIcon(createQIcon(iconSVGName));
+    action->setIcon(createQIcon(iconSVGName, false, true));
   action->setIconVisibleInMenu(false);
   addAction(action);
 #ifdef MACOSX
@@ -2984,7 +2984,7 @@ void MainWindow::defineActions() {
   menuAct =
       createMiscAction(MI_RefreshTree, QT_TR_NOOP("Refresh Folder Tree"), "");
   menuAct->setIconText(tr("Refresh"));
-  menuAct->setIcon(createQIcon("refresh"));
+  menuAct->setIcon(createQIcon("refresh", false, true));
   createMiscAction("A_FxSchematicToggle",
                    QT_TR_NOOP("Toggle FX/Stage schematic"), "");
   // createAction(MI_SavePreview, QT_TR_NOOP("&Save Preview"), "");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1679,6 +1679,12 @@ QAction *MainWindow::createToggle(const char *id, const char *name,
                                  iconSVGName);
   // Remove if the icon is not set. Checkbox will be drawn by style sheet.
   if (!iconSVGName || !*iconSVGName) action->setIcon(QIcon());
+#if defined(_WIN32)
+  else {
+    bool visible = Preferences::instance()->getBoolValue(showIconsInMenu);
+    action->setIconVisibleInMenu(visible);
+  }
+#endif
   action->setCheckable(true);
   if (startStatus == true) action->trigger();
   bool ret =

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1413,6 +1413,12 @@ QAction *MainWindow::createAction(const char *id, const char *name,
                                   QString newStatusTip, CommandType type,
                                   const char *iconSVGName) {
   QAction *action = new DVAction(tr(name), this);
+
+#if !defined(_WIN32)
+  bool visible = Preferences::instance()->getBoolValue(showIconsInMenu);
+  action->setIconVisibleInMenu(visible);
+#endif
+
   // In Qt5.15.2 - Windows, QMenu stylesheet has alignment issue when one item
   // has icon and another has not one. (See
   // https://bugreports.qt.io/browse/QTBUG-90242 for details.) To avoid the

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1019,6 +1019,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {colorCalibrationLutPaths,
        tr("3DLUT File for [%1]:")
            .arg(LutManager::instance()->getMonitorName())},
+      {showIconsInMenu, tr("Show Icons In Menu*")},
       {viewerIndicatorEnabled, tr("Show Viewer Indicators")},
 
       // Visualization
@@ -1476,6 +1477,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   // insertUI(interfaceFontStyle, lay, buildFontStyleList());
   QGridLayout* colorCalibLay = insertGroupBoxUI(colorCalibrationEnabled, lay);
   { insertUI(colorCalibrationLutPaths, colorCalibLay); }
+  insertUI(showIconsInMenu, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1477,7 +1477,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   // insertUI(interfaceFontStyle, lay, buildFontStyleList());
   QGridLayout* colorCalibLay = insertGroupBoxUI(colorCalibrationEnabled, lay);
   { insertUI(colorCalibrationLutPaths, colorCalibLay); }
-  insertUI(showIconsInMenu, lay);
+//  insertUI(showIconsInMenu, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -439,11 +439,11 @@ void Preferences::definePreferenceItems() {
 
   // hide menu icons by default in macOS since the icon color may not match with
   // the system color theme
-#ifdef Q_OS_MACOS
+//#ifdef Q_OS_MACOS
   bool defIconsVisible = false;
-#else
-  bool defIconsVisible = true;
-#endif
+//#else
+//  bool defIconsVisible = true;
+//#endif
   define(showIconsInMenu, "showIconsInMenu", QMetaType::Bool, defIconsVisible);
 
   setCallBack(pixelsOnly, &Preferences::setPixelsOnly);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -437,6 +437,15 @@ void Preferences::definePreferenceItems() {
   define(colorCalibrationLutPaths, "colorCalibrationLutPaths",
          QMetaType::QVariantMap, QVariantMap());
 
+  // hide menu icons by default in macOS since the icon color may not match with
+  // the system color theme
+#ifdef Q_OS_MACOS
+  bool defIconsVisible = false;
+#else
+  bool defIconsVisible = true;
+#endif
+  define(showIconsInMenu, "showIconsInMenu", QMetaType::Bool, defIconsVisible);
+
   setCallBack(pixelsOnly, &Preferences::setPixelsOnly);
   setCallBack(linearUnits, &Preferences::setUnits);
   setCallBack(cameraUnits, &Preferences::setCameraUnits);

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -267,7 +267,8 @@ QPixmap recolorPixmap(QPixmap pixmap, QColor color) {
 
 //-----------------------------------------------------------------------------
 
-QIcon createQIcon(const char *iconSVGName, bool useFullOpacity) {
+QIcon createQIcon(const char *iconSVGName, bool useFullOpacity,
+                  bool isForMenuItem) {
   static int devPixRatio = getDevPixRatio();
 
   QIcon themeIcon = QIcon::fromTheme(iconSVGName);
@@ -321,7 +322,8 @@ QIcon createQIcon(const char *iconSVGName, bool useFullOpacity) {
 #ifdef _WIN32
   bool showIconInMenu = Preferences::instance()->getBoolValue(showIconsInMenu);
   // set transparent icon
-  if (themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio) &&
+  if (isForMenuItem &&
+      themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio) &&
       !showIconInMenu) {
     static QPixmap emptyPm(16 * devPixRatio, 16 * devPixRatio);
     emptyPm.fill(Qt::transparent);

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -318,31 +318,47 @@ QIcon createQIcon(const char *iconSVGName, bool useFullOpacity) {
 
   QIcon icon;
 
-  // Base icon
-  icon.addPixmap(compositePixmap(themeIconPixmap, baseOpacity), QIcon::Normal,
-                 QIcon::Off);
-  icon.addPixmap(compositePixmap(themeIconPixmap, disabledOpacity),
-                 QIcon::Disabled, QIcon::Off);
+#ifdef _WIN32
+  bool showIconInMenu = Preferences::instance()->getBoolValue(showIconsInMenu);
+  // set transparent icon
+  if (themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio) &&
+      !showIconInMenu) {
+    static QPixmap emptyPm(16 * devPixRatio, 16 * devPixRatio);
+    emptyPm.fill(Qt::transparent);
 
-  // Over icon
-  icon.addPixmap(!overPixmap.isNull()
-                     ? compositePixmap(overPixmap, activeOpacity)
-                     : compositePixmap(themeIconPixmap, activeOpacity),
-                 QIcon::Active);
-
-  // On icon
-  if (!onPixmap.isNull()) {
-    icon.addPixmap(compositePixmap(onPixmap, activeOpacity), QIcon::Normal,
-                   QIcon::On);
-    icon.addPixmap(compositePixmap(onPixmap, disabledOpacity), QIcon::Disabled,
-                   QIcon::On);
-  } else {
-    icon.addPixmap(compositePixmap(themeIconPixmap, activeOpacity),
-                   QIcon::Normal, QIcon::On);
+    icon.addPixmap(emptyPm, QIcon::Normal, QIcon::Off);
+    icon.addPixmap(emptyPm, QIcon::Normal, QIcon::On);
+    icon.addPixmap(emptyPm, QIcon::Disabled, QIcon::Off);
+    icon.addPixmap(emptyPm, QIcon::Disabled, QIcon::On);
+    icon.addPixmap(emptyPm, QIcon::Active);
+  } else
+#endif
+  {
+    // Base icon
+    icon.addPixmap(compositePixmap(themeIconPixmap, baseOpacity), QIcon::Normal,
+                   QIcon::Off);
     icon.addPixmap(compositePixmap(themeIconPixmap, disabledOpacity),
-                   QIcon::Disabled, QIcon::On);
-  }
+                   QIcon::Disabled, QIcon::Off);
+ 
+    // Over icon
+    icon.addPixmap(!overPixmap.isNull()
+                       ? compositePixmap(overPixmap, activeOpacity)
+                       : compositePixmap(themeIconPixmap, activeOpacity),
+                   QIcon::Active);
 
+    // On icon
+    if (!onPixmap.isNull()) {
+      icon.addPixmap(compositePixmap(onPixmap, activeOpacity), QIcon::Normal,
+                     QIcon::On);
+      icon.addPixmap(compositePixmap(onPixmap, disabledOpacity),
+                     QIcon::Disabled, QIcon::On);
+    } else {
+      icon.addPixmap(compositePixmap(themeIconPixmap, activeOpacity),
+                     QIcon::Normal, QIcon::On);
+      icon.addPixmap(compositePixmap(themeIconPixmap, disabledOpacity),
+                     QIcon::Disabled, QIcon::On);
+    }
+  }
   //----------
 
   // For icons intended for menus that are 16x16 in dimensions, to repurpose

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -320,7 +320,7 @@ QIcon createQIcon(const char *iconSVGName, bool useFullOpacity,
   QIcon icon;
 
 #ifdef _WIN32
-  bool showIconInMenu = Preferences::instance()->getBoolValue(showIconsInMenu);
+  bool showIconInMenu = false; //Preferences::instance()->getBoolValue(showIconsInMenu);
   // set transparent icon
   if (isForMenuItem &&
       themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio) &&


### PR DESCRIPTION
This PR changes the build environment as follows:

- Windows Builds
  - Changed to use Qt 5.15.2
  - Builds using MSVC 2019

- Linux Builds
  - Changed to use Qt 5.15.2
  - Builds on Ubuntu 18.04 (required due to deprecation of Ubuntu 16.04)

- macOS Builds
  - No changes as they are already on 5.15.2

The following OpenToonz PR's were applied to address Qt 5.15 bugs:

opentoonz/opentoonz/#3842 - Make Menu Icons Optional  by @shun-iwasawa 
opentoonz/opentoonz/#3850 - Fix Hidden Icons  by @shun-iwasawa
opentoonz/opentoonz/#3857 - Fix Hide Icons in Windows with Scale 125 %  by @shun-iwasawa
opentoonz/opentoonz/#3898 - Fix Missing Checkboxes in Menu Item  by @shun-iwasawa
opentoonz/opentoonz/#3917 - Fix Raster Deformation Slowness  by @shun-iwasawa

NOTE: The icon related PRs were needed to fix Qt 5.15 icon alignment issue but menu icons are still hidden in Tahoma2d. Options to show/hide menu icons has been hidden.
