### PR TITLE
Set directory permissions on macOS/Linux builds

### DIFF
--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -44,6 +44,7 @@ then
    fi
    mkdir -p Tahoma2D/ffmpeg
    cp -R ../../thirdparty/apps/ffmpeg/bin/ffmpeg ../../thirdparty/apps/ffmpeg/bin/ffprobe Tahoma2D/ffmpeg
+   chmod -R 755 Tahoma2D/ffmpeg
 fi
 
 if [ -d ../../thirdparty/apps/rhubarb ]
@@ -55,6 +56,7 @@ then
    fi
    mkdir -p Tahoma2D/rhubarb
    cp -R ../../thirdparty/apps/rhubarb/rhubarb ../../thirdparty/apps/rhubarb/res Tahoma2D/rhubarb
+   chmod 755 -R Tahoma2D/rhubarb
 fi
 
 echo ">>> Creating Tahoma2D/Tahoma2D.AppImage"

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -32,6 +32,7 @@ then
    fi
    mkdir $TOONZDIR/Tahoma2D.app/ffmpeg
    cp -R thirdparty/apps/ffmpeg/bin/ffmpeg thirdparty/apps/ffmpeg/bin/ffprobe $TOONZDIR/Tahoma2D.app/ffmpeg
+   chmod -R 755 $TOONZDIR/Tahoma2D.app/ffmpeg
 fi
 
 if [ -d thirdparty/apps/rhubarb ]
@@ -44,6 +45,7 @@ then
    fi
    mkdir $TOONZDIR/Tahoma2D.app/rhubarb
    cp -R thirdparty/apps/rhubarb/rhubarb thirdparty/apps/rhubarb/res $TOONZDIR/Tahoma2D.app/rhubarb
+   chmod -R 755 $TOONZDIR/Tahoma2D.app/rhubarb
 fi
 
 if [ -d thirdparty/canon/Framework ]
@@ -54,6 +56,7 @@ then
       mkdir $TOONZDIR/Tahoma2D.app/Contents/Frameworks
    fi
    cp -R thirdparty/canon/Framework/ $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+   chmod -R 755 $TOONZDIR/Tahoma2D.app/Contents/Frameworks/EDSDK.framework
 fi
 
 echo ">>> Configuring Tahoma2D.app for deployment"


### PR DESCRIPTION
This PR fixes one of the issues reported in #784 where other users failed to start Tahoma2D due to missing Canon SDK.

For some reason the Contents\EDSDK.frameworks directory only had owner access and completely blocked group/world access.

Modified macOS and Linux build scripts to change permissions to 755 (owner = full, group = read/execute, world read/execute) for anything the build scripts copies to the final directory such as ffmpeg, rhubarb and the Canon framework (macOS only).
