### PR TITLE
Build using Qt 5.11.3

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Windows:
-    runs-on: windows-2019
+    runs-on: windows-2016
     steps:
       - uses: actions/checkout@v2
         with:

--- a/ci-scripts/windows/tahoma-build.bat
+++ b/ci-scripts/windows/tahoma-build.bat
@@ -10,16 +10,16 @@ IF NOT EXIST build mkdir build
 cd build
 
 REM Setup for local builds
-set MSVCVERSION="Visual Studio 16 2019"
+set MSVCVERSION="Visual Studio 15 2017"
 set BOOST_ROOT=C:\boost\boost_1_74_0
 set OPENCV_DIR=C:\opencv\451\build
-set QT_PATH=C:\Qt\5.11.3\msvc2015_64
+set QT_PATH=C:\Qt\5.11.3\msvc2017_64
 
 REM These are effective when running from Actions
 IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
 IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64 (
-	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2017_64 (
+	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2017_64
 )
 
 set WITH_CANON=N

--- a/ci-scripts/windows/tahoma-build.bat
+++ b/ci-scripts/windows/tahoma-build.bat
@@ -13,13 +13,13 @@ REM Setup for local builds
 set MSVCVERSION="Visual Studio 16 2019"
 set BOOST_ROOT=C:\boost\boost_1_74_0
 set OPENCV_DIR=C:\opencv\451\build
-set QT_PATH=C:\Qt\5.15.2\msvc2019_64
+set QT_PATH=C:\Qt\5.11.3\msvc2015_64
 
 REM These are effective when running from Actions
 IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
 IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64 (
-	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64 (
+	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64
 )
 
 set WITH_CANON=N

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -62,10 +62,10 @@ IF EXIST ..\..\thirdparty\apps\rhubarb (
 echo ">>> Configuring Tahoma2D.exe for deployment"
 
 REM Setup for local builds
-set QT_PATH=C:\Qt\5.15.2\msvc2019_64
+set QT_PATH=C:\Qt\5.11.3\msvc2015_64
 
 REM These are effective when running from Actions/Appveyor
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15\msvc2019_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64
 
 %QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe
 

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -62,10 +62,10 @@ IF EXIST ..\..\thirdparty\apps\rhubarb (
 echo ">>> Configuring Tahoma2D.exe for deployment"
 
 REM Setup for local builds
-set QT_PATH=C:\Qt\5.11.3\msvc2015_64
+set QT_PATH=C:\Qt\5.11.3\msvc2017_64
 
 REM These are effective when running from Actions/Appveyor
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2015_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2017_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.11\msvc2017_64
 
 %QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe
 

--- a/ci-scripts/windows/tahoma-install.bat
+++ b/ci-scripts/windows/tahoma-install.bat
@@ -1,9 +1,9 @@
 choco install opencv --version=4.5.1
 choco install boost-msvc-14.2
 
-REM Install Qt 5.15
-curl -fsSL -o Qt5.15.2_msvc2019_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.15.2/Qt5.15.2_msvc2019_64.zip
-7z x Qt5.15.2_msvc2019_64.zip
-rename Qt5.15.2_msvc2019_64 5.15
+REM Install Qt 5.11
+curl -fsSL -o Qt5.11.3_msvc2015_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.11.3/Qt5.11.3_msvc2015_64.zip
+7z x Qt5.11.3_msvc2015_64.zip
+rename Qt5.11.3_msvc2015_64 5.11
 mkdir thirdparty\qt
-move 5.15 thirdparty\qt
+move 5.11 thirdparty\qt

--- a/ci-scripts/windows/tahoma-install.bat
+++ b/ci-scripts/windows/tahoma-install.bat
@@ -1,9 +1,9 @@
 choco install opencv --version=4.5.1
-choco install boost-msvc-14.2
+choco install boost-msvc-14.1
 
 REM Install Qt 5.11
-curl -fsSL -o Qt5.11.3_msvc2015_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.11.3/Qt5.11.3_msvc2015_64.zip
-7z x Qt5.11.3_msvc2015_64.zip
-rename Qt5.11.3_msvc2015_64 5.11
+curl -fsSL -o Qt5.11.3_msvc2017_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.11.3/Qt5.11.3_msvc2017_64.zip
+7z x Qt5.11.3_msvc2017_64.zip
+rename Qt5.11.3_msvc2017_64 5.11
 mkdir thirdparty\qt
 move 5.11 thirdparty\qt

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 5;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 5;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 5;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #a0c1dd;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 5;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #5385a6;

--- a/stuff/config/qss/Medium/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Medium/less/layouts/mainwindow.less
@@ -140,7 +140,7 @@ QMenu {
   padding: 2 0;
   &::item {
     border: 0;
-    padding: 3 28 3 5;
+    padding: 3 28;
     &:selected {
       background-color: @menu-item-bg-color-selected;
       color: @menu-item-text-color-selected;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 5;
+  padding: 3 28;
 }
 QMenu::item:selected {
   background-color: #8FA0B2;


### PR DESCRIPTION
This PR will drop back to building Windows builds using Qt 5.11.3, the last version before Qt added Windows Ink support to their libraries starting in 5.12.0.

I am doing this because 5.15.2 with/without WinTab support doesn't appear to fix the issues in T2D as it does in OT, despite all 5.15.2 changes being ported over.  In addition to that, the 5.15.2 w/ WinTab support didn't fix any of the reported 5.15.2 issues reported in OT on 3 separate machines I have, yet appears to work for others.