### PR TITLE
Current Cell Indicator color preference

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -410,6 +410,9 @@ public:
   void getCurrentColumnData(TPixel &color) const {
     color = getColorValue(currentColumnColor);
   }
+  void getCurrentCellData(TPixel &color) const {
+    color = getColorValue(currentCellColor);
+  }
 
   LevelNameDisplayType getLevelNameDisplayType() const {
     return LevelNameDisplayType(getIntValue(levelNameDisplayType));

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -133,6 +133,7 @@ enum PreferencesItemId {
   syncLevelRenumberWithXsheet,
   currentTimelineEnabled,
   currentColumnColor,
+  currentCellColor,
   levelNameDisplayType,
   showFrameNumberWithLetters,
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1211,6 +1211,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {currentTimelineEnabled,
        tr("Show Current Time Indicator (Timeline Mode only)")},
       {currentColumnColor, tr("Current Column Color:")},
+      {currentCellColor, tr("Current Cell Color:")},
       //{ levelNameOnEachMarkerEnabled, tr("Display Level Name on Each Marker")
       //},
       {levelNameDisplayType, tr("Level Name Display:")},
@@ -1892,6 +1893,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   // insertUI(syncLevelRenumberWithXsheet, lay);
   // insertUI(currentTimelineEnabled, lay);
   insertUI(currentColumnColor, lay);
+  insertUI(currentCellColor, lay);
   // insertUI(showFrameNumberWithLetters, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1950,6 +1950,15 @@ QColor XsheetViewer::getSelectedColumnTextColor() const {
   return currentColumnColor;
 }
 
+QColor XsheetViewer::getCellFocusColor() const {
+  // get colors
+  TPixel currentCellPixel;
+  Preferences::instance()->getCurrentCellData(currentCellPixel);
+  QColor currentCellColor((int)currentCellPixel.r, (int)currentCellPixel.g,
+                          (int)currentCellPixel.b, 255);
+  return currentCellColor;
+}
+
 //-----------------------------------------------------------------------------
 
 bool XsheetViewer::event(QEvent *e) {

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -255,9 +255,9 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
                  setSelectedEmptyCellColor)
 
   // Cell focus
-  QColor m_cellFocusColor;
-  Q_PROPERTY(
-      QColor CellFocusColor READ getCellFocusColor WRITE setCellFocusColor)
+  //  QColor m_cellFocusColor;
+  //  Q_PROPERTY(
+  //      QColor CellFocusColor READ getCellFocusColor WRITE setCellFocusColor)
 
   // Play range
   QColor m_playRangeColor;
@@ -828,8 +828,8 @@ public:
   QColor getSelectedEmptyCellColor() const { return m_selectedEmptyCellColor; }
 
   // Cell focus
-  void setCellFocusColor(const QColor &color) { m_cellFocusColor = color; }
-  QColor getCellFocusColor() const { return m_cellFocusColor; }
+  //  void setCellFocusColor(const QColor &color) { m_cellFocusColor = color; }
+  QColor getCellFocusColor() const;  // { return m_cellFocusColor; }
 
   // Play range
   QColor getPlayRangeColor() const { return m_playRangeColor; }

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -582,6 +582,8 @@ void Preferences::definePreferenceItems() {
          true);
   define(currentColumnColor, "currentColumnColor", QMetaType::QColor,
          QColor(Qt::yellow));
+  define(currentCellColor, "currentCellColor", QMetaType::QColor,
+         QColor(Qt::black));
   // define(levelNameOnEachMarkerEnabled, "levelNameOnEachMarkerEnabled",
   //  QMetaType::Bool, false);
   define(levelNameDisplayType, "levelNameDisplayType", QMetaType::Int,


### PR DESCRIPTION
This PR moves the current cell indicator color setting out of the stylesheets and into `Preferences` -> `Scene` - `Current Cell Color` so users can change it to a color they prefer since the current color, black, is hard to see on darker backgrounds.  I've left the default color as black, for now.