### PR TITLE
Fix palette saving issues

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -3158,23 +3158,20 @@ public:
       return;
     }
 
-    int levelType = UNKNOWN_XSHLEVEL;
+    int levelType = palette->getDefaultPaletteType();
     QString levelTypeStr, displayStr;
 
-    if (palette->isDefaultPalette()) {
-      levelType = palette->getDefaultPaletteType();
-    } else {
+    if (levelType == UNKNOWN_XSHLEVEL) {
       TXshLevel *level = TApp::instance()->getCurrentLevel()->getLevel();
-      if (!level) {
-        DVGui::warning("No current level.");
-        return;
-      }
-      TXshSimpleLevel *sl = level->getSimpleLevel();
-      if (!sl) {
-        DVGui::warning("Current level is not a drawing level.");
-        return;
-      }
-      levelType = sl->getType();
+      if (level) {
+        TXshSimpleLevel *sl = level->getSimpleLevel();
+        if (!sl) {
+          DVGui::warning("Current level is not a drawing level.");
+          return;
+        }
+        levelType = sl->getType();
+      } else
+        levelType = Preferences::instance()->getDefLevelType();
     }
 
     switch (levelType) {

--- a/toonz/sources/toonzlib/txshpalettelevel.cpp
+++ b/toonz/sources/toonzlib/txshpalettelevel.cpp
@@ -100,7 +100,8 @@ void TXshPaletteLevel::load() {
 
 void TXshPaletteLevel::save() {
   TFilePath path = getScene()->decodeFilePath(m_path);
-  if (TSystem::doesExistFileOrLevel(path) && m_palette) {
+  if (TSystem::doesExistFileOrLevel(path) && m_palette &&
+      m_palette->getDirtyFlag()) {
     TFileStatus fs(path);
     if (!fs.isWritable()) {
       throw TSystemException(
@@ -108,6 +109,7 @@ void TXshPaletteLevel::save() {
     }
     TOStream os(path);
     os << m_palette;
+    m_palette->setDirtyFlag(false);
   }
 }
 

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -652,6 +652,7 @@ void PaletteViewer::updateSavePaletteToolBar() {
         if (levelType == UNKNOWN_XSHLEVEL)
           levelType = Preferences::instance()->getDefLevelType();
         setSaveDefaultText(act, levelType);
+        if (levelType == PLT_XSHLEVEL) enable = false;
       }
       act->setEnabled(enable);
     } else if (m_viewType != STUDIO_PALETTE && i == 1)  // move action
@@ -690,6 +691,7 @@ void PaletteViewer::updatePaletteMenu() {
         if (levelType == UNKNOWN_XSHLEVEL)
           levelType = Preferences::instance()->getDefLevelType();
         setSaveDefaultText(act, levelType);
+        if (levelType == PLT_XSHLEVEL) enable = false;
       }
       act->setEnabled(enable);
     } else
@@ -777,7 +779,7 @@ void PaletteViewer::contextMenuEvent(QContextMenuEvent *event) {
     QAction *action =
         CommandManager::instance()->getAction("MI_SaveAsDefaultPalette");
     menu->addAction(action);
-
+    bool enable = true;
     if (m_levelHandle) {
       int levelType = m_levelHandle->getLevel()
                           ? m_levelHandle->getLevel()->getType()
@@ -786,7 +788,9 @@ void PaletteViewer::contextMenuEvent(QContextMenuEvent *event) {
       if (levelType == UNKNOWN_XSHLEVEL)
         levelType = Preferences::instance()->getDefLevelType();
       setSaveDefaultText(action, levelType);
+      if (levelType == PLT_XSHLEVEL) enable = false;
     }
+    action->setEnabled(enable);
   }
 
   if (m_viewType == LEVEL_PALETTE && !getPalette()->isLocked() &&

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -649,6 +649,8 @@ void PaletteViewer::updateSavePaletteToolBar() {
                             : getPalette()
                                   ? getPalette()->getDefaultPaletteType()
                                   : UNKNOWN_XSHLEVEL;
+        if (levelType == UNKNOWN_XSHLEVEL)
+          levelType = Preferences::instance()->getDefLevelType();
         setSaveDefaultText(act, levelType);
       }
       act->setEnabled(enable);
@@ -685,6 +687,8 @@ void PaletteViewer::updatePaletteMenu() {
                             : getPalette()
                                   ? getPalette()->getDefaultPaletteType()
                                   : UNKNOWN_XSHLEVEL;
+        if (levelType == UNKNOWN_XSHLEVEL)
+          levelType = Preferences::instance()->getDefLevelType();
         setSaveDefaultText(act, levelType);
       }
       act->setEnabled(enable);
@@ -779,6 +783,8 @@ void PaletteViewer::contextMenuEvent(QContextMenuEvent *event) {
                           ? m_levelHandle->getLevel()->getType()
                           : getPalette() ? getPalette()->getDefaultPaletteType()
                                          : UNKNOWN_XSHLEVEL;
+      if (levelType == UNKNOWN_XSHLEVEL)
+        levelType = Preferences::instance()->getDefLevelType();
       setSaveDefaultText(action, levelType);
     }
   }


### PR DESCRIPTION
The PR fixes the following palette saving issues:

- When a Palette Level's palette is changed and you `Save All`, it throws a warning that the palette level could not be saved though it was actually saved.  Corrected by clearing the palette's dirty flag after saving
- When Raster is the default level type, the Raster palette could not save to Default Raster Palette if you were not on a raster level. Modified  logic to use default level type as the default raster type when not on a level
- Disabled Save As Default Palette for Palette Levels since those levels are not associated by type.