### PR TITLE
Implicit hold fixes

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1071,10 +1071,10 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
       // Test for Mesh-deformed levels
       const TStageObjectId &parentId = obj->getParent();
       if (parentId.isColumn() && obj->getParentHandle()[0] != 'H') {
-        TXshSimpleLevel *parentSl =
-            xsh->getCell(rowIndex, parentId.getIndex()).getSimpleLevel();
-        if (parentSl && parentSl->getType() == MESH_XSHLEVEL &&
-            m_name != T_Selection)
+        TXshCell parentCell       = xsh->getCell(rowIndex, parentId.getIndex());
+        TXshSimpleLevel *parentSl = parentCell.getSimpleLevel();
+        if (!parentCell.getFrameId().isStopFrame() && parentSl &&
+            parentSl->getType() == MESH_XSHLEVEL && m_name != T_Selection)
           return (
               enable(false),
               QObject::tr(

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -1381,7 +1381,7 @@ void OutputSettingsPopup::onFrameFldEditFinished() {
     error = true;
     r1    = r0;
   }
-  if (r1 > maxR0) {
+  if (r1 > maxR0 && !Preferences::instance()->isImplicitHoldEnabled()) {
     error = true;
     r1    = maxR0;
   }

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -210,7 +210,9 @@ bool RenderCommand::init(bool isPreview) {
     m_r1 = scene->getFrameCount() - 1;
   }
   if (m_r0 < 0) m_r0                       = 0;
-  if (m_r1 >= scene->getFrameCount()) m_r1 = scene->getFrameCount() - 1;
+  if (m_r1 >= scene->getFrameCount() &&
+      !Preferences::instance()->isImplicitHoldEnabled())
+    m_r1 = scene->getFrameCount() - 1;
   // nothing to render
   if (m_r1 < m_r0) {
     DVGui::warning(QObject::tr(

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2894,7 +2894,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
       p.drawLine(continueLine);
       p.setPen(oldPen);
     }
-  } else {
+  } else if(!isStopFrame) {
     if (isSimpleView) {
       if (!o->isVerticalTimeline()) {
         // Lets not draw normal marker if there is a keyframe here

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2074,6 +2074,8 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     return;
   }
 
+  int cellColorAlpha;
+
   if (isReference) {
     cellColor = (isSelected) ? m_viewer->getSelectedReferenceColumnColor()
                              : m_viewer->getReferenceColumnColor();
@@ -2083,7 +2085,10 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     m_viewer->getCellTypeAndColors(levelType, cellColor, sideColor, cell,
                                    isSelected);
     if (isImplicitCell) cellColor.setAlpha(m_viewer->getImplicitCellAlpha());
-    if (isStopFrame) cellColor.setAlpha(0);
+    if (isStopFrame) {
+      cellColorAlpha = cellColor.alpha();
+      cellColor.setAlpha(0);
+    }
   }
 
   // check if the level is scanned but not cleanupped
@@ -2103,6 +2108,8 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     p.fillRect(rect.adjusted(0, 0, 0, 1), QBrush(cellColor));
   else
     p.fillRect(rect, QBrush(cellColor));
+
+  if (isStopFrame) cellColor.setAlpha(cellColorAlpha);
 
   if (yetToCleanupCell && !isImplicitCell)  // ORIENTATION: what's this?
   {
@@ -2137,7 +2144,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     bool isStart = row > 0 && (prevCell.isEmpty() || prevIsImplicit);
     drawDragHandle(p, isStart, xy, sideColor);
 
-    bool isLastRow = nextCell.isEmpty() ||
+    bool isLastRow = nextCell.isEmpty() || isImplicitCellNext ||
                      cell.m_level.getPointer() != nextCell.m_level.getPointer();
     drawEndOfDragHandle(p, isLastRow, xy, cellColor);
 
@@ -2828,6 +2835,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
   }
 
   QColor cellColor, sideColor;
+  int cellColorAlpha;
   if (isReference) {
     cellColor = (isSelected) ? m_viewer->getSelectedReferenceColumnColor()
                              : m_viewer->getReferenceColumnColor();
@@ -2837,7 +2845,10 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
                              : m_viewer->getPaletteColumnColor();
     sideColor = m_viewer->getPaletteColumnBorderColor();
     if (isImplicitCell) cellColor.setAlpha(m_viewer->getImplicitCellAlpha());
-    if (isStopFrame) cellColor.setAlpha(0);
+    if (isStopFrame) {
+      cellColorAlpha = cellColor.alpha();
+      cellColor.setAlpha(0);
+    }
   }
 
   // paint cell
@@ -2848,6 +2859,8 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
     p.fillRect(rect.adjusted(0, 0, 0, 1), QBrush(cellColor));
   else
     p.fillRect(rect, QBrush(cellColor));
+
+  if (isStopFrame) cellColor.setAlpha(cellColorAlpha);
 
   // cell mark
   drawCellMarker(p, markId, rect, !isImplicitCell,
@@ -2869,7 +2882,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
   if (!isImplicitCell) {
     bool isStart = row > 0 && (prevCell.isEmpty() || prevIsImplicit);
     drawDragHandle(p, isStart, xy, sideColor);
-    bool isLastRow = nextCell.isEmpty() ||
+    bool isLastRow = nextCell.isEmpty() || isImplicitCellNext ||
                      cell.m_level.getPointer() != nextCell.m_level.getPointer();
     drawEndOfDragHandle(p, isLastRow, xy, cellColor);
     drawLockedDottedLine(p, xsh->getColumn(col)->isLocked(), isStart, xy,
@@ -2894,7 +2907,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
       p.drawLine(continueLine);
       p.setPen(oldPen);
     }
-  } else if(!isStopFrame) {
+  } else if (!isStopFrame) {
     if (isSimpleView) {
       if (!o->isVerticalTimeline()) {
         // Lets not draw normal marker if there is a keyframe here

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -449,8 +449,12 @@ void GlobalKeyframeUndo::doInsertGlobalKeyframes(
       objectId = TStageObjectId::ColumnId(c);
 
     TXshColumn *xshColumn = xsh->getColumn(c);
+    TXshCell cell;
+    if (xshColumn) cell = xsh->getCell(frame, c);
     if (!xshColumn || xshColumn->isLocked() ||
-        (xshColumn->isCellEmpty(frame) && !objectId.isCamera()))
+        (cell.isEmpty() && !xsh->isImplicitCell(frame, c) &&
+         !objectId.isCamera()) ||
+        cell.getFrameId().isStopFrame())
       continue;
 
     TStageObject *obj = xsh->getStageObject(objectId);

--- a/toonz/sources/toonzlib/plasticdeformerfx.cpp
+++ b/toonz/sources/toonzlib/plasticdeformerfx.cpp
@@ -10,6 +10,7 @@
 #include "toonz/txshlevelcolumn.h"
 #include "toonz/dpiscale.h"
 #include "toonz/stage.h"
+#include "toonz/preferences.h"
 
 // TnzExt includes
 #include "ext/plasticskeleton.h"
@@ -194,7 +195,16 @@ bool PlasticDeformerFx::buildTextureDataSl(double frame, TRenderSettings &info,
   TLevelColumnFx *lcfx       = (TLevelColumnFx *)m_port.getFx();
   TXshLevelColumn *texColumn = lcfx->getColumn();
 
-  const TXshCell &texCell = texColumn->getCell(row);
+  TXshCell texCell = texColumn->getCell(row);
+  if (texCell.isEmpty() && Preferences::instance()->isImplicitHoldEnabled()) {
+    int r0, r1;
+    texColumn->getRange(r0, r1);
+    for (int r = std::min(r1, (int)frame); r >= r0; r--) {
+      texCell = texColumn->getCell(r);
+      if (texCell.isEmpty()) continue;
+      break;
+    }
+  }
 
   TXshSimpleLevel *texSl = texCell.getSimpleLevel();
   const TFrameId &texFid = texCell.getFrameId();

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -677,6 +677,9 @@ bool FxBuilder::addPlasticDeformerFx(PlacedFx &pf) {
         m_xsh->getStageObject(parentId)->getPlasticSkeletonDeformation();
 
     const TXshCell &parentCell = m_xsh->getCell(m_frame, parentId.getIndex());
+
+    if (parentCell.getFrameId().isStopFrame()) return false;
+
     TXshSimpleLevel *parentSl  = parentCell.getSimpleLevel();
 
     if (sd && parentSl && (parentSl->getType() == MESH_XSHLEVEL)) {
@@ -871,7 +874,8 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
   pf.m_fx = lcfx;
 
   /*-- subXsheetのとき、その中身もBuildFxを実行 --*/
-  if (!cell.isEmpty() && cell.m_level->getChildLevel()) {
+  if (!cell.isEmpty() && !cell.getFrameId().isStopFrame() &&
+      cell.m_level->getChildLevel()) {
     // Treat the sub-xsheet case - build the sub-render-tree and reassign stuff
     // to pf
     TXsheet *xsh = cell.m_level->getChildLevel()->getXsheet();
@@ -893,7 +897,9 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
 
   if (columnVisible) {
     // Column is visible, alright
-    TXshSimpleLevel *sl = cell.isEmpty() ? 0 : cell.m_level->getSimpleLevel();
+    TXshSimpleLevel *sl = cell.isEmpty() || cell.getFrameId().isStopFrame()
+                              ? 0
+                              : cell.m_level->getSimpleLevel();
     if (sl) {
       // If the level should sustain a Plastic deformation, add the
       // corresponding fx

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -1355,6 +1355,9 @@ TStageObject *plasticDeformedObj(const Stage::Player &player,
 
         const TXshCell &parentCell =
             player.m_xsh->getCell(player.m_frame, parentId.getIndex());
+
+        if (parentCell.getFrameId().isStopFrame()) return 0;
+
         TXshSimpleLevel *parentSl = parentCell.getSimpleLevel();
 
         if (sd && locals::isDeformableMeshLevel(parentSl)) return playerObj;

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -281,8 +281,8 @@ bool TXsheet::isImplicitCell(const CellPosition &pos) const {
   xshColumn->getRange(r0, r1);
   for (int r = std::min(r1, pos.frame()); r >= r0; r--) {
     tempCell = xshColumn->getCell(r);
-    if (!tempCell.isEmpty()) return true;
     if (tempCell.getFrameId().isStopFrame()) return false;
+    if (!tempCell.isEmpty()) return true;
   }
   return false;
 }

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -23,6 +23,8 @@ TFrameId qstringToFrameId(QString str) {
     return TFrameId::EMPTY_FRAME;
   else if (str == "-" || str == "-2")
     return TFrameId::NO_FRAME;
+  else if (str == "x" || str == "-3")
+    return TFrameId::STOP_FRAME;
 
   QString regExpStr = QString("^%1$").arg(TFilePath::fidRegExpStr());
   QRegExp rx(regExpStr);


### PR DESCRIPTION
This PR fixes the following issues related to Implicit Holds:

- Implicit frames that are mesh deformed do not render/preview
- Mesh Level stop frames prevent rendering/preview of deformed level's frame
- Mesh Level stop frames load in as missing frames instead of stop frames
- Cannot drawing on deformed frame where the Mesh Level stop frame is
- Insert Multiple Keys does not work on Implicit Cells and incorrectly works on stop frames
- Palette Level name shows in Stop Frame when not in Implicit mode
- End frame in Preview and Output settings cannot be set beyond last actual frame when in Implicit mode
- Cannot Render beyond last actual frame when in Implicit mode
