### PR TITLE
Fix viewer/flipbook background buttons not working

### DIFF
--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -1665,6 +1665,7 @@ else*/
 void FlipBook::onDrawFrame(int frame, const ImagePainter::VisualSettings &vs,
                            QElapsedTimer *timer, qint64 targetInstant) {
   try {
+    m_imageViewer->setVisual(vs);
     m_imageViewer->setTimerAndTargetInstant(timer, targetInstant);
 
     TImageP img = getCurrentImage(frame);

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -278,6 +278,7 @@ void SceneViewerPanel::onDrawFrame(int frame,
                                    const ImagePainter::VisualSettings &settings,
                                    QElapsedTimer *timer, qint64 targetInstant) {
   TApp *app = TApp::instance();
+  m_sceneViewer->setVisual(settings);
   m_sceneViewer->setTimerAndTargetInstant(timer, targetInstant);
 
   TFrameHandle *frameHandle = app->getCurrentFrame();


### PR DESCRIPTION
Due to an improper application of the Enhanced Flipbook playback OT patch applied in PR #874 some lines were replaced (either manually or via automatic merge) that caused the viewer and flipbook background buttons to not update the view properly when changed.

This PR restores the missing lines and corrects the issue in Viewer and Flipbook. Combo Viewer was not impacted by this.