### PR TITLE
Convert scene to/from using Implicit Holds

### DIFF
--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -588,6 +588,9 @@ in TXsheetImp.
   void notifyStageObjectAdded(const TStageObjectId id);
   bool isReferenceManagementIgnored(TDoubleParam *);
 
+  void convertToImplicitHolds();
+  void convertToExplicitHolds();
+
 protected:
   bool checkCircularReferences(TXsheet *childCandidate);
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2021,6 +2021,10 @@ void MainWindow::defineActions() {
   createMenuXsheetAction(MI_RemoveEmptyColumns,
                          QT_TR_NOOP("Remove Empty Columns"), "",
                          "remove_empty_columns");
+  createMenuXsheetAction(MI_ConvertToImplicitHolds,
+                         QT_TR_NOOP("Convert to use Implicit Holds"), "", "");
+  createMenuXsheetAction(MI_ConvertToExplicitHolds,
+                         QT_TR_NOOP("Convert to use Explicit Holds"), "", "");
   createMenuXsheetAction(MI_LipSyncPopup,
                          QT_TR_NOOP("&Apply Lip Sync to Column"), "Alt+L",
                          "dialogue");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -433,6 +433,9 @@ void TopBar::loadMenubar() {
   addMenuItem(sceneMenu, MI_LipSyncPopup);
   sceneMenu->addSeparator();
   addMenuItem(sceneMenu, MI_RemoveEmptyColumns);
+  sceneMenu->addSeparator();
+  addMenuItem(sceneMenu, MI_ConvertToImplicitHolds);
+  addMenuItem(sceneMenu, MI_ConvertToExplicitHolds);
 
   // Menu' LEVEL
   QMenu *levelMenu = addMenu(ShortcutTree::tr("Level"), m_menuBar);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -44,6 +44,8 @@
 #define MI_ImportMagpieFile "MI_ImportMagpieFile"
 #define MI_NewNoteLevel "MI_NewNoteLevel"
 #define MI_RemoveEmptyColumns "MI_RemoveEmptyColumns"
+#define MI_ConvertToImplicitHolds "MI_ConvertToImplicitHolds"
+#define MI_ConvertToExplicitHolds "MI_ConvertToExplicitHolds"
 #define MI_NewProject "MI_NewProject"
 #define MI_OpenRecentProject "MI_OpenRecentProject"
 #define MI_LoadProject "MI_LoadProject"


### PR DESCRIPTION
This PR adds 2 new `Scene` menu commands to convert the current scene to use Implicit or Explicit Holds. 

![image](https://user-images.githubusercontent.com/19245851/149943658-cd606f6d-fd9a-4193-ada5-6cb685556d9c.png)

- There is no Undo action for this.  To revert the change, you much use `Revert Scene` to restore scene from the last save.
- After conversion, the Implicit Hold setting will be toggled on or off depending on which hold type was chosen.
- When converting to Explicit Holds, if a column does not have a final Stop Frame (implicit frames are held forever) the explicit hold will end at the last populated scene frame.