### PR TITLE
Add additional zoom levels to the zoom in/out commands.

### DIFF
--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -764,10 +764,10 @@ void convertOldLevel2Tlv(const TFilePath &source, const TFilePath &dest,
 
 //=============================================================================
 
-#define ZOOMLEVELS 13
+#define ZOOMLEVELS 19
 #define NOZOOMINDEX 6
 double ZoomFactors[ZOOMLEVELS] = {
-    0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64};
+    0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.375, 0.5, 0.625, 1, 1.5, 2, 2.5, 3, 3.5, 4, 8, 16, 32, 64};
 
 double getQuantizedZoomFactor(double zf, bool forward) {
   if (forward && (zf > ZoomFactors[ZOOMLEVELS - 1] ||

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -764,10 +764,10 @@ void convertOldLevel2Tlv(const TFilePath &source, const TFilePath &dest,
 
 //=============================================================================
 
-#define ZOOMLEVELS 19
+#define ZOOMLEVELS 17
 #define NOZOOMINDEX 6
 double ZoomFactors[ZOOMLEVELS] = {
-    0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.375, 0.5, 0.625, 1, 1.5, 2, 2.5, 3, 3.5, 4, 8, 16, 32, 64};
+    0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.375, 0.5, 0.625, 1, 1.5, 2, 2.5, 4, 8, 16, 32, 64};
 
 double getQuantizedZoomFactor(double zf, bool forward) {
   if (forward && (zf > ZoomFactors[ZOOMLEVELS - 1] ||


### PR DESCRIPTION
Adds some additional, uniform zoom levels around 100% for the `Zoom In` and `Zoom Out` commands.

Old zoom levels were: `0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64`.
New zoom levels are: `0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.375, 0.5, 0.625, 1, 1.5, 2, 2.5, 4, 8, 16, 32, 64`

![zoom](https://user-images.githubusercontent.com/42298081/148856827-9866771f-85de-4d6e-8af1-8258b522870a.gif)
.