### PR TITLE
Update Actions build scripts

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -64,12 +64,12 @@ jobs:
           name: Tahoma2D-linux-${{ matrix.compiler }}.tar.gz
           path: toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz
       - name: Get Nightly Release Date
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           echo "NIGHTLYDATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
           echo "NIGHTLYDATETIME=$(date '+%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_ENV
       - name: Create/Update Nightlies Tag
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
           git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
@@ -81,7 +81,7 @@ jobs:
           git push -f nightly_repo nightly-${{ github.sha }}
           git remote rm nightly_repo
       - name: Update Latest Nightly Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -95,7 +95,7 @@ jobs:
           tag: nightly
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Nightlies Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-
       - name: Get CanonSDK
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' }}
         run: |
           wget --header="Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" --header="Accept:application/octet-stream" -O EDSDK_v131231_Macintosh.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/25267390
           unzip EDSDK_v131231_Macintosh.zip -d EDSDK_v131231_Macintosh
@@ -58,12 +58,12 @@ jobs:
           name: Tahoma2D-osx.dmg
           path: toonz/build/Tahoma2D-osx.dmg
       - name: Get Nightly Release Date
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           echo "NIGHTLYDATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
           echo "NIGHTLYDATETIME=$(date '+%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_ENV
       - name: Create/Update Nightlies Tag
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
           git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
@@ -75,7 +75,7 @@ jobs:
           git push -f nightly_repo nightly-${{ github.sha }}
           git remote rm nightly_repo
       - name: Update Latest Nightly Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -89,7 +89,7 @@ jobs:
           tag: nightly
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Nightlies Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           ci-scripts\windows\tahoma-install.bat
       - name: Get CanonSDK
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' }}
         run: |
           curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_v131231_Windows.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/25267396
           7z x EDSDK_v131231_Windows.zip -oEDSDK_v131231_Windows
@@ -42,13 +42,13 @@ jobs:
           name: debug-symbols.zip
           path: toonz\build\debug-symbols.zip
       - name: Get Nightly Release Date
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           chcp 65001 #set code page to utf-8
           echo ("NIGHTLYDATE=" + (Get-Date -format "yyyy-MM-dd")) >> $env:GITHUB_ENV
           echo ("NIGHTLYDATETIME=" + (Get-Date -format "yyyy-MM-dd HH:mm:ss UTC")) >> $env:GITHUB_ENV
       - name: Create/Update Nightlies Tag
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
           git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
@@ -60,7 +60,7 @@ jobs:
           git push -f nightly_repo nightly-${{ github.sha }}
           git remote rm nightly_repo
       - name: Update Latest Nightly Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -74,7 +74,7 @@ jobs:
           tag: nightly
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Nightlies Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -31,10 +31,12 @@ jobs:
       - name: Create Package
         run: |
           ci-scripts\windows\tahoma-buildpkg.bat
+          mkdir artifact
+          cp -r toonz\build\Tahoma2D artifact
       - uses: actions/upload-artifact@v1
         with:
-          name: Tahoma2D-win.zip
-          path: toonz\build\Tahoma2D-win.zip
+          name: Tahoma2D-win
+          path: artifact
       - uses: actions/upload-artifact@v1
         with:
           name: debug-symbols.zip


### PR DESCRIPTION
This PR does the following:

- The build scripts zip up the builds and posts them as artifacts.  When downloading a github artifact, github automatically zips it again (on Windows at least), resulting in a double-zipped download.

I've modified the Windows workflow to uploaded the unzipped Tahoma2D folder as the artifact rather than the zipped build.  The zipped build will still be used when for updating the nightly releases.

- Currently when this repo is forked, the action scripts are copied to the fork and executed when the owner pushes to their master.  The fork's actions fail in SDK steps because it does not have access to the private SDK repo.

This adds checks around steps for SDK and Nightlies updates so those steps only work when the repository_owner = tahoma2d