### PR TITLE
Various bug fixes

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -111,12 +111,14 @@ void copyCellsWithoutUndo(int r0, int c0, int r1, int c1) {
 
 bool pasteCellsWithoutUndo(const TCellData *cellData, int &r0, int &c0, int &r1,
                            int &c1, bool insert = true,
-                           bool doZeraryClone = true) {
+                           bool doZeraryClone  = true,
+                           bool skipEmptyCells = true) {
   TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
   if (!cellData) return false;
   if (r0 < 0 || c0 < 0) return false;
 
-  bool ret = cellData->getCells(xsh, r0, c0, r1, c1, insert, doZeraryClone);
+  bool ret = cellData->getCells(xsh, r0, c0, r1, c1, insert, doZeraryClone,
+                                skipEmptyCells);
   if (!ret) return false;
 
   return true;
@@ -360,7 +362,7 @@ public:
     int r0, c0, r1, c1;
     m_selection->getSelectedCells(r0, c0, r1, c1);
 
-    pasteCellsWithoutUndo(m_data, r0, c0, r1, c1, true);
+    pasteCellsWithoutUndo(m_data, r0, c0, r1, c1, true, true, false);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   }
 

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -544,6 +544,9 @@ void EachUndo::undo() const {
 void TCellSelection::eachCells(int each) {
   if (isEmpty() || areAllColSelectedLocked()) return;
 
+  // Do nothing if they select less than Each #
+  if ((m_range.m_r1 - m_range.m_r0 + 1) < each) return;
+
   TUndo *undo = new EachUndo(m_range.m_r0, m_range.m_c0, m_range.m_r1,
                              m_range.m_c1, each);
   TUndoManager::manager()->add(undo);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1700,7 +1700,7 @@ void Filmstrip::updateCurrentLevelComboItem() {
   TXshSimpleLevel *currentLevel =
       TApp::instance()->getCurrentLevel()->getSimpleLevel();
   if (!currentLevel) {
-    int noLevelIndex = m_chooseLevelCombo->findText(tr("- No Current Level -"));
+    int noLevelIndex = m_chooseLevelCombo->findText(tr("- No Level -"));
     m_chooseLevelCombo->setCurrentIndex(noLevelIndex);
     return;
   }
@@ -1718,7 +1718,7 @@ void Filmstrip::updateCurrentLevelComboItem() {
     }
   }
 
-  int noLevelIndex = m_chooseLevelCombo->findText(tr("- No Current Level -"));
+  int noLevelIndex = m_chooseLevelCombo->findText(tr("- No Level -"));
   m_chooseLevelCombo->setCurrentIndex(noLevelIndex);
 }
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -329,8 +329,8 @@ bool beforeCellsInsert(TXsheet *xsh, int row, int &col, int rowCount,
   int type = (column && !column->isEmpty()) ? column->getColumnType()
                                             : newLevelColumnType;
   // If some used cells in range or column type mismatch must insert a column.
-  if (col < 0 || i < rowCount || newLevelColumnType != type) {
-    col += 1;
+  if (col < 0 || i < rowCount || newLevelColumnType != type || !column) {
+    if (column) col += 1;
     TApp::instance()->getCurrentColumn()->setColumnIndex(col);
     shiftColumn = true;
     xsh->insertColumn(col);

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -96,8 +96,11 @@ public:
     TXsheet *xsh      = scene->getXsheet();
     if (m_areColumnsShifted)
       xsh->removeColumn(m_columnIndex);
-    else if (m_frameCount > 0)
+    else if (m_frameCount > 0) {
+      // remove the cells and add back blank ones
       xsh->removeCells(m_rowIndex, m_columnIndex, m_frameCount);
+      xsh->insertCells(m_rowIndex, m_columnIndex, m_frameCount);
+    }
 
     TLevelSet *levelSet = scene->getLevelSet();
     if (levelSet) {

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1875,21 +1875,30 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
 
 //-----------------------------------------------------------------------------
 
-void CellArea::drawEndOfLevelMarker(QPainter &p, QRect rect, bool isStopFrame) {
+void CellArea::drawEndOfLevelMarker(QPainter &p, QRect rect, bool isNextEmpty,
+                                    bool isStopFrame) {
   const Orientation *o = m_viewer->orientation();
 
   QColor levelEndColor = m_viewer->getTextColor();
   QPoint topLeft       = rect.topLeft();
   QPoint topRight      = rect.topRight();
-  if (!o->isVerticalTimeline() && isStopFrame) {
-    QRect dragRect = o->rect(PredefinedRect::DRAG_AREA);
-    topLeft.setY(topLeft.y() + dragRect.height());
-    topRight.setY(topRight.y() + dragRect.height());
+  QPoint bottomLeft    = rect.bottomLeft();
+  QPoint bottomRight   = rect.bottomRight();
+  if (!o->isVerticalTimeline()) {
+    if (isStopFrame) {
+      QRect dragRect = o->rect(PredefinedRect::DRAG_AREA);
+      topLeft.setY(topLeft.y() + dragRect.height());
+      topRight.setY(topRight.y() + dragRect.height());
+    }
+    if (!isNextEmpty) {
+      topRight.setX(topRight.x() - 2);
+      bottomRight.setX(bottomRight.x() - 2);
+    }
   }
   levelEndColor.setAlphaF(0.3);
   p.setPen(levelEndColor);
-  p.drawLine(topLeft, rect.bottomRight());
-  p.drawLine(topRight, rect.bottomLeft());
+  p.drawLine(topLeft, bottomRight);
+  p.drawLine(topRight, bottomLeft);
 }
 
 //-----------------------------------------------------------------------------
@@ -2052,7 +2061,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
 
     // Implicit holds use Stop Frame Hold to denote end of level
     if (!Preferences::instance()->isImplicitHoldEnabled())
-      drawEndOfLevelMarker(p, rect);
+      drawEndOfLevelMarker(p, rect, nextCell.isEmpty() || isImplicitCellNext);
 
     drawFrameSeparator(p, row, col, false, heldFrame);
 
@@ -2112,7 +2121,9 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
                  nextCell.isEmpty() || isImplicitCellNext);
 
   // Implicit holds use Stop Frame Hold to denote end of level
-  if (isStopFrame) drawEndOfLevelMarker(p, rect, true);
+  if (isStopFrame)
+    drawEndOfLevelMarker(p, rect, nextCell.isEmpty() || isImplicitCellNext,
+                         true);
 
   drawFrameSeparator(p, row, col, false, heldFrame);
 
@@ -2332,7 +2343,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
     // cell mark
     drawCellMarker(p, markId, rect);
 
-    drawEndOfLevelMarker(p, rect);
+    drawEndOfLevelMarker(p, rect, nextCell.isEmpty());
 
     drawFrameSeparator(p, row, col, false, heldFrame);
 
@@ -2544,6 +2555,7 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
       prevCell       = xsh->getCell(row - 1, col);
       prevIsImplicit = xsh->isImplicitCell(row - 1, col);
     }
+    TXshCell nextCell = xsh->getCell(row + 1, col);
 
     // if the cell is empty
     if (cell.isEmpty()) {
@@ -2551,7 +2563,8 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
       // cell mark
       drawCellMarker(p, info.markId, info.rect);
       // draw X shape after the occupied cell
-      if (!prevCell.isEmpty()) drawEndOfLevelMarker(p, info.rect);
+      if (!prevCell.isEmpty())
+        drawEndOfLevelMarker(p, info.rect, nextCell.isEmpty());
       drawFrameSeparator(p, row, col, true);
       if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
           !m_viewer->orientation()->isVerticalTimeline() &&
@@ -2801,7 +2814,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
 
     // Implicit holds use Stop Frame Hold to denote end of level
     if (!Preferences::instance()->isImplicitHoldEnabled())
-      drawEndOfLevelMarker(p, rect);
+      drawEndOfLevelMarker(p, rect, nextCell.isEmpty() || isImplicitCellNext);
 
     drawFrameSeparator(p, row, col, false, heldFrame);
 
@@ -2841,7 +2854,9 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
                  nextCell.isEmpty() || isImplicitCellNext);
 
   // Implicit holds use Stop Frame Hold to denote end of level
-  if (isStopFrame) drawEndOfLevelMarker(p, rect, true);
+  if (isStopFrame)
+    drawEndOfLevelMarker(p, rect, nextCell.isEmpty() || isImplicitCellNext,
+                         true);
 
   drawFrameSeparator(p, row, col, false, heldFrame);
 

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -131,7 +131,8 @@ class CellArea final : public QWidget {
 
   void drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
                        bool isKeyFrame = false, bool isCamera = false);
-  void drawEndOfLevelMarker(QPainter &p, QRect rect, bool isStopFrame = false);
+  void drawEndOfLevelMarker(QPainter &p, QRect rect, bool isNextEmpty,
+                            bool isStopFrame = false);
   void drawCellMarker(QPainter &p, int markId, QRect rect,
                       bool hasFrame = false, bool isNextEmpty = true);
 

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -103,12 +103,12 @@ class CellArea final : public QWidget {
   void drawSelectionBackground(QPainter &p) const;
   void drawExtenderHandles(QPainter &p);
 
-  void drawDragHandle(QPainter &p, const QPoint &xy,
+  void drawDragHandle(QPainter &p, bool isStart, const QPoint &xy,
                       const QColor &sideColor) const;
   void drawEndOfDragHandle(QPainter &p, bool isEnd, const QPoint &xy,
                            const QColor &cellColor) const;
-  void drawLockedDottedLine(QPainter &p, bool isLocked, const QPoint &xy,
-                            const QColor &cellColor) const;
+  void drawLockedDottedLine(QPainter &p, bool isLocked, bool isStart,
+                            const QPoint &xy, const QColor &cellColor) const;
 
   void drawFrameSeparator(QPainter &p, int row, int col, bool emptyFrame,
                           bool heldFrame = false);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -654,7 +654,7 @@ void Preferences::definePreferenceItems() {
 
   // Others (not appeared in the popup)
   // Shortcut popup settings
-  define(shortcutPreset, "shortcutPreset", QMetaType::QString, "defopentoonz");
+  define(shortcutPreset, "shortcutPreset", QMetaType::QString, "deftahoma2d");
   // Viewer context menu
   define(guidedDrawingType, "guidedDrawingType", QMetaType::Int, 0);  // Off
   define(guidedAutoInbetween, "guidedAutoInbetween", QMetaType::Bool,


### PR DESCRIPTION
This PR will fix a few minor bugs I've run across.  The following have been fixed:

- Fixed default Shortcut Preference preset still pointing to `defopentoonz` when it should be `deftahoms2d`
- Fixed Level Strip selection box referencing `- No Current Level -` in some places when it should be `- No Level -`
- Fixed undoing `Cut` of selection of only empty cells. Cut would shifts cells up but when you `Undo`, it doesn't shift cells back down
- Fixed undoing a `New Level` creation in an empty frame in middle of existing level. `Undo` shifts cells up incorrectly instead of restoring prior empty cells
- Fixed undoing `Each 2/3/4` when you select frames less than the `Each #` (example: select 2 cells, but choose Each 3). Nothing happens, but if you `Undo` the action, it adds a new cell incorrectly.
- Fixed start of drag bars starting over frame
- Fixed undoing column loaded PSD file leaving empty columns behind when it should remove the added columns
- Fixed how the X for end of levels and stop frames were drawn incorrectly 