### PR TITLE
Add Tahoma2D Stuff and Downloads folder access from Browser

### DIFF
--- a/toonz/sources/include/toonz/toonzfolders.h
+++ b/toonz/sources/include/toonz/toonzfolders.h
@@ -41,6 +41,7 @@ DVAPI TFilePath getFirstProjectsFolder();
 DVAPI TFilePath getStudioPaletteFolder();
 DVAPI TFilePath getFxPresetFolder();
 DVAPI TFilePath getLibraryFolder();
+DVAPI TFilePath getPluginsFolder();
 DVAPI TFilePath getReslistPath(bool forCleanup);
 DVAPI TFilePath getCacheRootFolder();
 DVAPI TFilePath getProfileFolder();

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -598,6 +598,7 @@ void FileBrowser::refreshCurrentFolderItems() {
         if (it->getType() != "tnz" && it->getType() != "scr" &&
             it->getType() != "tnzbat" && it->getType() != "mpath" &&
             it->getType() != "curve" && it->getType() != "tpl" &&
+            it->getType() != "macrofx" && it->getType() != "plugin" &&
             TFileType::getInfo(*it) == TFileType::UNKNOW_FILE)
           continue;
       } else if (!m_filter.contains(QString::fromStdString(it->getType())))

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -1068,7 +1068,7 @@ void DvDirModelStuffFolderNode::refreshChildren() {
   addChild(child);
 
   child = new DvDirModelSpecialFileFolderNode(
-      this, L"Sudio Palettes", ToonzFolder::getStudioPaletteFolder());
+      this, L"Studio Palettes", ToonzFolder::getStudioPaletteFolder());
   child->setPixmap(
       recolorPixmap(svgToPixmap(getIconThemePath("actions/16/palette.svg"))));
   addChild(child);

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -1024,6 +1024,57 @@ QPixmap DvDirModelNetworkNode::getPixmap(bool isOpen) const {
 
 //=============================================================================
 //
+// DvDirModelStuffFolderNode [Tahoma2D]
+//
+//-----------------------------------------------------------------------------
+
+DvDirModelStuffFolderNode::DvDirModelStuffFolderNode(DvDirModelNode *parent)
+    : DvDirModelNode(parent, L"Tahoma2D") {
+  m_nodeType = "StuffFolder";
+}
+
+//-----------------------------------------------------------------------------
+
+void DvDirModelStuffFolderNode::refreshChildren() {
+  m_childrenValid = true;
+  if (!m_children.empty()) clearPointerContainer(m_children);
+
+  DvDirModelSpecialFileFolderNode *child = new DvDirModelSpecialFileFolderNode(
+      this, L"Library", ToonzFolder::getLibraryFolder());
+  child->setPixmap(
+      recolorPixmap(svgToPixmap(getIconThemePath("actions/16/library.svg"))));
+  addChild(child);
+
+  child = new DvDirModelSpecialFileFolderNode(
+      this, L"Fx Macros",
+      ToonzFolder::getFxPresetFolder() + TFilePath("presets/macroFx"));
+  child->setPixmap(
+      recolorPixmap(svgToPixmap(getIconThemePath("actions/16/fx_logo.svg"))));
+  addChild(child);
+
+  child = new DvDirModelSpecialFileFolderNode(this, L"Fx Plugins",
+                                              ToonzFolder::getPluginsFolder());
+  child->setPixmap(
+      recolorPixmap(svgToPixmap(getIconThemePath("actions/16/plugins.svg"))));
+  addChild(child);
+
+  child = new DvDirModelSpecialFileFolderNode(
+      this, L"Sudio Palettes", ToonzFolder::getStudioPaletteFolder());
+  child->setPixmap(
+      recolorPixmap(svgToPixmap(getIconThemePath("actions/16/palette.svg"))));
+  addChild(child);
+}
+
+//-----------------------------------------------------------------------------
+
+QPixmap DvDirModelStuffFolderNode::getPixmap(bool isOpen) const {
+  QIcon icon            = createQIcon("tahoma2d");
+  static QPixmap pixmap = icon.pixmap(16);
+  return pixmap;
+}
+
+//=============================================================================
+//
 // DvDirModelRootNode [Root]
 //
 //-----------------------------------------------------------------------------
@@ -1070,12 +1121,14 @@ void DvDirModelRootNode::refreshChildren() {
     m_specialNodes.push_back(child);
     addChild(child);
 
-    child = new DvDirModelSpecialFileFolderNode(
-        this, L"Library", ToonzFolder::getLibraryFolder());
-    child->setPixmap(
-        recolorPixmap(svgToPixmap(getIconThemePath("actions/16/library.svg"))));
-    m_specialNodes.push_back(child);
-    addChild(child);
+    DvDirModelStuffFolderNode *childstuff = new DvDirModelStuffFolderNode(this);
+    for (int i = 0; i < childstuff->getChildCount(); i++) {
+      DvDirModelSpecialFileFolderNode *node =
+          dynamic_cast<DvDirModelSpecialFileFolderNode *>(
+              childstuff->getChild(i));
+      m_specialNodes.push_back(node);
+    }
+    addChild(childstuff);
 
     addChild(new DvDirModelHistoryNode(this));
 

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -20,6 +20,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QDirIterator>
+#include <QStandardPaths>
 
 #ifdef _WIN32
 #include <shlobj.h>
@@ -76,6 +77,14 @@ TFilePath getDesktopPath() {
   if (!dir.cd("Desktop")) return TFilePath();
   return TFilePath(dir.absolutePath().toStdString());
 #endif
+}
+
+// Downloads Path
+TFilePath getDownloadsPath() {
+  QStringList stdLocs =
+      QStandardPaths::standardLocations(QStandardPaths::DownloadLocation);
+  if (stdLocs.isEmpty()) return TFilePath();
+  return TFilePath(stdLocs[0]);
 }
 }  // namespace
 
@@ -1118,6 +1127,13 @@ void DvDirModelRootNode::refreshChildren() {
         new DvDirModelSpecialFileFolderNode(this, L"Desktop", getDesktopPath());
     child->setPixmap(
         recolorPixmap(svgToPixmap(getIconThemePath("actions/16/desktop.svg"))));
+    m_specialNodes.push_back(child);
+    addChild(child);
+
+    child = new DvDirModelSpecialFileFolderNode(this, L"Downloads",
+                                                getDownloadsPath());
+    child->setPixmap(recolorPixmap(
+        svgToPixmap(getIconThemePath("actions/16/downloads.svg"))));
     m_specialNodes.push_back(child);
     addChild(child);
 

--- a/toonz/sources/toonz/filebrowsermodel.h
+++ b/toonz/sources/toonz/filebrowsermodel.h
@@ -304,6 +304,16 @@ public:
 
 //-----------------------------------------------------------------------------
 
+class DvDirModelStuffFolderNode final : public DvDirModelNode {
+public:
+  DvDirModelStuffFolderNode(DvDirModelNode *parent);
+  void refreshChildren() override;
+  QPixmap getPixmap(bool isOpen) const override;
+  bool isFolder() const override { return true; }
+};
+
+//-----------------------------------------------------------------------------
+
 class DvDirModelRootNode final : public DvDirModelNode {
   std::vector<DvDirModelFileFolderNode *> m_versionControlNodes;
   std::vector<DvDirModelProjectNode *> m_projectNodes;

--- a/toonz/sources/toonz/icons/dark/actions/16/downloads.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/downloads.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg10"
+   sodipodi:docname="downloads.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   id="metadata16"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs14" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1776"
+   inkscape:window-height="924"
+   id="namedview12"
+   showgrid="true"
+   inkscape:zoom="45.6875"
+   inkscape:cx="4.3009576"
+   inkscape:cy="8.1071639"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg10"><inkscape:grid
+     type="xygrid"
+     id="grid823" /></sodipodi:namedview>
+    
+    
+<path
+   style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
+   d="M 5 1 L 5 9 L 1 9 L 8 15 L 15 9 L 11 9 L 11 1 L 5 1 z M 6 2 L 10 2 L 10 10 L 12.240234 10 L 8 13.496094 L 3.7382812 10 L 6 10 L 6 2 z "
+   id="rect815" /></svg>

--- a/toonz/sources/toonz/icons/dark/actions/16/plugins.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/plugins.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg10"
+   sodipodi:docname="plugins.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   id="metadata16"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs14" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1776"
+   inkscape:window-height="924"
+   id="namedview12"
+   showgrid="true"
+   inkscape:zoom="32.305941"
+   inkscape:cx="5.6225993"
+   inkscape:cy="9.8678116"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg10"><inkscape:grid
+     type="xygrid"
+     id="grid823" /></sodipodi:namedview>
+    
+    
+<path
+   style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
+   d="M 12.31029,11.228219 C 9.2989358,13.063976 8.0396828,12.660467 5.1650498,10.898304 4.8840244,10.726034 2.785243,12.893926 2.0230434,11.643623 1.3201538,10.490611 4.1657951,9.5349931 4.1347896,9.2149275 3.8106811,5.8691998 4.0865049,4.5298897 7.1051139,2.6897101 7.8940569,4.0402884 12.200257,10.985438 12.31029,11.228219 Z"
+   id="path830"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="cscscc" /><path
+   style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
+   d="M 9,3.8768944 C 9.8538509,3.3563768 9.7645646,3.4108068 10.707702,2.8358592 11.650839,2.2609116 12.415404,1.794824 12.935921,2.6486749 13.456439,3.5025258 12.691874,3.9686134 11.748737,4.543561 10.8056,5.1185087 10.894886,5.0640786 10.041035,5.5845962"
+   id="path833"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="csssc" /><path
+   style="clip-rule:evenodd;opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.25;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
+   d="M 11.08207,7.2922981 C 11.935921,6.7717805 11.846635,6.8262105 12.789772,6.2512629 13.73291,5.6763153 14.497474,5.2102277 15.017992,6.0640786 15.538509,6.9179296 14.773945,7.3840172 13.830808,7.9589648 12.88767,8.5339124 12.976957,8.4794824 12.123106,9"
+   id="path833-6"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="csssc" /></svg>

--- a/toonz/sources/toonz/icons/dark/actions/16/tahoma2d.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/tahoma2d.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg10"
+   sodipodi:docname="tahoma2d.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   id="metadata16"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs14" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1776"
+   inkscape:window-height="924"
+   id="namedview12"
+   showgrid="true"
+   inkscape:zoom="45.6875"
+   inkscape:cx="8"
+   inkscape:cy="8.1071639"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg10"><inkscape:grid
+     type="xygrid"
+     id="grid823" /></sodipodi:namedview>
+    
+    
+<path
+   style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
+   d="M 1,1 V 15 H 15 V 1 Z M 2,2 H 9 L 2,3 Z M 14,2 V 14 H 2 V 4 Z"
+   id="rect881"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="cccccccccccccc" /><path
+   style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
+   d="M 10.030687,5.6615521 14,5 V 7 L 11,7.5048656 V 14 h -1 z"
+   id="rect890"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="ccccccc" /><path
+   style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
+   d="M 2,7 7.0208156,6.1631974 7,14 H 5 V 8.5253077 L 2,9 Z"
+   id="rect892"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="ccccccc" /></svg>

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -53,7 +53,10 @@
 		<file>icons/dark/actions/16/rotateleft.svg</file>
 		<file>icons/dark/actions/16/rotateright.svg</file>
 
-		<!-- File / Common -->
+    <file>icons/dark/actions/16/tahoma2d.svg</file>
+    <file>icons/dark/actions/16/plugins.svg</file>
+
+    <!-- File / Common -->
 		<file>icons/dark/actions/16/menu.svg</file>
 		<file>icons/dark/actions/16/export.svg</file>
 		<file>icons/dark/actions/16/import.svg</file>

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -55,6 +55,7 @@
 
     <file>icons/dark/actions/16/tahoma2d.svg</file>
     <file>icons/dark/actions/16/plugins.svg</file>
+    <file>icons/dark/actions/16/downloads.svg</file>
 
     <!-- File / Common -->
 		<file>icons/dark/actions/16/menu.svg</file>

--- a/toonz/sources/toonzlib/toonzfolders.cpp
+++ b/toonz/sources/toonzlib/toonzfolders.cpp
@@ -107,6 +107,11 @@ TFilePath ToonzFolder::getFxPresetFolder() {
   return fp;
 }
 
+TFilePath ToonzFolder::getPluginsFolder() {
+  TFilePath fp = getStuffDir() + TFilePath("plugins");
+  return fp;
+}
+
 TFilePath ToonzFolder::getCacheRootFolder() {
   static enum STATE { FIRSTTIME, OK, NG } state = FIRSTTIME;
   QString cacheDir =

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -641,7 +641,8 @@ bool isResource(const QString &path) {
 
   return (TFileType::isViewable(type) || type & TFileType::MESH_IMAGE ||
           type == TFileType::AUDIO_LEVEL || type == TFileType::TABSCENE ||
-          type == TFileType::TOONZSCENE || fp.getType() == "tpl");
+          type == TFileType::TOONZSCENE || fp.getType() == "tpl" ||
+          fp.getType() == "macrofx" || fp.getType() == "plugin");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds access to `Downloads` folder and specific `tahomastuff` folders (under a `Tahoma2D` group) from the Browser pane:

This is especially useful for macOS users whose stuff folder isn't easily accessible through the system's file browser.

![image](https://user-images.githubusercontent.com/19245851/135091051-8d6fe83c-7fa4-4198-8cf3-578ffa443af0.png)

- `Library` - maps to `tahomastuff\library` (already existed but moved into Tahoma2D group)
- `Fx Macros` - maps to `tahomastuff\fxs\presets\macroFx`
- `Fx Plugins` - maps to `tahomastuff\plugins`
- `Studio Palettes` - maps to `tahomastuff\studiopalette`