### PR TITLE
Fix column switching when clicking on column drag bar

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2341,6 +2341,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
                                                          // becomes dragbar
            && (o->rect(PredefinedRect::LAYER_NUMBER).contains(mouseInCell) ||
                o->rect(PredefinedRect::LAYER_NAME).contains(mouseInCell)))) {
+        m_viewer->setCurrentColumn(m_col);
         setDragTool(XsheetGUI::DragTool::makeColumnMoveTool(m_viewer));
       } else if (o->rect(PredefinedRect::LOCK_AREA).contains(mouseInCell)) {
         // lock button


### PR DESCRIPTION
This PR fixes an issue introduced with #758 where clicking on an unselected column's drag bar doesn't select the column automatically and causes the cells not to move with the column until after the column is released.

