### PR TITLE
Disable local WinInk Support with Qt 5.12

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -845,7 +845,9 @@ int main(int argc, char *argv[]) {
 #endif
 #endif
 
-#ifdef _WIN32
+// Windows Ink Support was introduce into Qt 5.12 so disable
+// our version when compiling with it
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
   if (Preferences::instance()->isWinInkEnabled()) {
     KisTabletSupportWin8 *penFilter = new KisTabletSupportWin8();
     if (penFilter->init()) {

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1933,7 +1933,7 @@ QWidget* PreferencesPopup::createVersionControlPage() {
 
 QWidget* PreferencesPopup::createTouchTabletPage() {
   bool winInkAvailable = false;
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
   winInkAvailable = KisTabletSupportWin8::isAvailable();
 #endif
 


### PR DESCRIPTION
With Qt adding support for Windows Ink starting with Qt 5.12 or later, we no longer need to have our local Windows Ink support option.  It should not be used and causes issues with Vector lines when enabled.

Added macros to disable it when compiling with Qt 5.12 or later.