### PR TITLE
Fix missing returns

### DIFF
--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -925,7 +925,7 @@ public:
   void editStyleSetName(StyleChooserPage *styleSetPage);
   void renameStyleSet(StyleChooserPage *styleSetPage, QString newName);
 
-  std::vector<StyleChooserPage *> getStyleSetList(StylePageType pageType);
+  std::vector<StyleChooserPage *> *getStyleSetList(StylePageType pageType);
 
   void setUpdated(TFilePath setPath);
   TFilePath getSetStyleFolder(QString setName);

--- a/toonz/sources/toonz/graphwidget.cpp
+++ b/toonz/sources/toonz/graphwidget.cpp
@@ -318,8 +318,7 @@ QPointF GraphWidget::getInvertedPoint(QPointF p) {
     y *= 0.5;
   }
 
-  else
-    return QPointF(x, height() - y);
+  return QPointF(x, height() - y);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #811 

> toonz/sources/toonz/graphwidget.cpp:318:7: error: control reaches end of non-void function [-Werror=return-type]

The impacted function is used by the GraphWidget which is used only in the Motion Path panel

This appears to have had a misplaced `else` which I removed.

> toonz/sources/toonzqt/styleeditor.cpp:2515:1: error: control reaches end of non-void function [-Werror=return-type]

The impacted function is used to delete files from Style Folders, part of the new Style Management feature.

Corrected logic to skip files it could not find and return TRUE if it deleted 1 or more files or FALSE otherwise.

> toonz/sources/toonzqt/styleeditor.cpp:6819:1: error: control reaches end of non-void function [-Werror=return-type]

The impacted function is used primarily in the Style Management context menu when displaying a list of style sets for various functions (i.e copy to style set)

Modified logic to assign and return a pointer to the appropriate page set.
