### PR TITLE
Fix GIF rendering on older versions

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_gif.h
+++ b/toonz/sources/image/ffmpeg/tiio_gif.h
@@ -38,6 +38,7 @@ private:
   // double m_fps;
   int m_scale;
   bool m_looping  = true;
+  bool m_palette  = false;
   int m_mode      = 0;
   int m_maxcolors = 256;
 };
@@ -82,6 +83,7 @@ class GifWriterProperties : public TPropertyGroup {
 public:
   TIntProperty m_scale;
   TBoolProperty m_looping;
+  TBoolProperty m_palette;
   TEnumProperty m_mode;
   TIntProperty m_maxcolors;
 

--- a/toonz/sources/toonz/formatsettingspopups.cpp
+++ b/toonz/sources/toonz/formatsettingspopups.cpp
@@ -65,9 +65,11 @@ FormatSettingsPopup::FormatSettingsPopup(QWidget *parent,
       buildValueField(i, m_props);
     else if (dynamic_cast<TDoubleProperty *>(m_props->getProperty(i)))
       buildDoubleField(i, m_props);
-    else if (dynamic_cast<TBoolProperty *>(m_props->getProperty(i)))
-      buildPropertyCheckBox(i, m_props);
-    else if (dynamic_cast<TStringProperty *>(m_props->getProperty(i)))
+    else if (dynamic_cast<TBoolProperty *>(m_props->getProperty(i))) {
+      if (m_props->getProperty(i)->getName() !=
+          "Generate Palette")  // Hide. Not using but still needed here
+        buildPropertyCheckBox(i, m_props);
+    } else if (dynamic_cast<TStringProperty *>(m_props->getProperty(i)))
       buildPropertyLineEdit(i, m_props);
     else
       assert(false);


### PR DESCRIPTION
Due to changes made for #855, scenes rendered to GIF and saved in a version with those changes will crash when attempting to render GIF in older versions.  This was due to a tag `Generate Palette` that is no longer written to the scene file but older versions expect it and crash when not found.

To maintain backwards compatibility, I've restored the code related to `Generate Palette`  in case we decide to restore it's functionality, but have hidden the control and blocked out the code so it doesn't execute on GIF renders.  This will still enable T2D to read and write out the tag.