### PR TITLE
Fix implicit scene saving as explicit

### DIFF
--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -172,14 +172,14 @@ void TXshLevelColumn::saveData(TOStream &os) {
   if (getRange(r0, r1)) {
     os.openChild("cells");
     for (int r = r0; r <= r1; r++) {
-      TXshCell cell = getCell(r);
+      TXshCell cell = getCell(r, false);
       if (cell.isEmpty()) continue;
       TFrameId fid = cell.m_frameId;
       int n = 1, inc = 0, dr = fid.getNumber();
       // If fid has not letter save more than one cell and its incrementation;
       // otherwise save one cell.
       if (r < r1 && fid.getLetter().isEmpty()) {
-        TXshCell cell2 = getCell(r + 1);
+        TXshCell cell2 = getCell(r + 1, false);
         TFrameId fid2  = cell2.m_frameId;
         if (cell2.m_level.getPointer() == cell.m_level.getPointer() &&
             fid2.getLetter().isEmpty()) {
@@ -187,7 +187,7 @@ void TXshLevelColumn::saveData(TOStream &os) {
           n++;
           for (;;) {
             if (r + n > r1) break;
-            cell2         = getCell(r + n);
+            cell2         = getCell(r + n, false);
             TFrameId fid2 = cell2.m_frameId;
             if (cell2.m_level.getPointer() != cell.m_level.getPointer() ||
                 !fid2.getLetter().isEmpty())

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -76,7 +76,7 @@ void TXshMeshColumn::saveData(TOStream &os) {
     os.openChild("cells");
     {
       for (int r = r0; r <= r1; ++r) {
-        TXshCell cell = getCell(r);
+        TXshCell cell = getCell(r, false);
         if (cell.isEmpty()) continue;
 
         TFrameId fid = cell.m_frameId;
@@ -85,7 +85,7 @@ void TXshMeshColumn::saveData(TOStream &os) {
         // If fid has no letter save more than one cell and its increment -
         // otherwise save just one cell
         if (r < r1 && fid.getLetter().isEmpty()) {
-          TXshCell cell2 = getCell(r + 1);
+          TXshCell cell2 = getCell(r + 1, false);
           TFrameId fid2  = cell2.m_frameId;
 
           if (cell2.m_level.getPointer() == cell.m_level.getPointer() &&
@@ -94,7 +94,7 @@ void TXshMeshColumn::saveData(TOStream &os) {
             for (++n;; ++n) {
               if (r + n > r1) break;
 
-              cell2         = getCell(r + n);
+              cell2         = getCell(r + n, false);
               TFrameId fid2 = cell2.m_frameId;
 
               if (cell2.m_level.getPointer() != cell.m_level.getPointer() ||

--- a/toonz/sources/toonzlib/txshpalettecolumn.cpp
+++ b/toonz/sources/toonzlib/txshpalettecolumn.cpp
@@ -86,17 +86,17 @@ void TXshPaletteColumn::saveData(TOStream &os) {
   if (getRange(r0, r1)) {
     os.openChild("cells");
     for (int r = r0; r <= r1; r++) {
-      TXshCell cell = getCell(r);
+      TXshCell cell = getCell(r, false);
       if (cell.isEmpty()) continue;
       int n = 1, inc = 0, dr = cell.m_frameId.getNumber();
       if (r < r1) {
-        TXshCell cell2 = getCell(r + 1);
+        TXshCell cell2 = getCell(r + 1, false);
         if (cell2.m_level.getPointer() == cell.m_level.getPointer()) {
           inc = cell2.m_frameId.getNumber() - dr;
           n++;
           for (;;) {
             if (r + n > r1) break;
-            cell2 = getCell(r + n);
+            cell2 = getCell(r + n, false);
             if (cell2.m_level.getPointer() != cell.m_level.getPointer()) break;
             if (cell2.m_frameId.getNumber() != dr + n * inc) break;
             n++;

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -194,14 +194,14 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
   if (getRange(r0, r1)) {
     os.openChild("cells");
     for (int r = r0; r <= r1; r++) {
-      TXshCell cell = getCell(r);
+      TXshCell cell = getCell(r, false);
       if (cell.isEmpty()) continue;
       int fnum           = cell.m_frameId.getNumber();
       if (fnum > 1) fnum = 1;  // Should always be 1 unless it's stopframe
       int n              = 1;
 
       if (r < r1) {
-        TXshCell cell2 = getCell(r + 1);
+        TXshCell cell2 = getCell(r + 1, false);
         if (!cell2.isEmpty()) {
           int fnum2            = cell2.m_frameId.getNumber();
           if (fnum2 > 1) fnum2 = 1;  // Should always be 1 unless it's stopframe
@@ -209,7 +209,7 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
             n++;
             for (;;) {
               if (r + n > r1) break;
-              cell2 = getCell(r + n);
+              cell2 = getCell(r + n, false);
               if (cell2.isEmpty()) break;
               fnum2 = cell2.m_frameId.getNumber();
               if (fnum2 > 1)


### PR DESCRIPTION
Accidentally broke scene saving using implicit holds as part of PR #875.  Causes it to save using explicit holds.

This PR will fix it. 

I will merge this once this PR builds successfully as a quick fix.