### PR TITLE
Fix missing Motion Path data causing crash

### DIFF
--- a/toonz/sources/toonzlib/tstageobjectspline.cpp
+++ b/toonz/sources/toonzlib/tstageobjectspline.cpp
@@ -211,7 +211,6 @@ void TStageObjectSpline::setStroke(TStroke *stroke) {
 
 void TStageObjectSpline::loadData(TIStream &is) {
   std::vector<TThickPoint> points;
-  m_interpolationStroke.clear();
   VersionNumber tnzVersion = is.getVersion();
 
     std::string tagName;
@@ -245,6 +244,7 @@ void TStageObjectSpline::loadData(TIStream &is) {
           points.push_back(p);
         }
       } else if (tagName == "interpolationStroke") {
+        m_interpolationStroke.clear();
         int i, n = 0;
         is >> n;
         for (i = 0; i < n; i++) {


### PR DESCRIPTION
This PR fixes a crash that is caused when trying to select a Motion Path node in the Schematic or in the Motion Path panel.

This happens when loading scene files from older versions of T2D or from OT where new T2D Motion path data is missing.  The default `interpolationStroke` data was being erased on load regardless if the scene file contained interpolation data or not.  The lack of interpolation data would cause a crash when trying to display it in the graph.

Fixed it by only clearing interpolation data if it detects data in the scene file, otherwise the default is kept.