### PR TITLE
Fix icons showing in menus

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2005,7 +2005,7 @@ void MainWindow::defineActions() {
   createMenuXsheetAction(MI_MergeColumns, QT_TR_NOOP("&Merge Levels"), "",
                          "merge_levels");
   createMenuXsheetAction(MI_InsertFx, QT_TR_NOOP("&New FX..."), "Ctrl+F",
-                         "fx_new");
+                         "fx_logo");
   createMenuXsheetAction(MI_NewOutputFx, QT_TR_NOOP("&New Output"), "Alt+O",
                          "output");
   createMenuXsheetAction(MI_InsertSceneFrame, QT_TR_NOOP("Insert Frame"), "",
@@ -2313,10 +2313,10 @@ void MainWindow::defineActions() {
   // Right Click
 
   createRightClickMenuAction(MI_SavePaletteAs,
-                             QT_TR_NOOP("&Save Palette As..."), "", "",
+                             QT_TR_NOOP("&Save Palette As..."), "", "saveas",
                              tr("Save the current style palette as a separate file with a new name."));
   createRightClickMenuAction(MI_OverwritePalette, QT_TR_NOOP("&Save Palette"),
-                             "", "", tr("Save the current style palette as a separate file."));
+                             "", "save", tr("Save the current style palette as a separate file."));
   createRightClickMenuAction(MI_RegeneratePreview,
                              QT_TR_NOOP("&Regenerate Preview"), "", "",
                              tr("Recreates a set of preview images."));

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -506,23 +506,12 @@ void PaletteViewer::createSavePaletteToolBar() {
   });
   m_viewMode->addAction(m_showStyleIndex);
 
-  // QIcon saveAsPaletteIcon = createQIconOnOff("savepaletteas", false);
-  QIcon saveAsPaletteIcon = createQIcon("saveas");
-  QAction *saveAsPalette  = new QAction(
-      saveAsPaletteIcon, tr("&Save Palette As"), m_savePaletteToolBar);
-  saveAsPalette->setToolTip(tr("Save palette with a different name."));
-  // overwrite palette
-  QIcon savePaletteIcon = createQIcon("save");
-  QAction *savePalette =
-      new QAction(savePaletteIcon, tr("&Save Palette"), m_savePaletteToolBar);
-  savePalette->setToolTip(tr("Save the palette."));
-  QAction *saveDefaultPalette =
-      new QAction(tr("&Save As Default Palette"), m_savePaletteToolBar);
-  saveDefaultPalette->setToolTip(
-      tr("Save the palette as the default for new levels of the current level "
-         "type."));
-
   if (m_viewType == STUDIO_PALETTE) {
+    QIcon savePaletteIcon = createQIcon("save");
+    QAction *savePalette =
+        new QAction(savePaletteIcon, tr("&Save Palette"), m_savePaletteToolBar);
+    savePalette->setToolTip(tr("Save the palette."));
+
     connect(savePalette, SIGNAL(triggered()), this, SLOT(saveStudioPalette()));
     // m_viewMode->addSeparator();
     // m_viewMode->addAction(savePalette);
@@ -532,21 +521,18 @@ void PaletteViewer::createSavePaletteToolBar() {
     m_viewMode->addSeparator();
 
     // overwrite palette
-    connect(savePalette, SIGNAL(triggered()),
-            CommandManager::instance()->getAction("MI_OverwritePalette"),
-            SIGNAL(triggered()));
+    QAction *savePalette =
+        CommandManager::instance()->getAction("MI_OverwritePalette");
     m_viewMode->addAction(savePalette);
 
     // save palette as
-    connect(saveAsPalette, SIGNAL(triggered()),
-            CommandManager::instance()->getAction("MI_SavePaletteAs"),
-            SIGNAL(triggered()));
+    QAction *saveAsPalette =
+        CommandManager::instance()->getAction("MI_SavePaletteAs");
     m_viewMode->addAction(saveAsPalette);
 
     // save as default palette
-    connect(saveDefaultPalette, SIGNAL(triggered()),
-            CommandManager::instance()->getAction("MI_SaveAsDefaultPalette"),
-            SIGNAL(triggered()));
+    QAction *saveDefaultPalette =
+        CommandManager::instance()->getAction("MI_SaveAsDefaultPalette");
     m_viewMode->addAction(saveDefaultPalette);
   }
 
@@ -736,7 +722,6 @@ void PaletteViewer::setSaveDefaultText(QAction *action, int levelType) {
     action->setText(tr("&Save As Default Palette"));
     break;
   }
-  action->setIcon(createQIcon("save"));
 }
 
 void PaletteViewer::contextMenuEvent(QContextMenuEvent *event) {

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -1047,10 +1047,6 @@ void SchematicViewer::createActions() {
 
       // InsertFx
       insertFx = CommandManager::instance()->getAction("MI_InsertFx");
-      if (insertFx) {
-        QIcon insertFxIcon = createQIcon("fx_logo");
-        insertFx->setIcon(insertFxIcon);
-      }
 
       // AddOutputFx
       addOutputFx = CommandManager::instance()->getAction("MI_NewOutputFx");


### PR DESCRIPTION
This PR hides some icons that were showing in dropdown menus even though icons are supposed to be hidden. 

The following were fixed
- `Scene` menu item: `New FX...`
  - Global action created with incorrect icon name and Schematic was forcing the correct icon overriding the hide icon setting
  - Corrected Global action to use the correct icon name and removed the forced icon setting in schematic viewer.
- Palette menu items: `Save Palette`, `Save Palette As`, `Save As Default Palette`
  - Local actions were created with icons which were then configured to trigger their global action counterpart when used.
  - Replaced unnecessary local actions with global actions except for Studio Palette's `Save Palette` button as it had custom functionality