### PR TITLE
Allow renaming of revamped Pass Through Fx nodes

### DIFF
--- a/toonz/sources/include/toonzqt/fxschematicnode.h
+++ b/toonz/sources/include/toonzqt/fxschematicnode.h
@@ -609,17 +609,21 @@ class FxPassThroughPainter final : public QObject, public QGraphicsItem {
   Q_INTERFACES(QGraphicsItem)
 
   double m_width, m_height;
+  QString m_name;
+  bool m_showName;
 
   FxSchematicPassThroughNode *m_parent;
 
 public:
   FxPassThroughPainter(FxSchematicPassThroughNode *parent, double width,
-                       double height);
+                       double height, const QString &name, bool showName);
   ~FxPassThroughPainter();
 
   QRectF boundingRect() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
              QWidget *widget = 0) override;
+  void setName(const QString &name) { m_name = name; }
+  void setShowName(bool showName) { m_showName = showName; }
 
 protected:
   void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
@@ -632,6 +636,8 @@ protected:
 class FxSchematicPassThroughNode final : public FxSchematicNode {
   Q_OBJECT
 
+  bool m_showName;
+
   FxPassThroughPainter *m_passThroughPainter;
 
 public:
@@ -641,9 +647,15 @@ public:
   QRectF boundingRect() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
              QWidget *widget = 0) override;
+  bool isOpened() override { return false; }
 
 protected:
+  void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *me) override;
   void mousePressEvent(QGraphicsSceneMouseEvent *me) override;
+
+protected slots:
+
+  void onNameChanged();
 };
 
 #endif  // FXSCHEMATICNODE_H

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1583,10 +1583,13 @@ void StageSchematicNode::onHandleReleased() {
 StageSchematicPegbarNode::StageSchematicPegbarNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
     : StageSchematicNode(scene, pegbar, 90, 18, false, false) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
+
   std::string name = m_stageObject->getFullName();
   std::string id   = m_stageObject->getId().toString();
   m_name           = QString::fromStdString(name);
   m_nameItem       = new SchematicName(this, 72, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);
@@ -1728,6 +1731,7 @@ StageSchematicColumnNode::StageSchematicColumnNode(StageSchematicScene *scene,
                        SLOT(onChangedSize(bool)));
 
   m_nameItem = new SchematicName(this, 54, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);
@@ -2027,10 +2031,13 @@ void StageSchematicColumnNode::onCameraStandToggleClicked(int state) {
 StageSchematicCameraNode::StageSchematicCameraNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
     : StageSchematicNode(scene, pegbar, 90, 18, false, false) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
+
   std::string name = m_stageObject->getFullName();
   m_name           = QString::fromStdString(name);
 
   m_nameItem = new SchematicName(this, 54, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
 
   m_nameItem->setPos(16, -2);
@@ -2106,6 +2113,8 @@ void StageSchematicCameraNode::onNameChanged() {
 StageSchematicSplineNode::StageSchematicSplineNode(StageSchematicScene *scene,
                                                    TStageObjectSpline *spline)
     : SchematicNode(scene), m_spline(spline), m_isOpened(false) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
+
   m_width  = 90;
   m_height = 18;
   assert(spline);
@@ -2123,6 +2132,7 @@ StageSchematicSplineNode::StageSchematicSplineNode(StageSchematicScene *scene,
   std::string name = m_spline->getName();
   m_splineName     = QString::fromStdString(name);
   m_nameItem       = new SchematicName(this, 72, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_splineName);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);
@@ -2239,6 +2249,8 @@ StageSchematicGroupNode::StageSchematicGroupNode(
     : StageSchematicNode(scene, root, 90, 18, true)
     , m_root(root)
     , m_groupedObj(groupedObj) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
+
   int i;
   for (i   = 0; i < m_groupedObj.size(); i++) m_groupedObj[i]->addRef();
   bool ret = true;
@@ -2246,6 +2258,7 @@ StageSchematicGroupNode::StageSchematicGroupNode(
   m_name            = QString::fromStdWString(name);
 
   m_nameItem = new SchematicName(this, 72, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);


### PR DESCRIPTION
This PR adds the ability to rename the revamped Pass Through Fx node that was added as part of #753.

By default, a newly added Pass Through node does not show it's name (usually PassThrough##).  When renamed by double-clicking the node, the name will appear immediately above it. If the name is blank, it will reset the name back to it's original name and will not be displayed.

Also sets the default text color when renaming stage or fx nodes by using the viewer text color specified by theme's stylesheet. 