### PR TITLE
Fix Scene Cast Level drag/drop indicator

### DIFF
--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -2056,14 +2056,21 @@ class DataDragTool final : public XsheetGUI::DragTool {
 
 protected:
   bool canChange(int row, int col) {
-    int c        = col;
-    int r        = row;
-    TXsheet *xsh = getViewer()->getXsheet();
-    TRect rect   = m_data->getLevelFrameRect(
-        getViewer()->orientation()->isVerticalTimeline());
-    for (c = col; c < rect.getLx() + col; c++) {
-      for (r = row; r < rect.getLy() + row; r++)
+    int c           = col;
+    int r           = row;
+    TXsheet *xsh    = getViewer()->getXsheet();
+    bool isVeritcal = getViewer()->orientation()->isVerticalTimeline();
+    TRect rect      = m_data->getLevelFrameRect(isVeritcal);
+    int rectCols    = isVeritcal ? rect.getLx() : rect.getLy();
+    int rectRows    = isVeritcal ? rect.getLy() : rect.getLx();
+    for (c = col; c < rectCols + col; c++) {
+      for (r = row; r < rectRows + row; r++) {
+        if (xsh->getColumn(c) &&
+            xsh->getColumn(c)->getColumnType() !=
+                TXshColumn::ColumnType::eLevelType)
+          return false;
         if (!xsh->getCell(r, c, false).isEmpty()) return false;
+      }
     }
     return true;
   }


### PR DESCRIPTION
This PR corrects the drag/drop indicator on the timeline incorrectly showing a Scene Cast level can be dropped (blue) in cells that are exposed.  Also corrects the indicator when attempting to drop over non-level columns (mesh, sound, note text, palette, zerary). In both cases, the indicator should show red.