### PR TITLE
Fix memo style editor color change crash

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1687,8 +1687,7 @@ void XsheetViewer::resetXsheetNotes() {
 void XsheetViewer::updateNoteWidgets() {
   int i;
   for (i = 0; i < m_noteWidgets.size(); i++) m_noteWidgets.at(i)->update();
-  m_noteArea->updatePopup();
-  m_layerFooterPanel->m_noteArea->updatePopup();
+  if (XsheetGUI::NotePopupWidget) XsheetGUI::NotePopupWidget->update();
   updateCells();
 }
 

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -166,6 +166,10 @@ NotePopup::NotePopup(XsheetViewer *viewer, int noteIndex)
 
 //-----------------------------------------------------------------------------
 
+void NotePopup::setCurrentViewer(XsheetViewer *viewer) { m_viewer = viewer; }
+
+//-----------------------------------------------------------------------------
+
 void NotePopup::setCurrentNoteIndex(int index) { m_noteIndex = index; }
 
 //-----------------------------------------------------------------------------
@@ -426,14 +430,17 @@ void NoteWidget::paint(QPainter *painter, QPoint pos, bool isCurrent) {
 //-----------------------------------------------------------------------------
 
 void NoteWidget::openNotePopup() {
-  if (!m_noteEditor) {
-    m_noteEditor.reset(new XsheetGUI::NotePopup(m_viewer, m_noteIndex));
+  if (!NotePopupWidget)
+    NotePopupWidget = new XsheetGUI::NotePopup(m_viewer, m_noteIndex);
+  else {
+    NotePopupWidget->setCurrentViewer(m_viewer);
+    NotePopupWidget->setCurrentNoteIndex(m_noteIndex);
   }
 
-  if (m_noteEditor->isVisible()) {
-    m_noteEditor->activateWindow();
+  if (NotePopupWidget->isVisible()) {
+    NotePopupWidget->activateWindow();
   } else {
-    m_noteEditor->show();
+    NotePopupWidget->show();
   }
 }
 
@@ -689,13 +696,17 @@ void NoteArea::onXsheetOrientationChanged(const Orientation *newOrientation) {
 //-----------------------------------------------------------------------------
 
 void NoteArea::toggleNewNote() {
-  if (!m_newNotePopup)
-    m_newNotePopup.reset(new XsheetGUI::NotePopup(m_viewer, -1));
+  if (!NotePopupWidget)
+    NotePopupWidget = new XsheetGUI::NotePopup(m_viewer, -1);
+  else {
+    NotePopupWidget->setCurrentViewer(m_viewer);
+    NotePopupWidget->setCurrentNoteIndex(-1);
+  }
 
-  if (m_newNotePopup->isVisible()) {
-    m_newNotePopup->activateWindow();
+  if (NotePopupWidget->isVisible()) {
+    NotePopupWidget->activateWindow();
   } else {
-    m_newNotePopup->show();
+    NotePopupWidget->show();
   }
 }
 
@@ -872,13 +883,17 @@ void FooterNoteArea::onXsheetOrientationChanged(
 //-----------------------------------------------------------------------------
 
 void FooterNoteArea::toggleNewNote() {
-  if (!m_newNotePopup)
-    m_newNotePopup.reset(new XsheetGUI::NotePopup(m_viewer, -1));
+  if (!NotePopupWidget)
+    NotePopupWidget = new XsheetGUI::NotePopup(m_viewer, -1);
+  else {
+    NotePopupWidget->setCurrentViewer(m_viewer);
+    NotePopupWidget->setCurrentNoteIndex(-1);
+  }
 
-  if (m_newNotePopup->isVisible()) {
-    m_newNotePopup->activateWindow();
+  if (NotePopupWidget->isVisible()) {
+    NotePopupWidget->activateWindow();
   } else {
-    m_newNotePopup->show();
+    NotePopupWidget->show();
   }
 }
 

--- a/toonz/sources/toonz/xshnoteviewer.h
+++ b/toonz/sources/toonz/xshnoteviewer.h
@@ -48,6 +48,7 @@ public:
   NotePopup(XsheetViewer *viewer, int noteIndex);
   ~NotePopup() {}
 
+  void setCurrentViewer(XsheetViewer *viewer);
   void setCurrentNoteIndex(int index);
 
   void update();
@@ -82,6 +83,8 @@ protected slots:
   void onXsheetSwitched();
 };
 
+static NotePopup *NotePopupWidget;
+
 //=============================================================================
 // NoteWidget
 //-----------------------------------------------------------------------------
@@ -90,7 +93,6 @@ class NoteWidget final : public QWidget {
   Q_OBJECT
   XsheetViewer *m_viewer;
   int m_noteIndex;
-  std::unique_ptr<NotePopup> m_noteEditor;
   bool m_isHovered;
 
 public:
@@ -99,7 +101,7 @@ public:
   int getNoteIndex() const { return m_noteIndex; }
   void setNoteIndex(int index) {
     m_noteIndex = index;
-    if (m_noteEditor) m_noteEditor->setCurrentNoteIndex(index);
+    if (NotePopupWidget) NotePopupWidget->setCurrentNoteIndex(index);
   }
 
   void paint(QPainter *painter, QPoint pos = QPoint(), bool isCurrent = false);
@@ -117,7 +119,6 @@ protected:
 class NoteArea final : public QFrame {
   Q_OBJECT
 
-  std::unique_ptr<NotePopup> m_newNotePopup;  // Popup used to create new note
   XsheetViewer *m_viewer;
 
   // QPushButton *m_flipOrientationButton;
@@ -142,7 +143,6 @@ public:
   NoteArea(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
 #endif
 
-  void updatePopup() { m_newNotePopup->update(); }
   void updateButtons();
 
 protected slots:
@@ -168,7 +168,6 @@ protected:
 class FooterNoteArea final : public QFrame {
   Q_OBJECT
 
-  std::unique_ptr<NotePopup> m_newNotePopup;  // Popup used to create new note
   XsheetViewer *m_viewer;
 
   QToolButton *m_noteButton;
@@ -183,7 +182,6 @@ public:
   FooterNoteArea(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
 #endif
 
-  void updatePopup() { m_newNotePopup->update(); }
   void updateButtons();
 
 protected slots:


### PR DESCRIPTION
This PR fixes #871.

The Timeline and Xsheet had separate Memo popup widgets that only got initialized in the timeline or the xsheet it was created in. The crash would occur when changing style color via Style Editor when it tried to update both popups without checking if it was created.  Side note: even if both were created and didn't crash, the popup color list were not in sync.

Modified to use a common Memo popup to prevent this crash and also to fix any out-of-sync issues caused my multiple popups.