### PR TITLE
Allow multiple key stroke shortcuts

### DIFF
--- a/toonz/sources/toonz/shortcutpopup.h
+++ b/toonz/sources/toonz/shortcutpopup.h
@@ -27,6 +27,8 @@ class ShortcutViewer final : public QKeySequenceEdit {
   Q_OBJECT
   QAction *m_action;
 
+  int m_keysPressed;
+
 public:
   ShortcutViewer(QWidget *parent);
   ~ShortcutViewer();
@@ -68,8 +70,6 @@ protected:
   // CommandType::MenubarCommandType
   void addFolder(const QString &title, int commandType,
                  QTreeWidgetItem *folder = 0);
-
-  void resizeEvent(QResizeEvent *event);
 
 public slots:
   void onCurrentItemChanged(QTreeWidgetItem *current,


### PR DESCRIPTION
This PR enhances shortcuts by allowing you to use up to 4 key strokes to trigger an action.

For example, you could set `Play` to `P,L,A,Y` if you wanted to.  Only when you hit those 4 keys in that order will the Play action be triggered.

With this change, keys like arrow keys, numbers, home, and others that are normally blocked for shortcuts are only blocked for the 1st key. These keys can now be used in 2nd-4th keys in a sequence.

Example:
	- `P,Right (arrow)` = `Play`
	- `S,Left (arrow)` = `Short Play`

**Limitation:**

The beginning part of the sequence (1st key, 1st 2 keys, 1st 3keys) cannot match another shortcut using the same number of keys since the actions with the fewer key strokes will take priority and trigger.

Examples of bad assignments:
- 1-key matches
  - `P` = `Play`
  - `P,L` = `Short Play` => would never be reached because 1st `P` would trigger Play
- 2-key matches
  - `P,L` = `Play`
  - `P,L,A` = `Short Play` => would never be reached because `P,L` would trigger Play
- 3-key matches
  - `P,L,A` = `Play`
  - `P,L,A,Y` = `Short Play` => would never be reached because `P,L,A` would trigger Play

A warning will be provided if you try to do this.
  
You could instead do:
- 2-key
  - `P` = Not a shortcut
  - `P,P` = `Play`
  - `P,S` = `Short Play`
- 3-key 
  - `P` = Not a shortcut
  - `P,L` = Not a shortcut
  - `P,L,A` = `Play`
  - `P,L,S` = `Short Play`
- 4-key
  - `P` = Not a shortcut
  - `P,L` = Not a shortcut
  - `P,L,A` = Not a shortcut
  - `P,L,A,Y` = `Play`
  - `P,L,A,S` = `Short Play`
