### PR TITLE
Change Level Editor background for Vector levels

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1151,7 +1151,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {previewBGColor, tr("Preview BG Color:")},
       {useThemeViewerColors,
        tr("Use the Curent Theme's Viewer Background Colors")},
-      {levelEditorBoxColor, tr("Level Editor Box Color:")},
+      {levelEditorBoxColor, tr("Level Editor Canvas Color:")},
       {chessboardColor1, tr("Chessboard Color 1:")},
       {chessboardColor2, tr("Chessboard Color 2:")},
       {transpCheckInkOnWhite, tr("Ink Color on White BG:")},

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1373,10 +1373,17 @@ void SceneViewer::drawBackground() {
       } else
         bgColor = Preferences::instance()->getPreviewBgColor();
     } else {
-      if (Preferences::instance()->getUseThemeViewerColors()) {
+      TXshLevelHandle *levelHandle = TApp::instance()->getCurrentLevel();
+      TXshSimpleLevel *sl = levelHandle ? levelHandle->getSimpleLevel() : 0;
+      bool isVectorLevel = sl ? sl->getType() == PLI_XSHLEVEL : false;
+      bool isEditingLevel = TApp::instance()->getCurrentFrame()->isEditingLevel();
+
+      if (Preferences::instance()->getUseThemeViewerColors() && (!isEditingLevel || !isVectorLevel)) {
         QColor qtBgColor = getBGColor();
         bgColor =
             TPixel32(qtBgColor.red(), qtBgColor.green(), qtBgColor.blue());
+      } else if (isVectorLevel && isEditingLevel) {
+        bgColor = Preferences::instance()->getLevelEditorBoxColor();
       } else
         bgColor = Preferences::instance()->getViewerBgColor();
     }


### PR DESCRIPTION
This PR (probably controversial) will change the background color for Vector Levels in the Level Editor to use the `Level Editor Canvas Color` setting (previously called `Level Editor Box Color`) which is  already used in the box/canvas when editing Raster and Smart Raster levels.

Why the change?

When in Level Editor, Raster and Smart raster levels show a fixed-sized box/canvas on top of the theme's background color. Vectors have an unlimited canvas and therefore do not show anything other than the theme's background color since there is no box drawn.

Currently the default background color uses the theme's color so for Dark and especially Darker themes it's hard to see your drawings if using a dark style, in many cases, black.  Workaround is to uncheck this theme which then uses the default `Viewer BG Color` value.

![image](https://user-images.githubusercontent.com/19245851/149368799-e5a1562a-1556-43b7-805a-cbe8192bc4d9.png)

This change...
- Mimics the workaround in that instead of unchecking the use of theme colors, it now uses the default `Level Editor Canvas Color` which happens to be the same color as the default `Viewer BG Color`.
- Syncs the "drawing canvas colors" between the 3 level types.