### PR TITLE
Update Windows builds to use MSVC 2019 with Qt5.9.7

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Windows:
-    runs-on: windows-2016
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
         with:

--- a/ci-scripts/windows/tahoma-build.bat
+++ b/ci-scripts/windows/tahoma-build.bat
@@ -10,16 +10,16 @@ IF NOT EXIST build mkdir build
 cd build
 
 REM Setup for local builds
-set MSVCVERSION="Visual Studio 15 2017"
+set MSVCVERSION="Visual Studio 16 2019"
 set BOOST_ROOT=C:\boost\boost_1_74_0
 set OPENCV_DIR=C:\opencv\451\build
-set QT_PATH=C:\Qt\5.9.7\msvc2017_64
+set QT_PATH=C:\Qt\5.9.7\msvc2019_64
 
 REM These are effective when running from Actions
 IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
 IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64 (
-	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 (
+	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
 )
 
 set WITH_CANON=N

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -62,10 +62,10 @@ IF EXIST ..\..\thirdparty\apps\rhubarb (
 echo ">>> Configuring Tahoma2D.exe for deployment"
 
 REM Setup for local builds
-set QT_PATH=C:\Qt\5.9.7\msvc2017_64
+set QT_PATH=C:\Qt\5.9.7\msvc2019_64
 
 REM These are effective when running from Actions/Appveyor
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2017_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
 
 %QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe
 

--- a/ci-scripts/windows/tahoma-install.bat
+++ b/ci-scripts/windows/tahoma-install.bat
@@ -1,9 +1,9 @@
 choco install opencv --version=4.5.1
-choco install boost-msvc-14.1
+choco install boost-msvc-14.2
 
 REM Install Qt 5.9
-curl -fsSL -o Qt5.9.7_msvc2017_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.9.7/Qt5.9.7_msvc2017_64.zip
-7z x Qt5.9.7_msvc2017_64.zip
-rename Qt5.9.7_msvc2017_64 5.9
+curl -fsSL -o Qt5.9.7_msvc2019_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.9.7/Qt5.9.7_msvc2019_64.zip
+7z x Qt5.9.7_msvc2019_64.zip
+rename Qt5.9.7_msvc2019_64 5.9
 mkdir thirdparty\qt
 move 5.9 thirdparty\qt


### PR DESCRIPTION
On March 15, 2022, Github is deprecating the `windows-2016` build environment that uses MSVC 2017. As such, we need to move the Windows build environment to `windows-2019` which uses MSVC 2019

Unfortunately Qt 5.9 is not officially supported on this version and moving to Qt 5.15 caused significant problems for random users that I could not duplicate. 

As I am not ready to deal with Qt 5.15 issues for the T2D 1.3 release, I've had to compile Qt 5.9.7 from source and package it in the `tahoma2d\qt` repo for Github builds to build with on MSVC 2019.

This will buy us a bit more time until I am ready to switch to 5.15 (or later) and fix the issues that were being reported.

I have confirmed locally that I could build, package and run T2D with this configuration.

Additional verification by other users would be extremely welcomed.
