### PR TITLE
Revert enhanced flipbook playback

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -19,7 +19,6 @@
 #include "toonz/imagepainter.h"
 #include "tstopwatch.h"
 #include <QThread>
-#include <QElapsedTimer>
 
 #undef DVAPI
 #undef DVVAR
@@ -72,7 +71,6 @@ class PlaybackExecutor final : public QThread {
 
   int m_fps;
   bool m_abort;
-  QElapsedTimer m_timer;
 
 public:
   PlaybackExecutor();
@@ -82,14 +80,11 @@ public:
   void run() override;
   void abort() { m_abort = true; }
 
-  bool isAborted() { return m_abort; }
-  void emitNextFrame(int fps) { emit nextFrame(fps, nullptr, 0); }
+  void emitNextFrame(int fps) { emit nextFrame(fps); }
 
 signals:
-  void nextFrame(
-      int fps, QElapsedTimer *timer,
-      qint64 targetInstant);  // Must be connect with
-                              // Qt::BlockingQueuedConnection connection type.
+  void nextFrame(int fps);  // Must be connect with Qt::BlockingQueuedConnection
+                            // connection type.
   void playbackAborted();
 };
 
@@ -326,7 +321,7 @@ public:
   }
 
   bool isLinkable() const { return m_isLinkable; }
-  void playNextFrame(QElapsedTimer *timer = nullptr, qint64 targetInstant = 0);
+  void playNextFrame();
   void updateCurrentFPS(int val);
 
   bool hasButton(std::vector<int> buttonMask, FlipConsole::EGadget buttonId) {
@@ -435,10 +430,10 @@ protected slots:
   }
   void onButtonPressed(int button);
   void incrementCurrentFrame(int delta);
-  void onNextFrame(int fps, QElapsedTimer *timer, qint64 target);
+  void onNextFrame(int fps);
   void setFpsFieldColors();
   void onCustomizeButtonPressed(QAction *);
-  bool drawBlanks(int from, int to, QElapsedTimer *timer, qint64 target);
+  bool drawBlanks(int from, int to);
   void onSliderRelease();
 
   void onFPSEdited();

