### PR TITLE
Fix reloading stop motion scene crashing application

### DIFF
--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -2429,6 +2429,7 @@ bool StopMotion::loadXmlFile() {
     }
     xmlReader.readNext();
   }
+  emit(updateStopMotionControls(webcam));
   return true;
 }
 
@@ -2976,7 +2977,8 @@ void StopMotion::changeCameras(int index) {
 #endif
 
   // close live view if open
-  if (m_liveViewStatus > LiveViewClosed) {
+  int liveViewStatus = m_liveViewStatus;
+  if (liveViewStatus > LiveViewClosed) {
     toggleLiveView();
   }
 
@@ -3032,7 +3034,8 @@ void StopMotion::changeCameras(int index) {
     setWebcamResolution(
         QString(QString::number(width) + " x " + QString::number(height)));
     setTEnvCameraName(m_webcam->getWebcamDescription().toStdString());
-    emit(newCameraSelected(index + 1, true));
+//    emit(newCameraSelected(index + 1, true));
+    emit(changeCameraIndex(index + 1));
     emit(webcamResolutionsChanged());
     emit(newWebcamResolutionSelected(sizeCount));
 
@@ -3045,7 +3048,8 @@ void StopMotion::changeCameras(int index) {
     }
     m_webcam->clearWebcam();
 
-    emit(newCameraSelected(index + 1, false));
+//    emit(newCameraSelected(index + 1, false));
+    emit(changeCameraIndex(index + 1));
 #endif
   }
   if (m_useNumpadShortcuts) toggleNumpadShortcuts(true);
@@ -3060,14 +3064,15 @@ void StopMotion::changeCameras(int index) {
   emit(liveViewChanged(false));
   refreshFrameInfo();
   // after all live view data is cleared, start it again.
-  if (m_liveViewStatus > LiveViewClosed) {
+  if (liveViewStatus > LiveViewClosed) {
     toggleLiveView();
   }
 }
 //-----------------------------------------------------------------
 
 void StopMotion::setWebcamResolution(QString resolution) {
-  m_webcam->releaseWebcam();
+  bool webcamActive = m_webcam->isWebcamActive();
+  if (webcamActive) m_webcam->releaseWebcam();
 
   // resolution is written in the itemText with the format "<width> x
   // <height>" (e.g. "800 x 600")
@@ -3099,6 +3104,7 @@ void StopMotion::setWebcamResolution(QString resolution) {
   refreshFrameInfo();
 
   int index = m_webcam->getIndexOfResolution();
+  if (webcamActive) m_webcam->initWebcam(m_webcam->getWebcamIndex());
   emit(newWebcamResolutionSelected(index));
 }
 

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -3060,7 +3060,9 @@ void StopMotion::changeCameras(int index) {
   emit(liveViewChanged(false));
   refreshFrameInfo();
   // after all live view data is cleared, start it again.
-  toggleLiveView();
+  if (m_liveViewStatus > LiveViewClosed) {
+    toggleLiveView();
+  }
 }
 //-----------------------------------------------------------------
 

--- a/toonz/sources/stopmotion/stopmotion.h
+++ b/toonz/sources/stopmotion/stopmotion.h
@@ -237,6 +237,8 @@ signals:
   void webcamResolutionsChanged();
   void newWebcamResolutionSelected(int);
   void updateCameraList(QString);
+  void changeCameraIndex(int);
+  void updateStopMotionControls(bool);
 
   // live view and images
   void newLiveViewImageReady();

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -1816,6 +1816,10 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
                        SLOT(refreshCameraList(QString)));
   ret = ret && connect(m_stopMotion, SIGNAL(optionsChanged()), this,
                        SLOT(refreshOptionsLists()));
+  ret = ret && connect(m_stopMotion, SIGNAL(changeCameraIndex(int)), this,
+                       SLOT(onCameraIndexChanged(int)));
+  ret = ret && connect(m_stopMotion, SIGNAL(updateStopMotionControls(bool)),
+                       this, SLOT(onUpdateStopMotionControls(bool)));
 
   // EOS Connections
   ret = ret &&
@@ -2754,13 +2758,28 @@ void StopMotionController::onCameraListComboActivated(int comboIndex) {
   if (cameraCount != m_cameraListCombo->count() - 1) return;
 
   m_stopMotion->changeCameras(comboIndex);
+  m_stopMotion->updateStopMotionControls(m_stopMotion->m_usingWebcam);
 }
 
 //-----------------------------------------------------------------------------
 
 void StopMotionController::onNewCameraSelected(int index, bool useWebcam) {
+  onCameraIndexChanged(index);
+  onUpdateStopMotionControls(useWebcam);
+}
+
+//-----------------------------------------------------------------------------
+
+void StopMotionController::onCameraIndexChanged(int index) {
   if (index < m_cameraListCombo->count())
     m_cameraListCombo->setCurrentIndex(index);
+}
+
+//-----------------------------------------------------------------------------
+
+void StopMotionController::onUpdateStopMotionControls(bool useWebcam) {
+  int index = m_cameraListCombo->currentIndex();
+
   if (index == 0) {
     m_cameraListCombo->setCurrentIndex(index);
     m_resolutionCombo->hide();

--- a/toonz/sources/stopmotion/stopmotioncontroller.h
+++ b/toonz/sources/stopmotion/stopmotioncontroller.h
@@ -388,6 +388,8 @@ protected slots:
   void onDrawBeneathSignal(bool);
   void onLiveViewChanged(bool);
   void onNewCameraSelected(int, bool);
+  void onCameraIndexChanged(int);
+  void onUpdateStopMotionControls(bool);
 
   // webcam
   void onWebcamResolutionsChanged();

--- a/toonz/sources/stopmotion/webcam.h
+++ b/toonz/sources/stopmotion/webcam.h
@@ -86,6 +86,8 @@ public:
   void computeLut();
   cv::Mat getWebcamImage() { return m_webcamImage; }
 
+  bool isWebcamActive() { return m_cvWebcam.isOpened(); }
+
 private:
   // Webcam Properties
   QList<QCameraInfo> m_webcams;


### PR DESCRIPTION
This PR attempts to fix the crash reported in #900.

When opening a stop motion scene, T2D attempts to connect to the camera and immediately turns on `Live View` mode, however the camera may not be connected.  On some systems, this may cause a crash at startup.  

This change will not automatically turn on `Live View` mode at startup.