### PR TITLE
Add polyline point handle Shift/Alt modifiers

### DIFF
--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -254,7 +254,11 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
            spacer +
            tr("%1%2Snap to Angle")
                .arg(trModKey("Shift"))
-               .arg(cmd2TextSeparator)});
+               .arg(cmd2TextSeparator) +
+           spacer +
+           tr("%1%2Change Curve Handle Angle")
+               .arg(trModKey("Alt"))
+               .arg(cmd2TextSeparator) });
   lMap.insert({"T_GeometricVector",
                tr("Geometry Tool: Draws geometric shapes") + spacer +
                    tr("%1%2Allow or Disallow Snapping")


### PR DESCRIPTION
This PR adds the following keyboard modifiers to adjust the cusp point handles of Polyline.

- `Shift` - Snap to angles
- `Alt` - Change angle of handle

![polyline_controls](https://user-images.githubusercontent.com/19245851/150991235-e27a69cd-0aa6-4c94-b5f0-d3ca9d2d137d.gif)