--- a/toonz/sources/include/toonzqt/flipconsoleowner.h
+++ b/toonz/sources/include/toonzqt/flipconsoleowner.h
@@ -16,9 +16,7 @@ class FlipConsole;
 class FlipConsoleOwner {
 public:
   virtual void onDrawFrame(int frame,
-                           const ImagePainter::VisualSettings& settings,
-                           QElapsedTimer* timer = nullptr,
-                           qint64 targetInstant = 0) = 0;
+                           const ImagePainter::VisualSettings &settings) = 0;
 
   virtual void swapBuffers(){};
   virtual void changeSwapBehavior(bool enable){};

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -2780,8 +2780,8 @@ void StopMotionController::onNewCameraSelected(int index, bool useWebcam) {
     m_resolutionCombo->hide();
     m_resolutionLabel->hide();
     m_cameraStatusLabel->hide();
-    m_pickZoomButton->setStyleSheet("border:1px solid rgba(0, 0, 0, 0);");
-    m_zoomButton->setStyleSheet("border:1px solid rgba(0, 0, 0, 0);");
+    m_pickZoomButton->setStyleSheet("border:1px solid rgb(0, 0, 0, 0);");
+    m_zoomButton->setStyleSheet("border:1px solid rgb(0, 0, 0, 0);");
     m_pickZoomButton->setChecked(false);
     m_zoomButton->setChecked(false);
     m_dslrFrame->hide();
@@ -3261,9 +3261,9 @@ void StopMotionController::onLiveViewCompensationChangedSignal(int value) {
 void StopMotionController::onFocusCheckToggled(bool on) {
 #ifdef WITH_CANON
   if (on) {
-    m_zoomButton->setStyleSheet("border:1px solid rgba(0, 255, 0, 255);");
+    m_zoomButton->setStyleSheet("border:1px solid rgb(0, 255, 0, 255);");
   } else {
-    m_zoomButton->setStyleSheet("border:1px solid rgba(0, 0, 0, 0);");
+    m_zoomButton->setStyleSheet("border:1px solid rgb(0, 0, 0, 0);");
   }
   m_zoomButton->blockSignals(true);
   m_zoomButton->setChecked(on);
@@ -3276,10 +3276,10 @@ void StopMotionController::onFocusCheckToggled(bool on) {
 void StopMotionController::onPickFocusCheckToggled(bool on) {
 #ifdef WITH_CANON
   if (on) {
-    m_pickZoomButton->setStyleSheet("border:1px solid rgba(0, 255, 0, 255);");
+    m_pickZoomButton->setStyleSheet("border:1px solid rgb(0, 255, 0, 255);");
 
   } else {
-    m_pickZoomButton->setStyleSheet("border:1px solid rgba(0, 0, 0, 0);");
+    m_pickZoomButton->setStyleSheet("border:1px solid rgb(0, 0, 0, 0);");
   }
   m_pickZoomButton->blockSignals(true);
   m_pickZoomButton->setChecked(on);

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -309,13 +309,10 @@ void ComboViewerPanel::onShowHideActionTriggered(QAction *act) {
 
 //-----------------------------------------------------------------------------
 
-void ComboViewerPanel::onDrawFrame(int frame,
-                                   const ImagePainter::VisualSettings &settings,
-                                   QElapsedTimer *timer, qint64 targetInstant) {
+void ComboViewerPanel::onDrawFrame(
+    int frame, const ImagePainter::VisualSettings &settings) {
   TApp *app = TApp::instance();
   m_sceneViewer->setVisual(settings);
-  m_sceneViewer->setTimerAndTargetInstant(timer, targetInstant);
-
   TFrameHandle *frameHandle = app->getCurrentFrame();
 
   if (m_sceneViewer->isPreviewEnabled()) {
@@ -350,12 +347,6 @@ void ComboViewerPanel::onDrawFrame(int frame,
 
   else if (settings.m_blankColor != TPixel::Transparent)
     m_sceneViewer->update();
-
-  // make sure to redraw the frame here.
-  // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying())
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
-                        QEventLoop::ExcludeSocketNotifiers);
 }
 
 //-----------------------------------------------------------------------------
@@ -696,10 +687,10 @@ void ComboViewerPanel::changeWindowTitle() {
     name = name + tr("   ::   Level: ") + imageName;
 
     if (!m_sceneViewer->is3DView()) {
-      TAffine aff = m_sceneViewer->getViewMatrix();
+      TAffine aff                             = m_sceneViewer->getViewMatrix();
       if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
       if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
-      name = name + "  ::  Zoom : " +
+      name                                    = name + "  ::  Zoom : " +
              QString::number((int)(100.0 * sqrt(aff.det()) *
                                    m_sceneViewer->getDpiFactor())) +
              "%";
@@ -711,15 +702,16 @@ void ComboViewerPanel::changeWindowTitle() {
                  ->isActualPixelViewOnSceneEditingModeEnabled() &&
              TApp::instance()->getCurrentLevel()->getSimpleLevel() &&
              !CleanupPreviewCheck::instance()
-                  ->isEnabled()               // cleanup preview must be OFF
-             && !CameraTestCheck::instance()  // camera test mode must be OFF
-                                              // neither
-                     ->isEnabled() &&
+                  ->isEnabled()  // cleanup preview must be OFF
+             &&
+             !CameraTestCheck::instance()  // camera test mode must be OFF
+                                           // neither
+                  ->isEnabled() &&
              !m_sceneViewer->is3DView()) {
-      TAffine aff = m_sceneViewer->getViewMatrix();
+      TAffine aff                             = m_sceneViewer->getViewMatrix();
       if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
       if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
-      name = name + "  ::  Zoom : " +
+      name                                    = name + "  ::  Zoom : " +
              QString::number((int)(100.0 * sqrt(aff.det()) *
                                    m_sceneViewer->getDpiFactor())) +
              "%";
@@ -739,7 +731,7 @@ void ComboViewerPanel::changeWindowTitle() {
         TAffine aff = m_sceneViewer->getViewMatrix();
         if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
         if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
-        name = name + "  ::  Zoom : " +
+        name                                    = name + "  ::  Zoom : " +
                QString::number((int)(100.0 * sqrt(aff.det()) *
                                      m_sceneViewer->getDpiFactor())) +
                "%";

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -353,7 +353,9 @@ void ComboViewerPanel::onDrawFrame(int frame,
 
   // make sure to redraw the frame here.
   // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying()) qApp->processEvents();
+  if (frameHandle->isPlaying())
+    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
+                        QEventLoop::ExcludeSocketNotifiers);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/comboviewerpane.h
+++ b/toonz/sources/toonz/comboviewerpane.h
@@ -88,8 +88,8 @@ public:
   void updateShowHide();
   void addShowHideContextMenu(QMenu *);
 
-  void onDrawFrame(int frame, const ImagePainter::VisualSettings &settings,
-                   QElapsedTimer *timer, qint64 targetInstant) override;
+  void onDrawFrame(int frame,
+                   const ImagePainter::VisualSettings &settings) override;
 
   void onEnterPanel() {
     m_sceneViewer->setFocus(Qt::OtherFocusReason);

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -1665,7 +1665,6 @@ else*/
 void FlipBook::onDrawFrame(int frame, const ImagePainter::VisualSettings &vs,
                            QElapsedTimer *timer, qint64 targetInstant) {
   try {
-    m_imageViewer->setVisual(vs);
     m_imageViewer->setTimerAndTargetInstant(timer, targetInstant);
 
     TImageP img = getCurrentImage(frame);

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -1662,10 +1662,9 @@ else*/
 
 /*! Set current level frame to image viewer. Add the view image in cache.
  */
-void FlipBook::onDrawFrame(int frame, const ImagePainter::VisualSettings &vs,
-                           QElapsedTimer *timer, qint64 targetInstant) {
+void FlipBook::onDrawFrame(int frame, const ImagePainter::VisualSettings &vs) {
   try {
-    m_imageViewer->setTimerAndTargetInstant(timer, targetInstant);
+    m_imageViewer->setVisual(vs);
 
     TImageP img = getCurrentImage(frame);
 

--- a/toonz/sources/toonz/flipbook.h
+++ b/toonz/sources/toonz/flipbook.h
@@ -238,8 +238,7 @@ public:
 
   void reset();
 
-  void onDrawFrame(int frame, const ImagePainter::VisualSettings &vs,
-                   QElapsedTimer *timer, qint64 targetInstant) override;
+  void onDrawFrame(int frame, const ImagePainter::VisualSettings &vs) override;
 
   void minimize(bool doMinimize);
 

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -422,7 +422,9 @@ void ImageViewer::setImage(TImageP image) {
   // make sure to redraw the frame here.
   // repaint() does NOT immediately redraw the frame for QOpenGLWidget
   update();
-  if (!isColorModel()) qApp->processEvents();
+  if (!isColorModel())
+    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
+                        QEventLoop::ExcludeSocketNotifiers);
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -225,8 +225,7 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
     , m_histogramPopup(0)
     , m_isRemakingPreviewFx(false)
     , m_rectRGBPick(false)
-    , m_firstImage(true)
-    , m_timer(nullptr) {
+    , m_firstImage(true) {
   m_visualSettings.m_sceneProperties =
       TApp::instance()->getCurrentScene()->getScene()->getProperties();
   m_visualSettings.m_drawExternalBG = true;
@@ -418,13 +417,10 @@ void ImageViewer::setImage(TImageP image) {
 
   if (m_isHistogramEnable && m_histogramPopup->isVisible())
     m_histogramPopup->setImage(image);
-
-  // make sure to redraw the frame here.
-  // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  update();
   if (!isColorModel())
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
-                        QEventLoop::ExcludeSocketNotifiers);
+    repaint();
+  else
+    update();
 }
 
 //-------------------------------------------------------------------
@@ -569,12 +565,6 @@ void ImageViewer::paintGL() {
   if (!m_image) {
     if (m_lutCalibrator && m_lutCalibrator->isValid())
       m_lutCalibrator->onEndDraw(m_fbo);
-    if (m_timer && m_timer->isValid()) {
-      qint64 currentInstant = m_timer->nsecsElapsed();
-      while (currentInstant < m_targetInstant) {
-        currentInstant = m_timer->nsecsElapsed();
-      }
-    }
     return;
   }
 
@@ -654,14 +644,6 @@ void ImageViewer::paintGL() {
 
   if (m_lutCalibrator && m_lutCalibrator->isValid())
     m_lutCalibrator->onEndDraw(m_fbo);
-
-  // wait to achieve precise fps
-  if (m_timer && m_timer->isValid()) {
-    qint64 currentInstant = m_timer->nsecsElapsed();
-    while (currentInstant < m_targetInstant) {
-      currentInstant = m_timer->nsecsElapsed();
-    }
-  }
 }
 
 //------------------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -17,7 +17,6 @@ class QOpenGLFramebufferObject;
 class LutCalibrator;
 class QTouchEvent;
 class QGestureEvent;
-class QElapsedTimer;
 //-----------------------------------------------------------------------------
 
 //====================
@@ -80,10 +79,6 @@ class ImageViewer final : public GLWidgetForHighDpi {
   bool m_stylusUsed       = false;
   bool m_firstInitialized = true;
 
-  // passed from PlaybackExecutor
-  QElapsedTimer *m_timer;
-  qint64 m_targetInstant;
-
   int getDragType(const TPoint &pos, const TRect &loadBox);
   void updateLoadbox(const TPoint &curPos);
   void updateCursor(const TPoint &curPos);
@@ -136,11 +131,6 @@ public:
   void doSwapBuffers();
   void changeSwapBehavior(bool enable);
   void invalidateCompHisto();
-
-  void setTimerAndTargetInstant(QElapsedTimer *timer, qint64 target) {
-    m_timer         = timer;
-    m_targetInstant = target;
-  }
 
 protected:
   void contextMenuEvent(QContextMenuEvent *event) override;

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -800,8 +800,7 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
     , m_mousePanning(0)
     , m_mouseZooming(0)
     , m_mouseRotating(0)
-    , m_keyAction(0)
-    , m_timer(nullptr) {
+    , m_keyAction(0) {
   m_visualSettings.m_sceneProperties =
       TApp::instance()->getCurrentScene()->getScene()->getProperties();
   m_stopMotion = StopMotion::instance();
@@ -2053,14 +2052,6 @@ void SceneViewer::paintGL() {
 
   if (!m_isPicking && m_lutCalibrator && m_lutCalibrator->isValid())
     m_lutCalibrator->onEndDraw(m_fbo);
-
-  // wait to achieve precise fps
-  if (m_timer && m_timer->isValid()) {
-    qint64 currentInstant = m_timer->nsecsElapsed();
-    while (currentInstant < m_targetInstant) {
-      currentInstant = m_timer->nsecsElapsed();
-    }
-  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -40,7 +40,6 @@ class QOpenGLFramebufferObject;
 class LutCalibrator;
 class StopMotion;
 class TStopWatch;
-class QElapsedTimer;
 
 namespace ImageUtils {
 class FullScreenWidget;
@@ -219,10 +218,6 @@ class SceneViewer final : public GLWidgetForHighDpi,
 
   QAction *m_keyAction;
 
-  // passed from PlaybackExecutor
-  QElapsedTimer *m_timer;
-  qint64 m_targetInstant;
-
 public:
   enum ReferenceMode {
     NORMAL_REFERENCE   = 1,
@@ -330,11 +325,6 @@ public:
   QColor getBGColor() const { return m_bgColor; }
   void setPreviewBGColor(const QColor &color) { m_previewBgColor = color; }
   QColor getPreviewBGColor() const { return m_previewBgColor; }
-
-  void setTimerAndTargetInstant(QElapsedTimer *timer, qint64 target) {
-    m_timer         = timer;
-    m_targetInstant = target;
-  }
 
 public:
   // SceneViewer's gadget public functions

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -274,12 +274,10 @@ void SceneViewerPanel::onShowHideActionTriggered(QAction *act) {
   updateShowHide();
 }
 
-void SceneViewerPanel::onDrawFrame(int frame,
-                                   const ImagePainter::VisualSettings &settings,
-                                   QElapsedTimer *timer, qint64 targetInstant) {
+void SceneViewerPanel::onDrawFrame(
+    int frame, const ImagePainter::VisualSettings &settings) {
   TApp *app = TApp::instance();
-  m_sceneViewer->setTimerAndTargetInstant(timer, targetInstant);
-
+  m_sceneViewer->setVisual(settings);
   TFrameHandle *frameHandle = app->getCurrentFrame();
 
   if (m_sceneViewer->isPreviewEnabled()) {
@@ -313,12 +311,6 @@ void SceneViewerPanel::onDrawFrame(int frame,
 
   else if (settings.m_blankColor != TPixel::Transparent)
     m_sceneViewer->update();
-
-  // make sure to redraw the frame here.
-  // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying())
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
-                        QEventLoop::ExcludeSocketNotifiers);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -278,7 +278,6 @@ void SceneViewerPanel::onDrawFrame(int frame,
                                    const ImagePainter::VisualSettings &settings,
                                    QElapsedTimer *timer, qint64 targetInstant) {
   TApp *app = TApp::instance();
-  m_sceneViewer->setVisual(settings);
   m_sceneViewer->setTimerAndTargetInstant(timer, targetInstant);
 
   TFrameHandle *frameHandle = app->getCurrentFrame();

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -316,7 +316,9 @@ void SceneViewerPanel::onDrawFrame(int frame,
 
   // make sure to redraw the frame here.
   // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying()) qApp->processEvents();
+  if (frameHandle->isPlaying())
+    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
+                        QEventLoop::ExcludeSocketNotifiers);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -64,8 +64,8 @@ public:
   void updateShowHide();
   void addShowHideContextMenu(QMenu *);
 
-  void onDrawFrame(int frame, const ImagePainter::VisualSettings &settings,
-                   QElapsedTimer *timer, qint64 targetInstant) override;
+  void onDrawFrame(int frame,
+                   const ImagePainter::VisualSettings &settings) override;
 
   void onEnterPanel() {
     m_sceneViewer->setFocus(Qt::OtherFocusReason);

--- a/toonz/sources/toonzqt/intfield.cpp
+++ b/toonz/sources/toonzqt/intfield.cpp
@@ -213,7 +213,7 @@ void IntLineEdit::setLineEditBackgroundColor(QColor color) {
     value = 255;  // white
 
   QString sheet =
-      QString("background-color: rgba(") + QString::number(color.red()) +
+      QString("background-color: rgb(") + QString::number(color.red()) +
       QString(",") + QString::number(color.green()) + QString(",") +
       QString::number(color.blue()) + QString(",") +
       QString::number(color.alpha()) +
@@ -309,7 +309,7 @@ IntField::IntField(QWidget *parent, bool isMaxRangeLimited, bool isRollerHide)
   m_slider = new QSlider(Qt::Horizontal, this);
   ret      = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
                        SLOT(onSliderChanged(int)));
-  ret      = ret && connect(m_slider, SIGNAL(sliderReleased()), this,
+  ret = ret && connect(m_slider, SIGNAL(sliderReleased()), this,
                        SLOT(onSliderReleased()));
 
   ret = ret && connect(m_lineEdit, SIGNAL(editingFinished()), this,
@@ -417,7 +417,7 @@ int IntField::pos2value(int x) const {
   else if (posRatio <= 0.9)
     t = -0.26 + 0.4 * posRatio;
   else
-    t = -8.0 + 9.0 * posRatio;
+    t              = -8.0 + 9.0 * posRatio;
   double sliderVal = (double)m_slider->minimum() + rangeSize * t;
   return (int)round(sliderVal * pow(0.1, NonLinearSliderPrecision));
 }


### PR DESCRIPTION
Due to slow Xsheet playback issues (and to some degree the Timeline) that was introduced when the Enhanced flipbook playback OT patch added in PR #874, this PR will revert those changes and related changes, for now.

Should OT ever fix the issue, I'll revert this revert and apply the fix.
