### PR TITLE
Fix Studio Palette Crash from Style Management change

### DIFF
--- a/toonz/sources/include/toonzqt/studiopaletteviewer.h
+++ b/toonz/sources/include/toonzqt/studiopaletteviewer.h
@@ -4,7 +4,9 @@
 #define STUDIOPALETTEVIEWER_H
 
 #include "toonz/studiopalette.h"
+#include "toonz/tapplication.h"
 #include "toonz/tproject.h"
+#include "toonzqt/paletteviewer.h"
 #include "toonzqt/dvdialog.h"
 
 #include <QTreeWidget>
@@ -218,6 +220,8 @@ class DVAPI StudioPaletteViewer final : public QSplitter {
   StudioPaletteTreeViewer *m_studioPaletteTreeViewer;
   PaletteViewer *m_studioPaletteViewer;
 
+  TApplication *m_app;
+
 public:
   StudioPaletteViewer(QWidget *parent, TPaletteHandle *studioPaletteHandle,
                       TPaletteHandle *levelPaletteHandle,
@@ -230,6 +234,12 @@ public:
 
   int getViewMode() const;
   void setViewMode(int mode);
+
+  void setApplication(TApplication *app) {
+    m_app = app;
+    if (m_studioPaletteViewer) m_studioPaletteViewer->setApplication(app);
+  }
+  TApplication *getApplication() { return m_app; }
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -699,6 +699,7 @@ StudioPaletteViewerPanel::StudioPaletteViewerPanel(QWidget *parent)
       this, m_studioPaletteHandle,
       app->getPaletteController()->getCurrentLevelPalette(),
       app->getCurrentFrame(), app->getCurrentXsheet(), app->getCurrentLevel());
+  m_studioPaletteViewer->setApplication(app);
   setWidget(m_studioPaletteViewer);
 }
 

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -105,7 +105,8 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
     , m_lockPaletteAction(0)
     , m_frozen(false)
     , m_freezePaletteToolButton(0)
-    , m_lockPaletteToolButton(0) {
+    , m_lockPaletteToolButton(0)
+    , m_app(0) {
   setObjectName("OnePixelMarginFrame");
   setFrameStyle(QFrame::StyledPanel);
 
@@ -871,7 +872,7 @@ void PaletteViewer::hideEvent(QHideEvent *) {
 //-----------------------------------------------------------------------------
 
 void PaletteViewer::enterEvent(QEvent *) {
-  getApplication()->getPaletteController()->setCurrentPaletteViewer(this);
+  if (m_app) m_app->getPaletteController()->setCurrentPaletteViewer(this);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #817 which was crashing due to a Style Management enhancement that was not properly set up for Studio Palette Viewer.