### PR TITLE
OpenToonz patches thru 12/22

### DIFF
--- a/toonz/sources/common/tcontenthistory.cpp
+++ b/toonz/sources/common/tcontenthistory.cpp
@@ -73,7 +73,7 @@ inline QString blanks(const QString &str, int count = 15) {
 //--------------------------------------------------------------------
 
 inline QString getStr(const TFrameId &id) {
-  if (id.getLetter() != 0)
+  if (!id.getLetter().isEmpty())
     return QString::number(id.getNumber()) + id.getLetter();
   else
     return QString::number(id.getNumber());
@@ -159,7 +159,7 @@ const QString TContentHistory::currentToString() const {
     dateSorted.insert(pair<QDateTime, TFrameId>(it->second, it->first));
 
   std::multimap<QDateTime, TFrameId>::const_iterator it1 = dateSorted.begin();
-  QDateTime currDate = it1->first;
+  QDateTime currDate                                     = it1->first;
 
   while (it1 != dateSorted.end()) {
     set<TFrameId> frames;

--- a/toonz/sources/common/timage_io/tlevel_io.cpp
+++ b/toonz/sources/common/timage_io/tlevel_io.cpp
@@ -132,6 +132,9 @@ TLevelP TLevelReader::loadInfo() {
   if (!data.empty()) {
     std::vector<TFilePath>::iterator it =
         std::min_element(data.begin(), data.end(), myLess);
+
+    m_frameFormat = (*it).getFrame().getCurrentFormat();
+    /*
     TFilePath fr = (*it).withoutParentDir().withName("").withType("");
     wstring ws   = fr.getWideString();
     if (ws.length() == 5) {
@@ -150,7 +153,7 @@ TLevelP TLevelReader::loadInfo() {
       else
         m_frameFormat = TFrameId::UNDERSCORE_NO_PAD;
     }
-
+    */
   } else
     m_frameFormat = TFrameId::FOUR_ZEROS;
 

--- a/toonz/sources/image/avi/tiio_avi.cpp
+++ b/toonz/sources/image/avi/tiio_avi.cpp
@@ -332,7 +332,7 @@ void TLevelWriterAvi::createBitmap(int lx, int ly) {
 TImageWriterP TLevelWriterAvi::getFrameWriter(TFrameId fid) {
   if (IOError != 0)
     throw TImageException(m_path, buildAVIExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageWriterP(0);
+  if (!fid.getLetter().isEmpty()) return TImageWriterP(0);
   int index            = fid.getNumber() - 1;
   TImageWriterAvi *iwa = new TImageWriterAvi(m_path, index, this);
   return TImageWriterP(iwa);
@@ -879,7 +879,7 @@ TLevelP TLevelReaderAvi::loadInfo() {
 TImageReaderP TLevelReaderAvi::getFrameReader(TFrameId fid) {
   if (IOError != 0)
     throw TImageException(m_path, buildAVIExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageReaderP(0);
+  if (!fid.getLetter().isEmpty()) return TImageReaderP(0);
   int index = fid.getNumber() - 1;
 
   TImageReaderAvi *ira = new TImageReaderAvi(m_path, index, this);

--- a/toonz/sources/image/ffmpeg/tiio_gif.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_gif.cpp
@@ -119,7 +119,7 @@ TLevelWriterGif::~TLevelWriterGif() {
 TImageWriterP TLevelWriterGif::getFrameWriter(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildGifExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageWriterP(0);
+  if (!fid.getLetter().isEmpty()) return TImageWriterP(0);
   int index            = fid.getNumber();
   TImageWriterGif *iwg = new TImageWriterGif(m_path, index, this);
   return TImageWriterP(iwg);
@@ -224,7 +224,7 @@ TLevelP TLevelReaderGif::loadInfo() {
 TImageReaderP TLevelReaderGif::getFrameReader(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildAVIExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageReaderP(0);
+  if (!fid.getLetter().isEmpty()) return TImageReaderP(0);
   int index            = fid.getNumber();
   TImageReaderGif *irm = new TImageReaderGif(m_path, index, this, m_info);
   return TImageReaderP(irm);

--- a/toonz/sources/image/ffmpeg/tiio_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mov.cpp
@@ -104,7 +104,7 @@ TLevelWriterMov::~TLevelWriterMov() {
 TImageWriterP TLevelWriterMov::getFrameWriter(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildMovExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageWriterP(0);
+  if (!fid.getLetter().isEmpty()) return TImageWriterP(0);
   int index            = fid.getNumber();
   TImageWriterMov *iwg = new TImageWriterMov(m_path, index, this);
   return TImageWriterP(iwg);
@@ -207,7 +207,7 @@ TLevelP TLevelReaderMov::loadInfo() {
 TImageReaderP TLevelReaderMov::getFrameReader(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildAVIExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageReaderP(0);
+  if (!fid.getLetter().isEmpty()) return TImageReaderP(0);
   int index = fid.getNumber();
 
   TImageReaderMov *irm = new TImageReaderMov(m_path, index, this, m_info);

--- a/toonz/sources/image/ffmpeg/tiio_mp4.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.cpp
@@ -100,7 +100,7 @@ TLevelWriterMp4::~TLevelWriterMp4() {
 TImageWriterP TLevelWriterMp4::getFrameWriter(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildMp4ExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageWriterP(0);
+  if (!fid.getLetter().isEmpty()) return TImageWriterP(0);
   int index            = fid.getNumber();
   TImageWriterMp4 *iwg = new TImageWriterMp4(m_path, index, this);
   return TImageWriterP(iwg);
@@ -203,7 +203,7 @@ TLevelP TLevelReaderMp4::loadInfo() {
 TImageReaderP TLevelReaderMp4::getFrameReader(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildAVIExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageReaderP(0);
+  if (!fid.getLetter().isEmpty()) return TImageReaderP(0);
   int index = fid.getNumber();
 
   TImageReaderMp4 *irm = new TImageReaderMp4(m_path, index, this, m_info);

--- a/toonz/sources/image/ffmpeg/tiio_webm.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_webm.cpp
@@ -101,7 +101,7 @@ TLevelWriterWebm::~TLevelWriterWebm() {
 TImageWriterP TLevelWriterWebm::getFrameWriter(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildGifExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageWriterP(0);
+  if (!fid.getLetter().isEmpty()) return TImageWriterP(0);
   int index             = fid.getNumber();
   TImageWriterWebm *iwg = new TImageWriterWebm(m_path, index, this);
   return TImageWriterP(iwg);
@@ -204,7 +204,7 @@ TLevelP TLevelReaderWebm::loadInfo() {
 TImageReaderP TLevelReaderWebm::getFrameReader(TFrameId fid) {
   // if (IOError != 0)
   //	throw TImageException(m_path, buildAVIExceptionString(IOError));
-  if (fid.getLetter() != 0) return TImageReaderP(0);
+  if (!fid.getLetter().isEmpty()) return TImageReaderP(0);
   int index = fid.getNumber();
 
   TImageReaderWebm *irm = new TImageReaderWebm(m_path, index, this, m_info);

--- a/toonz/sources/image/pli/tiio_pli.cpp
+++ b/toonz/sources/image/pli/tiio_pli.cpp
@@ -160,7 +160,7 @@ void buildPalette(ParsedPli *pli, const TImageP img) {
   assert(vPalette->getPageCount());
 
   std::vector<TStyleParam> pageNames(vPalette->getPageCount());
-  for (i         = 0; i < pageNames.size(); i++)
+  for (i = 0; i < pageNames.size(); i++)
     pageNames[i] = TStyleParam(::to_string(vPalette->getPage(i)->getName()));
   StyleTag *pageNamesTag =
       new StyleTag(0, 0, pageNames.size(), pageNames.data());
@@ -414,18 +414,18 @@ TImageP TImageReaderPli::doLoad() {
     }  // switch(groupTag->m_object[j]->m_type)
   }    // for (i=0; i<imageTag->m_numObjects; i++)
 
-//} // try
+  //} // try
 
-// catch(...) // cosi' e' inutile o raccolgo qualcosa prima di rilanciare o lo
-// elimino
-//{
-//  throw;
-// }
+  // catch(...) // cosi' e' inutile o raccolgo qualcosa prima di rilanciare o lo
+  // elimino
+  //{
+  //  throw;
+  // }
 
-//  if (regionsComputed) //WARNING !!! la seedFill mette il flag a ValidRegion a
-//  TRUE
-//    outVectImage->seedFill(); //le vecchie immagini hanno il seed
-//    (version<3.1)
+  //  if (regionsComputed) //WARNING !!! la seedFill mette il flag a ValidRegion
+  //  a TRUE
+  //    outVectImage->seedFill(); //le vecchie immagini hanno il seed
+  //    (version<3.1)
 
 #ifdef _DEBUG
   outVectImage->checkIntersections();
@@ -564,6 +564,9 @@ solo nel costruttore)
     PliTag *tag = new PrecisionScaleTag(precisionScale);
     tags.push_back((PliObjectTag *)tag);
   }
+
+  // update the format version if multiple suffixes is supported0
+  if (!TFilePath::useStandard()) pli->setVersion(150, 0);
   // Store the auto close tolerance
   double pliTolerance = m_lwp->m_pli->getAutocloseTolerance();
   // write the tag if the frame's tolerance has been changed or
@@ -744,7 +747,7 @@ TPalette *readPalette(GroupTag *paletteTag, int majorVersion,
                  // caricarli!
 
     std::vector<TStyleParam> params(styleTag->m_numParams);
-    for (int j  = 0; j < styleTag->m_numParams; j++)
+    for (int j = 0; j < styleTag->m_numParams; j++)
       params[j] = styleTag->m_param[j];
 
     PliInputStream chan(&params, majorVersion, minorVersion);

--- a/toonz/sources/image/sprite/tiio_sprite.cpp
+++ b/toonz/sources/image/sprite/tiio_sprite.cpp
@@ -190,7 +190,7 @@ TLevelWriterSprite::~TLevelWriterSprite() {
 //-----------------------------------------------------------
 
 TImageWriterP TLevelWriterSprite::getFrameWriter(TFrameId fid) {
-  if (fid.getLetter() != 0) return TImageWriterP(0);
+  if (!fid.getLetter().isEmpty()) return TImageWriterP(0);
   int index               = fid.getNumber();
   TImageWriterSprite *iwg = new TImageWriterSprite(m_path, index, this);
   return TImageWriterP(iwg);
@@ -265,9 +265,9 @@ void TLevelWriterSprite::save(const TImageP &img, int frameIndex) {
     m_top       = t;
     m_bottom    = b;
   } else {
-    if (l < m_left) m_left     = l;
-    if (r > m_right) m_right   = r;
-    if (t < m_top) m_top       = t;
+    if (l < m_left) m_left = l;
+    if (r > m_right) m_right = r;
+    if (t < m_top) m_top = t;
     if (b > m_bottom) m_bottom = b;
   }
   QImage *newQi = new QImage(m_lx, m_ly, QImage::Format_ARGB32_Premultiplied);

--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -67,6 +67,7 @@ enum class PredefinedRect {
   BEGIN_EXTENDER,           //! top / left extender
   KEYFRAME_AREA,            //! part of cell dedicated to key frames
   DRAG_AREA,                //! draggable side bar
+  CELL_MARK_AREA,           //! cell mark
   SOUND_TRACK,              //! area dedicated to waveform display
   PREVIEW_TRACK,            //! sound preview area
   BEGIN_SOUND_EDIT,         //! top sound resize

--- a/toonz/sources/include/tcg/poly_ops.h
+++ b/toonz/sources/include/tcg/poly_ops.h
@@ -5,6 +5,7 @@
 
 // tcg includes
 #include "macros.h"
+#include <algorithm>
 
 /*!
   \file     tcg_poly_ops.h

--- a/toonz/sources/include/toonz/cleanupparameters.h
+++ b/toonz/sources/include/toonz/cleanupparameters.h
@@ -160,6 +160,12 @@ public:
   /*--- オフセットを軸ごとにロックする ---*/
   bool m_offx_lock, m_offy_lock;
 
+  // hold brightness and contrast values for each line processing modes (grey
+  // and color).
+  double m_altBrightness, m_altContrast;
+  // exporting file format when Line Processing = None
+  std::string m_lpNoneFormat;
+
 public:
   CleanupParameters();
   CleanupParameters(const CleanupParameters &p) { assign(&p); }

--- a/toonz/sources/include/toonz/filepathproperties.h
+++ b/toonz/sources/include/toonz/filepathproperties.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#ifndef FILEPATHPROPERTIES_H
+#define FILEPATHPROPERTIES_H
+
+#include "tcommon.h"
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZLIB_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+//=============================================================================
+// forward declarations
+class TIStream;
+class TOStream;
+
+//=============================================================================
+// FilePathProperties
+// This class defines file path condition for sequential image level
+
+class DVAPI FilePathProperties {
+  bool m_useStandard;
+  bool m_acceptNonAlphabetSuffix;
+  int m_letterCountForSuffix;
+
+public:
+  FilePathProperties();
+
+  bool useStandard() { return m_useStandard; }
+  void setUseStandard(bool on) { m_useStandard = on; }
+
+  bool acceptNonAlphabetSuffix() { return m_acceptNonAlphabetSuffix; }
+  void setAcceptNonAlphabetSuffix(bool on) { m_acceptNonAlphabetSuffix = on; }
+
+  int letterCountForSuffix() { return m_letterCountForSuffix; }
+  void setLetterCountForSuffix(int val) { m_letterCountForSuffix = val; }
+
+  void saveData(TOStream& os) const;
+  void loadData(TIStream& is);
+
+  bool isDefault();
+};
+
+#endif

--- a/toonz/sources/include/toonz/sceneproperties.h
+++ b/toonz/sources/include/toonz/sceneproperties.h
@@ -49,6 +49,11 @@ class DVAPI TSceneProperties {
 public:
   typedef std::vector<double> Guides;
 
+  struct CellMark {
+    QString name;
+    TPixel32 color;
+  };
+
 private:
   Guides m_hGuides, m_vGuides;
 
@@ -72,6 +77,9 @@ private:
 
   //! Xsheet Note Color, color number = 7.
   QList<TPixel32> m_notesColor;
+
+  // Cell Mark colors and names
+  QList<CellMark> m_cellMarks;
 
   bool m_columnColorFilterOnRender;
   TFilePath m_camCapSaveInPath;
@@ -273,6 +281,12 @@ and height.
   QList<TPixel32> getNoteColors() const;
   TPixel32 getNoteColor(int colorIndex) const;
   void setNoteColor(TPixel32 color, int colorIndex);
+
+  QList<CellMark> getCellMarks() const;
+  CellMark getCellMark(int index) const;
+  void setCellMark(const CellMark &mark, int index);
+  bool hasDefaultCellMarks()
+      const;  // check if the cell mark settings are modified
 
 private:
   // not implemented

--- a/toonz/sources/include/toonz/tcleanupper.h
+++ b/toonz/sources/include/toonz/tcleanupper.h
@@ -89,10 +89,11 @@ time, to unlock a possibly useful memory block.
 */
   CleanupPreprocessedImage *process(TRasterImageP &image, bool first_image,
                                     TRasterImageP &onlyResampledImage,
-                                    bool isCameraTest    = false,
-                                    bool returnResampled = false,
-                                    bool onlyForSwatch   = false,
-                                    TAffine *aff         = 0);
+                                    bool isCameraTest             = false,
+                                    bool returnResampled          = false,
+                                    bool onlyForSwatch            = false,
+                                    TAffine *aff                  = 0,
+                                    TRasterP templateForResampled = 0);
 
   void finalize(const TRaster32P &dst, CleanupPreprocessedImage *src);
   TToonzImageP finalize(CleanupPreprocessedImage *src,

--- a/toonz/sources/include/toonz/tproject.h
+++ b/toonz/sources/include/toonz/tproject.h
@@ -9,6 +9,7 @@
 
 class ToonzScene;
 class TSceneProperties;
+class FilePathProperties;
 
 #undef DVAPI
 #undef DVVAR
@@ -27,6 +28,8 @@ class DVAPI TProject final : public TSmartObject {
   std::map<std::string, bool> m_useScenePathFlags;
   bool m_useSubScenePath;
   TSceneProperties *m_sprop;
+
+  FilePathProperties *m_fpProp;
 
 public:
   // default folders names
@@ -69,6 +72,8 @@ public:
 
   void setSceneProperties(const TSceneProperties &sprop);
   const TSceneProperties &getSceneProperties() const { return *m_sprop; }
+
+  FilePathProperties *getFilePathProperties() const { return m_fpProp; }
 
   //?????????????????????????????????????????????
   void setUseScenePath(std::string folderName, bool on);

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -9,6 +9,7 @@
 
 #include <QPair>
 #include <QString>
+#include <QMap>
 
 #undef DVAPI
 #undef DVVAR
@@ -304,6 +305,9 @@ protected:
   std::vector<TXshCell> m_cells;
   int m_first;
 
+  // cell marks information key:frame value:id
+  QMap<int, int> m_cellMarkIds;
+
 public:
   /*!
 Constructs a TXshCellColumn with default value.
@@ -398,6 +402,13 @@ last row with not empty cell of same level.
   bool getLevelRange(int row, int &r0, int &r1) const override;
 
   // virtual void updateIcon() = 0;
+
+  void saveCellMarks(TOStream &os);
+  bool loadCellMarks(std::string tagName, TIStream &is);
+  void setCellMark(int frame, int id);
+  int getCellMark(int frame) const;
+  QMap<int, int> getCellMarks() const;
+  void clearCellMarks();
 };
 
 #endif

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -442,8 +442,9 @@ frame duplication.
 
   // cutomized exposseLevel used from LoadLevel command
   int exposeLevel(int row, int col, TXshLevel *xl, std::vector<TFrameId> &fIds_,
-                  int xFrom = -1, int xTo = -1, int step = -1, int inc = -1,
-                  int frameCount = -1, bool doesFileActuallyExist = true);
+                  TFrameId xFrom = TFrameId(), TFrameId xTo = TFrameId(),
+                  int step = -1, int inc = -1, int frameCount = -1,
+                  bool doesFileActuallyExist = true);
 
   /*! Exposes level \b \e xl \b \e fids in xsheet starting from cell identified
    * by \b \e row and \b \e col.

--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -202,7 +202,8 @@ table) it returns the proper insertion index
   // load icon (and image) data of all frames into cache
   void loadAllIconsAndPutInCache(bool cacheImagesAsWell);
 
-  TRasterImageP getFrameToCleanup(const TFrameId &fid) const;
+  TRasterImageP getFrameToCleanup(const TFrameId &fid,
+                                  bool toBeLineProcessed) const;
 
   std::string getImageId(const TFrameId &fid, int frameStatus = -1) const;
   std::string getIconId(const TFrameId &fid, int frameStatus = -1) const;

--- a/toonz/sources/include/toonzqt/menubarcommand.h
+++ b/toonz/sources/include/toonzqt/menubarcommand.h
@@ -65,7 +65,8 @@ enum CommandType {
   MiscCommandType,
   MenuCommandType,
   VisualizationButtonCommandType,
-  StopMotionCommandType
+  StopMotionCommandType,
+  CellMarkCommandType
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -160,19 +160,25 @@ QString fidsToString(const std::vector<TFrameId> &fids,
   } else {
     bool beginBlock = true;
     for (int f = 0; f < fids.size() - 1; f++) {
-      int num      = fids[f].getNumber();
-      int next_num = fids[f + 1].getNumber();
-      if (num + 1 == next_num) {
+      int num          = fids[f].getNumber();
+      char letter      = fids[f].getLetter();
+      int next_num     = fids[f + 1].getNumber();
+      char next_letter = fids[f + 1].getLetter();
+
+      if (num + 1 == next_num && letter == '\0' && next_letter == '\0') {
         if (beginBlock) {
           retStr += QString::number(num) + " - ";
           beginBlock = false;
         }
       } else {
-        retStr += QString::number(num) + ", ";
+        retStr += QString::number(num);
+        if (letter != '\0') retStr += QString(letter);
+        retStr += ", ";
         beginBlock = true;
       }
     }
-    retStr += QString::number(fids.back().getNumber());
+    if (fids.back().getLetter() != '\0')
+      retStr += QString(fids.back().getLetter());
   }
   return retStr;
 }

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -160,25 +160,24 @@ QString fidsToString(const std::vector<TFrameId> &fids,
   } else {
     bool beginBlock = true;
     for (int f = 0; f < fids.size() - 1; f++) {
-      int num          = fids[f].getNumber();
-      char letter      = fids[f].getLetter();
-      int next_num     = fids[f + 1].getNumber();
-      char next_letter = fids[f + 1].getLetter();
+      int num             = fids[f].getNumber();
+      QString letter      = fids[f].getLetter();
+      int next_num        = fids[f + 1].getNumber();
+      QString next_letter = fids[f + 1].getLetter();
 
-      if (num + 1 == next_num && letter == '\0' && next_letter == '\0') {
+      if (num + 1 == next_num && letter.isEmpty() && next_letter.isEmpty()) {
         if (beginBlock) {
           retStr += QString::number(num) + " - ";
           beginBlock = false;
         }
       } else {
         retStr += QString::number(num);
-        if (letter != '\0') retStr += QString(letter);
+        if (!letter.isEmpty()) retStr += letter;
         retStr += ", ";
         beginBlock = true;
       }
     }
-    if (fids.back().getLetter() != '\0')
-      retStr += QString(fids.back().getLetter());
+    if (!fids.back().getLetter().isEmpty()) retStr += fids.back().getLetter();
   }
   return retStr;
 }

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -666,42 +666,44 @@ void StopMotionSaveInFolderPopup::updateParentFolder() {
 
 //=============================================================================
 
-FrameNumberLineEdit::FrameNumberLineEdit(QWidget *parent, int value)
+FrameNumberLineEdit::FrameNumberLineEdit(QWidget* parent, TFrameId fId,
+                                         bool acceptLetter)
     : LineEdit(parent) {
-  setFixedWidth(54);
-  m_intValidator = new QIntValidator(this);
-  setValue(value);
-  m_intValidator->setRange(1, 9999);
+  setFixedWidth(60);
+  if (acceptLetter)
+    m_regexpValidator =
+        new QRegExpValidator(QRegExp("^\\d{1,4}[A-Za-z]?$"), this);
+  else
+    m_regexpValidator = new QRegExpValidator(QRegExp("^\\d{1,4}$"), this);
 
-  QRegExp rx("^[0-9]{1,4}[A-Ia-i]?$");
-  m_regexpValidator = new QRegExpValidator(rx, this);
+  m_regexpValidator_alt =
+      new QRegExpValidator(QRegExp("^\\d{1,3}[A-Ia-i]?$"), this);
 
   updateValidator();
+
+  setValue(fId);
 }
 
 //-----------------------------------------------------------------------------
 
 void FrameNumberLineEdit::updateValidator() {
   if (Preferences::instance()->isShowFrameNumberWithLettersEnabled())
-    setValidator(m_regexpValidator);
+    setValidator(m_regexpValidator_alt);
   else
-    setValidator(m_intValidator);
+    setValidator(m_regexpValidator);
 }
 
 //-----------------------------------------------------------------------------
 
-void FrameNumberLineEdit::setValue(int value) {
-  if (value <= 0)
-    value = 1;
-  else if (value > 9999)
-    value = 9999;
-
+void FrameNumberLineEdit::setValue(TFrameId fId) {
   QString str;
   if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
-    str = convertToFrameWithLetter(value, 3);
+    if (fId.getLetter() != '\0') {
+      // need some warning?
+    }
+    str = convertToFrameWithLetter(fId.getNumber(), 3);
   } else {
-    str.setNum(value);
-    while (str.length() < 4) str.push_front("0");
+    str = QString::fromStdString(fId.expand());
   }
   setText(str);
   setCursorPosition(0);
@@ -709,18 +711,27 @@ void FrameNumberLineEdit::setValue(int value) {
 
 //-----------------------------------------------------------------------------
 
-int FrameNumberLineEdit::getValue() {
+TFrameId FrameNumberLineEdit::getValue() {
   if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
     QString str = text();
+    int f;
     // if no letters added
     if (str.at(str.size() - 1).isDigit())
-      return str.toInt() * 10;
+      f = str.toInt() * 10;
     else {
-      return str.left(str.size() - 1).toInt() * 10 +
-             letterToNum(str.at(str.size() - 1));
+      f = str.left(str.size() - 1).toInt() * 10 +
+          letterToNum(str.at(str.size() - 1));
     }
-  } else
-    return text().toInt();
+    return TFrameId(f);
+  } else {
+    QRegExp rx("^(\\d{1,4})([A-Za-z]?)$");
+    int pos = rx.indexIn(text());
+    if (pos < 0) return TFrameId();
+    if (rx.cap(2).isEmpty())
+      return TFrameId(rx.cap(1).toInt());
+    else
+      return TFrameId(rx.cap(1).toInt(), rx.cap(2).at(0).toLatin1());
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -3578,7 +3589,7 @@ void StopMotionController::onFileTypeActivated() {
 //-----------------------------------------------------------------------------
 
 void StopMotionController::onFrameNumberChanged() {
-  m_stopMotion->setFrameNumber(m_frameNumberEdit->getValue());
+  m_stopMotion->setFrameNumber(m_frameNumberEdit->getValue().getNumber());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/stopmotion/stopmotioncontroller.h
+++ b/toonz/sources/stopmotion/stopmotioncontroller.h
@@ -8,6 +8,8 @@
 #include "toonzqt/dvdialog.h"
 #include "toonzqt/lineedit.h"
 
+#include "tfilepath.h"
+
 // TnzQt includes
 #include "toonzqt/tabbar.h"
 #include "toonzqt/gutil.h"
@@ -72,20 +74,20 @@ class IntLineEdit;
 class FrameNumberLineEdit : public DVGui::LineEdit {
   Q_OBJECT
   /* having two validators and switch them according to the preferences*/
-  QIntValidator *m_intValidator;
-  QRegExpValidator *m_regexpValidator;
+  QRegExpValidator *m_regexpValidator, *m_regexpValidator_alt;
 
   void updateValidator();
   QString m_textOnFocusIn;
 
 public:
-  FrameNumberLineEdit(QWidget *parent = 0, int value = 1);
+  FrameNumberLineEdit(QWidget* parent = 0, TFrameId fId = TFrameId(1),
+                      bool acceptLetter = true);
   ~FrameNumberLineEdit() {}
 
   /*! Set text in field to \b value. */
-  void setValue(int value);
+  void setValue(TFrameId fId);
   /*! Return an integer with text field value. */
-  int getValue();
+  TFrameId getValue();
 
 protected:
   /*! If focus is lost and current text value is out of range emit signal

--- a/toonz/sources/stopmotion/stopmotioncontroller.h
+++ b/toonz/sources/stopmotion/stopmotioncontroller.h
@@ -9,6 +9,7 @@
 #include "toonzqt/lineedit.h"
 
 #include "tfilepath.h"
+#include "toonz/tproject.h"
 
 // TnzQt includes
 #include "toonzqt/tabbar.h"
@@ -71,7 +72,8 @@ class IntLineEdit;
 // "Show ABC Appendix to the Frame Number in Xsheet Cell" is active.
 //-----------------------------------------------------------------------------
 
-class FrameNumberLineEdit : public DVGui::LineEdit {
+class FrameNumberLineEdit : public DVGui::LineEdit,
+                            public TProjectManager::Listener {
   Q_OBJECT
   /* having two validators and switch them according to the preferences*/
   QRegExpValidator *m_regexpValidator, *m_regexpValidator_alt;
@@ -88,6 +90,10 @@ public:
   void setValue(TFrameId fId);
   /*! Return an integer with text field value. */
   TFrameId getValue();
+
+  // TProjectManager::Listener
+  void onProjectSwitched() override;
+  void onProjectChanged() override;
 
 protected:
   /*! If focus is lost and current text value is out of range emit signal

--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -411,7 +411,10 @@ static void cleanupLevel(TXshSimpleLevel *xl, std::set<TFrameId> fidsInXsheet,
                   QString::fromStdString(fid.expand()));
       continue;
     }
-    TRasterImageP original = xl->getFrameToCleanup(fid);
+    CleanupParameters *params = scene->getProperties()->getCleanupParameters();
+    // if lines are not processed, obtain the original sampled image
+    bool toBeLineProcessed = params->m_lineProcessingMode != lpNone;
+    TRasterImageP original = xl->getFrameToCleanup(fid, toBeLineProcessed);
     if (!original) {
       string err = "    *error* missed frame";
       m_userLog.error(err);
@@ -419,11 +422,9 @@ static void cleanupLevel(TXshSimpleLevel *xl, std::set<TFrameId> fidsInXsheet,
       continue;
     }
 
-    CleanupParameters *params = scene->getProperties()->getCleanupParameters();
-
     if (params->m_lineProcessingMode == lpNone) {
-      TRasterImageP ri;
-      if (params->m_autocenterType == CleanupTypes::AUTOCENTER_NONE)
+      TRasterImageP ri(original);
+      /*if (params->m_autocenterType == CleanupTypes::AUTOCENTER_NONE)
         ri = original;
       else {
         bool autocentered;
@@ -432,7 +433,9 @@ static void cleanupLevel(TXshSimpleLevel *xl, std::set<TFrameId> fidsInXsheet,
           m_userLog.error("The autocentering failed on the current drawing.");
           cout << "The autocentering failed on the current drawing." << endl;
         }
-      }
+      }*/
+      cl->process(original, false, ri, false, true, true, nullptr,
+                  ri->getRaster());
       updater.update(fid, ri);
       continue;
     }

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -102,8 +102,8 @@ TFrameId getNewFrameId(TXshSimpleLevel *sl, int row) {
   TFrameId fid(row + 1);
   if (sl->isFid(fid)) {
     fid = TFrameId(fid.getNumber(), 'a');
-    while (fid.getLetter() < 'z' && sl->isFid(fid))
-      fid = TFrameId(fid.getNumber(), fid.getLetter() + 1);
+    while (fid.getLetter().toUtf8().at(0) < 'z' && sl->isFid(fid))
+      fid = TFrameId(fid.getNumber(), fid.getLetter().toUtf8().at(0) + 1);
   }
   return fid;
 }
@@ -123,9 +123,15 @@ TFrameId getDesiredFId(TXshCellColumn *column, int r0, TXshSimpleLevel *sl,
     if (neighborFId.isEmptyFrame()) neighborFId = tmpFId;
     if (maxFId < tmpFId) maxFId = tmpFId;
   }
-  if (maxFId.getLetter() && maxFId.getLetter() < 'z' && maxFId == neighborFId)
-    return TFrameId(maxFId.getNumber(), maxFId.getLetter() + 1);
-  else
+
+  QByteArray suffix = maxFId.getLetter().toUtf8();
+  // increment letter
+  if (suffix.size() == 1 &&
+      ((suffix.at(0) >= 'A' && suffix.at(0) < 'Z') ||
+       (suffix.at(0) >= 'a' && suffix.at(0) < 'z')) &&
+      maxFId == neighborFId) {
+    return TFrameId(maxFId.getNumber(), suffix.at(0) + 1);
+  } else
     return TFrameId(maxFId.getNumber() + 1);
 }
 

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -1827,6 +1827,15 @@ bool ToolUtils::doUpdateXSheet(TXshSimpleLevel *sl,
 
 bool ToolUtils::renumberForInsertFId(TXshSimpleLevel *sl, const TFrameId &fid,
                                      const TFrameId &maxFid, TXsheet *xsh) {
+  auto getNextLetter = [](const QString &letter) {
+    if (letter.isEmpty()) return QString('a');
+    if (letter == 'z' || letter == 'Z') return QString();
+    QByteArray byteArray = letter.toUtf8();
+    // return incrementing the last letter
+    byteArray.data()[byteArray.size() - 1]++;
+    return QString::fromUtf8(byteArray);
+  };
+
   std::vector<TFrameId> fids;
   std::vector<TFrameId> oldFrames;
   sl->getFids(oldFrames);
@@ -1840,10 +1849,10 @@ bool ToolUtils::renumberForInsertFId(TXshSimpleLevel *sl, const TFrameId &fid,
   for (auto itr = fidsSet.upper_bound(maxFid); itr != fidsSet.end(); ++itr) {
     if (*itr > tmpFid) break;
     fIdsToBeShifted.push_back(*itr);
-    if (fid.getLetter()) {
-      if ((*itr).getLetter() < 'z')
-        tmpFid = TFrameId((*itr).getNumber(),
-                          ((*itr).getLetter()) ? (*itr).getLetter() + 1 : 'a');
+    if (!fid.getLetter().isEmpty()) {
+      QString nextLetter = getNextLetter((*itr).getLetter());
+      if (!nextLetter.isEmpty())
+        tmpFid = TFrameId((*itr).getNumber(), nextLetter);
       else
         tmpFid = TFrameId((*itr).getNumber() + 1);
     } else
@@ -1854,11 +1863,10 @@ bool ToolUtils::renumberForInsertFId(TXshSimpleLevel *sl, const TFrameId &fid,
 
   for (TFrameId &tmpFid : fids) {
     if (fIdsToBeShifted.contains(tmpFid)) {
-      if (fid.getLetter()) {
-        if (tmpFid.getLetter() < 'z')
-          tmpFid =
-              TFrameId(tmpFid.getNumber(),
-                       (tmpFid.getLetter()) ? tmpFid.getLetter() + 1 : 'a');
+      if (!fid.getLetter().isEmpty()) {
+        QString nextLetter = getNextLetter(tmpFid.getLetter());
+        if (!nextLetter.isEmpty())
+          tmpFid = TFrameId(tmpFid.getNumber(), nextLetter);
         else
           tmpFid = TFrameId(tmpFid.getNumber() + 1);
       } else

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -74,7 +74,6 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_playXSheetCB       = new QCheckBox(tr("Sync with XSheet/Timeline"), this);
   m_timer              = new QElapsedTimer();
   m_recordedLevels     = QMap<qint64, double>();
-  m_oldElapsed         = 0;
   m_player             = new QMediaPlayer(this);
   m_console            = FlipConsole::getCurrent();
 
@@ -294,7 +293,6 @@ void AudioRecordingPopup::onRecordButtonPressed() {
     m_comboSamplerate->setDisabled(true);
     m_comboSamplefmt->setDisabled(true);
     m_recordedLevels.clear();
-    m_oldElapsed   = 0;
     m_pausedTime   = 0;
     m_startPause   = 0;
     m_endPause     = 0;
@@ -319,6 +317,7 @@ void AudioRecordingPopup::onRecordButtonPressed() {
       m_saveButton->setEnabled(true);
       m_playButton->setEnabled(true);
     }
+    m_audioWriterWAV->freeup();
     m_audioLevelsDisplay->setLevel(-1);
     m_recordButton->setIcon(m_recordIcon);
     m_pauseRecordingButton->setDisabled(true);
@@ -626,6 +625,9 @@ void AudioRecordingPopup::hideEvent(QHideEvent *event) {
   if (TSystem::doesExistFileOrLevel(TFilePath(m_filePath.getQString()))) {
     TSystem::removeFileOrLevel(TFilePath(m_filePath.getQString()));
   }
+  // Free up memory used in recording
+  m_recordedLevels.clear();
+  m_audioWriterWAV->freeup();
 }
 
 //-----------------------------------------------------------------------------
@@ -793,6 +795,8 @@ bool AudioWriterWAV::save(const QString &filename)
   out.writeRawData(m_barray.constData(), m_barray.size());
   return true;
 }
+
+void AudioWriterWAV::freeup() { m_barray.clear(); }
 
 //-----------------------------------------------------------------------------
 // AudioLevelsDisplay Class

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -66,29 +66,47 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_saveButton           = new QPushButton(tr("Save and Insert"));
   m_pauseRecordingButton = new QPushButton(this);
   m_pausePlaybackButton  = new QPushButton(this);
-  // m_refreshDevicesButton = new QPushButton(tr("Refresh"));
-  m_duration           = new QLabel("00:00");
-  m_playDuration       = new QLabel("00:00");
+  m_refreshDevicesButton = new QPushButton(this);
+  m_duration           = new QLabel("00:00.000");
+  m_playDuration       = new QLabel("00:00.000");
   m_deviceListCB       = new QComboBox();
   m_audioLevelsDisplay = new AudioLevelsDisplay(this);
-  m_playXSheetCB       = new QCheckBox(tr("Sync with Scene"), this);
+  m_playXSheetCB       = new QCheckBox(tr("Sync with XSheet/Timeline"), this);
   m_timer              = new QElapsedTimer();
   m_recordedLevels     = QMap<qint64, double>();
   m_oldElapsed         = 0;
-  m_probe              = new QAudioProbe;
   m_player             = new QMediaPlayer(this);
   m_console            = FlipConsole::getCurrent();
-  m_audioRecorder      = new QAudioRecorder;
 
-  m_recordButton->setMaximumWidth(25);
-  m_playButton->setMaximumWidth(25);
-  m_pauseRecordingButton->setMaximumWidth(25);
-  m_pausePlaybackButton->setMaximumWidth(25);
+  m_labelDevice     = new QLabel(tr("Device: "));
+  m_labelSamplerate = new QLabel(tr("Sample rate: "));
+  m_labelSamplefmt  = new QLabel(tr("Sample format: "));
+  m_comboSamplerate = new QComboBox();
+  m_comboSamplefmt  = new QComboBox();
+  m_comboSamplerate->addItem(tr("8000 Hz"), QVariant::fromValue(8000));
+  m_comboSamplerate->addItem(tr("11025 Hz"), QVariant::fromValue(11025));
+  m_comboSamplerate->addItem(tr("22050 Hz"), QVariant::fromValue(22050));
+  m_comboSamplerate->addItem(tr("44100 Hz"), QVariant::fromValue(44100));
+  m_comboSamplerate->addItem(tr("48000 Hz"), QVariant::fromValue(48000));
+  m_comboSamplerate->addItem(tr("96000 Hz"), QVariant::fromValue(96000));
+  m_comboSamplerate->setCurrentIndex(3);  // 44.1KHz
+  m_comboSamplefmt->addItem(tr("Mono 8-Bits"), QVariant::fromValue(9));
+  m_comboSamplefmt->addItem(tr("Stereo 8-Bits"), QVariant::fromValue(10));
+  m_comboSamplefmt->addItem(tr("Mono 16-Bits"), QVariant::fromValue(17));
+  m_comboSamplefmt->addItem(tr("Stereo 16-Bits"), QVariant::fromValue(18));
+  m_comboSamplefmt->setCurrentIndex(2);  // Mono 16-Bits
+
+  m_recordButton->setMaximumWidth(32);
+  m_playButton->setMaximumWidth(32);
+  m_pauseRecordingButton->setMaximumWidth(32);
+  m_pausePlaybackButton->setMaximumWidth(32);
+  m_refreshDevicesButton->setMaximumWidth(25);
 
   QString playDisabled   = QString(":Resources/play_disabled.svg");
   QString pauseDisabled  = QString(":Resources/pause_disabled.svg");
   QString stopDisabled   = QString(":Resources/stop_disabled.svg");
   QString recordDisabled = QString(":Resources/record_disabled.svg");
+  QString refreshDisabled = QString(":Resources/repeat_icon.svg");
 
   m_pauseIcon = createQIcon("pause");
   m_pauseIcon.addFile(pauseDisabled, QSize(), QIcon::Disabled);
@@ -98,6 +116,9 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_recordIcon.addFile(recordDisabled, QSize(), QIcon::Disabled);
   m_stopIcon = createQIcon("stop");
   m_stopIcon.addFile(stopDisabled, QSize(), QIcon::Disabled);
+  m_refreshIcon = createQIcon("repeat");
+  m_refreshIcon.addFile(refreshDisabled, QSize(), QIcon::Disabled);
+
   m_pauseRecordingButton->setIcon(m_pauseIcon);
   m_pauseRecordingButton->setIconSize(QSize(17, 17));
   m_playButton->setIcon(m_playIcon);
@@ -106,12 +127,32 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_recordButton->setIconSize(QSize(17, 17));
   m_pausePlaybackButton->setIcon(m_pauseIcon);
   m_pausePlaybackButton->setIconSize(QSize(17, 17));
+  m_refreshDevicesButton->setIcon(m_refreshIcon);
+  m_refreshDevicesButton->setIconSize(QSize(17, 17));
 
-  QStringList inputs = m_audioRecorder->audioInputs();
-  m_deviceListCB->addItems(inputs);
-  QString selectedInput = m_audioRecorder->defaultAudioInput();
-  m_deviceListCB->setCurrentText(selectedInput);
-  m_audioRecorder->setAudioInput(selectedInput);
+  // Enumerate devices and initialize default device
+  enumerateAudioDevices("");
+  QAudioDeviceInfo m_audioDeviceInfo = QAudioDeviceInfo::defaultInputDevice();
+  QAudioFormat format;
+  format.setSampleRate(44100);
+  format.setChannelCount(1);
+  format.setSampleSize(16);
+  format.setSampleType(QAudioFormat::SignedInt);
+  format.setByteOrder(QAudioFormat::LittleEndian);
+  format.setCodec("audio/pcm");
+  if (!m_audioDeviceInfo.isFormatSupported(format)) {
+    format = m_audioDeviceInfo.nearestFormat(format);
+  }
+  m_audioInput = new QAudioInput(m_audioDeviceInfo, format);
+  m_audioWriterWAV = new AudioWriterWAV(format);
+
+  // Tool tips to provide additional info to the user
+  m_deviceListCB->setToolTip(tr("Audio input device to record"));
+  m_comboSamplerate->setToolTip(tr("Number of samples per second, 44.1KHz = CD Quality"));
+  m_comboSamplefmt->setToolTip(tr("Number of channels and bits per sample, 16-bits recommended"));
+  m_playXSheetCB->setToolTip(tr("Play animation from current frame while recording/playback"));
+  m_saveButton->setToolTip(tr("Save recording and insert into new column"));
+  m_refreshDevicesButton->setToolTip(tr("Refresh list of connected audio input devices"));
 
   m_topLayout->setMargin(5);
   m_topLayout->setSpacing(8);
@@ -124,11 +165,19 @@ AudioRecordingPopup::AudioRecordingPopup()
     recordGridLay->setHorizontalSpacing(2);
     recordGridLay->setVerticalSpacing(3);
     {
-      recordGridLay->addWidget(m_deviceListCB, 0, 0, 1, 4, Qt::AlignCenter);
-      // recordGridLay->addWidget(m_refreshDevicesButton, 0, 3, Qt::AlignLeft);
-      recordGridLay->addWidget(new QLabel(tr(" ")), 1, 0, Qt::AlignCenter);
-      recordGridLay->addWidget(m_audioLevelsDisplay, 2, 0, 1, 4,
+      recordGridLay->addWidget(m_labelDevice, 0, 0, 1, 2, Qt::AlignRight);
+      recordGridLay->addWidget(m_deviceListCB, 0, 2, 1, 2, Qt::AlignLeft);
+
+      recordGridLay->addWidget(m_labelSamplerate, 1, 0, 1, 2, Qt::AlignRight);
+      recordGridLay->addWidget(m_comboSamplerate, 1, 2, 1, 1, Qt::AlignLeft);
+      recordGridLay->addWidget(m_refreshDevicesButton, 1, 3, Qt::AlignRight);
+
+      recordGridLay->addWidget(m_labelSamplefmt, 2, 0, 1, 2, Qt::AlignRight);
+      recordGridLay->addWidget(m_comboSamplefmt, 2, 2, 1, 2, Qt::AlignLeft);
+
+      recordGridLay->addWidget(m_audioLevelsDisplay, 3, 0, 1, 4,
                                Qt::AlignCenter);
+      recordGridLay->addWidget(m_playXSheetCB, 4, 0, 1, 5, Qt::AlignCenter);
       QHBoxLayout *recordLay = new QHBoxLayout();
       recordLay->setSpacing(4);
       recordLay->setContentsMargins(0, 0, 0, 0);
@@ -139,7 +188,7 @@ AudioRecordingPopup::AudioRecordingPopup()
         recordLay->addWidget(m_duration);
         recordLay->addStretch();
       }
-      recordGridLay->addLayout(recordLay, 3, 0, 1, 4, Qt::AlignCenter);
+      recordGridLay->addLayout(recordLay, 5, 0, 1, 4, Qt::AlignCenter);
       QHBoxLayout *playLay = new QHBoxLayout();
       playLay->setSpacing(4);
       playLay->setContentsMargins(0, 0, 0, 0);
@@ -150,11 +199,9 @@ AudioRecordingPopup::AudioRecordingPopup()
         playLay->addWidget(m_playDuration);
         playLay->addStretch();
       }
-      recordGridLay->addLayout(playLay, 4, 0, 1, 4, Qt::AlignCenter);
-      recordGridLay->addWidget(new QLabel(tr(" ")), 5, 0, Qt::AlignCenter);
-      recordGridLay->addWidget(m_saveButton, 6, 0, 1, 4,
-                               Qt::AlignCenter | Qt::AlignVCenter);
-      recordGridLay->addWidget(m_playXSheetCB, 7, 0, 1, 4,
+      recordGridLay->addLayout(playLay, 6, 0, 1, 4, Qt::AlignCenter);
+      recordGridLay->addWidget(new QLabel(tr(" ")), 7, 0, Qt::AlignCenter);
+      recordGridLay->addWidget(m_saveButton, 8, 0, 1, 4,
                                Qt::AlignCenter | Qt::AlignVCenter);
     }
     recordGridLay->setColumnStretch(0, 0);
@@ -172,23 +219,6 @@ AudioRecordingPopup::AudioRecordingPopup()
 
   m_playXSheetCB->setChecked(true);
 
-  m_probe->setSource(m_audioRecorder);
-  QAudioEncoderSettings audioSettings;
-  audioSettings.setCodec("audio/PCM");
-  // setting the sample rate to some value (like 44100)
-  // may cause divide-by-zero crash in QAudioDeviceInfo::nearestFormat()
-  // so here we set the value to -1, as the documentation says;
-  // "A value of -1 indicates the encoder should make an optimal choice"
-  audioSettings.setSampleRate(-1);
-  audioSettings.setChannelCount(1);
-  audioSettings.setBitRate(16);
-  audioSettings.setEncodingMode(QMultimedia::ConstantBitRateEncoding);
-  audioSettings.setQuality(QMultimedia::HighQuality);
-  m_audioRecorder->setContainerFormat("wav");
-  m_audioRecorder->setEncodingSettings(audioSettings);
-
-  connect(m_probe, SIGNAL(audioBufferProbed(QAudioBuffer)), this,
-          SLOT(processBuffer(QAudioBuffer)));
   connect(m_playXSheetCB, SIGNAL(stateChanged(int)), this,
           SLOT(onPlayXSheetCBChanged(int)));
   connect(m_saveButton, SIGNAL(clicked()), this, SLOT(onSaveButtonPressed()));
@@ -199,16 +229,18 @@ AudioRecordingPopup::AudioRecordingPopup()
           SLOT(onPauseRecordingButtonPressed()));
   connect(m_pausePlaybackButton, SIGNAL(clicked()), this,
           SLOT(onPausePlaybackButtonPressed()));
-  connect(m_audioRecorder, SIGNAL(durationChanged(qint64)), this,
+  connect(m_audioWriterWAV, SIGNAL(update(qint64)), this,
           SLOT(updateRecordDuration(qint64)));
-  connect(m_console, SIGNAL(playStateChanged(bool)), this,
+  if (m_console) connect(m_console, SIGNAL(playStateChanged(bool)), this,
           SLOT(onPlayStateChanged(bool)));
   connect(m_deviceListCB, SIGNAL(currentTextChanged(const QString)), this,
           SLOT(onInputDeviceChanged()));
-  // connect(m_refreshDevicesButton, SIGNAL(clicked()), this,
-  // SLOT(onRefreshButtonPressed()));
-  // connect(m_audioRecorder, SIGNAL(availableAudioInputsChanged()), this,
-  // SLOT(onRefreshButtonPressed()));
+  connect(m_refreshDevicesButton, SIGNAL(clicked()), this,
+          SLOT(onRefreshButtonPressed()));
+  connect(m_comboSamplerate, SIGNAL(currentTextChanged(const QString)), this,
+          SLOT(onAudioSettingChanged()));
+  connect(m_comboSamplefmt, SIGNAL(currentTextChanged(const QString)), this,
+          SLOT(onAudioSettingChanged()));
 }
 
 //-----------------------------------------------------------------------------
@@ -218,11 +250,24 @@ AudioRecordingPopup::~AudioRecordingPopup() {}
 //-----------------------------------------------------------------------------
 
 void AudioRecordingPopup::onRecordButtonPressed() {
-  if (m_audioRecorder->state() == QAudioRecorder::StoppedState) {
-    if (m_audioRecorder->status() == QMediaRecorder::UnavailableStatus) {
+#if QT_VERSION >= 0x051000
+  if (m_audioInput->state() == QAudio::InterruptedState) {
+    DVGui::warning(
+        tr("The microphone is not available: "
+           "\nPlease select a different device or check the microphone."));
+    return;
+  } else if (m_audioInput->state() == QAudio::StoppedState) {
+    if (!m_console) {
+      DVGui::warning(
+          tr("Record failed: "
+             "\nMake sure there's XSheet or Timeline in the room."));
+#else
+  if (m_audioInput->state() == QAudio::StoppedState) {
+    if (!m_console) {
       DVGui::warning(
           tr("The microphone is not available: "
              "\nPlease select a different device or check the microphone."));
+#endif
       return;
     }
     // clear the player in case the file is open there
@@ -236,8 +281,6 @@ void AudioRecordingPopup::onRecordButtonPressed() {
     // (rarely)
     // could cause a crash.  I think OT tried to import the level before the
     // final file was fully copied to the new location
-    m_audioRecorder->setOutputLocation(
-        QUrl::fromLocalFile(m_filePath.getQString()));
     if (TSystem::doesExistFileOrLevel(m_filePath)) {
       TSystem::removeFileOrLevel(m_filePath);
     }
@@ -246,15 +289,21 @@ void AudioRecordingPopup::onRecordButtonPressed() {
     m_playButton->setDisabled(true);
     m_pausePlaybackButton->setDisabled(true);
     m_pauseRecordingButton->setEnabled(true);
+    m_deviceListCB->setDisabled(true);
+    m_refreshDevicesButton->setDisabled(true);
+    m_comboSamplerate->setDisabled(true);
+    m_comboSamplefmt->setDisabled(true);
     m_recordedLevels.clear();
     m_oldElapsed   = 0;
     m_pausedTime   = 0;
     m_startPause   = 0;
     m_endPause     = 0;
     m_stoppedAtEnd = false;
-    m_playDuration->setText("00:00");
+    m_playDuration->setText("00:00.000");
     m_timer->restart();
-    m_audioRecorder->record();
+    m_audioWriterWAV->restart(m_audioInput->format());
+    m_audioWriterWAV->start();
+    m_audioInput->start(m_audioWriterWAV);
     // this sometimes sets to one frame off, so + 1.
     m_currentFrame = TApp::instance()->getCurrentFrame()->getFrame() + 1;
     if (m_syncPlayback && !m_isPlaying) {
@@ -264,13 +313,20 @@ void AudioRecordingPopup::onRecordButtonPressed() {
     }
 
   } else {
-    m_audioRecorder->stop();
-    m_audioLevelsDisplay->setLevel(0);
+    m_audioInput->stop();
+    m_audioWriterWAV->stop();
+    if (m_audioWriterWAV->save(m_filePath.getQString())) {
+      m_saveButton->setEnabled(true);
+      m_playButton->setEnabled(true);
+    }
+    m_audioLevelsDisplay->setLevel(-1);
     m_recordButton->setIcon(m_recordIcon);
-    m_saveButton->setEnabled(true);
-    m_playButton->setEnabled(true);
     m_pauseRecordingButton->setDisabled(true);
     m_pauseRecordingButton->setIcon(m_pauseIcon);
+    m_deviceListCB->setEnabled(true);
+    m_refreshDevicesButton->setEnabled(true);
+    m_comboSamplerate->setEnabled(true);
+    m_comboSamplefmt->setEnabled(true);
     if (m_syncPlayback) {
       if (m_isPlaying) {
         m_console->pressButton(FlipConsole::ePause);
@@ -285,15 +341,18 @@ void AudioRecordingPopup::onRecordButtonPressed() {
 //-----------------------------------------------------------------------------
 
 void AudioRecordingPopup::updateRecordDuration(qint64 duration) {
-  // this is only called every second or so - sometimes duration ~= 950
-  // this gives some padding so it doesn't take two seconds to show one second
-  // has passed
-  if (duration % 1000 > 850) duration += 150;
   int minutes        = duration / 60000;
   int seconds        = (duration / 1000) % 60;
+  int milis          = duration % 1000;
   QString strMinutes = QString::number(minutes).rightJustified(2, '0');
   QString strSeconds = QString::number(seconds).rightJustified(2, '0');
-  m_duration->setText(strMinutes + ":" + strSeconds);
+  QString strMilis   = QString::number(milis).rightJustified(3, '0');
+  m_duration->setText(strMinutes + ":" + strSeconds + "." + strMilis);
+
+  // Show and record amplitude
+  qreal level = m_audioWriterWAV->level();
+  m_audioLevelsDisplay->setLevel(level);
+  m_recordedLevels[duration / 20] = level;
 }
 
 //-----------------------------------------------------------------------------
@@ -301,9 +360,11 @@ void AudioRecordingPopup::updateRecordDuration(qint64 duration) {
 void AudioRecordingPopup::updatePlaybackDuration(qint64 duration) {
   int minutes        = duration / 60000;
   int seconds        = (duration / 1000) % 60;
+  int milis          = duration % 1000;
   QString strMinutes = QString::number(minutes).rightJustified(2, '0');
   QString strSeconds = QString::number(seconds).rightJustified(2, '0');
-  m_playDuration->setText(strMinutes + ":" + strSeconds);
+  QString strMilis   = QString::number(milis).rightJustified(3, '0');
+  m_playDuration->setText(strMinutes + ":" + strSeconds + "." + strMilis);
 
   // the qmediaplayer probe doesn't work on all platforms, so we fake it by
   // using
@@ -328,6 +389,10 @@ void AudioRecordingPopup::onPlayButtonPressed() {
     m_recordButton->setDisabled(true);
     m_saveButton->setDisabled(true);
     m_pausePlaybackButton->setEnabled(true);
+    m_deviceListCB->setDisabled(true);
+    m_refreshDevicesButton->setDisabled(true);
+    m_comboSamplerate->setDisabled(true);
+    m_comboSamplefmt->setDisabled(true);
     m_stoppedAtEnd = false;
     m_player->play();
     // this sometimes sets to one frame off, so + 1.
@@ -343,25 +408,29 @@ void AudioRecordingPopup::onPlayButtonPressed() {
     m_playButton->setIcon(m_playIcon);
     m_pausePlaybackButton->setDisabled(true);
     m_pausePlaybackButton->setIcon(m_pauseIcon);
+    m_deviceListCB->setEnabled(true);
+    m_refreshDevicesButton->setEnabled(true);
+    m_comboSamplerate->setEnabled(true);
+    m_comboSamplefmt->setEnabled(true);
   }
 }
 
 //-----------------------------------------------------------------------------
 
 void AudioRecordingPopup::onPauseRecordingButtonPressed() {
-  if (m_audioRecorder->state() == QAudioRecorder::StoppedState) {
+  if (m_audioInput->state() == QAudio::StoppedState) {
     return;
-  } else if (m_audioRecorder->state() == QAudioRecorder::PausedState) {
+  } else if (m_audioInput->state() == QAudio::SuspendedState) {
     m_endPause = m_timer->elapsed();
     m_pausedTime += m_endPause - m_startPause;
-    m_audioRecorder->record();
+    m_audioInput->resume();
     m_pauseRecordingButton->setIcon(m_pauseIcon);
     if (m_syncPlayback && !m_isPlaying && !m_stoppedAtEnd) {
       m_console->pressButton(FlipConsole::ePlay);
       m_isPlaying = true;
     }
   } else {
-    m_audioRecorder->pause();
+    m_audioInput->suspend();
     m_pauseRecordingButton->setIcon(m_recordIcon);
     m_startPause = m_timer->elapsed();
     if (m_syncPlayback && m_isPlaying) {
@@ -398,7 +467,7 @@ void AudioRecordingPopup::onPausePlaybackButtonPressed() {
 void AudioRecordingPopup::onMediaStateChanged(QMediaPlayer::State state) {
   // stopping can happen through the stop button or the file ending
   if (state == QMediaPlayer::StoppedState) {
-    m_audioLevelsDisplay->setLevel(0);
+    m_audioLevelsDisplay->setLevel(-1);
     if (m_syncPlayback) {
       if (m_isPlaying) {
         m_console->pressButton(FlipConsole::ePause);
@@ -410,6 +479,10 @@ void AudioRecordingPopup::onMediaStateChanged(QMediaPlayer::State state) {
     m_pausePlaybackButton->setIcon(m_pauseIcon);
     m_pausePlaybackButton->setDisabled(true);
     m_recordButton->setEnabled(true);
+    m_deviceListCB->setEnabled(true);
+    m_refreshDevicesButton->setEnabled(true);
+    m_comboSamplerate->setEnabled(true);
+    m_comboSamplefmt->setEnabled(true);
     m_saveButton->setEnabled(true);
     m_isPlaying = false;
   }
@@ -426,36 +499,36 @@ void AudioRecordingPopup::onPlayXSheetCBChanged(int status) {
 
 //-----------------------------------------------------------------------------
 
-// Refresh isn't working right now, but I'm leaving the code in case a future
-// change
-// makes it work
+void AudioRecordingPopup::onRefreshButtonPressed() {
+  QAudioDeviceInfo m_audioDeviceInfo =
+      m_deviceListCB->itemData(m_deviceListCB->currentIndex())
+          .value<QAudioDeviceInfo>();
 
-// void AudioRecordingPopup::onRefreshButtonPressed() {
-//	m_deviceListCB->clear();
-//	QStringList inputs = m_audioRecorder->audioInputs();
-//	int count = inputs.count();
-//	m_deviceListCB->addItems(inputs);
-//	QString selectedInput = m_audioRecorder->defaultAudioInput();
-//	m_deviceListCB->setCurrentText(selectedInput);
-//
-//}
+  enumerateAudioDevices(m_audioDeviceInfo.deviceName());
+}
 
 //-----------------------------------------------------------------------------
 
 void AudioRecordingPopup::onInputDeviceChanged() {
-  m_audioRecorder->setAudioInput(m_deviceListCB->currentText());
+  reinitAudioInput();
+}
+
+//-----------------------------------------------------------------------------
+
+void AudioRecordingPopup::onAudioSettingChanged() {
+  reinitAudioInput();
 }
 
 //-----------------------------------------------------------------------------
 
 void AudioRecordingPopup::onSaveButtonPressed() {
-  if (m_audioRecorder->state() != QAudioRecorder::StoppedState) {
-    m_audioRecorder->stop();
-    m_audioLevelsDisplay->setLevel(0);
+  if (m_audioInput->state() != QAudio::StoppedState) {
+    m_audioInput->stop();
+    m_audioLevelsDisplay->setLevel(-1);
   }
   if (m_player->state() != QMediaPlayer::StoppedState) {
     m_player->stop();
-    m_audioLevelsDisplay->setLevel(0);
+    m_audioLevelsDisplay->setLevel(-1);
   }
   if (!TSystem::doesExistFileOrLevel(m_filePath)) return;
 
@@ -499,31 +572,6 @@ void AudioRecordingPopup::makePaths() {
 
 //-----------------------------------------------------------------------------
 
-void AudioRecordingPopup::processBuffer(const QAudioBuffer &buffer) {
-  // keep from processing too many times
-  // get 50 signals per second
-  if (m_timer->elapsed() < m_oldElapsed + 20) return;
-  m_oldElapsed = m_timer->elapsed() - m_pausedTime;
-  qint16 value = 0;
-
-  if (!buffer.format().isValid() ||
-      buffer.format().byteOrder() != QAudioFormat::LittleEndian)
-    return;
-
-  if (buffer.format().codec() != "audio/pcm") return;
-
-  const qint16 *data = buffer.constData<qint16>();
-  qreal maxValue     = 0;
-  qreal tempValue    = 0;
-  for (int i = 0; i < buffer.frameCount(); ++i) {
-    tempValue                          = qAbs(qreal(data[i]));
-    if (tempValue > maxValue) maxValue = tempValue;
-  }
-  maxValue /= SHRT_MAX;
-  m_audioLevelsDisplay->setLevel(maxValue);
-  m_recordedLevels[m_oldElapsed / 20] = maxValue;
-}
-
 void AudioRecordingPopup::onPlayStateChanged(bool playing) {
   // m_isPlaying = playing;
   if (!playing && m_isPlaying) m_stoppedAtEnd = true;
@@ -545,28 +593,205 @@ void AudioRecordingPopup::resetEverything() {
   m_pauseRecordingButton->setIcon(m_pauseIcon);
   m_pauseRecordingButton->setDisabled(true);
   m_pausePlaybackButton->setDisabled(true);
+  m_deviceListCB->setEnabled(true);
+  m_refreshDevicesButton->setEnabled(true);
+  m_comboSamplerate->setEnabled(true);
+  m_comboSamplefmt->setEnabled(true);
   m_recordedLevels.clear();
-  m_duration->setText("00:00");
-  m_playDuration->setText("00:00");
-  m_audioLevelsDisplay->setLevel(0);
+  m_duration->setText("00:00.000");
+  m_playDuration->setText("00:00.000");
+  m_audioLevelsDisplay->setLevel(-1);
+  if (!m_console) {
+    m_console = FlipConsole::getCurrent();
+    if (m_console)
+      connect(m_console, SIGNAL(playStateChanged(bool)), this,
+              SLOT(onPlayStateChanged(bool)));
+  }
 }
 
 //-----------------------------------------------------------------------------
 
 void AudioRecordingPopup::hideEvent(QHideEvent *event) {
-  if (m_audioRecorder->state() != QAudioRecorder::StoppedState) {
-    m_audioRecorder->stop();
+  if (m_audioInput->state() != QAudio::StoppedState) {
+    m_audioInput->stop();
   }
   if (m_player->state() != QMediaPlayer::StoppedState) {
     m_player->stop();
   }
   // make sure the file is freed before deleting
+  delete m_player;
   m_player = new QMediaPlayer(this);
   // this should only remove files that haven't been used in the scene
   // make paths checks to only create path names that don't exist yet.
   if (TSystem::doesExistFileOrLevel(TFilePath(m_filePath.getQString()))) {
     TSystem::removeFileOrLevel(TFilePath(m_filePath.getQString()));
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void AudioRecordingPopup::enumerateAudioDevices(const QString &selectedDeviceName) {
+  const QAudioDeviceInfo &defaultDeviceInfo =
+      QAudioDeviceInfo::defaultInputDevice();
+
+  m_blockAudioSettings = true;
+  m_deviceListCB->clear();
+  m_deviceListCB->addItem(defaultDeviceInfo.deviceName(),
+                          QVariant::fromValue(defaultDeviceInfo));
+
+  for (auto &deviceInfo :
+       QAudioDeviceInfo::availableDevices(QAudio::AudioInput)) {
+    if (deviceInfo != defaultDeviceInfo &&
+        m_deviceListCB->findText(deviceInfo.deviceName()) == -1) {
+      m_deviceListCB->addItem(deviceInfo.deviceName(),
+                              QVariant::fromValue(deviceInfo));
+    }
+  }
+
+  int deviceIndex = m_deviceListCB->findText(selectedDeviceName);
+  if (deviceIndex != -1) m_deviceListCB->setCurrentIndex(deviceIndex);
+  m_blockAudioSettings = false;
+}
+
+//-----------------------------------------------------------------------------
+
+void AudioRecordingPopup::reinitAudioInput() {
+  if (m_blockAudioSettings) return;
+
+  QAudioDeviceInfo m_audioDeviceInfo =
+      m_deviceListCB->itemData(m_deviceListCB->currentIndex())
+          .value<QAudioDeviceInfo>();
+  int samplerate =
+      m_comboSamplerate->itemData(m_comboSamplerate->currentIndex())
+          .value<int>();
+  int sampletype =
+      m_comboSamplefmt->itemData(m_comboSamplefmt->currentIndex()).value<int>();
+  int bitdepth = sampletype & 56;
+  int channels = sampletype & 7;
+
+  QAudioFormat format;
+  format.setSampleRate(samplerate);
+  format.setChannelCount(channels);
+  format.setSampleSize(bitdepth);
+  format.setSampleType(bitdepth == 8 ? QAudioFormat::UnSignedInt
+                                     : QAudioFormat::SignedInt);
+  format.setByteOrder(QAudioFormat::LittleEndian);
+  format.setCodec("audio/pcm");
+  if (!m_audioDeviceInfo.isFormatSupported(format)) {
+    DVGui::warning(tr(
+        "Audio format unsupported:\nNearest format will be internally used."));
+    format = m_audioDeviceInfo.nearestFormat(format);
+  }
+
+  // Recreate input
+  delete m_audioInput;
+  m_audioInput = new QAudioInput(m_audioDeviceInfo, format);
+  m_audioWriterWAV->restart(format);
+}
+
+//-----------------------------------------------------------------------------
+// AudioWriterWAV Class
+//-----------------------------------------------------------------------------
+// IODevice to write standard WAV files, performs peak level calc
+//
+// 8-bits audio must be unsigned
+// 16-bits audio must be signed
+// 32-bits isn't supported
+
+AudioWriterWAV::AudioWriterWAV(const QAudioFormat &format)
+    : m_level(0.0), m_maxAmp(0.0) {
+  restart(format);
+}
+
+bool AudioWriterWAV::restart(const QAudioFormat &format) {
+  m_format = format;
+  if (m_format.sampleSize() == 8) {
+    m_rbytesms = 1000.0 / (m_format.sampleRate() * m_format.channelCount());
+    m_maxAmp   = 127.0;
+  } else if (m_format.sampleSize() == 16) {
+    m_rbytesms = 500.0 / (m_format.sampleRate() * m_format.channelCount());
+    m_maxAmp   = 32767.0;
+  } else {
+    // 32-bits isn't supported
+    m_rbytesms = 250.0 / (m_format.sampleRate() * m_format.channelCount());
+    m_maxAmp   = 1.0;
+  }
+  m_barray.clear();
+  return this->reset();
+}
+
+void AudioWriterWAV::start() {
+    open(QIODevice::WriteOnly);
+}
+
+void AudioWriterWAV::stop() {
+    close();
+}
+
+qint64 AudioWriterWAV::readData(char *data, qint64 maxlen) {
+  Q_UNUSED(data)
+  Q_UNUSED(maxlen)
+  return 0;
+}
+
+qint64 AudioWriterWAV::writeData(const char *data, qint64 len) {
+  qreal tmp, peak = 0.0;
+
+  // Measure peak
+  if (m_format.sampleSize() == 8) {
+    const quint8 *sdata = (const quint8 *)data;
+    int slen            = len;
+    for (int i = 0; i < slen; ++i) {
+      tmp = qAbs(qreal(sdata[i]) - 128.0);
+      if (tmp > peak) peak = tmp;
+    }
+  } else if (m_format.sampleSize() == 16) {
+    const qint16 *sdata = (const qint16 *)data;
+    int slen            = len / 2;
+    for (int i = 0; i < slen; ++i) {
+      tmp = qAbs(qreal(sdata[i]));
+      if (tmp > peak) peak = tmp;
+    }
+  } else {
+    // 32-bits isn't supported
+    peak = -1.0;
+  }
+  m_level = peak / m_maxAmp;
+
+  // Write to buffer
+  m_barray.append(data, len);
+
+  // Emit an update
+  emit update(m_barray.size() * m_rbytesms);
+  return len;
+}
+
+bool AudioWriterWAV::save(const QString &filename)
+{
+  QFile file;
+  quint16 channels   = m_format.channelCount();
+  quint32 samplerate = m_format.sampleRate();
+  quint16 bitrate    = m_format.sampleSize();
+  file.setFileName(filename);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    DVGui::warning(tr(
+        "Failed to save WAV file:\nMake sure you have folder permissions."));
+    return false;
+  }
+  QDataStream out(&file);
+  out.setByteOrder(QDataStream::LittleEndian);
+  out.writeRawData("RIFF", 4);
+  out << (quint32)(m_barray.size() + 44);
+  out.writeRawData("WAVEfmt ", 8);
+  out << (quint32)16 << (quint16)1;
+  out << channels << samplerate;
+  out << quint32(samplerate * channels * bitrate / 8);
+  out << quint16(channels * bitrate / 8);
+  out << bitrate;
+  out.writeRawData("data", 4);
+  out << (quint32)m_barray.size();
+  out.writeRawData(m_barray.constData(), m_barray.size());
+  return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -591,11 +816,11 @@ void AudioLevelsDisplay::paintEvent(QPaintEvent *event) {
 
   QPainter painter(this);
   QColor color;
-  if (m_level < 0.5) {
+  if (m_level < 0.0) {
+    return; // draw nothing...
+  } else if (m_level < 0.5) {
     color = Qt::green;
-  }
-
-  else if (m_level < 0.75) {
+  } else if (m_level < 0.75) {
     color = QColor(204, 205, 0);  // yellow
   } else if (m_level < 0.95) {
     color = QColor(255, 115, 0);  // orange

--- a/toonz/sources/toonz/audiorecordingpopup.h
+++ b/toonz/sources/toonz/audiorecordingpopup.h
@@ -18,7 +18,6 @@ class QPushButton;
 class QLabel;
 class AudioLevelsDisplay;
 class FlipConsole;
-class QAudioProbe;
 class QAudioBuffer;
 class QMediaPlayer;
 class QElapsedTimer;
@@ -42,13 +41,11 @@ class AudioRecordingPopup : public DVGui::Dialog {
   QCheckBox *m_playXSheetCB;
   int m_currentFrame;
   AudioLevelsDisplay *m_audioLevelsDisplay;
-  QAudioProbe *m_probe;
   QMediaPlayer *m_player;
   TFilePath m_filePath;
   FlipConsole *m_console;
   QElapsedTimer *m_timer;
   QMap<qint64, double> m_recordedLevels;
-  qint64 m_oldElapsed;
   qint64 m_startPause = 0;
   qint64 m_endPause   = 0;
   qint64 m_pausedTime = 0;
@@ -103,6 +100,7 @@ public:
   void start();
   void stop();
   bool save(const QString &filename);
+  void freeup();
 
   qint64 readData(char *data, qint64 maxlen) override;
   qint64 writeData(const char *data, qint64 len) override;

--- a/toonz/sources/toonz/audiorecordingpopup.h
+++ b/toonz/sources/toonz/audiorecordingpopup.h
@@ -97,22 +97,26 @@ public:
   AudioWriterWAV(const QAudioFormat &format);
   bool restart(const QAudioFormat &format);
 
-  void start();
-  void stop();
-  bool save(const QString &filename);
-  void freeup();
+  bool start(const QString &filename, bool useMem);
+  bool stop();
 
   qint64 readData(char *data, qint64 maxlen) override;
   qint64 writeData(const char *data, qint64 len) override;
 
   qreal level() const { return m_level; }
+  qreal peakLevel() const { return m_peakL; }
 
 private:
-  QByteArray m_barray;
+  QString m_filename;
+  QFile *m_wavFile;
+  QByteArray *m_wavBuff; // if not null then use memory
   QAudioFormat m_format;
+  quint64 m_wrRawB; // Written raw bytes
   qreal m_rbytesms;
   qreal m_maxAmp;
-  qreal m_level;
+  qreal m_level, m_peakL;
+
+  void writeWAVHeader(QFile &file);
 
 signals:
   void update(qint64 duration);
@@ -128,12 +132,13 @@ public:
   explicit AudioLevelsDisplay(QWidget *parent = 0);
 
   // Using [0; 1.0] range
-  void setLevel(qreal level);
+  void setLevel(qreal level, qreal peak);
 
 protected:
   void paintEvent(QPaintEvent *event);
 
 private:
   qreal m_level;
+  qreal m_peakL;
 };
 #endif

--- a/toonz/sources/toonz/autoinputcellnumberpopup.cpp
+++ b/toonz/sources/toonz/autoinputcellnumberpopup.cpp
@@ -196,9 +196,9 @@ AutoInputCellNumberPopup::AutoInputCellNumberPopup()
              "AutoInputCellNumberPopup") {
   setWindowTitle(tr("Auto Input Cell Number"));
 
-  m_from      = new FrameNumberLineEdit(this);
+  m_from      = new FrameNumberLineEdit(this, TFrameId(1), false);
   m_increment = new DVGui::IntLineEdit(this, 0, 0);
-  m_to        = new FrameNumberLineEdit(this);
+  m_to        = new FrameNumberLineEdit(this, TFrameId(1), false);
   m_interval  = new DVGui::IntLineEdit(this, 0, 0);
   m_step      = new DVGui::IntLineEdit(this, 1, 1);
   m_repeat    = new DVGui::IntLineEdit(this, 1, 1);
@@ -301,8 +301,8 @@ void AutoInputCellNumberPopup::doExecute(bool overwrite) {
   }
   AutoInputCellNumberUndo *undo = new AutoInputCellNumberUndo(
       m_increment->getValue(), m_interval->getValue(), m_step->getValue(),
-      m_repeat->getValue(), m_from->getValue(), m_to->getValue(), r0, r1,
-      overwrite, columnIndices, levels);
+      m_repeat->getValue(), m_from->getValue().getNumber(),
+      m_to->getValue().getNumber(), r0, r1, overwrite, columnIndices, levels);
   // if no cells will be arranged, then return
   if (undo->rowsCount() == 0) {
     DVGui::MsgBox(DVGui::WARNING,

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -3013,6 +3013,13 @@ static void dRenumberCells(int col, int r0, int r1) {
         levelsTable[sl].push_back(std::make_pair(oldFid, newFid));
     }
   }
+  auto getNextLetter = [](const QString &letter) {
+    if (letter.isEmpty()) return QString('a');
+    QByteArray byteArray = letter.toUtf8();
+    // return incrementing the last letter
+    byteArray.data()[byteArray.size() - 1]++;
+    return QString::fromUtf8(byteArray);
+  };
 
   // Ensure renumber consistency in case some destination fid would overwrite
   // some unrenumbered fid in the level
@@ -3022,8 +3029,7 @@ static void dRenumberCells(int col, int r0, int r1) {
       if (cellsMap.find(it->second) == cellsMap.end() &&
           it->first.getSimpleLevel()->isFid(it->second.getFrameId())) {
         TFrameId &fid = it->second.m_frameId;
-        fid           = TFrameId(fid.getNumber(),
-                       fid.getLetter() ? fid.getLetter() + 1 : 'a',
+        fid = TFrameId(fid.getNumber(), getNextLetter(fid.getLetter()),
                        fid.getZeroPadding(), fid.getStartSeqInd());
       }
     }
@@ -3218,8 +3224,8 @@ static void createNewDrawing(TXsheet *xsh, int row, int col,
   TFrameId fid(row + 1);
   if (sl->isFid(fid)) {
     fid = TFrameId(fid.getNumber(), 'a');
-    while (fid.getLetter() < 'z' && sl->isFid(fid))
-      fid = TFrameId(fid.getNumber(), fid.getLetter() + 1);
+    while (fid.getLetter().toUtf8().at(0) < 'z' && sl->isFid(fid))
+      fid = TFrameId(fid.getNumber(), fid.getLetter().toUtf8().at(0) + 1);
   }
   // add the new frame
   sl->setFrame(fid, sl->createEmptyFrame());

--- a/toonz/sources/toonz/cleanuppopup.h
+++ b/toonz/sources/toonz/cleanuppopup.h
@@ -144,6 +144,7 @@ public:
   OverwriteDialog();
 
   void reset() override;
+  void enableOptions(bool writingOnSource);
 
 private:
   DVGui::LineEdit *m_suffix;

--- a/toonz/sources/toonz/cleanupsettingsmodel.cpp
+++ b/toonz/sources/toonz/cleanupsettingsmodel.cpp
@@ -405,7 +405,7 @@ void CleanupSettingsModel::rebuildPreview() {
 void CleanupSettingsModel::processFrame(TXshSimpleLevel *sl, TFrameId fid) {
   assert(sl);
 
-  TRasterImageP imageToCleanup = sl->getFrameToCleanup(fid);
+  TRasterImageP imageToCleanup = sl->getFrameToCleanup(fid, true);
   if (!imageToCleanup) return;
 
   // Store the original image
@@ -741,5 +741,6 @@ TFilePath CleanupSettingsModel::getOutputPath(TXshSimpleLevel *sl,
   const TFilePath &outDir = params->getPath(scene);
 
   return lineProcessing ? (outDir + inPath.getWideName()).withType("tlv")
-                        : (outDir + inPath.getLevelNameW()).withType("tif");
+                        : (outDir + inPath.getLevelNameW())
+                              .withType(params->m_lpNoneFormat);
 }

--- a/toonz/sources/toonz/cleanupsettingspane.h
+++ b/toonz/sources/toonz/cleanupsettingspane.h
@@ -62,6 +62,8 @@ private:
   QLabel *m_aaValueLabel;
   DVGui::IntField *m_aaValue;
   QComboBox *m_lineProcessing;
+  QLabel *m_lpNoneFormatLabel;
+  QComboBox *m_lpNoneFormat;
   //----Cleanup Palette
   CleanupPaletteViewer *m_paletteViewer;
   //----Bottom Parts

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -874,7 +874,8 @@ void XSheetPDFTemplate::drawCellNumber(QPainter& painter, QRect rect,
       str = getFrameNumberWithLetters(cell.m_frameId.getNumber());
     } else {
       str = QString::number(cell.m_frameId.getNumber());
-      if (cell.m_frameId.getLetter() != '\0') str += cell.m_frameId.getLetter();
+      if (!cell.m_frameId.getLetter().isEmpty())
+        str += cell.m_frameId.getLetter();
     }
     painter.drawText(rect, Qt::AlignCenter, str);
   }

--- a/toonz/sources/toonz/exportxsheetpdf.h
+++ b/toonz/sources/toonz/exportxsheetpdf.h
@@ -85,6 +85,12 @@ typedef void (*DecoFunc)(QPainter&, QRect, QMap<XSheetPDFDataType, QRect>&,
 
 enum ExportArea { Area_Actions = 0, Area_Cells };
 enum ContinuousLineMode { Line_Always = 0, Line_MoreThan3s, Line_None };
+enum TickMarkType {
+  TickMark_Dot = 0,
+  TickMark_Circle,
+  TickMark_Filled,
+  TickMark_Asterisk
+};
 
 struct XSheetPDFFormatInfo {
   QColor lineColor;
@@ -101,6 +107,11 @@ struct XSheetPDFFormatInfo {
   bool serialFrameNumber;
   bool drawLevelNameOnBottom;
   ContinuousLineMode continuousLineMode;
+  int tick1MarkId;
+  int tick2MarkId;
+  int keyMarkId;
+  TickMarkType tick1MarkType;
+  TickMarkType tick2MarkType;
 };
 
 class XSheetPDFTemplate {
@@ -172,7 +183,9 @@ protected:
   void addInfo(int w, QString lbl, DecoFunc f = nullptr);
 
   void drawContinuousLine(QPainter& painter, QRect rect, bool isEmpty);
-  void drawCellNumber(QPainter& painter, QRect rect, TXshCell& cell);
+  void drawCellNumber(QPainter& painter, QRect rect, TXshCell& cell,
+                      bool isKey);
+  void drawTickMark(QPainter& painter, QRect rect, TickMarkType type);
   void drawEndMark(QPainter& painter, QRect upperRect);
   void drawLevelName(QPainter& painter, QRect rect, QString name,
     bool isBottom = false);
@@ -281,6 +294,9 @@ class ExportXsheetPdfPopup final : public DVGui::Dialog {
   int m_totalPageCount;
   QPushButton *m_prev, *m_next;
 
+  QComboBox *m_tick1IdCombo, *m_tick2IdCombo, *m_keyIdCombo;
+  QComboBox *m_tick1MarkCombo, *m_tick2MarkCombo;
+
   // column and column name (if manually specified)
   QList<QPair<TXshLevelColumn*, QString>> m_columns;
   QList<TXshSoundColumn*> m_soundColumns;
@@ -315,6 +331,8 @@ protected slots:
   void onLogoImgPathChanged();
   void onPrev();
   void onNext();
+
+  void onTickIdComboActivated();
 };
 
 #endif

--- a/toonz/sources/toonz/exportxsheetpdf.h
+++ b/toonz/sources/toonz/exportxsheetpdf.h
@@ -21,6 +21,7 @@ class QComboBox;
 class QCheckBox;
 class TXshLevelColumn;
 class TXshSoundColumn;
+class TXshSoundTextColumn;
 namespace DVGui {
   class FileField;
   class ColorField;
@@ -149,6 +150,7 @@ protected:
   // column and column name (if manually specified)
   QList<QPair<TXshLevelColumn*, QString>> m_columns;
   QList<TXshSoundColumn*> m_soundColumns;
+  TXshSoundTextColumn* m_noteColumn;
 
   int m_duration;
   bool m_useExtraColumns;
@@ -191,6 +193,7 @@ protected:
     bool isBottom = false);
   void drawLogo(QPainter& painter);
   void drawSound(QPainter& painter, int framePage);
+  void drawDialogue(QPainter& painter, int framePage);
 
   int param(const std::string& id, int defaultValue = 0) {
     if (!m_params.contains(id)) std::cout << id << std::endl;
@@ -213,6 +216,9 @@ public:
   void setLogoPixmap(QPixmap pm);
   void setSoundColumns(const QList<TXshSoundColumn*>& soundColumns) {
     m_soundColumns = soundColumns;
+  }
+  void setNoteColumn(TXshSoundTextColumn* noteColumn) {
+    m_noteColumn = noteColumn;
   }
   void setInfo(const XSheetPDFFormatInfo& info);
 };
@@ -275,11 +281,13 @@ class ExportXsheetPdfPopup final : public DVGui::Dialog {
   XsheetPdfPreviewArea* m_previewArea;
   DVGui::FileField* m_pathFld;
   QLineEdit* m_fileNameFld;
-  QComboBox *m_templateCombo, *m_exportAreaCombo, *m_continuousLineCombo;
+  QComboBox *m_templateCombo, *m_exportAreaCombo, *m_continuousLineCombo,
+      *m_dialogueColCombo;
   DVGui::ColorField* m_lineColorFld;
 
   QCheckBox *m_addDateTimeCB, *m_addScenePathCB, *m_drawSoundCB,
-    *m_addSceneNameCB, *m_serialFrameNumberCB, *m_levelNameOnBottomCB;
+      *m_addSceneNameCB, *m_serialFrameNumberCB, *m_levelNameOnBottomCB,
+      *m_drawDialogueCB;
 
   QFontComboBox *m_templateFontCB, *m_contentsFontCB;
   QTextEdit* m_memoEdit;
@@ -300,6 +308,7 @@ class ExportXsheetPdfPopup final : public DVGui::Dialog {
   // column and column name (if manually specified)
   QList<QPair<TXshLevelColumn*, QString>> m_columns;
   QList<TXshSoundColumn*> m_soundColumns;
+  QMap<int, TXshSoundTextColumn*> m_noteColumns;
   int m_duration;
 
   XSheetPDFTemplate* m_currentTmpl;

--- a/toonz/sources/toonz/expressionreferencemanager.cpp
+++ b/toonz/sources/toonz/expressionreferencemanager.cpp
@@ -310,6 +310,21 @@ void ExpressionReferenceManager::onSceneSwitched() {
 
 //-----------------------------------------------------------------------------
 
+void ExpressionReferenceManager::refreshXsheetRefInfo(TXsheet* xsh) {
+  xsh->setObserver(this);
+  m_model->refreshData(xsh);
+  xsh->getExpRefMonitor()->clearAll();
+  for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+    checkRef(m_model->getStageObjectChannel(i), xsh);
+  }
+  for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+    checkRef(m_model->getFxChannel(i), xsh);
+  }
+  onXsheetSwitched();
+}
+
+//-----------------------------------------------------------------------------
+
 void ExpressionReferenceManager::onXsheetSwitched() {
   TXsheet* xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
   xsh->setObserver(this);
@@ -772,7 +787,8 @@ void ExpressionReferenceManager::transferReference(
 
   // 1. create 3 tables for replacing; column indices, parameter pointers, and
   // expression texts. Note that moving columns in the same xsheet does not need
-  // to replace the parameter pointers since they are swapped along with columns.
+  // to replace the parameter pointers since they are swapped along with
+  // columns.
   QMap<int, int> colIdReplaceTable;
   QMap<TDoubleParam*, TDoubleParam*> curveReplaceTable;
   std::map<std::string, std::string> exprReplaceTable;

--- a/toonz/sources/toonz/expressionreferencemanager.h
+++ b/toonz/sources/toonz/expressionreferencemanager.h
@@ -79,6 +79,7 @@ public:
 
   bool askIfParamIsIgnoredOnSave(bool saveSubXsheet);
 
+  void refreshXsheetRefInfo(TXsheet* xsh);
 protected slots:
   void onSceneSwitched();
   void onXsheetSwitched();

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -1193,7 +1193,9 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
   }
 
   for (i = 0; i < files.size(); i++)
-    if (!TFileType::isViewable(TFileType::getInfo(files[i]))) break;
+    if (!TFileType::isViewable(TFileType::getInfo(files[i])) &&
+        files[i].getType() != "tpl")
+      break;
   if (i == files.size()) {
     std::string type = files[0].getType();
     for (j = 0; j < files.size(); j++)

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -479,8 +479,9 @@ TFilePath GenericLoadFilePopup::getPath() {
 //    GenericSaveFilePopup  implementation
 //***********************************************************************************
 
-GenericSaveFilePopup::GenericSaveFilePopup(const QString &title)
-    : FileBrowserPopup(title, Options(FOR_SAVING)) {
+GenericSaveFilePopup::GenericSaveFilePopup(const QString &title,
+                                           QWidget *customWidget)
+    : FileBrowserPopup(title, Options(FOR_SAVING), "", customWidget) {
   connect(m_nameField, SIGNAL(returnPressedNow()), m_okButton,
           SLOT(animateClick()));
 }

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -15,6 +15,12 @@
 #include "convertpopup.h"
 #include "matchline.h"
 #include "colormodelbehaviorpopup.h"
+//#if defined(x64)
+//#include "penciltestpopup.h"  // FrameNumberLineEdit
+//#else
+//#include "penciltestpopup_qt.h"
+//#endif
+#include "../stopmotion/stopmotioncontroller.h" // FrameNumberLineEdit
 
 // TnzQt includes
 #include "toonzqt/gutil.h"
@@ -707,8 +713,8 @@ LoadLevelPopup::LoadLevelPopup()
   QPushButton *showSubsequenceButton = createShowButton(this);
   QLabel *subsequenceLabel = new QLabel(tr("Load Subsequence Level"), this);
   m_subsequenceFrame       = new QFrame(this);
-  m_fromFrame              = new DVGui::IntLineEdit(this, 1, 1);
-  m_toFrame                = new DVGui::IntLineEdit(this, 1, 1);
+  m_fromFrame              = new FrameNumberLineEdit(this, TFrameId(1));
+  m_toFrame                = new FrameNumberLineEdit(this, TFrameId(1));
 
   //----Arrangement in Xsheet
   m_arrLvlPropWidget                 = new QWidget(this);
@@ -716,8 +722,8 @@ LoadLevelPopup::LoadLevelPopup()
   QLabel *arrangementLabel =
       new QLabel(tr("Level Settings & Arrangement in Scene"), this);
   m_arrangementFrame = new QFrame(this);
-  m_xFrom            = new DVGui::IntLineEdit(this, 1, 1);
-  m_xTo              = new DVGui::IntLineEdit(this, 1, 1);
+  m_xFrom            = new FrameNumberLineEdit(this, TFrameId(1));
+  m_xTo              = new FrameNumberLineEdit(this, TFrameId(1));
   m_stepCombo        = new QComboBox(this);
   m_incCombo         = new QComboBox(this);
   m_posFrom          = new DVGui::IntLineEdit(this, 1, 1);
@@ -968,12 +974,12 @@ void LoadLevelPopup::onNameSetEditted() {
     } else {
       m_notExistLabel->show();
 
-      m_fromFrame->setText("1");
-      m_toFrame->setText("1");
+      m_fromFrame->setValue(TFrameId(1));
+      m_toFrame->setValue(TFrameId(1));
       m_subsequenceFrame->setEnabled(true);
 
-      m_xFrom->setText("1");
-      m_xTo->setText("1");
+      m_xFrom->setValue(TFrameId(1));
+      m_xTo->setValue(TFrameId(1));
 
       m_levelName->setText(QString::fromStdString(path.getName()));
 
@@ -998,26 +1004,39 @@ void LoadLevelPopup::updatePosTo() {
     return;
   }
 
-  int xFrom = m_xFrom->text().toInt();
-  int xTo   = m_xTo->text().toInt();
+  TFrameId xFrom = m_xFrom->getValue();
+  TFrameId xTo   = m_xTo->getValue();
 
   int frameLength;
 
   bool isScene = (QString::fromStdString(fp.getType()) == "tnz");
+
+  if (isScene) {  // scene does not consider frame suffixes
+    xFrom = TFrameId(xFrom.getNumber());
+    xTo   = TFrameId(xTo.getNumber());
+  }
+
+  auto frameLengthBetweenFIds = [&]() {
+    if (xFrom > xTo) return 0;
+    int ret = xTo.getNumber() - xFrom.getNumber() + 1;
+    if (!xTo.getLetter().isEmpty()) ret++;
+    return ret;
+  };
 
   //--- if loading the "missing" level
   if (m_notExistLabel->isVisible()) {
     int inc = m_incCombo->currentIndex();
     if (inc == 0)  // Inc = Auto
     {
-      frameLength = (xTo - xFrom + 1) * ((m_stepCombo->currentIndex() == 0)
-                                             ? 1
-                                             : m_stepCombo->currentIndex());
+      frameLength =
+          frameLengthBetweenFIds() * ((m_stepCombo->currentIndex() == 0)
+                                          ? 1
+                                          : m_stepCombo->currentIndex());
 
     } else  // Inc =! Auto
     {
       int loopAmount;
-      loopAmount  = tceil((double)(xTo - xFrom + 1) / (double)inc);
+      loopAmount  = tceil((double)(frameLengthBetweenFIds()) / (double)inc);
       frameLength = loopAmount * ((m_stepCombo->currentIndex() == 0)
                                       ? inc
                                       : m_stepCombo->currentIndex());
@@ -1028,7 +1047,7 @@ void LoadLevelPopup::updatePosTo() {
   else if (m_incCombo->currentIndex() == 0)  // Inc = Auto
   {
     if (isScene) {
-      frameLength = xTo - xFrom + 1;
+      frameLength = frameLengthBetweenFIds();
     } else {
       std::vector<TFrameId> fIds = getCurrentFIds();
       //--- If loading the level with sequential files, reuse the list of
@@ -1036,32 +1055,23 @@ void LoadLevelPopup::updatePosTo() {
       if (fIds.size() != 0) {
         if (m_stepCombo->currentIndex() == 0)  // Step = Auto
         {
+          frameLength = 0;
           std::vector<TFrameId>::iterator it;
-          int firstFrame = 0;
-          int lastFrame  = 0;
           for (it = fIds.begin(); it != fIds.end(); it++) {
-            if (xFrom <= it->getNumber()) {
-              firstFrame = it->getNumber();
+            if (xFrom <= *it && *it <= xTo)
+              frameLength++;
+            else if (xTo < *it)
               break;
-            }
           }
-          for (it = fIds.begin(); it != fIds.end(); it++) {
-            if (it->getNumber() <= xTo) {
-              lastFrame = it->getNumber();
-            }
-          }
-          frameLength = lastFrame - firstFrame + 1;
         } else  // Step != Auto
         {
           std::vector<TFrameId>::iterator it;
           int loopAmount = 0;
           for (it = fIds.begin(); it != fIds.end(); it++) {
-            if (xFrom <= it->getNumber() && it->getNumber() <= xTo)
-              loopAmount++;
+            if (xFrom <= *it && *it <= xTo) loopAmount++;
           }
           frameLength = loopAmount * m_stepCombo->currentIndex();
         }
-
       }
       // loading another type of level such as tlv
       else {
@@ -1074,29 +1084,20 @@ void LoadLevelPopup::updatePosTo() {
 
           if (m_stepCombo->currentIndex() == 0)  // Step = Auto
           {
+            frameLength = 0;
             TLevel::Iterator it;
-            int firstFrame = 0;
-            int lastFrame  = 0;
             for (it = level->begin(); it != level->end(); it++) {
-              if (xFrom <= it->first.getNumber()) {
-                firstFrame = it->first.getNumber();
+              if (xFrom <= it->first && it->first <= xTo)
+                frameLength++;
+              else if (xTo < it->first)
                 break;
-              }
             }
-            for (it = level->begin(); it != level->end(); it++) {
-              if (it->first.getNumber() <= xTo) {
-                lastFrame = it->first.getNumber();
-              }
-            }
-            frameLength = lastFrame - firstFrame + 1;
           } else  // Step != Auto
           {
             TLevel::Iterator it;
             int loopAmount = 0;
             for (it = level->begin(); it != level->end(); it++) {
-              if (xFrom <= it->first.getNumber() &&
-                  it->first.getNumber() <= xTo)
-                loopAmount++;
+              if (xFrom <= it->first && it->first <= xTo) loopAmount++;
             }
             frameLength = loopAmount * m_stepCombo->currentIndex();
           }
@@ -1110,7 +1111,7 @@ void LoadLevelPopup::updatePosTo() {
   else {
     int inc = m_incCombo->currentIndex();
     int loopAmount;
-    loopAmount  = tceil((double)(xTo - xFrom + 1) / (double)inc);
+    loopAmount  = tceil((double)(frameLengthBetweenFIds()) / (double)inc);
     frameLength = loopAmount * ((m_stepCombo->currentIndex() == 0)
                                     ? inc
                                     : m_stepCombo->currentIndex());
@@ -1123,8 +1124,8 @@ void LoadLevelPopup::updatePosTo() {
 /*! if the from / to values in the subsequent box, update m_xFrom and m_xTo
  */
 void LoadLevelPopup::onSubsequentFrameChanged() {
-  m_xFrom->setText(m_fromFrame->text());
-  m_xTo->setText(m_toFrame->text());
+  m_xFrom->setValue(m_fromFrame->getValue());
+  m_xTo->setValue(m_toFrame->getValue());
   updatePosTo();
 }
 
@@ -1192,9 +1193,9 @@ bool LoadLevelPopup::execute() {
     //---- SubSequent load
     // if loading the "missing" level
     if (m_notExistLabel->isVisible()) {
-      int firstFrameNumber = m_fromFrame->text().toInt();
-      int lastFrameNumber  = m_toFrame->text().toInt();
-      setLoadingLevelRange(firstFrameNumber, lastFrameNumber);
+      TFrameId firstLoadingFId = m_fromFrame->getValue();
+      TFrameId lastLoadingFId  = m_toFrame->getValue();
+      setLoadingLevelRange(firstLoadingFId, lastLoadingFId);
     } else if (m_subsequenceFrame->isEnabled() &&
                m_subsequenceFrame->isVisible()) {
       std::vector<TFrameId> fIds = getCurrentFIds();
@@ -1220,11 +1221,10 @@ bool LoadLevelPopup::execute() {
           return false;
         }
       }
-      int firstFrameNumber = m_fromFrame->text().toInt();
-      int lastFrameNumber  = m_toFrame->text().toInt();
-      if (firstFrame.getNumber() != firstFrameNumber ||
-          lastFrame.getNumber() != lastFrameNumber)
-        setLoadingLevelRange(firstFrameNumber, lastFrameNumber);
+      TFrameId firstLoadingFId = m_fromFrame->getValue();
+      TFrameId lastLoadingFId  = m_toFrame->getValue();
+      if (firstFrame != firstLoadingFId || lastFrame != lastLoadingFId)
+        setLoadingLevelRange(firstLoadingFId, lastLoadingFId);
     }
 
     IoCmd::LoadResourceArguments args(fp);
@@ -1237,20 +1237,27 @@ bool LoadLevelPopup::execute() {
       args.frameIdsSet.push_back(*getCurrentFIdsSet().begin());
 
     else if (m_notExistLabel->isVisible()) {
-      int firstFrameNumber = m_fromFrame->text().toInt();
-      int lastFrameNumber  = m_toFrame->text().toInt();
+      TFrameId firstLoadingFId = m_fromFrame->getValue();
+      TFrameId lastLoadingFId  = m_toFrame->getValue();
       // putting the Fids in order to avoid LoadInfo later
       std::vector<TFrameId> tmp_fids;
-      for (int i = firstFrameNumber; i <= lastFrameNumber; i++) {
+      int i = firstLoadingFId.getNumber();
+      if (!firstLoadingFId.getLetter().isEmpty()) {
+        tmp_fids.push_back(firstLoadingFId);
+        i++;
+      }
+      for (; i <= lastLoadingFId.getNumber(); i++) {
         tmp_fids.push_back(TFrameId(i));
       }
+      if (!lastLoadingFId.getLetter().isEmpty())
+        tmp_fids.push_back(lastLoadingFId);
       args.frameIdsSet.push_back(tmp_fids);
     }
 
-    int xFrom             = m_xFrom->text().toInt();
-    if (xFrom) args.xFrom = xFrom;
-    int xTo               = m_xTo->text().toInt();
-    if (xTo) args.xTo     = xTo;
+    TFrameId xFrom = m_xFrom->getValue();
+    if (!xFrom.isEmptyFrame()) args.xFrom = xFrom;
+    TFrameId xTo = m_xTo->getValue();
+    if (!xTo.isEmptyFrame()) args.xTo = xTo;
 
     args.levelName             = m_levelName->text().toStdWString();
     args.step                  = m_stepCombo->currentIndex();
@@ -1372,9 +1379,8 @@ void LoadLevelPopup::updateBottomGUI() {
     disableAll();
     return;
   } else if (ext == "tpl") {
-    QString str;
-    m_fromFrame->setText(str.number(1));
-    m_toFrame->setText(str.number(1));
+    m_fromFrame->setText("1");
+    m_toFrame->setText("1");
     m_subsequenceFrame->setEnabled(false);
 
     m_xFrom->setText("1");
@@ -1420,13 +1426,12 @@ void LoadLevelPopup::updateBottomGUI() {
         return;
       }
     }
-
-    m_fromFrame->setText(QString().number(firstFrame.getNumber()));
-    m_toFrame->setText(QString().number(lastFrame.getNumber()));
+    m_fromFrame->setValue(firstFrame);
+    m_toFrame->setValue(lastFrame);
     m_subsequenceFrame->setEnabled(true);
 
-    m_xFrom->setText(m_fromFrame->text());
-    m_xTo->setText(m_toFrame->text());
+    m_xFrom->setValue(firstFrame);
+    m_xTo->setValue(lastFrame);
 
     // if some option in the preferences is selected, load the level with
     // removing

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -32,6 +32,7 @@ class QPushButton;
 class QComboBox;
 class QGroupBox;
 class QCheckBox;
+class FrameNumberLineEdit;
 
 namespace DVGui {
 class ColorField;
@@ -266,11 +267,11 @@ class LoadLevelPopup final : public FileBrowserPopup {
   Q_OBJECT
 
   QFrame *m_subsequenceFrame;
-  DVGui::IntLineEdit *m_fromFrame, *m_toFrame;
+  FrameNumberLineEdit *m_fromFrame, *m_toFrame;
 
   QWidget *m_arrLvlPropWidget;
   QFrame *m_arrangementFrame;
-  DVGui::IntLineEdit *m_xFrom, *m_xTo;
+  FrameNumberLineEdit *m_xFrom, *m_xTo;
   QComboBox *m_stepCombo, *m_incCombo;
   DVGui::IntLineEdit *m_posFrom, *m_posTo;
 

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -185,7 +185,7 @@ protected:
 //! asks the user for a \a single file path to save something to.
 class GenericSaveFilePopup : public FileBrowserPopup {
 public:
-  GenericSaveFilePopup(const QString &title);
+  GenericSaveFilePopup(const QString &title, QWidget *customWidget = nullptr);
 
   /*!
 This function shows the popup and blocks until a suitable

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -23,6 +23,7 @@
 #include "toonzqt/icongenerator.h"
 #include "toonzqt/gutil.h"
 #include "historytypes.h"
+#include "toonzqt/menubarcommand.h"
 
 // TnzLib includes
 #include "toonz/tproject.h"
@@ -30,6 +31,9 @@
 #include "toonz/sceneresources.h"
 #include "toonz/preferences.h"
 #include "toonz/tscenehandle.h"
+#include "toonz/studiopalette.h"
+#include "toonz/palettecontroller.h"
+#include "toonz/tpalettehandle.h"
 
 // TnzCore includes
 #include "tfiletype.h"
@@ -185,6 +189,8 @@ public:
     return str;
   }
 };
+
+TPaletteP viewedPalette;
 //-----------------------------------------------------------------------------
 }  // namespace
 
@@ -372,12 +378,21 @@ void FileSelection::viewFile() {
   getSelectedFiles(files);
   int i = 0;
   for (i = 0; i < files.size(); i++) {
-    if (!TFileType::isViewable(TFileType::getInfo(files[0]))) continue;
+    if (!TFileType::isViewable(TFileType::getInfo(files[i])) &&
+        files[i].getType() != "tpl")
+      continue;
 
     if (Preferences::instance()->isDefaultViewerEnabled() &&
         (files[i].getType() == "avi"))
       QDesktopServices::openUrl(QUrl("file:///" + toQString(files[i])));
-    else {
+    else if (files[i].getType() == "tpl") {
+      viewedPalette = StudioPalette::instance()->getPalette(files[i], false);
+      TApp::instance()
+          ->getPaletteController()
+          ->getCurrentLevelPalette()
+          ->setPalette(viewedPalette.getPointer());
+      CommandManager::instance()->execute("MI_OpenPalette");
+    } else {
       FlipBook *fb = ::viewFile(files[i]);
       if (fb) {
         FileBrowserPopup::setModalBrowserToParent(fb->parentWidget());

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -711,9 +711,9 @@ void FilmstripFrames::paintEvent(QPaintEvent *evt) {
       }
       // for sequential frame
       else {
-        char letter = fid.getLetter();
-        text        = QString::number(fid.getNumber()).rightJustified(4, '0') +
-               (letter != '\0' ? QString(letter) : "");
+        QString letter = fid.getLetter();
+        text = QString::number(fid.getNumber()).rightJustified(4, '0') +
+               (!letter.isEmpty() ? letter : "");
       }
       p.drawText(tmp_frameRect.adjusted(0, 0, -3, 2), text,
                  QTextOption(Qt::AlignRight | Qt::AlignBottom));

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -51,7 +51,8 @@
 //=============================================================================
 
 TFrameId operator+(const TFrameId &fid, int d) {
-  return TFrameId(fid.getNumber() + d, fid.getLetter());
+  return TFrameId(fid.getNumber() + d, fid.getLetter(), fid.getZeroPadding(),
+                  fid.getStartSeqInd());
 }
 
 //-----------------------------------------------------------------------------
@@ -1367,10 +1368,14 @@ void FilmstripCmd::addFrames(TXshSimpleLevel *sl, int start, int end,
   std::vector<TFrameId> oldFids;
   sl->getFids(oldFids);
 
+  TFrameId tmplFid;
+  if (!oldFids.empty()) tmplFid = oldFids.front();
+
   std::set<TFrameId> fidsToInsert;
   int frame = 0;
   for (frame = start; frame <= end; frame += step)
-    fidsToInsert.insert(TFrameId(frame));
+    fidsToInsert.insert(TFrameId(frame, "", tmplFid.getZeroPadding(),
+                                 tmplFid.getStartSeqInd()));
 
   makeSpaceForFids(sl, fidsToInsert);
 
@@ -1499,7 +1504,8 @@ void FilmstripCmd::renumber(
       if (tmp.count(tarFid) > 0) {
         do {
           tarFid =
-              TFrameId(tarFid.getNumber(), getNextLetter(tarFid.getLetter()));
+              TFrameId(tarFid.getNumber(), getNextLetter(tarFid.getLetter()),
+                       tarFid.getZeroPadding(), tarFid.getStartSeqInd());
         } while (!tarFid.getLetter().isEmpty() && tmp.count(tarFid) > 0);
         if (tarFid.getLetter().isEmpty()) {
           // todo: error message
@@ -1557,7 +1563,8 @@ void FilmstripCmd::renumber(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
   std::vector<TFrameId>::iterator j = fids.begin();
   for (it = frames.begin(); it != frames.end(); ++it) {
     TFrameId srcFid(*it);
-    TFrameId dstFid(frame);
+    TFrameId dstFid(frame, "", srcFid.getZeroPadding(),
+                    srcFid.getStartSeqInd());
     frame += stepFrame;
     // faccio il controllo su tmp e non su fids. considera:
     // fids = [1,2,3,4], renumber = [2->3,3->5]
@@ -1590,7 +1597,8 @@ void FilmstripCmd::renumber(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
   it2 = frames.begin();
   std::set<TFrameId> newFrames;
   for (i = 0; i < frames.size(); i++, it2++)
-    newFrames.insert(TFrameId(startFrame + (i * stepFrame), it2->getLetter()));
+    newFrames.insert(TFrameId(startFrame + (i * stepFrame), it2->getLetter(),
+                              it2->getZeroPadding(), it2->getStartSeqInd()));
   assert(frames.size() == newFrames.size());
   frames.swap(newFrames);
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2253,7 +2253,7 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
     assert(childLevel);
     childXsh = childLevel->getXsheet();
   }
-  int subCol0 = args.col0;
+  int subCol0 = 0;
   loadedPsdLevelIndex.clear();
   // for each layer in psd
   for (int i = 0; i < popup->getPsdLevelCount(); i++) {
@@ -2265,7 +2265,7 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
         count +=
             createSubXSheetFromPSDFolder(args, childXsh, subCol0, i, popup);
       else
-        count += createSubXSheetFromPSDFolder(args, xsh, subCol0, i, popup);
+        count += createSubXSheetFromPSDFolder(args, xsh, col0, i, popup);
     } else {
       TFilePath psdpath = popup->getPsdPath(i);
       TXshLevel *xl     = 0;
@@ -2280,14 +2280,14 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
         // lo importo nell'xsheet
         if (popup->subxsheet() && childXsh) {
           childXsh->exposeLevel(0, subCol0, xl);
+          subCol0++;
+        } else {
+          // move the current column to the right
+          col0++;
+          app->getCurrentColumn()->setColumnIndex(col0);
         }
         args.loadedLevels.push_back(xl);
-        subCol0++;
         count++;
-
-        // move the current column to the right
-        col0++;
-        app->getCurrentColumn()->setColumnIndex(col0);
       }
     }
   }

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -891,9 +891,9 @@ TXshLevel *loadLevel(ToonzScene *scene,
                      const IoCmd::LoadResourceArguments::ResourceData &rd,
                      const TFilePath &castFolder, int row0, int &col0, int row1,
                      int &col1, bool expose, std::vector<TFrameId> &fIds,
-                     int xFrom = -1, int xTo = -1, std::wstring levelName = L"",
-                     int step = -1, int inc = -1, int frameCount = -1,
-                     bool doesFileActuallyExist = true) {
+                     TFrameId xFrom = TFrameId(), TFrameId xTo = TFrameId(),
+                     std::wstring levelName = L"", int step = -1, int inc = -1,
+                     int frameCount = -1, bool doesFileActuallyExist = true) {
   TFilePath actualPath = scene->decodeFilePath(rd.m_path);
 
   LoadLevelUndo *undo                  = 0;
@@ -1022,12 +1022,15 @@ TXshLevel *loadLevel(ToonzScene *scene,
 // loadResource(scene, path, castFolder, row, col, expose)
 //---------------------------------------------------------------------------
 
-TXshLevel *loadResource(
-    ToonzScene *scene, const IoCmd::LoadResourceArguments::ResourceData &rd,
-    const TFilePath &castFolder, int row0, int &col0, int row1, int &col1,
-    bool expose, std::vector<TFrameId> fIds = std::vector<TFrameId>(),
-    int xFrom = -1, int xTo = -1, std::wstring levelName = L"", int step = -1,
-    int inc = -1, int frameCount = -1, bool doesFileActuallyExist = true) {
+TXshLevel *loadResource(ToonzScene *scene,
+                        const IoCmd::LoadResourceArguments::ResourceData &rd,
+                        const TFilePath &castFolder, int row0, int &col0,
+                        int row1, int &col1, bool expose,
+                        std::vector<TFrameId> fIds = std::vector<TFrameId>(),
+                        TFrameId xFrom = TFrameId(), TFrameId xTo = TFrameId(),
+                        std::wstring levelName = L"", int step = -1,
+                        int inc = -1, int frameCount = -1,
+                        bool doesFileActuallyExist = true) {
   IoCmd::LoadResourceArguments::ResourceData actualRd(rd);
   actualRd.m_path = scene->decodeFilePath(rd.m_path);
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -324,7 +324,8 @@ bool beforeCellsInsert(TXsheet *xsh, int row, int &col, int rowCount,
 
   for (i = 0; i < rowCount && xsh->getCell(row + i, col).isEmpty(); i++) {
   }
-  int type = column ? column->getColumnType() : newLevelColumnType;
+  int type = (column && !column->isEmpty()) ? column->getColumnType()
+                                            : newLevelColumnType;
   // If some used cells in range or column type mismatch must insert a column.
   if (col < 0 || i < rowCount || newLevelColumnType != type) {
     col += 1;

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -127,7 +127,7 @@ public:
   std::vector<TXshLevel *> loadedLevels;  //!< [\p Out]     Levels loaded by
                                           //! resource loading procedures.
 
-  int xFrom, xTo;
+  TFrameId xFrom, xTo;
   std::wstring levelName;
   int step, inc, frameCount;
   bool doesFileActuallyExist;

--- a/toonz/sources/toonz/levelcommand.cpp
+++ b/toonz/sources/toonz/levelcommand.cpp
@@ -512,6 +512,14 @@ void LevelCmd::addMissingLevelsToCast(const QList<TXshColumnP> &columns) {
 }
 
 void LevelCmd::addMissingLevelsToCast(std::set<TXshLevel *> &levels) {
+  // remove zerary fx levels which are not registered in the cast
+  for (auto it = levels.begin(); it != levels.end();) {
+    if ((*it)->getZeraryFxLevel())
+      it = levels.erase(it);
+    else
+      ++it;
+  }
+
   if (levels.empty()) return;
   TUndoManager::manager()->beginBlock();
   TLevelSet *levelSet =

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3066,6 +3066,16 @@ void MainWindow::defineActions() {
                          "");
   createStopMotionAction(MI_StopMotionToggleUseLiveViewImages,
                          QT_TR_NOOP("Show original live view images."), "");
+
+  // create cell mark actions
+  for (int markId = 0; markId < 12; markId++) {
+    std::string cmdId = (std::string)MI_SetCellMark + std::to_string(markId);
+    std::string labelStr =
+        QT_TR_NOOP("Set Cell Mark ") + std::to_string(markId);
+    QAction *action =
+        createAction(cmdId.c_str(), labelStr.c_str(), "", "", CellMarkCommandType);
+    action->setData(markId);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -471,6 +471,9 @@
 #define MI_ExportTvpJson "MI_ExportTvpJson"
 #define MI_ExportXsheetPDF "MI_ExportXsheetPDF"
 
+// mark id is added for each actual command (i.g. MI_SetCellMark1)
+#define MI_SetCellMark "MI_SetCellMark"
+
 #define MI_ToggleAutoCreate "MI_ToggleAutoCreate"
 #define MI_ToggleCreationInHoldCells "MI_ToggleCreationInHoldCells"
 #define MI_ToggleAutoStretch "MI_ToggleAutoStretch"

--- a/toonz/sources/toonz/projectpopup.h
+++ b/toonz/sources/toonz/projectpopup.h
@@ -16,11 +16,12 @@ namespace DVGui {
 class FileField;
 class LineEdit;
 class CheckBox;
-}
+}  // namespace DVGui
 
 class QComboBox;
 class QGridLayout;
 class QGroupBox;
+class QButtonGroup;
 
 //=============================================================================
 // ProjectPopup
@@ -46,6 +47,11 @@ protected:
   QFrame *m_settingsBox;
   QPushButton *m_showSettingsButton;
 
+  // file path settings
+  QButtonGroup *m_rulePreferenceBG;
+  DVGui::CheckBox *m_acceptNonAlphabetSuffixCB;
+  QComboBox *m_letterCountCombo;
+
 public:
   ProjectPopup(bool isModal);
   // da TProjectManager::Listener
@@ -60,6 +66,9 @@ public:
 
 protected:
   void showEvent(QShowEvent *) override;
+
+protected slots:
+  void onRulePreferenceToggled(int);
 };
 
 //=============================================================================
@@ -75,8 +84,7 @@ public:
   ProjectSettingsPopup();
 
 public slots:
-  void onFolderChanged();
-  void onUseSceneChekboxChanged(int);
+  void onSomethingChanged();
   void projectChanged();
   void onProjectChanged() override;
 

--- a/toonz/sources/toonz/scenesettingspopup.h
+++ b/toonz/sources/toonz/scenesettingspopup.h
@@ -13,6 +13,25 @@
 // forward declaration
 class TSceneProperties;
 class QComboBox;
+class QLineEdit;
+
+class CellMarksPopup final : public QDialog {
+  Q_OBJECT
+  struct MarkerField {
+    int id;
+    DVGui::ColorField *colorField;
+    QLineEdit *nameField;
+  };
+
+  QList<MarkerField> m_fields;
+
+public:
+  CellMarksPopup(QWidget *parent);
+  void update();
+protected slots:
+  void onColorChanged(const TPixel32 &, bool);
+  void onNameChanged();
+};
 
 //=============================================================================
 // SceneSettingsPopup
@@ -36,6 +55,8 @@ class SceneSettingsPopup final : public QDialog {
   DVGui::CheckBox *m_colorFilterOnRenderCB;
 
   TSceneProperties *getProperties() const;
+
+  CellMarksPopup *m_cellMarksPopup;
 
 public:
   SceneSettingsPopup();
@@ -61,6 +82,8 @@ public slots:
   void setBgColor(const TPixel32 &value, bool isDragging);
 
   void onColorFilterOnRenderChanged();
+
+  void onEditCellMarksButtonClicked();
 };
 
 #endif  // SCENESETTINGSPOPUP_H

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -223,6 +223,8 @@ ShortcutTree::ShortcutTree(QWidget *parent) : QTreeWidget(parent) {
   addFolder(tr("Help"), MenuHelpCommandType, menuCommandFolder);
 
   addFolder(tr("Right-click Menu Commands"), RightClickMenuCommandType);
+  QTreeWidgetItem *rcmSubFolder = m_folders.back();
+  addFolder(tr("Cell Mark"), CellMarkCommandType, rcmSubFolder);
 
   addFolder(tr("Tools"), ToolCommandType);
   addFolder(tr("Tool Modifiers"), ToolModifierCommandType);

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -470,7 +470,7 @@ ShortcutPopup::ShortcutPopup()
   connect(searchEdit, SIGNAL(textChanged(const QString &)), this,
           SLOT(onSearchTextChanged(const QString &)));
   connect(m_presetChoiceCB, SIGNAL(currentIndexChanged(int)),
-          SLOT(onPresetChanged(int)));
+          SLOT(onPresetChanged()));
   connect(m_exportButton, SIGNAL(clicked()), SLOT(onExportButton()));
   connect(m_deletePresetButton, SIGNAL(clicked()), SLOT(onDeletePreset()));
   connect(m_savePresetButton, SIGNAL(clicked()), SLOT(onSavePreset()));
@@ -495,8 +495,8 @@ void ShortcutPopup::onSearchTextChanged(const QString &text) {
 
 //-----------------------------------------------------------------------------
 
-void ShortcutPopup::onPresetChanged(int index) {
-  if (m_presetChoiceCB->currentText() == "Load from file...") {
+void ShortcutPopup::onPresetChanged() {
+  if (m_presetChoiceCB->currentData().toString() == QString("LoadFromFile")) {
     importPreset();
   }
 }
@@ -607,7 +607,10 @@ void ShortcutPopup::onExportButton(TFilePath fp) {
     if (fp == TFilePath()) return;
   }
   showDialog(tr("Saving Shortcuts"));
-  QString shortcutString = "[shortcuts]\n";
+
+  QSettings preset(toQString(fp), QSettings::IniFormat);
+  preset.beginGroup("shortcuts");
+
   for (int commandType = UndefinedCommandType; commandType <= MenuCommandType;
        commandType++) {
     std::vector<QAction *> actions;
@@ -618,24 +621,22 @@ void ShortcutPopup::onExportButton(TFilePath fp) {
       std::string shortcut =
           CommandManager::instance()->getShortcutFromAction(action);
       if (shortcut != "") {
-        shortcutString = shortcutString + QString::fromStdString(id) + "=" +
-                         QString::fromStdString(shortcut) + "\n";
+        preset.setValue(QString::fromStdString(id),
+                        QString::fromStdString(shortcut));
       }
     }
   }
-  QFile file(fp.getQString());
-  file.open(QIODevice::WriteOnly | QIODevice::Text);
-  QTextStream out(&file);
-  out << shortcutString;
-  file.close();
+
+  preset.endGroup();
+
   m_dialog->hide();
 }
 
 //-----------------------------------------------------------------------------
 
 void ShortcutPopup::onDeletePreset() {
-  // change this to 4 once RETAS shortcuts are updated
-  if (m_presetChoiceCB->currentIndex() <= 3) {
+  // change this to 5 once RETAS shortcuts are updated
+  if (m_presetChoiceCB->currentIndex() <= 4) {
     DVGui::MsgBox(DVGui::CRITICAL, tr("Included presets cannot be deleted."));
     return;
   }
@@ -649,7 +650,7 @@ void ShortcutPopup::onDeletePreset() {
   }
   TFilePath presetDir =
       ToonzFolder::getMyModuleDir() + TFilePath("shortcutpresets");
-  QString presetName = m_presetChoiceCB->currentText();
+  QString presetName = m_presetChoiceCB->currentData().toString();
   if (TSystem::doesExistFileOrLevel(presetDir +
                                     TFilePath(presetName + ".ini"))) {
     TSystem::deleteFile(presetDir + TFilePath(presetName + ".ini"));
@@ -693,48 +694,26 @@ void ShortcutPopup::importPreset() {
 //-----------------------------------------------------------------------------
 
 void ShortcutPopup::onLoadPreset() {
-  QString preset = m_presetChoiceCB->currentText();
-  TFilePath presetDir =
-      ToonzFolder::getMyModuleDir() + TFilePath("shortcutpresets");
-  TFilePath defaultPresetDir =
-      ToonzFolder::getProfileFolder() + TFilePath("layouts/shortcuts");
-  if (preset == "") return;
-  if (preset == "Load from file...") {
+  QString preset = m_presetChoiceCB->currentData().toString();
+  TFilePath presetDir;
+  if (m_presetChoiceCB->currentIndex() <= 4)
+    presetDir =
+        ToonzFolder::getProfileFolder() + TFilePath("layouts/shortcuts");
+  else
+    presetDir = ToonzFolder::getMyModuleDir() + TFilePath("shortcutpresets");
+
+  if (preset.isEmpty()) return;
+  if (preset == QString("LoadFromFile")) {
     importPreset();
     return;
   }
 
   if (!showConfirmDialog()) return;
   showDialog(tr("Setting Shortcuts"));
-  if (preset == "Tahoma2D") {
+  TFilePath presetFilePath(preset + ".ini");
+  if (TSystem::doesExistFileOrLevel(presetDir + presetFilePath)) {
     clearAllShortcuts(false);
-    TFilePath fp = defaultPresetDir + TFilePath("deftahoma2d.ini");
-    setPresetShortcuts(fp);
-    return;
-  } else if (preset == "Toon Boom Harmony") {
-    clearAllShortcuts(false);
-    TFilePath fp = defaultPresetDir + TFilePath("otharmony.ini");
-    setPresetShortcuts(fp);
-    return;
-  } else if (preset == "Adobe Animate") {
-    clearAllShortcuts(false);
-    TFilePath fp = defaultPresetDir + TFilePath("otanimate.ini");
-    setPresetShortcuts(fp);
-    return;
-  } else if (preset == "Adobe Flash Pro") {
-    clearAllShortcuts(false);
-    TFilePath fp = defaultPresetDir + TFilePath("otadobe.ini");
-    setPresetShortcuts(fp);
-    return;
-  } else if (preset == "RETAS PaintMan") {
-    clearAllShortcuts(false);
-    TFilePath fp = defaultPresetDir + TFilePath("otretas.ini");
-    setPresetShortcuts(fp);
-    return;
-  } else if (TSystem::doesExistFileOrLevel(presetDir +
-                                           TFilePath(preset + ".ini"))) {
-    clearAllShortcuts(false);
-    TFilePath fp = presetDir + TFilePath(preset + ".ini");
+    TFilePath fp = presetDir + presetFilePath;
     setPresetShortcuts(fp);
     return;
   }
@@ -743,14 +722,16 @@ void ShortcutPopup::onLoadPreset() {
 
 //-----------------------------------------------------------------------------
 
-QStringList ShortcutPopup::buildPresets() {
-  QStringList presets;
-  presets << ""
-          << "Tahoma2D"
-          //<< "RETAS PaintMan"
-          << "Toon Boom Harmony"
-          << "Adobe Animate"
-          << "Adobe Flash Pro";
+void ShortcutPopup::buildPresets() {
+  m_presetChoiceCB->clear();
+
+  m_presetChoiceCB->addItem("", QString(""));
+  m_presetChoiceCB->addItem("Tahoma2D", QString("deftahoma2d"));
+  // m_presetChoiceCB->addItem("RETAS PaintMan", QString("otretas"));
+  m_presetChoiceCB->addItem("Toon Boom Harmony", QString("otharmony"));
+  m_presetChoiceCB->addItem("Adobe Animate", QString("otanimate"));
+  m_presetChoiceCB->addItem("Adobe Flash Pro", QString("otadobe"));
+
   TFilePath presetDir =
       ToonzFolder::getMyModuleDir() + TFilePath("shortcutpresets");
   if (TSystem::doesExistFileOrLevel(presetDir)) {
@@ -763,12 +744,10 @@ QStringList ShortcutPopup::buildPresets() {
       }
     }
     customPresets.sort();
-    presets = presets + customPresets;
+    for (auto customPreset : customPresets)
+      m_presetChoiceCB->addItem(customPreset, customPreset);
   }
-  presets << tr("Load from file...");
-  m_presetChoiceCB->clear();
-  m_presetChoiceCB->addItems(presets);
-  return presets;
+  m_presetChoiceCB->addItem(tr("Load from file..."), QString("LoadFromFile"));
 }
 
 //-----------------------------------------------------------------------------
@@ -808,19 +787,9 @@ void ShortcutPopup::setCurrentPresetPref(QString name) {
 
 void ShortcutPopup::getCurrentPresetPref() {
   QString name = Preferences::instance()->getShortcutPreset();
-  if (name == "DELETED")
-    m_presetChoiceCB->setCurrentText("");
-  else if (name == "deftahoma2d")
-    m_presetChoiceCB->setCurrentText("Tahoma2D");
-  else if (name == "otharmony")
-    m_presetChoiceCB->setCurrentText("Toon Boom Harmony");
-  else if (name == "otadobe")
-    m_presetChoiceCB->setCurrentText("Adobe Animate(Flash)");
-  else if (name == "otretas")
-    m_presetChoiceCB->setCurrentText("RETAS PaintMan");
+  if (name == "DELETED") name = "";
 
-  else
-    m_presetChoiceCB->setCurrentText(name);
+  m_presetChoiceCB->setCurrentIndex(m_presetChoiceCB->findData(name));
 }
 
 OpenPopupCommandHandler<ShortcutPopup> openShortcutPopup(MI_ShortcutPopup);

--- a/toonz/sources/toonz/shortcutpopup.h
+++ b/toonz/sources/toonz/shortcutpopup.h
@@ -115,7 +115,7 @@ private:
   bool showConfirmDialog();
   bool showOverwriteDialog(QString name);
   void importPreset();
-  QStringList buildPresets();
+  void buildPresets();
   void showEvent(QShowEvent *se) override;
   void setCurrentPresetPref(QString preset);
   void getCurrentPresetPref();
@@ -123,7 +123,7 @@ private:
 protected slots:
   void clearAllShortcuts(bool warning = true);
   void onSearchTextChanged(const QString &text);
-  void onPresetChanged(int index);
+  void onPresetChanged();
   void onExportButton(TFilePath fp = TFilePath());
   void onDeletePreset();
   void onSavePreset();

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -1297,7 +1297,7 @@ void collapseColumns(std::set<int> indices, bool columnsOnly) {
   data->storeColumns(indices, xsh, StageObjectsData::eDoClone);
   data->storeColumnFxs(indices, xsh, StageObjectsData::eDoClone);
 
-  ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
+  // ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXshLevel *xl     = scene->createNewLevel(CHILD_XSHLEVEL);
@@ -1320,6 +1320,7 @@ void collapseColumns(std::set<int> indices, bool columnsOnly) {
   if (!columnsOnly)
     bringPegbarsInsideChildXsheet(xsh, childXsh, indices, newIndices, idTable);
 
+  ExpressionReferenceManager::instance()->refreshXsheetRefInfo(childXsh);
   ExpressionReferenceManager::instance()->transferReference(xsh, childXsh,
                                                             idTable, fxTable);
 
@@ -1408,7 +1409,7 @@ void collapseColumns(std::set<int> indices,
                      StageObjectsData::eDoClone);
   data->storeColumnFxs(indices, xsh, StageObjectsData::eDoClone);
 
-  ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
+  // ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXshLevel *xl     = scene->createNewLevel(CHILD_XSHLEVEL);
@@ -1427,6 +1428,7 @@ void collapseColumns(std::set<int> indices,
                        fxTable);
   childXsh->updateFrameCount();
 
+  ExpressionReferenceManager::instance()->refreshXsheetRefInfo(childXsh);
   ExpressionReferenceManager::instance()->transferReference(xsh, childXsh,
                                                             idTable, fxTable);
 
@@ -1472,7 +1474,7 @@ void collapseColumns(std::set<int> indices, const std::set<TFx *> &fxs,
   data->storeColumns(indices, xsh, StageObjectsData::eDoClone);
   data->storeFxs(fxs, xsh, StageObjectsData::eDoClone);
 
-  ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
+  // ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXshLevel *xl     = scene->createNewLevel(CHILD_XSHLEVEL);
@@ -1491,6 +1493,7 @@ void collapseColumns(std::set<int> indices, const std::set<TFx *> &fxs,
   if (!columnsOnly)
     bringPegbarsInsideChildXsheet(xsh, childXsh, indices, newIndices, idTable);
 
+  ExpressionReferenceManager::instance()->refreshXsheetRefInfo(childXsh);
   ExpressionReferenceManager::instance()->transferReference(xsh, childXsh,
                                                             idTable, fxTable);
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -796,30 +796,31 @@ void ColorFieldEditorController::edit(DVGui::ColorField *colorField) {
   connect(m_currentColorField, SIGNAL(colorChanged(const TPixel32 &, bool)),
           SLOT(onColorChanged(const TPixel32 &, bool)));
   connect(m_colorFieldHandle, SIGNAL(colorStyleChanged(bool)),
-          SLOT(onColorStyleChanged()));
+          SLOT(onColorStyleChanged(bool)));
 }
 
 //-----------------------------------------------------------------------------
 
 void ColorFieldEditorController::hide() {
   disconnect(m_colorFieldHandle, SIGNAL(colorStyleChanged(bool)), this,
-             SLOT(onColorStyleChanged()));
+             SLOT(onColorStyleChanged(bool)));
 }
 
 //-----------------------------------------------------------------------------
 
-void ColorFieldEditorController::onColorStyleChanged() {
+void ColorFieldEditorController::onColorStyleChanged(bool isDragging) {
   if (!m_currentColorField) return;
   assert(!!m_palette);
   TPixel32 color = m_palette->getStyle(1)->getMainColor();
-  if (m_currentColorField->getColor() == color) return;
+  if (m_currentColorField->getColor() == color && isDragging) return;
   m_currentColorField->setColor(color);
-  m_currentColorField->notifyColorChanged(color, false);
+  m_currentColorField->notifyColorChanged(color, isDragging);
 }
 
 //-----------------------------------------------------------------------------
 
-void ColorFieldEditorController::onColorChanged(const TPixel32 &color, bool) {
+void ColorFieldEditorController::onColorChanged(const TPixel32 &color,
+                                                bool isDragging) {
   if (!m_currentColorField) return;
   TColorStyle *style = m_palette->getStyle(1);
   if (style->getMainColor() == color) return;
@@ -827,7 +828,7 @@ void ColorFieldEditorController::onColorChanged(const TPixel32 &color, bool) {
   TApp::instance()
       ->getPaletteController()
       ->getCurrentPalette()
-      ->notifyColorStyleChanged();
+      ->notifyColorStyleChanged(isDragging);
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -574,6 +574,7 @@ void PaletteViewerPanel::onFreezeButtonToggled(bool frozen) {
 
   // Cambio il livello corrente
   if (!frozen) {
+    m_frozenPalette = nullptr;
     std::set<TXshSimpleLevel *> levels;
     TXsheet *xsheet = app->getCurrentXsheet()->getXsheet();
     int row, column;
@@ -605,6 +606,7 @@ void PaletteViewerPanel::onFreezeButtonToggled(bool frozen) {
     app->getCurrentLevel()->setLevel(level);
     m_paletteViewer->setPaletteHandle(ph);
   } else {
+    m_frozenPalette = ph->getPalette();
     m_paletteHandle->setPalette(ph->getPalette());
     m_paletteViewer->setPaletteHandle(m_paletteHandle);
   }

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -133,7 +133,7 @@ public:
   void hide() override;
 
 protected slots:
-  void onColorStyleChanged();
+  void onColorStyleChanged(bool);
   void onColorChanged(const TPixel32 &color, bool);
 };
 

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -44,6 +44,7 @@ class PaletteViewerPanel final : public StyleShortcutSwitchablePanel {
   PaletteViewer *m_paletteViewer;
 
   bool m_isFrozen;
+  TPaletteP m_frozenPalette;
 
 public:
   PaletteViewerPanel(QWidget *parent);

--- a/toonz/sources/toonz/tvpjson_io.cpp
+++ b/toonz/sources/toonz/tvpjson_io.cpp
@@ -250,12 +250,13 @@ void TvpJsonLayer::build(int index, ToonzScene* scene, TXshCellColumn* column) {
       if (Preferences::instance()->isShowFrameNumberWithLettersEnabled())
         instance_name = getFrameNumberWithLetters(fid.getNumber());
       else {
-        std::string frameNumber("");
+        QString frameNumber("");
         // set number
-        if (fid.getNumber() >= 0) frameNumber = std::to_string(fid.getNumber());
+        if (fid.getNumber() >= 0)
+          frameNumber = QString::number(fid.getNumber());
         // add letter
-        if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
-        instance_name = QString::fromStdString(frameNumber);
+        if (!fid.getLetter().isEmpty()) frameNumber += fid.getLetter();
+        instance_name = frameNumber;
       }
 
       fid.setZeroPadding(frameFormats[cell.m_level.getPointer()].first);

--- a/toonz/sources/toonz/tvpjson_io.cpp
+++ b/toonz/sources/toonz/tvpjson_io.cpp
@@ -366,7 +366,7 @@ void TvpJsonClip::build(ToonzScene* scene, TXsheet* xsheet) {
       continue;
     }
     TvpJsonLayer layer;
-    layer.build(col, scene, column);
+    layer.build(m_layers.size(), scene, column);
     if (!layer.isEmpty()) m_layers.append(layer);
   }
 }

--- a/toonz/sources/toonz/xdtsimportpopup.h
+++ b/toonz/sources/toonz/xdtsimportpopup.h
@@ -10,19 +10,23 @@ namespace DVGui {
 class FileField;
 }
 class ToonzScene;
+class QComboBox;
 
 class XDTSImportPopup : public DVGui::Dialog {
   Q_OBJECT
-  QMap<QString, DVGui::FileField *> m_fields;
+  QMap<QString, DVGui::FileField*> m_fields;
   QStringList m_pathSuggestedLevels;
-  ToonzScene *m_scene;
+  ToonzScene* m_scene;
+
+  QComboBox *m_tick1Combo, *m_tick2Combo;
 
   void updateSuggestions(const QString samplePath);
 
 public:
-  XDTSImportPopup(QStringList levelNames, ToonzScene *scene,
+  XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
                   TFilePath scenePath);
   QString getLevelPath(QString levelName);
+  void getMarkerIds(int& tick1Id, int& tick2Id);
 protected slots:
   void onPathChanged();
 };

--- a/toonz/sources/toonz/xdtsio.cpp
+++ b/toonz/sources/toonz/xdtsio.cpp
@@ -60,21 +60,23 @@ void XdtsHeader::write(QJsonObject &json) const {
 //-----------------------------------------------------------------------------
 
 TFrameId XdtsFrameDataItem::str2Fid(const QString &str) const {
+  if (str.isEmpty()) return TFrameId::EMPTY_FRAME;
   bool ok;
   int frame = str.toInt(&ok);
   if (ok) return TFrameId(frame);
-  // separate the last word as suffix
-  frame = str.left(str.size() - 1).toInt(&ok);
-  if (!ok) return TFrameId(-1);                              // EMPTY
-  if (!str[str.size() - 1].isLetter()) return TFrameId(-1);  // EMPTY
-  char c = str[str.size() - 1].toLatin1();
-
-  return TFrameId(frame, c);
+  QString regExpStr = QString("^%1$").arg(TFilePath::fidRegExpStr());
+  QRegExp rx(regExpStr);
+  int pos = rx.indexIn(str);
+  if (pos < 0) return TFrameId();
+  if (rx.cap(2).isEmpty())
+    return TFrameId(rx.cap(1).toInt());
+  else
+    return TFrameId(rx.cap(1).toInt(), rx.cap(2));
 }
 
 QString XdtsFrameDataItem::fid2Str(const TFrameId &fid) const {
-  if (fid.getLetter() == 0) return QString::number(fid.getNumber());
-  return QString::number(fid.getNumber()) + QString(fid.getLetter());
+  if (fid.getLetter().isEmpty()) return QString::number(fid.getNumber());
+  return QString::number(fid.getNumber()) + fid.getLetter();
 }
 
 void XdtsFrameDataItem::read(const QJsonObject &json) {

--- a/toonz/sources/toonz/xdtsio.cpp
+++ b/toonz/sources/toonz/xdtsio.cpp
@@ -32,10 +32,22 @@
 #include <QApplication>
 #include <QDesktopServices>
 #include <QUrl>
+#include <QComboBox>
+#include <QLabel>
 using namespace XdtsIo;
 namespace {
 static QByteArray identifierStr("exchangeDigitalTimeSheet Save Data");
+
+QIcon getColorChipIcon(TPixel32 color) {
+  QPixmap pm(15, 15);
+  pm.fill(QColor(color.r, color.g, color.b));
+  return QIcon(pm);
 }
+
+int _tick1Id          = -1;
+int _tick2Id          = -1;
+bool _exportAllColumn = true;
+}  // namespace
 //-----------------------------------------------------------------------------
 void XdtsHeader::read(const QJsonObject &json) {
   QRegExp rx("\\d{1,4}");
@@ -75,7 +87,14 @@ TFrameId XdtsFrameDataItem::str2Fid(const QString &str) const {
 }
 
 QString XdtsFrameDataItem::fid2Str(const TFrameId &fid) const {
-  if (fid.getLetter().isEmpty()) return QString::number(fid.getNumber());
+  if (fid.getNumber() == -1)
+    return QString("SYMBOL_NULL_CELL");
+  else if (fid.getNumber() == SYMBOL_TICK_1)
+    return QString("SYMBOL_TICK_1");
+  else if (fid.getNumber() == SYMBOL_TICK_2)
+    return QString("SYMBOL_TICK_2");
+  else if (fid.getLetter().isEmpty())
+    return QString::number(fid.getNumber());
   return QString::number(fid.getNumber()) + fid.getLetter();
 }
 
@@ -103,11 +122,13 @@ TFrameId XdtsFrameDataItem::getFrameId() const {
   if (val == "SYMBOL_NULL_CELL")
     return TFrameId(-1);  // EMPTY
                           // ignore sheet symbols for now
-  else if (val == "SYMBOL_HYPHEN" || val == "SYMBOL_TICK_1" ||
-           val == "SYMBOL_TICK_2")
+  else if (val == "SYMBOL_HYPHEN")
     return TFrameId(-2);  // IGNORE
-                          // return -1;
-                          // return cell number
+  else if (val == "SYMBOL_TICK_1")
+    return TFrameId(SYMBOL_TICK_1);
+  else if (val == "SYMBOL_TICK_2")
+    return TFrameId(SYMBOL_TICK_2);
+  // return cell number
   return str2Fid(m_values.at(0));
 }
 
@@ -171,7 +192,8 @@ static bool frameLessThan(const QPair<int, TFrameId> &v1,
   return v1.first < v2.first;
 }
 
-QVector<TFrameId> XdtsFieldTrackItem::getCellFrameIdTrack() const {
+QVector<TFrameId> XdtsFieldTrackItem::getCellFrameIdTrack(
+    QList<int> &tick1, QList<int> &tick2) const {
   QList<QPair<int, TFrameId>> frameFids;
   for (const XdtsTrackFrameItem &frame : m_frames)
     frameFids.append(frame.frameFid());
@@ -195,7 +217,15 @@ QVector<TFrameId> XdtsFieldTrackItem::getCellFrameIdTrack() const {
     TFrameId cellFid = frameFid.second;
     if (cellFid.getNumber() == -2)  // IGNORE case
       cells.append((cells.isEmpty()) ? TFrameId(-1) : cells.last());
-    else
+    else if (cellFid.getNumber() ==
+             XdtsFrameDataItem::SYMBOL_TICK_1) {  // SYMBOL_TICK_1
+      cells.append((cells.isEmpty()) ? TFrameId(-1) : cells.last());
+      tick1.append(currentFrame);
+    } else if (cellFid.getNumber() ==
+               XdtsFrameDataItem::SYMBOL_TICK_2) {  // SYMBOL_TICK_2
+      cells.append((cells.isEmpty()) ? TFrameId(-1) : cells.last());
+      tick2.append(currentFrame);
+    } else
       cells.append(cellFid);
     currentFrame++;
   }
@@ -219,7 +249,14 @@ QString XdtsFieldTrackItem::build(TXshCellColumn *column) {
     // handle as the empty cell
     if (!level || cell.m_level != level) cell = TXshCell();
     // continue if the cell is continuous
-    if (prevCell == cell) continue;
+    if (prevCell == cell) {
+      // cell mark to ticks
+      if (_tick1Id >= 0 && column->getCellMark(row) == _tick1Id)
+        addFrame(row, TFrameId(XdtsFrameDataItem::SYMBOL_TICK_1));
+      else if (_tick2Id >= 0 && column->getCellMark(row) == _tick2Id)
+        addFrame(row, TFrameId(XdtsFrameDataItem::SYMBOL_TICK_2));
+      continue;
+    }
 
     if (cell.isEmpty())
       addFrame(row, TFrameId(-1));
@@ -268,29 +305,37 @@ QList<int> XdtsTimeTableFieldItem::getOccupiedColumns() const {
   return ret;
 }
 
-QVector<TFrameId> XdtsTimeTableFieldItem::getColumnTrack(int col) const {
+QVector<TFrameId> XdtsTimeTableFieldItem::getColumnTrack(
+    int col, QList<int> &tick1, QList<int> &tick2) const {
   for (const XdtsFieldTrackItem &track : m_tracks) {
     if (track.getTrackNo() != col) continue;
-    return track.getCellFrameIdTrack();
+    return track.getCellFrameIdTrack(tick1, tick2);
   }
   return QVector<TFrameId>();
 }
 
 void XdtsTimeTableFieldItem::build(TXsheet *xsheet, QStringList &columnLabels) {
-  m_fieldId = CELL;
+  m_fieldId     = CELL;
+  int exportCol = 0;
   for (int col = 0; col < xsheet->getFirstFreeColumnIndex(); col++) {
     if (xsheet->isColumnEmpty(col)) {
       columnLabels.append("");
+      exportCol++;
       continue;
     }
     TXshCellColumn *column = xsheet->getColumn(col)->getCellColumn();
+    // skip non-cell column
     if (!column) {
-      columnLabels.append("");
       continue;
     }
-    XdtsFieldTrackItem track(col);
+    // skip inactive column
+    if (!_exportAllColumn && !column->isPreviewVisible()) {
+      continue;
+    }
+    XdtsFieldTrackItem track(exportCol);
     columnLabels.append(track.build(column));
     if (!track.isEmpty()) m_tracks.append(track);
+    exportCol++;
   }
 }
 //-----------------------------------------------------------------------------
@@ -503,6 +548,9 @@ bool XdtsIo::loadXdtsScene(ToonzScene *scene, const TFilePath &scenePath) {
     return false;
   }
 
+  int tick1Id, tick2Id;
+  popup.getMarkerIds(tick1Id, tick2Id);
+
   TXsheet *xsh                       = scene->getXsheet();
   XdtsTimeTableFieldItem cellField   = xdtsData.timeTable().getCellField();
   XdtsTimeTableHeaderItem cellHeader = xdtsData.timeTable().getCellHeader();
@@ -510,9 +558,10 @@ bool XdtsIo::loadXdtsScene(ToonzScene *scene, const TFilePath &scenePath) {
   QStringList layerNames             = cellHeader.getLayerNames();
   QList<int> columns                 = cellField.getOccupiedColumns();
   for (int column : columns) {
-    QString levelName       = layerNames.at(column);
-    TXshLevel *level        = levels.value(levelName);
-    QVector<TFrameId> track = cellField.getColumnTrack(column);
+    QString levelName = layerNames.at(column);
+    TXshLevel *level  = levels.value(levelName);
+    QList<int> tick1, tick2;
+    QVector<TFrameId> track = cellField.getColumnTrack(column, tick1, tick2);
 
     int row = 0;
     std::vector<TFrameId>::iterator it;
@@ -528,6 +577,15 @@ bool XdtsIo::loadXdtsScene(ToonzScene *scene, const TFilePath &scenePath) {
     if (lastFid.getNumber() != -1) {
       for (; row < duration; row++)
         xsh->setCell(row, column, TXshCell(level, TFrameId(lastFid)));
+    }
+
+    // set cell marks
+    TXshCellColumn *cellColumn = xsh->getColumn(column)->getCellColumn();
+    if (tick1Id >= 0) {
+      for (auto tick1f : tick1) cellColumn->setCellMark(tick1f, tick1Id);
+    }
+    if (tick2Id >= 0) {
+      for (auto tick2f : tick2) cellColumn->setCellMark(tick2f, tick2Id);
     }
 
     TStageObject *pegbar =
@@ -571,18 +629,80 @@ void ExportXDTSCommand::execute() {
   else
     duration = xsheet->getFrameCount();
 
-  XdtsData xdtsData;
-  xdtsData.build(xsheet, QString::fromStdString(fp.getName()), duration);
-  if (xdtsData.isEmpty()) {
-    DVGui::error(QObject::tr("No columns can be exported."));
-    return;
+  {
+    _tick1Id         = -1;
+    _tick2Id         = -1;
+    _exportAllColumn = true;
+    XdtsData pre_xdtsData;
+    pre_xdtsData.build(xsheet, QString::fromStdString(fp.getName()), duration);
+    if (pre_xdtsData.isEmpty()) {
+      DVGui::error(QObject::tr("No columns can be exported."));
+      return;
+    }
   }
 
   static GenericSaveFilePopup *savePopup = 0;
+  static QComboBox *tick1Id              = nullptr;
+  static QComboBox *tick2Id              = nullptr;
+  static QComboBox *targetColumnCombo    = nullptr;
+
+  auto refreshCellMarkComboItems = [](QComboBox *combo) {
+    int current = -1;
+    if (combo->count()) current = combo->currentData().toInt();
+
+    combo->clear();
+    QList<TSceneProperties::CellMark> marks = TApp::instance()
+                                                  ->getCurrentScene()
+                                                  ->getScene()
+                                                  ->getProperties()
+                                                  ->getCellMarks();
+    combo->addItem(tr("None"), -1);
+    int curId = 0;
+    for (auto mark : marks) {
+      QString label = QString("%1: %2").arg(curId).arg(mark.name);
+      combo->addItem(getColorChipIcon(mark.color), label, curId);
+      curId++;
+    }
+    if (current >= 0) combo->setCurrentIndex(combo->findData(current));
+  };
+
   if (!savePopup) {
+    // create custom widget
+    QWidget *custonWidget = new QWidget();
+    tick1Id               = new QComboBox();
+    tick2Id               = new QComboBox();
+    refreshCellMarkComboItems(tick1Id);
+    refreshCellMarkComboItems(tick2Id);
+    tick1Id->setCurrentIndex(tick1Id->findData(0));
+    tick2Id->setCurrentIndex(tick2Id->findData(1));
+    targetColumnCombo = new QComboBox();
+    targetColumnCombo->addItem(tr("All columns"), true);
+    targetColumnCombo->addItem(tr("Only active columns"), false);
+    targetColumnCombo->setCurrentIndex(targetColumnCombo->findData(true));
+
+    QGridLayout *customLay = new QGridLayout();
+    customLay->setMargin(0);
+    customLay->setSpacing(10);
+    {
+      customLay->addWidget(new QLabel(tr("Inbetween symbol mark")), 0, 0,
+                           Qt::AlignRight | Qt::AlignVCenter);
+      customLay->addWidget(tick1Id, 0, 1);
+      customLay->addWidget(new QLabel(tr("Reverse sheet symbol mark")), 1, 0,
+                           Qt::AlignRight | Qt::AlignVCenter);
+      customLay->addWidget(tick2Id, 1, 1);
+      customLay->addWidget(new QLabel(tr("Target column")), 2, 0,
+                           Qt::AlignRight | Qt::AlignVCenter);
+      customLay->addWidget(targetColumnCombo, 2, 1);
+    }
+    customLay->setColumnStretch(0, 1);
+    custonWidget->setLayout(customLay);
+
     savePopup = new GenericSaveFilePopup(
-        QObject::tr("Export Exchange Digital Time Sheet (XDTS)"));
+        QObject::tr("Export Exchange Digital Time Sheet (XDTS)"), custonWidget);
     savePopup->addFilterType("xdts");
+  } else {
+    refreshCellMarkComboItems(tick1Id);
+    refreshCellMarkComboItems(tick2Id);
   }
   if (!scene->isUntitled())
     savePopup->setFolder(fp.getParentDir());
@@ -597,6 +717,16 @@ void ExportXDTSCommand::execute() {
 
   if (!saveFile.open(QIODevice::WriteOnly)) {
     qWarning("Couldn't open save file.");
+    return;
+  }
+
+  _tick1Id         = tick1Id->currentData().toInt();
+  _tick2Id         = tick2Id->currentData().toInt();
+  _exportAllColumn = targetColumnCombo->currentData().toBool();
+  XdtsData xdtsData;
+  xdtsData.build(xsheet, QString::fromStdString(fp.getName()), duration);
+  if (xdtsData.isEmpty()) {
+    DVGui::error(QObject::tr("No columns can be exported."));
     return;
   }
 

--- a/toonz/sources/toonz/xdtsio.h
+++ b/toonz/sources/toonz/xdtsio.h
@@ -83,10 +83,11 @@ class XdtsFrameDataItem {
   QString fid2Str(const TFrameId &) const;
 
 public:
+  enum { SYMBOL_TICK_1 = -100, SYMBOL_TICK_2 = -200 };
+
   XdtsFrameDataItem() : m_id(Default) {}
   XdtsFrameDataItem(TFrameId fId) : m_id(Default) {
-    m_values.append((fId.getNumber() == -1) ? QString("SYMBOL_NULL_CELL")
-                                            : fid2Str(fId));
+    m_values.append(fid2Str(fId));
   }
   void read(const QJsonObject &json);
   void write(QJsonObject &json) const;
@@ -132,7 +133,8 @@ public:
   void write(QJsonObject &json) const;
   bool isEmpty() const { return m_frames.isEmpty(); }
   int getTrackNo() const { return m_trackNo; }
-  QVector<TFrameId> getCellFrameIdTrack() const;
+  QVector<TFrameId> getCellFrameIdTrack(QList<int> &tick1,
+                                        QList<int> &tick2) const;
 
   QString build(TXshCellColumn *);
   void addFrame(int frame, TFrameId fId) {
@@ -154,7 +156,8 @@ public:
   void write(QJsonObject &json) const;
   bool isCellField() { return m_fieldId == CELL; }
   QList<int> getOccupiedColumns() const;
-  QVector<TFrameId> getColumnTrack(int col) const;
+  QVector<TFrameId> getColumnTrack(int col, QList<int> &tick1,
+                                   QList<int> &tick2) const;
 
   void build(TXsheet *, QStringList &);
 };

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1122,6 +1122,11 @@ void RenameCellField::keyPressEvent(QKeyEvent *event) {
     }
     offset = m_viewer->orientation()->arrowShift(key);
     break;
+  case Qt::Key_Shift:
+    // prevent the field to lose focus when typing shift key
+    event->accept();
+    return;
+    break;
   default:
     QLineEdit::keyPressEvent(event);
     return;

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -118,6 +118,7 @@ class CellArea final : public QWidget {
                      bool showLevelName = true);
   void drawSoundTextCell(QPainter &p, int row, int col);
   void drawSoundCell(QPainter &p, int row, int col, bool isReference = false);
+  void drawSoundTextColumn(QPainter &p, int r0, int r1, int col);
   void drawPaletteCell(QPainter &p, int row, int col, bool isReference = false);
 
   void drawKeyframe(QPainter &p, const QRect toBeUpdated);

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -8,6 +8,7 @@
 #include "orientation.h"
 
 #include "toonz/txshcell.h"
+#include "tundo.h"
 
 // forward declaration
 class XsheetViewer;
@@ -16,6 +17,20 @@ class TXsheetHandle;
 class TXshSoundTextColumn;
 
 namespace XsheetGUI {
+
+class SetCellMarkUndo final : public TUndo {
+  int m_row, m_col;
+  int m_idBefore, m_idAfter;
+
+public:
+  SetCellMarkUndo(int row, int col, int idAfter);
+  void setId(int id) const;
+  void undo() const override;
+  void redo() const override;
+  int getSize() const override;
+  QString getHistoryString() override;
+  int getHistoryType() override;
+};
 
 class NoteWidget;
 class DragTool;
@@ -166,7 +181,8 @@ protected:
   /*!Crea il menu' del tasto destro che si visualizza quando si clicca sulla
 cella,
 distinguendo i due casi: cella piena, cella vuota.*/
-  void createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell);
+  void createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell, int row,
+                      int col);
   //! Crea il menu' del tasto destro che si visualizza si clicca su un key
   //! frame.
   void createKeyMenu(QMenu &menu);
@@ -182,6 +198,7 @@ protected slots:
   void onStepChanged(QAction *);
   // replace level with another level in the cast
   void onReplaceByCastedLevel(QAction *action);
+  void onSetCellMark();
 };
 
 }  // namespace XsheetGUI

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1043,7 +1043,7 @@ void ColumnArea::DrawHeader::drawColumnName() const {
 
   // ZeraryFx columns store name elsewhere
   TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(column);
-  if (zColumn)
+  if (zColumn && !isEmpty)
     name = ::to_string(zColumn->getZeraryColumnFx()->getZeraryFx()->getName());
 
   QRect columnName = o->rect((col < 0) ? PredefinedRect::CAMERA_LAYER_NAME

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -60,6 +60,7 @@
 #include "duplicatepopup.h"
 #include "menubarcommandids.h"
 #include "columncommand.h"
+#include "xshcellviewer.h"  // SetCellMarkUndo
 
 // Qt includes
 #include <QClipboard>
@@ -2199,6 +2200,43 @@ public:
 
 } ToggleXsheetCameraColumnCommand;
 
+//-----------------------------------------------------------------------------
+
+class SetCellMarkCommand final : public MenuItemHandler {
+  int m_markId;
+
+public:
+  SetCellMarkCommand(int markId)
+      : MenuItemHandler(
+            ((std::string)MI_SetCellMark + std::to_string(markId)).c_str())
+      , m_markId(markId) {}
+
+  void execute() override {
+    TApp *app         = TApp::instance();
+    TXsheet *xsh      = app->getCurrentXsheet()->getXsheet();
+    int currentRow    = app->getCurrentFrame()->getFrame();
+    int currentColumn = app->getCurrentColumn()->getColumnIndex();
+    if (!xsh->getColumn(currentColumn)) return;
+    TXshCellColumn *cellColumn = xsh->getColumn(currentColumn)->getCellColumn();
+    if (!cellColumn) return;
+    XsheetGUI::SetCellMarkUndo *undo =
+        new XsheetGUI::SetCellMarkUndo(currentRow, currentColumn, m_markId);
+    undo->redo();
+    TUndoManager::manager()->add(undo);
+  }
+};
+SetCellMarkCommand CellMarkCommand0(0);
+SetCellMarkCommand CellMarkCommand1(1);
+SetCellMarkCommand CellMarkCommand2(2);
+SetCellMarkCommand CellMarkCommand3(3);
+SetCellMarkCommand CellMarkCommand4(4);
+SetCellMarkCommand CellMarkCommand5(5);
+SetCellMarkCommand CellMarkCommand6(6);
+SetCellMarkCommand CellMarkCommand7(7);
+SetCellMarkCommand CellMarkCommand8(8);
+SetCellMarkCommand CellMarkCommand9(9);
+SetCellMarkCommand CellMarkCommand10(10);
+SetCellMarkCommand CellMarkCommand11(11);
 
 //============================================================
 

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -551,7 +551,7 @@ public:
     int i;
     for (i = 1; i < count; i++)
       if (m_sourceCells[i].m_level != cell.m_level ||
-          m_sourceCells[i].m_frameId.getLetter() != 0)
+          !m_sourceCells[i].m_frameId.getLetter().isEmpty())
         return;
 
     // check if all the selected cells have the same frame number

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -162,6 +162,7 @@ set(HEADERS
     ../include/toonz/preferencesitemids.h
     ../include/toonz/txsheetcolumnchange.h
     ../include/toonz/expressionreferencemonitor.h
+    ../include/toonz/filepathproperties.h
 )
 
 set(SOURCES
@@ -320,6 +321,7 @@ set(SOURCES
     txshmeshcolumn.cpp
     textureutils.cpp
     boardsettings.cpp
+    filepathproperties.cpp
 )
 
 if(BUILD_TARGET_WIN)

--- a/toonz/sources/toonzlib/filepathproperties.cpp
+++ b/toonz/sources/toonzlib/filepathproperties.cpp
@@ -1,0 +1,38 @@
+#include "toonz/filepathproperties.h"
+
+// TnzCore includes
+#include "tstream.h"
+
+FilePathProperties::FilePathProperties()
+    : m_useStandard(true)
+    , m_acceptNonAlphabetSuffix(false)
+    , m_letterCountForSuffix(1) {}
+
+bool FilePathProperties::isDefault() {
+  return (m_useStandard == true && m_acceptNonAlphabetSuffix == false &&
+          m_letterCountForSuffix == 1);
+}
+
+void FilePathProperties::saveData(TOStream& os) const {
+  os.child("useStandard") << ((m_useStandard) ? 1 : 0);
+  os.child("acceptNonAlphabetSuffix") << ((m_acceptNonAlphabetSuffix) ? 1 : 0);
+  os.child("letterCountForSuffix") << m_letterCountForSuffix;
+}
+
+// make sure to let TFilePath to know the new properties!
+void FilePathProperties::loadData(TIStream& is) {
+  int val;
+  std::string tagName;
+  while (is.matchTag(tagName)) {
+    if (tagName == "useStandard") {
+      is >> val;
+      m_useStandard = (val == 1);
+    } else if (tagName == "acceptNonAlphabetSuffix") {
+      is >> val;
+      m_acceptNonAlphabetSuffix = (val == 1);
+    } else if (tagName == "letterCountForSuffix") {
+      is >> m_letterCountForSuffix;
+    }
+    is.closeChild();
+  }
+}

--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -129,6 +129,9 @@ inline void setFxParamToCurrentScene(TFx *fx, TXsheet *xsh) {
 void initializeFx(TXsheet *xsh, TFx *fx) {
   if (TZeraryColumnFx *zcfx = dynamic_cast<TZeraryColumnFx *>(fx))
     fx = zcfx->getZeraryFx();
+  // if the fx has not unique name then let assignUniqueId() set the default
+  // name
+  if (fx->getName() != L"" && fx->getName() == fx->getFxId()) fx->setName(L"");
 
   xsh->getFxDag()->assignUniqueId(fx);
   setFxParamToCurrentScene(fx, xsh);

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -335,6 +335,9 @@ TopToBottomOrientation::TopToBottomOrientation() {
   addRect(PredefinedRect::KEYFRAME_AREA,
           QRect(CELL_WIDTH - KEY_ICON_WIDTH, 0, KEY_ICON_WIDTH, CELL_HEIGHT));
   addRect(PredefinedRect::DRAG_AREA, QRect(0, 0, CELL_DRAG_WIDTH, CELL_HEIGHT));
+  int markSize = CELL_HEIGHT * 8 / 10;  // 80% size
+  addRect(PredefinedRect::CELL_MARK_AREA,
+          QRect(CELL_DRAG_WIDTH - 3, 2, markSize, markSize));
   QRect soundRect(CELL_DRAG_WIDTH, 0,
                   CELL_WIDTH - CELL_DRAG_WIDTH - SOUND_PREVIEW_WIDTH,
                   CELL_HEIGHT);
@@ -1111,6 +1114,9 @@ LeftToRightOrientation::LeftToRightOrientation() {
                 EXTENDER_HEIGHT));
   addRect(PredefinedRect::KEYFRAME_AREA, keyRect);
   addRect(PredefinedRect::DRAG_AREA, QRect(0, 0, CELL_WIDTH, CELL_DRAG_HEIGHT));
+  int markSize = CELL_HEIGHT / 2;  // 50% size (12px)
+  addRect(PredefinedRect::CELL_MARK_AREA,
+          QRect(1, CELL_DRAG_HEIGHT + 1, markSize, markSize));
   QRect soundRect(0, CELL_DRAG_HEIGHT, CELL_WIDTH,
                   CELL_HEIGHT - CELL_DRAG_HEIGHT - SOUND_PREVIEW_HEIGHT);
   addRect(PredefinedRect::SOUND_TRACK, soundRect);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -94,7 +94,7 @@ inline bool formatLess(const Preferences::LevelFormat &a,
 //=================================================================
 
 void getDefaultLevelFormats(LevelFormatVector &lfv) {
-  lfv.resize(3);
+  lfv.resize(2);
   {
     LevelFormat &lf = lfv[0];
 
@@ -214,6 +214,13 @@ void getValue(QSettings &settings,
         (*it).m_options.m_premultiply = false;
         ++it;
       }
+      changed = true;
+    }
+    // remove the "empty" condition which may inserted due to the previous bug
+    else if ((*it).m_name.isEmpty() &&
+             (*it).m_pathFormat == QRegExp(".*", Qt::CaseInsensitive) &&
+             (*it).m_priority == 1 && (*it).m_options == LevelOptions()) {
+      it      = lfv.erase(it);
       changed = true;
     } else
       ++it;

--- a/toonz/sources/toonzlib/scriptbinding_scene.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_scene.cpp
@@ -206,10 +206,10 @@ QScriptValue Scene::getCell(int row, int col) {
   if (sl) {
     QScriptValue level = create(engine(), new Level(sl));
     QScriptValue fid;
-    if (cell.m_frameId.getLetter() == 0)
+    if (cell.m_frameId.getLetter().isEmpty())
       fid = cell.m_frameId.getNumber();
     else
-      fid               = QString::fromStdString(cell.m_frameId.expand());
+      fid = QString::fromStdString(cell.m_frameId.expand());
     QScriptValue result = engine()->newObject();
     result.setProperty("level", level);
     result.setProperty("fid", fid);

--- a/toonz/sources/toonzlib/tcleanupper.cpp
+++ b/toonz/sources/toonzlib/tcleanupper.cpp
@@ -160,7 +160,7 @@ HSVColor HSVColor::fromRGB(double r, double g, double b) {
       h = 2.0 + (b - r) / delta;
     else if (b == max)
       h = 4.0 + (r - g) / delta;
-    h   = h * 60.0;
+    h = h * 60.0;
     if (h < 0) h += 360.0;
   }
 
@@ -569,7 +569,7 @@ TRasterP TCleanupper::processColors(const TRasterP &rin) {
 CleanupPreprocessedImage *TCleanupper::process(
     TRasterImageP &image, bool first_image, TRasterImageP &onlyResampledImage,
     bool isCameraTest, bool returnResampled, bool onlyForSwatch,
-    TAffine *resampleAff) {
+    TAffine *resampleAff, TRasterP templateForResampled) {
   TAffine aff;
   double blur;
   TDimension outDim(0, 0);
@@ -682,7 +682,9 @@ CleanupPreprocessedImage *TCleanupper::process(
   TRasterP tmp_ras;
 
   if (returnResampled || (fromGr8 && toGr8)) {
-    if (fromGr8 && toGr8)
+    if (templateForResampled)
+      tmp_ras = templateForResampled->create(outDim.lx, outDim.ly);
+    else if (fromGr8 && toGr8)
       tmp_ras = TRasterGR8P(outDim);
     else
       tmp_ras = TRaster32P(outDim);
@@ -709,7 +711,7 @@ CleanupPreprocessedImage *TCleanupper::process(
     flt_type = TRop::Hann2;
   TRop::resample(tmp_ras, image->getRaster(), aff, flt_type, blur);
 
-  if ((TRaster32P)tmp_ras)
+  if ((TRaster32P)tmp_ras && !templateForResampled)
     // Add white background to deal with semitransparent pixels
     TRop::addBackground(tmp_ras, TPixel32::White);
 

--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -10,6 +10,7 @@
 #include "toonz/toonzfolders.h"
 #include "toonz/cleanupparameters.h"
 #include "toonz/preferences.h"
+#include "toonz/filepathproperties.h"
 
 // TnzBase includes
 #include "tenv.h"
@@ -17,6 +18,7 @@
 // TnzCore includes
 #include "tsystem.h"
 #include "tstream.h"
+#include "tfilepath.h"
 #include "tfilepath_io.h"
 #include "tconvert.h"
 
@@ -321,11 +323,18 @@ TFilePath getDesktopPath() {
         \see TProjectManager and TOStream.
   */
 
-TProject::TProject() : m_name(), m_path(), m_sprop(new TSceneProperties()) {}
+TProject::TProject()
+    : m_name()
+    , m_path()
+    , m_sprop(new TSceneProperties())
+    , m_fpProp(new FilePathProperties()) {}
 
 //-------------------------------------------------------------------
 
-TProject::~TProject() { delete m_sprop; }
+TProject::~TProject() {
+  delete m_sprop;
+  delete m_fpProp;
+}
 
 //-------------------------------------------------------------------
 /*! Associates the \b name to the specified \b path.
@@ -615,6 +624,13 @@ bool TProject::save(const TFilePath &projectPath) {
   os.openChild("sceneProperties");
   getSceneProperties().saveData(os);
   os.closeChild();
+
+  if (!getFilePathProperties()->isDefault()) {
+    os.openChild("filePathProperties");
+    getFilePathProperties()->saveData(os);
+    os.closeChild();
+  }
+
   os.closeChild();
 
   // crea (se necessario) le directory relative ai vari folder
@@ -724,6 +740,9 @@ void TProject::load(const TFilePath &projectPath) {
       } catch (...) {
       }
       setSceneProperties(sprop);
+      is.matchEndTag();
+    } else if (tagName == "filePathProperties") {
+      m_fpProp->loadData(is);
       is.matchEndTag();
     }
   }
@@ -1038,6 +1057,12 @@ TProjectP TProjectManager::getCurrentProject() {
     assert(TProject::isAProjectPath(fp));
     currentProject = new TProject();
     currentProject->load(fp);
+
+    // update TFilePath condition on loading the current project
+    FilePathProperties *fpProp = currentProject->getFilePathProperties();
+    TFilePath::setFilePathProperties(fpProp->useStandard(),
+                                     fpProp->acceptNonAlphabetSuffix(),
+                                     fpProp->letterCountForSuffix());
   }
   return currentProject;
 }

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -1061,8 +1061,8 @@ int TXsheet::exposeLevel(int row, int col, TXshLevel *xl, bool overwrite) {
 //-----------------------------------------------------------------------------
 // customized version for load level popup
 int TXsheet::exposeLevel(int row, int col, TXshLevel *xl,
-                         std::vector<TFrameId> &fIds_, int xFrom, int xTo,
-                         int step, int inc, int frameCount,
+                         std::vector<TFrameId> &fIds_, TFrameId xFrom,
+                         TFrameId xTo, int step, int inc, int frameCount,
                          bool doesFileActuallyExist) {
   if (!xl) return 0;
   std::vector<TFrameId> fids;
@@ -1104,7 +1104,7 @@ int TXsheet::exposeLevel(int row, int col, TXshLevel *xl,
     {
       std::vector<TFrameId>::iterator it;
       it = fids.begin();
-      while (it->getNumber() < xFrom) it++;
+      while (*it < xFrom) it++;
 
       if (step == 0)  // Step = Auto
       {
@@ -1112,14 +1112,12 @@ int TXsheet::exposeLevel(int row, int col, TXshLevel *xl,
         next_it = it;
         next_it++;
 
-        int startFrame = it->getNumber();
-
-        for (int f = startFrame; f < startFrame + frameCount; f++) {
-          if (next_it != fids.end() && f >= next_it->getNumber()) {
+        for (int f = 0; f < frameCount; f++) {
+          setCell(row++, col, TXshCell(xl, *it));
+          if (next_it != fids.end()) {
             it++;
             next_it++;
           }
-          setCell(row++, col, TXshCell(xl, *it));
         }
       }
 
@@ -1143,7 +1141,7 @@ int TXsheet::exposeLevel(int row, int col, TXshLevel *xl,
       loopCount = frameCount / step;
 
       for (int loop = 0; loop < loopCount; loop++) {
-        TFrameId id(xFrom + loop * inc, fids.begin()->getLetter());
+        TFrameId id(xFrom.getNumber() + loop * inc, xFrom.getLetter());
         for (int s = 0; s < step; s++) {
           setCell(row++, col, TXshCell(xl, id));
         }

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -1222,6 +1222,12 @@ void TXsheet::loadData(TIStream &is) {
           }
         }
       }
+    } else if (tagName == "cameraColumn") {
+      while (is.openChild(tagName)) {
+        if (!m_cameraColumn->getCellColumn()->loadCellMarks(tagName, is))
+          throw TException("Camera Column, unknown tag: " + tagName);
+        is.closeChild();
+      }
     } else if (tagName == "pegbars") {
       TPersist *p = m_imp->m_pegTree;
       m_imp->m_pegTree->loadData(is, this);
@@ -1278,6 +1284,14 @@ void TXsheet::saveData(TOStream &os) {
     if (column && c < getFirstFreeColumnIndex()) os << column.getPointer();
   }
   os.closeChild();
+
+  // save cell marks in the camera column
+  if (!m_cameraColumn->getCellColumn()->getCellMarks().isEmpty()) {
+    os.openChild("cameraColumn");
+    m_cameraColumn->getCellColumn()->saveCellMarks(os);
+    os.closeChild();
+  }
+
   os.openChild("pegbars");
   m_imp->m_pegTree->saveData(os, getFirstFreeColumnIndex(), this);
   // os << *(m_imp->m_pegTree);

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -151,9 +151,10 @@ void TXshLevelColumn::loadData(TIStream &is) {
     {
       TFxSet fxSet;
       fxSet.loadData(is);
-    } else {
+    } else if (loadCellMarks(tagName, is)) {
+      // do nothing
+    } else
       throw TException("TXshLevelColumn, unknown tag: " + tagName);
-    }
     is.closeChild();
   }
 }
@@ -201,6 +202,9 @@ void TXshLevelColumn::saveData(TOStream &os) {
     os.closeChild();
   }
   os.child("fx") << m_fx;
+
+  // cell marks
+  saveCellMarks(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -111,6 +111,8 @@ void TXshMeshColumn::saveData(TOStream &os) {
     }
     os.closeChild();
   }
+  // cell marks
+  saveCellMarks(os);
 }
 
 //------------------------------------------------------------------
@@ -167,6 +169,8 @@ void TXshMeshColumn::loadData(TIStream &is) {
           is.skipCurrentTag();
       }
 
+      is.closeChild();
+    } else if (loadCellMarks(tagName, is)) {
       is.closeChild();
     } else
       is.skipCurrentTag();

--- a/toonz/sources/toonzlib/txshpalettecolumn.cpp
+++ b/toonz/sources/toonzlib/txshpalettecolumn.cpp
@@ -73,6 +73,8 @@ void TXshPaletteColumn::loadData(TIStream &is) {
       TPersist *p = 0;
       is >> p;
       if (TFx *fx = dynamic_cast<TFx *>(p)) setFx(fx);
+    } else if (loadCellMarks(tagName, is)) {
+      // do nothing
     } else {
       throw TException("TXshLevelColumn, unknown tag: " + tagName);
     }
@@ -107,6 +109,9 @@ void TXshPaletteColumn::saveData(TOStream &os) {
     os.closeChild();
   }
   os.child("fx") << m_fx;
+
+  // cell marks
+  saveCellMarks(os);
 }
 
 PERSIST_IDENTIFIER(TXshPaletteColumn, "paletteColumn")

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -643,7 +643,8 @@ void TXshSimpleLevel::loadAllIconsAndPutInCache(bool cacheImagesAsWell) {
 
 //-----------------------------------------------------------------------------
 
-TRasterImageP TXshSimpleLevel::getFrameToCleanup(const TFrameId &fid) const {
+TRasterImageP TXshSimpleLevel::getFrameToCleanup(const TFrameId &fid,
+                                                 bool toBeLineProcessed) const {
   assert(m_type != UNKNOWN_XSHLEVEL);
 
   FramesSet::const_iterator ft = m_frames.find(fid);
@@ -653,8 +654,12 @@ TRasterImageP TXshSimpleLevel::getFrameToCleanup(const TFrameId &fid) const {
   std::string imageId = getImageId(fid, flag ? Scanned : 0);
 
   ImageLoader::BuildExtData extData(this, fid, 1);
-  TRasterImageP img = ImageManager::instance()->getImage(
-      imageId, ImageManager::dontPutInCache, &extData);
+
+  UCHAR imFlags = ImageManager::dontPutInCache;
+  // if lines are not processed, obtain the original sampled image
+  if (!toBeLineProcessed) imFlags |= ImageManager::is64bitEnabled;
+  TRasterImageP img =
+      ImageManager::instance()->getImage(imageId, imFlags, &extData);
   if (!img) return img;
 
   double x_dpi, y_dpi;

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -485,7 +485,8 @@ int TXshSimpleLevel::guessStep() const {
 
   TFrameId firstFid = *ft++, secondFid = *ft++;
 
-  if (firstFid.getLetter() != 0 || secondFid.getLetter() != 0) return 1;
+  if (!firstFid.getLetter().isEmpty() || !secondFid.getLetter().isEmpty())
+    return 1;
 
   int step = secondFid.getNumber() - firstFid.getNumber();
   if (step == 1) return 1;
@@ -494,7 +495,7 @@ int TXshSimpleLevel::guessStep() const {
   // (cerco di limitare il numero di volte in cui devo controllare tutta la
   // lista)
   TFrameId lastFid = *m_frames.rbegin();
-  if (lastFid.getLetter() != 0) return 1;
+  if (!lastFid.getLetter().isEmpty()) return 1;
 
   if (lastFid.getNumber() != firstFid.getNumber() + step * (frameCount - 1))
     return 1;
@@ -502,7 +503,7 @@ int TXshSimpleLevel::guessStep() const {
   for (int i = 2; ft != m_frames.end(); ++ft, ++i) {
     const TFrameId &fid = *ft;
 
-    if (fid.getLetter() != 0) return 1;
+    if (!fid.getLetter().isEmpty()) return 1;
 
     if (fid.getNumber() != firstFid.getNumber() + step * i) return 1;
   }

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -262,6 +262,13 @@ void TXshSoundColumn::loadData(TIStream &is) {
     is >> status;
     setStatusWord(status);
   }
+
+  std::string tagName;
+  while (is.openChild(tagName)) {
+    if (!loadCellMarks(tagName, is))
+      throw TException("TXshLevelColumn, unknown tag: " + tagName);
+    is.closeChild();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -274,6 +281,8 @@ void TXshSoundColumn::saveData(TOStream &os) {
   int i;
   for (i = 0; i < levelsCount; i++) m_levels.at(i)->saveData(os);
   os << getStatusWord();
+  // cell marks
+  saveCellMarks(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshsoundtextcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundtextcolumn.cpp
@@ -80,6 +80,8 @@ void TXshSoundTextColumn::loadData(TIStream &is) {
           throw TException("TXshLevelColumn, unknown tag(2): " + tagName);
         is.closeChild();
       }
+    } else if (loadCellMarks(tagName, is)) {
+      // do nothing
     } else
       throw TException("TXshLevelColumn, unknown tag: " + tagName);
     is.closeChild();
@@ -100,6 +102,8 @@ void TXshSoundTextColumn::saveData(TOStream &os) {
     }
     os.closeChild();
   }
+  // cell marks
+  saveCellMarks(os);
 }
 
 PERSIST_IDENTIFIER(TXshSoundTextColumn, "soundTextColumn")

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -162,6 +162,8 @@ void TXshZeraryFxColumn::loadData(TIStream &is) {
           throw TException("expected <cell>");
         is.closeChild();
       }
+    } else if (loadCellMarks(tagName, is)) {
+      // do nothing
     } else
       throw TException("expected <status> or <cells>");
     is.closeChild();
@@ -186,6 +188,8 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
     }
     os.closeChild();
   }
+  // cell marks
+  saveCellMarks(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -29,7 +29,8 @@ TXshZeraryFxColumn::TXshZeraryFxColumn(int frameCount)
 
 TXshZeraryFxColumn::TXshZeraryFxColumn(const TXshZeraryFxColumn &src)
     : m_zeraryColumnFx(new TZeraryColumnFx())
-    , m_zeraryFxLevel(new TXshZeraryFxLevel()) {
+    , m_zeraryFxLevel(new TXshZeraryFxLevel())
+    , m_iconVisible(false) {
   m_zeraryColumnFx->addRef();
   m_zeraryColumnFx->setColumn(this);
   m_zeraryFxLevel->addRef();

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -129,7 +129,8 @@ void CommandManager::define(CommandId id, CommandType type,
       (node->m_enabled &&
        (node->m_handler || node->m_qaction->actionGroup() != 0)) ||
       node->m_type == MiscCommandType ||
-      node->m_type == ToolModifierCommandType);
+      node->m_type == ToolModifierCommandType ||
+      node->m_type == CellMarkCommandType);
 
   m_qactionTable[qaction] = node;
   qaction->setShortcutContext(Qt::ApplicationShortcut);
@@ -371,7 +372,7 @@ QAction *CommandManager::createAction(CommandId id, QObject *parent,
   if (!refAction) return 0;
   QString text = refAction->text();
   if (node->m_onText != "" && node->m_offText != "")
-    text          = state ? node->m_onText : node->m_offText;
+    text = state ? node->m_onText : node->m_offText;
   QAction *action = new QAction(text, parent);
   action->setShortcut(refAction->shortcut());
   return action;
@@ -533,24 +534,24 @@ void DVMenuAction::setActions(QList<QString> actions) {
 
 namespace {
 QString changeStringNumber(QString str, int index) {
-  QString newStr     = str;
-  int n              = 3;
+  QString newStr = str;
+  int n          = 3;
   if (index >= 10) n = 4;
   QString number;
   newStr.replace(0, n, number.number(index + 1) + QString(". "));
   return newStr;
 }
-}
+}  // namespace
 
 //-----------------------------------------------------------------------------
 
 void DVMenuAction::onTriggered(QAction *action) {
-  QVariant data                              = action->data();
+  QVariant data = action->data();
   if (data.isValid()) m_triggeredActionIndex = data.toInt();
   CommandManager::instance()->execute(action, menuAction());
   int oldIndex = m_triggeredActionIndex;
   if (m_triggeredActionIndex != -1) m_triggeredActionIndex = -1;
-  QString str                                              = data.toString();
+  QString str = data.toString();
   QAction *tableAction =
       CommandManager::instance()->getAction(str.toStdString().c_str());
   if (tableAction || oldIndex == 0) return;

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1020,8 +1020,8 @@ SplineAimChanger::~SplineAimChanger() {}
 
 void SplineAimChanger::mouseMoveEvent(QGraphicsSceneMouseEvent *me) {
   if (m_buttonState == Qt::LeftButton) {
-    bool increase           = false;
-    int delta               = me->screenPos().y() - me->lastScreenPos().y();
+    bool increase = false;
+    int delta     = me->screenPos().y() - me->lastScreenPos().y();
     if (delta < 0) increase = true;
     m_delta += abs(delta);
     if (m_delta > 15) {
@@ -2250,10 +2250,9 @@ StageSchematicGroupNode::StageSchematicGroupNode(
     , m_root(root)
     , m_groupedObj(groupedObj) {
   SchematicViewer *viewer = scene->getSchematicViewer();
-
   int i;
-  for (i   = 0; i < m_groupedObj.size(); i++) m_groupedObj[i]->addRef();
-  bool ret = true;
+  for (i = 0; i < m_groupedObj.size(); i++) m_groupedObj[i]->addRef();
+  bool ret          = true;
   std::wstring name = m_stageObject->getGroupName(false);
   m_name            = QString::fromStdWString(name);
 


### PR DESCRIPTION
Ported the following PRs from OT

### Fixes
opentoonz/opentoonz/#4163 - Fix crash on   creating Macro Fx from the Fx Browser  by @shun-iwasawa
opentoonz/opentoonz/#4167 - Fix PSD   loading and level format preferences  by @shun-iwasawa
opentoonz/opentoonz/#4169 - Fix FxId and   expression handling  by @shun-iwasawa
opentoonz/opentoonz/#4172 - Fix Zerary Fx   bugs  by @shun-iwasawa
opentoonz/opentoonz/#4175 - Fix shortcut   loading from file  by @shun-iwasawa**
opentoonz/opentoonz/#4185 - Fix TVP JSON   export  by @shun-iwasawa
opentoonz/opentoonz/#4186 - Fix FrameIds   Inconsistency in Level Strip Commands  by @shun-iwasawa
opentoonz/opentoonz/#4187 - Fix build   with clang 13: no member named 'copy' in namespace 'std'  by @rozhuk-im
opentoonz/opentoonz/#4194 - Fix pressing   Shift key loses focus when renaming cell    by @shun-iwasawa

### Enhancements
opentoonz/opentoonz/#4037 - Enable Inputting Frame with Suffix in Camera Capture  by @shun-iwasawa
opentoonz/opentoonz/#4160 - File Path   Processing Using Regular Expression  by @shun-iwasawa***
opentoonz/opentoonz/#4164 - Improvements   to Audio Recording  by @justburner***
opentoonz/opentoonz/#4182 - Enable to   Cleanup Without Line Processing  by @shun-iwasawa
opentoonz/opentoonz/#4183 - Enable To   View Palette Files From the File Browser  by @shun-iwasawa
opentoonz/opentoonz/#4190 - Note level   column enhancement by @shun-iwasawa

### New Features
opentoonz/opentoonz/#4178 - Cell Mark   feature  by @shun-iwasawa***

** Modified slightly for Tahoma2D
*** Modified slightly for QT 5.9 because it used QT 5.11 or greater feature

