### PR TITLE
Fix Note Text cell issues

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2436,6 +2436,7 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
     QPoint xy;
     int markId;
     QRect nameRect;
+    bool isEndOfRange;
   };
 
   auto getCellInfo = [&](int r) {
@@ -2452,6 +2453,7 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
     QRect cellRect  = o->rect(PredefinedRect::CELL).translated(ret.xy);
     cellRect.adjust(0, 0, -frameAdj.x(), -frameAdj.y());
     TXshCell nextCell = xsh->getCell(r + 1, col);
+    ret.isEndOfRange  = nextCell.isEmpty();
     ret.rect          = cellRect.adjusted(
         1, 1,
         (!m_viewer->orientation()->isVerticalTimeline() && !nextCell.isEmpty()
@@ -2568,7 +2570,7 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
         drawCurrentTimeIndicator(p, info.xy);
 
       drawDragHandle(p, info.xy, sideColor);
-      drawEndOfDragHandle(p, info.row == rowTo, info.xy, tmpCellColor);
+      drawEndOfDragHandle(p, info.isEndOfRange, info.xy, tmpCellColor);
       drawLockedDottedLine(p, xsh->getColumn(col)->isLocked(), info.xy,
                            tmpCellColor);
     }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2455,15 +2455,19 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
     TXshCell nextCell = xsh->getCell(r + 1, col);
     ret.isEndOfRange  = nextCell.isEmpty();
     ret.rect          = cellRect.adjusted(
-        1, 1,
+        (!m_viewer->orientation()->isVerticalTimeline() && r == 0 ? 0 : 1), 1,
         (!m_viewer->orientation()->isVerticalTimeline() && !nextCell.isEmpty()
              ? 2
              : 0),
         0);
     ret.markId = xsh->getColumn(col)->getCellColumn()->getCellMark(r);
-    ret.nameRect = o->rect(PredefinedRect::CELL_NAME)
-                       .translated(ret.xy)
-                       .adjusted(0, 0, -frameAdj.x(), -frameAdj.y());
+    ret.nameRect =
+        o->rect(PredefinedRect::CELL_NAME)
+            .translated(ret.xy)
+            .adjusted(
+                (!m_viewer->orientation()->isVerticalTimeline() && r == 0 ? -1
+                                                                          : 0),
+                0, -frameAdj.x(), -frameAdj.y());
 
     return ret;
   };


### PR DESCRIPTION
The Xsheet cell resizing and Note Text changes ported from OT introduced some issues relating to how Note Text cells were drawn.  This mostly impacted the Timeline.

This PR fixes the following issues:
- Fixed text no longer displaying when zoomed out all the way in the timeline.
- Fixed text written too high in the timeline cell because it didn't account for drag bar
- Fixed the timeline indicator in Frame 1 being offset by 1 pixel
- Fixed the Note text cell height in the timeline being 1 pixel too tall
- Fixed the frame separator between cells changing colors as timeline/xsheet was zoomed in/out
  - Also fixed this for Sound column in the Xsheet
- Fixed the drag bar not being continuous when adjacent cells are populated.
- Fixed cell color gap in Frame 1	 
