### PR TITLE
Fix vector fill crash caused by missing refer visible option

### DIFF
--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1701,7 +1701,7 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
         m_multiFrameMode->isChecked())
       m_onionMode->setEnabled(false);
     if (m_autopaintMode) m_autopaintMode->setEnabled(false);
-    m_referenced->setEnabled(false);
+    if (m_referenced) m_referenced->setEnabled(false);
   }
   if (m_toolType->getProperty()->getValue() != L"Normal") {
     if (m_segmentMode) m_segmentMode->setEnabled(false);
@@ -1738,7 +1738,7 @@ void FillToolOptionsBox::onColorModeChanged(int index) {
   }
   enabled = range[index] != L"Lines" && !m_multiFrameMode->isChecked();
   m_onionMode->setEnabled(enabled);
-  m_referenced->setEnabled(enabled);
+  if (m_referenced) m_referenced->setEnabled(enabled);
   checkGapSettingsVisibility();
 }
 
@@ -1796,7 +1796,7 @@ void FillToolOptionsBox::checkGapSettingsVisibility() {
 void FillToolOptionsBox::onToolTypeChanged(int index) {
   const TEnumProperty::Range &range = m_toolType->getProperty()->getRange();
   bool enabled                      = range[index] == L"Normal";
-  m_referenced->setEnabled(enabled);
+  if (m_referenced) m_referenced->setEnabled(enabled);
   if (m_segmentMode)
     m_segmentMode->setEnabled(
         enabled ? m_colorMode->getProperty()->getValue() != L"Areas" : false);


### PR DESCRIPTION
This PR fixes a crash reported on a vector level when attempting to change the mode on the Fill Tool.

This was caused by the addition of the Refer Visible fill tool option which is not available for Vector levels.  The option is not properly initialized for Vector levels and crashes when the Fill Tool attempts to update the tool options bar.

Added checks to ignore the Refer Visible option when it is not available as is the case for Vector levels.