### PR TITLE
Enhance vanishing point management

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -331,28 +331,27 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   m_assistantPoints         = simLevel->getProperties()->getVanishingPoints();
 
   if (e.isAltPressed() && e.isCtrlPressed() && !e.isShiftPressed()) {
-    m_addingAssistant = true;
-    bool deletedPoint = false;
+    m_modifyingAssistant = true;
+    m_assistantIndex     = -1;
+    m_deleteAssistant    = true;  // Assume deleting unless we move it
     for (int i = 0; i < m_assistantPoints.size(); i++) {
       if (areAlmostEqual(m_assistantPoints.at(i).x, pos.x, 12) &&
           areAlmostEqual(m_assistantPoints.at(i).y, pos.y, 12)) {
-        TRectD pointRect = TRectD(
-            m_assistantPoints.at(i).x - 15, m_assistantPoints.at(i).y - 15,
-            m_assistantPoints.at(i).x + 15, m_assistantPoints.at(i).x + 15);
-        m_assistantPoints.erase(m_assistantPoints.begin() + i);
-        deletedPoint = true;
-        invalidate(pointRect);
-        break;
+        // We're over an assistant...we are either deleting or moving
+        m_assistantIndex = i;
+        return;
       }
     }
-    if (!deletedPoint) m_assistantPoints.push_back(pos);
+    m_assistantPoints.push_back(pos);
+    m_assistantIndex  = m_assistantPoints.size() - 1;
+    m_deleteAssistant = false;
     simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
     level->setDirtyFlag(true);
     invalidate();
     return;
   }
   if (e.isAltPressed() && e.isShiftPressed() && !e.isCtrlPressed()) {
-    m_addingAssistant                  = true;
+    m_modifyingAssistant               = true;
     std::vector<TPointD> pointsToClear = m_assistantPoints;
     m_assistantPoints.clear();
     for (auto point : pointsToClear) {
@@ -360,7 +359,9 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
           TRectD(point.x - 3, point.y - 3, point.x + 3, point.y + 3);
       invalidate(pointRect);
     }
-
+    simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
+    level->setDirtyFlag(true);
+    invalidate();
     return;
   }
 
