### PR TITLE
Update ffmpeg to v5.0

### DIFF
--- a/ci-scripts/linux/tahoma-buildffmpeg.sh
+++ b/ci-scripts/linux/tahoma-buildffmpeg.sh
@@ -16,7 +16,7 @@ sudo make install
 cd ..
 
 echo ">>> Cloning ffmpeg"
-git clone https://github.com/tahoma2d/ffmpeg ffmpeg
+git clone -b v4.3.1 https://github.com/tahoma2d/FFmpeg ffmpeg
 
 cd ffmpeg
 echo "*" >| .gitignore

--- a/ci-scripts/linux/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/linux/tahoma-get3rdpartyapps.sh
@@ -13,9 +13,9 @@ if [ -d ffmpeg ]
 then
    rm -rf ffmpeg
 fi
-wget https://github.com/tahoma2d/FFmpeg/releases/download/v4.3.1/ffmpeg-4.3.1-linux-static-lgpl.zip
-unzip ffmpeg-4.3.1-linux-static-lgpl.zip 
-mv ffmpeg-4.3.1-linux-static-lgpl ffmpeg
+wget https://github.com/tahoma2d/FFmpeg/releases/download/v5.0.0/ffmpeg-5.0.0-linux64-static-lgpl.zip
+unzip ffmpeg-5.0.0-linux64-static-lgpl.zip 
+mv ffmpeg-5.0.0-linux64-static-lgpl ffmpeg
 
 
 echo ">>> Getting Rhubarb Lip Sync"

--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -26,7 +26,7 @@ sudo make install
 cd ../..
 
 echo ">>> Cloning ffmpeg"
-git clone https://github.com/tahoma2d/ffmpeg
+git clone -b v4.3.1 https://github.com/tahoma2d/FFmpeg ffmpeg
 
 cd ffmpeg
 echo "*" >| .gitignore

--- a/ci-scripts/osx/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/osx/tahoma-get3rdpartyapps.sh
@@ -13,9 +13,9 @@ if [ -d ffmpeg ]
 then
    rm -rf ffmpeg
 fi
-wget https://github.com/tahoma2d/FFmpeg/releases/download/v4.3.1/ffmpeg-4.3.1-macos64-static-lgpl.zip
-unzip ffmpeg-4.3.1-macos64-static-lgpl.zip 
-mv ffmpeg-4.3.1-macos64-static-lgpl ffmpeg
+wget https://github.com/tahoma2d/FFmpeg/releases/download/v5.0.0/ffmpeg-5.0.0-macos64-static-lgpl.zip
+unzip ffmpeg-5.0.0-macos64-static-lgpl.zip 
+mv ffmpeg-5.0.0-macos64-static-lgpl ffmpeg
 
 
 echo ">>> Getting Rhubarb Lip Sync"

--- a/ci-scripts/windows/tahoma-get3rdpartyapps.bat
+++ b/ci-scripts/windows/tahoma-get3rdpartyapps.bat
@@ -19,9 +19,9 @@ move crashrpt\CrashRpt1500.lib ..\crashrpt
 echo ">>> Getting FFmpeg"
 
 IF EXIST ffmpeg rmdir /S /Q ffmpeg
-curl -fsSL -o ffmpeg-4.3.1-win64-static-lgpl.zip https://github.com/tahoma2d/FFmpeg/releases/download/v4.3.1/ffmpeg-4.3.1-win64-static-lgpl.zip
-7z x ffmpeg-4.3.1-win64-static-lgpl.zip
-rename ffmpeg-4.3.1-win64-static-lgpl ffmpeg
+curl -fsSL -o ffmpeg-5.0.0-win64-static-lgpl.zip https://github.com/tahoma2d/FFmpeg/releases/download/v5.0.0/ffmpeg-5.0.0-win64-static-lgpl.zip
+7z x ffmpeg-5.0.0-win64-static-lgpl.zip
+rename ffmpeg-5.0.0-win64-static-lgpl ffmpeg
 
 echo ">>> Getting Rhubarb Lip Sync"
 

--- a/stuff/doc/LICENSE/LICENSE_ffmpeg_info.txt
+++ b/stuff/doc/LICENSE/LICENSE_ffmpeg_info.txt
@@ -1,10 +1,10 @@
 Tahoma2D ships with FFmpeg, and uses FFmpeg through command line commands.
 Tahoma2D does not directly use FFmpeg libraries or code.
 
-As of July 2020, Tahoma2D is shipping with FFmpeg 4.3 LGPL version from https://ffmpeg.zeranoe.com/builds/
+As of January 2022, Windows and Linux versions of Tahoma2D are shipped with FFmpeg 5.0 LGPL version from https://github.com/BtbN/FFmpeg-Builds.
+MacOS versions of Tahoma2D are shipped with FFmpeg 5.0 LGL compiled from source at https://github.com/FFmpeg/FFmpeg.
 
 FFmpeg source code can be found at:
 https://github.com/tahoma2d/FFmpeg
 or 
 https://github.com/FFmpeg/FFmpeg
-

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -124,6 +124,28 @@ bool Ffmpeg::checkFormat(std::string format) {
   return false;
 }
 
+bool Ffmpeg::checkCodecs(std::string codec) {
+  QString path = Preferences::instance()->getFfmpegPath() + "/ffmpeg";
+#if defined(_WIN32)
+  path = path + ".exe";
+#endif
+  QStringList args;
+  args << "-codecs";
+  QProcess ffmpeg;
+  ffmpeg.start(path, args);
+  if (waitFfmpeg(ffmpeg, 60000)) { // 1 minute timeout
+    QString results = ffmpeg.readAllStandardError();
+    results += ffmpeg.readAllStandardOutput();
+    ffmpeg.close();
+    std::string strResults = results.toStdString();
+    std::string::size_type n;
+    n = strResults.find(codec);
+    if (n != std::string::npos)
+      return true;
+  }
+  return false;
+}
+
 TFilePath Ffmpeg::getFfmpegCache() {
   QString cacheRoot = ToonzFolder::getCacheRootFolder().getQString();
   if (!TSystem::doesExistFileOrLevel(TFilePath(cacheRoot + "/ffmpeg"))) {

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -34,6 +34,7 @@ public:
   static bool checkFfmpeg();
   static bool checkFfprobe();
   static bool checkFormat(std::string format);
+  static bool checkCodecs(std::string format);
   double getFrameRate();
   TDimension getSize();
   int getFrameCount();

--- a/toonz/sources/image/ffmpeg/tiio_mp4.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.cpp
@@ -90,6 +90,13 @@ TLevelWriterMp4::~TLevelWriterMp4() {
   postIArgs << QString::number(outLx) + "x" + QString::number(outLy);
   postIArgs << "-b";
   postIArgs << QString::number(finalBitrate) + "k";
+  if (Ffmpeg::checkCodecs("libopenh264")) {
+    postIArgs << "-c:v";
+    postIArgs << "libopenh264";
+  } else if (Ffmpeg::checkCodecs("libxh264")) {
+    postIArgs << "-c:v";
+    postIArgs << "libxh264";
+  }
 
   ffmpegWriter->runFfmpeg(preIArgs, postIArgs, false, false, true);
   ffmpegWriter->cleanUpFiles();


### PR DESCRIPTION
This PR will update all builds to include ffmpeg 5.0 (LGPL)

Windows and Linux versions will use version n5.0 builds from https://github.com/btBN/FFmpeg-builds.
MacOS was built locally using the 5.0 source from https://github.com/FFmpeg/FFmpeg

NOTE: Builds of OpenCV used for building macOS/Linux versions will continue to still use ffmpeg 4.3.1 for now.