### PR TITLE
Autorenumber column

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -433,6 +433,9 @@ class RenumberUndo::RedoNotifier final : public TUndo {
   }
 
   int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override { return QObject::tr("Autorenumber"); }
+  int getHistoryType() override { return HistoryType::Xsheet; }
 };
 
 class RenumberUndo::UndoNotifier final : public TUndo {
@@ -443,6 +446,9 @@ class RenumberUndo::UndoNotifier final : public TUndo {
   }
 
   int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override { return QObject::tr("Autorenumber"); }
+  int getHistoryType() override { return HistoryType::Xsheet; }
 };
 
 //=============================================================================

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -802,6 +802,31 @@ void TColumnSelection::reframeWithEmptyInbetweens() {
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
 }
 
+//=============================================================================
+
+void TColumnSelection::renumberColumns() {
+  if (isEmpty()) return;
+
+  int rowCount =
+    TApp::instance()->getCurrentXsheet()->getXsheet()->getFrameCount();
+  std::vector<int> colIndeces;
+  std::set<int>::const_iterator it;
+
+  TUndoManager *undoManager = TUndoManager::manager();
+  undoManager->beginBlock();
+
+  for (it = m_indices.begin(); it != m_indices.end(); it++) {
+    TCellSelection selection;
+    selection.selectCells(0, *it, rowCount, *it);
+    selection.dRenumberCells();
+  }
+
+  undoManager->endBlock();
+
+  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+}
+
 //*********************************************************************************
 //    Reset Step Cells  command
 //*********************************************************************************

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -94,6 +94,7 @@ void TColumnSelection::enableCommands() {
   enableCommand(this, MI_Reframe4, &TColumnSelection::reframe4Cells);
   enableCommand(this, MI_ReframeWithEmptyInbetweens,
                 &TColumnSelection::reframeWithEmptyInbetweens);
+  enableCommand(this, MI_Autorenumber, &TColumnSelection::renumberColumns);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/columnselection.h
+++ b/toonz/sources/toonz/columnselection.h
@@ -53,6 +53,8 @@ public:
   void reframe4Cells() { reframeCells(4); }
 
   void reframeWithEmptyInbetweens();
+
+  void renumberColumns();
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2918,6 +2918,7 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       }
       menu.addMenu(reframeSubMenu);
       menu.addAction(cmdManager->getAction(MI_AutoInputCellNumber));
+      menu.addAction(cmdManager->getAction(MI_Autorenumber));
     }
 
     if (containsRasterLevel(m_viewer->getColumnSelection())) {


### PR DESCRIPTION
This PR adds the ability to use `Autorenumber` on entire columns by selecting 1 or more columns and either right-clicking the selection and choosing `Autorenumber` from the context menu or using autorenumber shortcut if user defined one.

Also sets History action to "Autorenumber" instead of "Undefined"