@@ -425,10 +426,27 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
 
 void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
                                         const TMouseEvent &e) {
-  if ((e.isCtrlPressed() && e.isAltPressed()) ||
-      (e.isShiftPressed() && e.isAltPressed()) || m_addingAssistant) {
+  if (m_modifyingAssistant) {
+    TXshLevel *level = getApplication()->getCurrentLevel()->getLevel();
+    if (level == NULL) return;
+    TXshSimpleLevelP simLevel = level->getSimpleLevel();
+
+    if (e.isAltPressed() && e.isCtrlPressed() && !e.isShiftPressed()) {
+      if (m_assistantIndex < 0) return;
+
+      m_assistantPoints.at(m_assistantIndex).x = pos.x;
+      m_assistantPoints.at(m_assistantIndex).y = pos.y;
+      m_deleteAssistant                        = false;
+
+      simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
+      level->setDirtyFlag(true);
+      invalidate();
+      return;
+    }
+
     return;
   }
+
   TRectD invalidateRect;
   if (m_isStraight) {
     invalidateRect = TRectD(m_firstPoint, m_lastPoint).enlarge(2);
@@ -614,9 +632,27 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   TPointD previousBrushPos = m_brushPos;
   m_brushPos = m_mousePos = pos;
 
-  if ((e.isAltPressed() && e.isCtrlPressed()) ||
-      (e.isShiftPressed() && e.isAltPressed()) || m_addingAssistant) {
-    m_addingAssistant = false;
+  if (m_modifyingAssistant) {
+    if (m_deleteAssistant) {
+      TXshLevel *level = getApplication()->getCurrentLevel()->getLevel();
+      if (level) {
+        TXshSimpleLevelP simLevel = level->getSimpleLevel();
+
+        TRectD pointRect =
+            TRectD(m_assistantPoints.at(m_assistantIndex).x - 15,
+                   m_assistantPoints.at(m_assistantIndex).y - 15,
+                   m_assistantPoints.at(m_assistantIndex).x + 15,
+                   m_assistantPoints.at(m_assistantIndex).x + 15);
+        m_assistantPoints.erase(m_assistantPoints.begin() + m_assistantIndex);
+        invalidate(pointRect);
+        simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
+        level->setDirtyFlag(true);
+        invalidate();
+      }
+    }
+    m_modifyingAssistant = false;
+    m_assistantIndex     = -1;
+    m_deleteAssistant    = false;
     return;
   }
 

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -127,10 +127,12 @@ protected:
   TPointD m_firstPoint;
   TPointD m_lastPoint;
   std::vector<TPointD> m_assistantPoints;
-  bool m_addingAssistant   = false;
-  bool m_snapAssistant     = false;
-  double m_oldPressure     = -1.0;
-  int m_highlightAssistant = -1;
+  bool m_modifyingAssistant = false;
+  int m_assistantIndex      = -1;
+  bool m_deleteAssistant    = false;
+  bool m_snapAssistant      = false;
+  double m_oldPressure      = -1.0;
+  int m_highlightAssistant  = -1;
 
   bool m_propertyUpdating = false;
 };

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1295,28 +1295,27 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
 
   m_assistantPoints = simLevel->getProperties()->getVanishingPoints();
   if (e.isAltPressed() && e.isCtrlPressed() && !e.isShiftPressed()) {
-    m_addingAssistant = true;
-    bool deletedPoint = false;
+    m_modifyingAssistant = true;
+    m_assistantIndex     = -1;
+    m_deleteAssistant    = true;  // Assume deleting unless we move it
     for (int i = 0; i < m_assistantPoints.size(); i++) {
       if (areAlmostEqual(m_assistantPoints.at(i).x, pos.x, 12) &&
           areAlmostEqual(m_assistantPoints.at(i).y, pos.y, 12)) {
-        TRectD pointRect = TRectD(
-            m_assistantPoints.at(i).x - 15, m_assistantPoints.at(i).y - 15,
-            m_assistantPoints.at(i).x + 15, m_assistantPoints.at(i).x + 15);
-        m_assistantPoints.erase(m_assistantPoints.begin() + i);
-        deletedPoint = true;
-        invalidate(pointRect);
-        break;
+        // We're over an assistant...we are either deleting or moving
+        m_assistantIndex = i;
+        return;
       }
     }
-    if (!deletedPoint) m_assistantPoints.push_back(pos);
+    m_assistantPoints.push_back(pos);
+    m_assistantIndex  = m_assistantPoints.size() - 1;
+    m_deleteAssistant = false;
     simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
     level->setDirtyFlag(true);
     invalidate();
     return;
   }
   if (e.isAltPressed() && e.isShiftPressed() && !e.isCtrlPressed()) {
-    m_addingAssistant                  = true;
+    m_modifyingAssistant               = true;
     std::vector<TPointD> pointsToClear = m_assistantPoints;
     m_assistantPoints.clear();
     for (auto point : pointsToClear) {
@@ -1324,6 +1323,9 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
           TRectD(point.x - 3, point.y - 3, point.x + 3, point.y + 3);
       invalidate(pointRect);
     }
+    simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
+    level->setDirtyFlag(true);
+    invalidate();
 
     return;
   }
@@ -1488,8 +1490,24 @@ void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
     return;
   }
 
-  if ((e.isCtrlPressed() && e.isAltPressed()) ||
-      (e.isShiftPressed() && e.isAltPressed()) || m_addingAssistant) {
+  if (m_modifyingAssistant) {
+    TXshLevel *level = getApplication()->getCurrentLevel()->getLevel();
+    if (level == NULL) return;
+    TXshSimpleLevelP simLevel = level->getSimpleLevel();
+
+    if (e.isAltPressed() && e.isCtrlPressed() && !e.isShiftPressed()) {
+      if (m_assistantIndex < 0) return;
+
+      m_assistantPoints.at(m_assistantIndex).x = pos.x;
+      m_assistantPoints.at(m_assistantIndex).y = pos.y;
+      m_deleteAssistant                        = false;
+
+      simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
+      level->setDirtyFlag(true);
+      invalidate();
+      return;
+    }
+
     return;
   }
   TRectD invalidateRect;
@@ -1832,11 +1850,30 @@ void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
 
 void ToonzRasterBrushTool::leftButtonUp(const TPointD &pos,
                                         const TMouseEvent &e) {
-  if ((e.isAltPressed() && e.isCtrlPressed()) ||
-      (e.isShiftPressed() && e.isAltPressed()) || m_addingAssistant) {
-    m_addingAssistant = false;
+  if (m_modifyingAssistant) {
+    if (m_deleteAssistant) {
+      TXshLevel *level = getApplication()->getCurrentLevel()->getLevel();
+      if (level) {
+        TXshSimpleLevelP simLevel = level->getSimpleLevel();
+
+        TRectD pointRect =
+            TRectD(m_assistantPoints.at(m_assistantIndex).x - 15,
+                   m_assistantPoints.at(m_assistantIndex).y - 15,
+                   m_assistantPoints.at(m_assistantIndex).x + 15,
+                   m_assistantPoints.at(m_assistantIndex).x + 15);
+        m_assistantPoints.erase(m_assistantPoints.begin() + m_assistantIndex);
+        invalidate(pointRect);
+        simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
+        level->setDirtyFlag(true);
+        invalidate();
+      }
+    }
+    m_modifyingAssistant = false;
+    m_assistantIndex     = -1;
+    m_deleteAssistant    = false;
     return;
   }
+
   bool isValid = m_enabled && m_active;
   m_enabled    = false;
   m_active     = false;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -231,9 +231,11 @@ protected:
 
   bool m_isStraight = false;
   std::vector<TPointD> m_assistantPoints;
-  bool m_addingAssistant   = false;
-  bool m_snapAssistant     = false;
-  int m_highlightAssistant = -1;
+  bool m_modifyingAssistant = false;
+  int m_assistantIndex      = -1;
+  bool m_deleteAssistant    = false;
+  bool m_snapAssistant      = false;
+  int m_highlightAssistant  = -1;
   TPointD m_firstPoint;
   TPointD m_lastPoint;
   double m_oldPressure = -1.0;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -214,7 +214,9 @@ protected:
   bool m_propertyUpdating = false;
 
   std::vector<TPointD> m_assistantPoints;
-  bool m_addingAssistant = false;
+  bool m_modifyingAssistant = false;
+  int m_assistantIndex      = -1;
+  bool m_deleteAssistant    = false;
   TPointD m_firstPoint;
   TPointD m_lastPoint;
   int m_highlightAssistant = -1;

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -191,12 +191,16 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                        .arg(trModKey("Ctrl"))
                        .arg(cmd2TextSeparator) +
                    spacer +
-                   tr("%1%2Add / Remove Vanishing Point")
+                   tr("%1%2Add / Move / Remove Vanishing Point")
                        .arg(trModKey("Ctrl+Alt"))
-                       .arg(cmdTextSeparator) +
+                       .arg(cmd2TextSeparator) +
                    spacer +
                    tr("%1%2Draw to Vanishing Point")
                        .arg(trModKey("Alt"))
+                       .arg(cmd2TextSeparator) +
+                   spacer +
+                   tr("%1%2Clear All Vanishing Points")
+                       .arg(trModKey("Shift+Alt"))
                        .arg(cmd2TextSeparator) +
                    spacer +
                    tr("%1%2Allow or Disallow Snapping")
@@ -206,36 +210,44 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                tr("Brush Tool : Draws in the work area freehand") + spacer +
                    tr("%1%2Straight Lines")
                        .arg(trModKey("Shift"))
-                       .arg(cmd2TextSeparator) +
+                       .arg(cmdTextSeparator) +
                    spacer +
                    tr("%1%2Straight Lines Snapped to Angles")
                        .arg(trModKey("Ctrl"))
-                       .arg(cmd2TextSeparator) +
+                       .arg(cmdTextSeparator) +
                    spacer +
-                   tr("%1%2Add / Remove Vanishing Point")
+                   tr("%1%2Add / Move / Remove Vanishing Point")
                        .arg(trModKey("Ctrl+Alt"))
                        .arg(cmdTextSeparator) +
                    spacer +
                    tr("%1%2Draw to Vanishing Point")
                        .arg(trModKey("Alt"))
-                       .arg(cmd2TextSeparator)});
+                       .arg(cmdTextSeparator) +
+                   spacer +
+                   tr("%1%2Clear All Vanishing Points")
+                       .arg(trModKey("Shift+Alt"))
+                       .arg(cmdTextSeparator)});
   lMap.insert({"T_BrushRaster",
                tr("Brush Tool : Draws in the work area freehand") + spacer +
                    tr("%1%2Straight Lines")
                        .arg(trModKey("Shift"))
-                       .arg(cmd2TextSeparator) +
+                       .arg(cmdTextSeparator) +
                    spacer +
                    tr("%1%2Straight Lines Snapped to Angles")
                        .arg(trModKey("Ctrl"))
-                       .arg(cmd2TextSeparator) +
+                       .arg(cmdTextSeparator) +
                    spacer +
-                   tr("%1%2Add / Remove Vanishing Point")
+                   tr("%1%2Add / Move / Remove Vanishing Point")
                        .arg(trModKey("Ctrl+Alt"))
                        .arg(cmdTextSeparator) +
                    spacer +
                    tr("%1%2Draw to Vanishing Point")
                        .arg(trModKey("Alt"))
-                       .arg(cmd2TextSeparator)});
+                       .arg(cmdTextSeparator) +
+                   spacer +
+                   tr("%1%2Clear All Vanishing Points")
+                       .arg(trModKey("Shift+Alt"))
+                       .arg(cmdTextSeparator)});
   lMap.insert({"T_Geometric", tr("Geometry Tool: Draws geometric shapes")});
   lMap.insert({"T_GeometricRectangle",
                tr("Geometry Tool: Draws geometric shapes") + spacer +


### PR DESCRIPTION
This PR enhances the management of vanishing points as follows:

- `Ctrl+Alt` modified to...
  - Allow moving existing vanishing points by click-holding an existing vanishing point and dragging to new location.
  - Allow click-hold-drag to create a new vanishing point and immediately move it to the desired location.
  - Remove a vanishing point after you stop pressing the button provided the vanishing points was not moved.
- Fixed `Shift + Alt` to clear all vanishing points