### PR TITLE
Update Shader Fx: HSL Blend GPU

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -531,11 +531,12 @@
   <item>"SHADER_spinblurGPU.radius"		"Safe Radius"	</item>
   <item>"SHADER_spinblurGPU.blur"		"Blur"	</item>
 
-  <item>"SHADER_HSLBlendGPU"			"GPU HSL Blend"	</item>
-  <item>"SHADER_HSLBlendGPU.bhue"		"Hue"	</item>
-  <item>"SHADER_HSLBlendGPU.bsat"		"Saturation"	</item>
-  <item>"SHADER_HSLBlendGPU.blum"		"Luminosity"	</item>
-  <item>"SHADER_HSLBlendGPU.balpha"		"Blend Alpha"	</item>
+  <item>"SHADER_HSLBlendGPU"			"GPU HSL Blend"    </item>
+  <item>"SHADER_HSLBlendGPU.bhue"			"Hue"    </item>
+  <item>"SHADER_HSLBlendGPU.bsat"			"Saturation"    </item>
+  <item>"SHADER_HSLBlendGPU.blum"			"Luminosity"    </item>
+  <item>"SHADER_HSLBlendGPU.balpha"			"Opacity"    </item>
+  <item>"SHADER_HSLBlendGPU.bmask"			"Clipping Mask"    </item>
 
 <!---------------------------------------------------------------------------------------->
 

--- a/stuff/library/shaders/HSLBlendGPU.xml
+++ b/stuff/library/shaders/HSLBlendGPU.xml
@@ -60,4 +60,10 @@
       0 1
     </Range>
   </Parameter>
+  <Parameter>
+    bool bmask
+    <Default>
+      0
+    </Default>
+  </Parameter>
 </Parameters>

--- a/stuff/profiles/layouts/fxs/SHADER_HSLBlendGPU.xml
+++ b/stuff/profiles/layouts/fxs/SHADER_HSLBlendGPU.xml
@@ -4,5 +4,6 @@
     <control>bsat</control>
     <control>blum</control>
     <control>balpha</control>
+    <control>bmask</control>
   </page>
 </fxlayout>


### PR DESCRIPTION
This PR updates `HSL Blend GPU` shader (#413) to match the one merged recently in [OpenToonz #4146](https://github.com/opentoonz/opentoonz/pull/4146) by adding Clipping Mask feature.
