### PR TITLE
OpenToonz Patches thru 3/13/2022

### DIFF
--- a/toonz/sources/common/tfx/ttzpimagefx.cpp
+++ b/toonz/sources/common/tfx/ttzpimagefx.cpp
@@ -15,7 +15,7 @@ void parseIndexes(std::string indexes, std::vector<std::string> &items) {
   char seps[] = " ,;";
   char *token;
   if (indexes == "all" || indexes == "All" || indexes == "ALL")
-    indexes     = "0-4095";
+    indexes = "0-4095";
   char *context = 0;
   token         = strtok_s((char *)(indexes.c_str()), seps, &context);
   while (token != NULL) {
@@ -27,7 +27,7 @@ void parseIndexes(std::string indexes, std::vector<std::string> &items) {
   char *token;
   if (indexes == "all" || indexes == "All" || indexes == "ALL")
     indexes = "0-4095";
-  token     = strtok((char *)(indexes.c_str()), seps);
+  token = strtok((char *)(indexes.c_str()), seps);
   while (token != NULL) {
     items.push_back(token);
     token = strtok(NULL, seps);
@@ -39,48 +39,30 @@ void parseIndexes(std::string indexes, std::vector<std::string> &items) {
 
 void insertIndexes(std::vector<std::string> items,
                    PaletteFilterFxRenderData *t) {
+  for (int i = 0; i < (int)items.size(); i++) {
+    char *starttoken, *endtoken;
+    char subseps[]  = "-";
+    std::string tmp = items[i];
 #ifdef _MSC_VER
-  for (int i = 0; i < (int)items.size(); i++) {
-    char *starttoken, *endtoken;
-    char subseps[]  = "-";
-    std::string tmp = items[i];
-    char *context   = 0;
-    starttoken      = strtok_s((char *)tmp.c_str(), subseps, &context);
-    endtoken        = strtok_s(NULL, subseps, &context);
-    if (!endtoken && isInt(starttoken)) {
-      int index;
-      index = std::stoi(starttoken);
-      t->m_colors.insert(index);
-    } else {
-      if (isInt(starttoken) && isInt(endtoken)) {
-        int start, end;
-        start = std::stoi(starttoken);
-        end   = std::stoi(endtoken);
-        for (int i = start; i <= end; i++) t->m_colors.insert(i);
-      }
-    }
-  }
+    char *context = 0;
+    starttoken    = strtok_s((char *)tmp.c_str(), subseps, &context);
+    endtoken      = strtok_s(NULL, subseps, &context);
 #else
-  for (int i = 0; i < (int)items.size(); i++) {
-    char *starttoken, *endtoken;
-    char subseps[]  = "-";
-    std::string tmp = items[i];
-    starttoken      = strtok((char *)tmp.c_str(), subseps);
-    endtoken        = strtok(NULL, subseps);
-    if (!endtoken && isInt(starttoken)) {
+    starttoken = strtok((char *)tmp.c_str(), subseps);
+    endtoken   = strtok(NULL, subseps);
+#endif
+    if (!starttoken || !isInt(starttoken)) continue;
+    if (!endtoken) {
       int index;
       index = std::stoi(starttoken);
       t->m_colors.insert(index);
-    } else {
-      if (isInt(starttoken) && isInt(endtoken)) {
-        int start, end;
-        start = std::stoi(starttoken);
-        end   = std::stoi(endtoken);
-        for (int i = start; i <= end; i++) t->m_colors.insert(i);
-      }
+    } else if (isInt(endtoken)) {
+      int start, end;
+      start = std::stoi(starttoken);
+      end   = std::stoi(endtoken);
+      for (int i = start; i <= end; i++) t->m_colors.insert(i);
     }
   }
-#endif
 }
 
 //**********************************************************************************************

--- a/toonz/sources/image/ffmpeg/tiio_gif.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_gif.cpp
@@ -155,6 +155,8 @@ TLevelWriterGif::~TLevelWriterGif() {
   }
 #endif
 
+  preIArgs << "-r";
+  preIArgs << QString::number(framerate);
   preIArgs << "-v";
   preIArgs << "warning";
 #if 0
@@ -350,6 +352,9 @@ Tiio::GifWriterProperties::GifWriterProperties()
   m_mode.setItemUIName(L"NEW2", tr("New Pal Per Frame + Bayer2 Dither"));
   m_mode.setItemUIName(L"NEW3", tr("New Pal Per Frame + Bayer1 Dither"));
   m_mode.setItemUIName(L"NOPAL", tr("Opaque, Dither, 256 Colors Only"));
+
+  // Doesn't make Generate Palette property visible in the popup
+  m_palette.setVisible(false);
 
   bind(m_scale);
   bind(m_looping);

--- a/toonz/sources/include/tools/stylepicker.h
+++ b/toonz/sources/include/tools/stylepicker.h
@@ -8,6 +8,7 @@
 #include "tpalette.h"
 
 class TStroke;
+class QWidget;
 
 #undef DVAPI
 #undef DVVAR
@@ -22,15 +23,17 @@ class TStroke;
 class DVAPI StylePicker {
   TImageP m_image;
   TPaletteP m_palette;
+  const QWidget *m_widget;
 
 public:
-  StylePicker() {}
+  StylePicker(const QWidget *parent) : m_widget(parent) {}
 
   // usa come palette la palette dell'immagine
-  StylePicker(const TImageP &image);
+  StylePicker(const QWidget *parent, const TImageP &image);
 
   // palette esterna (ad es. se image e' di tipo raster)
-  StylePicker(const TImageP &image, const TPaletteP &palette);
+  StylePicker(const QWidget *parent, const TImageP &image,
+              const TPaletteP &palette);
 
   // pickStyleId(point, radius)
   //

--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -605,9 +605,10 @@ protected:
   int guidedStrokePickMode = 0;
   int m_guidedFrontStroke  = -1;
   int m_guidedBackStroke   = -1;
+  QWidget *m_viewerWidget  = nullptr;
 
 public:
-  Viewer() {}
+  Viewer(QWidget *widget) : m_viewerWidget(widget) {}
   virtual ~Viewer() {}
 
   const ImagePainter::VisualSettings &visualSettings() const {
@@ -717,6 +718,8 @@ public:
 
   void getGuidedFrameIdx(int *backIdx, int *frontIdx);
   void doPickGuideStroke(const TPointD &pos);
+
+  QWidget *viewerWidget() { return m_viewerWidget; }
 };
 
 #endif

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -402,6 +402,9 @@ public:
   bool isShowColumnNumbersEnabled() const {
     return getBoolValue(showColumnNumbers);
   }
+  bool isParentColorsInXsheetColumnEnabled() const {
+    return getBoolValue(parentColorsInXsheetColumn);
+  }
   bool isSyncLevelRenumberWithXsheetEnabled() const {
     return getBoolValue(syncLevelRenumberWithXsheet);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -131,6 +131,7 @@ enum PreferencesItemId {
   showQuickToolbar,
   expandFunctionHeader,
   showColumnNumbers,
+  parentColorsInXsheetColumn,
   syncLevelRenumberWithXsheet,
   currentTimelineEnabled,
   currentColumnColor,

--- a/toonz/sources/include/toonz/sceneproperties.h
+++ b/toonz/sources/include/toonz/sceneproperties.h
@@ -52,6 +52,9 @@ public:
   struct CellMark {
     QString name;
     TPixel32 color;
+    bool operator==(const CellMark &cm) {
+      return name == cm.name && color == cm.color;
+    }
   };
 
 private:

--- a/toonz/sources/include/toonzqt/glwidget_for_highdpi.h
+++ b/toonz/sources/include/toonzqt/glwidget_for_highdpi.h
@@ -19,6 +19,7 @@ public:
   int width() const { return QOpenGLWidget::width() * getDevPixRatio(); }
   int height() const { return QOpenGLWidget::height() * getDevPixRatio(); }
   QRect rect() const { return QRect(0, 0, width(), height()); }
+  int getDevPixRatio() const { return getDevicePixelRatio(this); }
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -104,7 +104,7 @@ svgToPixmap(const QString &svgFilePath, const QSize &size = QSize(),
 // returns device-pixel ratio. It is 1 for normal monitors and 2 (or higher
 // ratio) for high DPI monitors. Setting "Display > Set custom text size(DPI)"
 // for Windows corresponds to this ratio.
-int DVAPI getDevPixRatio();
+int DVAPI getDevicePixelRatio(const QWidget *widget = nullptr);
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -33,6 +33,7 @@ protected:
   void focusOutEvent(QFocusEvent *fe) override;
 
   void keyPressEvent(QKeyEvent *ke) override;
+  void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
 
 signals:
   void focusOut();

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -19,7 +19,15 @@ class SchematicName final : public QGraphicsTextItem {
   Q_OBJECT
   double m_width;
   double m_height;
-  bool m_noAllSelect;
+  bool m_refocus;
+  QString m_defName;
+  QString m_curName;
+  QMenu *popup;
+  QAction *actionCut;
+  QAction *actionCopy;
+  QAction *actionPaste;
+  QAction *actionDelete;
+  QAction *actionSelectAll;
 
 public:
   SchematicName(QGraphicsItem *parent, double width, double height);
@@ -27,7 +35,8 @@ public:
 
   bool eventFilter(QObject *object, QEvent *event) override;
 
-  void setName(const QString &name);
+  void setName(const QString &name); // Act as default name
+  void acceptName(const QString &name);
 
 protected:
   void focusInEvent(QFocusEvent *fe) override;
@@ -36,16 +45,16 @@ protected:
   void keyPressEvent(QKeyEvent *ke) override;
   void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
 
-  void reFocus();
-
 signals:
   void focusOut();
 
 protected slots:
   void onContentsChanged();
+  void onPopupHide();
+  void onCut();
   void onCopy();
   void onPaste();
-  void onCut();
+  void onDelete();
   void onSelectAll();
 };
 

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -19,6 +19,7 @@ class SchematicName final : public QGraphicsTextItem {
   Q_OBJECT
   double m_width;
   double m_height;
+  bool m_noAllSelect;
 
 public:
   SchematicName(QGraphicsItem *parent, double width, double height);
@@ -35,11 +36,17 @@ protected:
   void keyPressEvent(QKeyEvent *ke) override;
   void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
 
+  void reFocus();
+
 signals:
   void focusOut();
 
 protected slots:
   void onContentsChanged();
+  void onCopy();
+  void onPaste();
+  void onCut();
+  void onSelectAll();
 };
 
 //========================================================

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -43,19 +43,23 @@ protected:
   void focusOutEvent(QFocusEvent *fe) override;
 
   void keyPressEvent(QKeyEvent *ke) override;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
+#endif
 
 signals:
   void focusOut();
 
 protected slots:
   void onContentsChanged();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   void onPopupHide();
   void onCut();
   void onCopy();
   void onPaste();
   void onDelete();
   void onSelectAll();
+#endif
 };
 
 //========================================================

--- a/toonz/sources/include/toonzqt/swatchviewer.h
+++ b/toonz/sources/include/toonzqt/swatchviewer.h
@@ -161,6 +161,8 @@ public:
     SwatchViewer *m_viewer;
     bool m_started;
 
+    TRenderSettings m_info;
+
     ContentRender(TRasterFx *fx, int frame, const TDimension &size,
                   SwatchViewer *viewer);
     ~ContentRender();

--- a/toonz/sources/include/tproperty.h
+++ b/toonz/sources/include/tproperty.h
@@ -96,11 +96,15 @@ public:
   std::string getId() const { return m_id; }
   void setId(std::string id) { m_id = id; }
 
+  bool getVisible() const { return m_visible; }
+  void setVisible(bool state) { m_visible = state; }
+
 private:
   std::string m_name;
   QString m_qstringName;
   std::string m_id;
   std::vector<Listener *> m_listeners;
+  bool m_visible;
 };
 
 //---------------------------------------------------------

--- a/toonz/sources/include/tproperty.h
+++ b/toonz/sources/include/tproperty.h
@@ -71,7 +71,7 @@ public:
   class TypeError {};
   class RangeError {};
 
-  TProperty(std::string name) : m_name(name) {
+  TProperty(std::string name) : m_name(name), m_visible(true) {
     m_qstringName = QString::fromStdString(name);
   }
 

--- a/toonz/sources/stdfx/artcontourfx.cpp
+++ b/toonz/sources/stdfx/artcontourfx.cpp
@@ -190,6 +190,8 @@ void ArtContourFx::doDryCompute(TRectD &rect, double frame,
   TRectD controlBox;
   m_controller->getBBox(frame, controlBox, ri2);
 
+  if (controlBox == TConsts::infiniteRectD) controlBox = rect;
+
   TDimension dim = convert(controlBox).getSize();
   TRectD controlRect(controlBox.getP00(), TDimensionD(dim.lx, dim.ly));
 
@@ -223,6 +225,12 @@ void ArtContourFx::doCompute(TTile &tile, double frame,
 
   TRectD controlBox;
   m_controller->getBBox(frame, controlBox, ri2);
+
+  if (controlBox == TConsts::infiniteRectD) {
+    TDimension tileDim = tile.getRaster()->getSize();
+    controlBox = TRectD(tile.m_pos, TDimensionD(tileDim.lx, tileDim.ly));
+  }
+
   TTile ctrTile;
   ctrTile.m_pos  = controlBox.getP00();
   TDimension dim = convert(controlBox).getSize();

--- a/toonz/sources/stdfx/particlesengine.cpp
+++ b/toonz/sources/stdfx/particlesengine.cpp
@@ -752,15 +752,18 @@ void Particles_Engine::do_render(
 
     (*part_ports[part->level])->getBBox(ndx, bbox, riIdentity);
 
-    // A particle's bbox MUST be finite. Gradients and such which have an
-    // infinite bbox
-    // are just NOT rendered.
-
-    // NOTE: No fx returns half-planes or similar (ie if any coordinate is
-    // either
-    // (std::numeric_limits<double>::max)() or its opposite, then the rect IS
-    // THE infiniteRectD)
-    if (bbox.isEmpty() || bbox == TConsts::infiniteRectD) return;
+    // Now sources with infinite bounding box are retrieved with the output tile
+    // size. This is especially for levels deformed by plastic mesh which must
+    // have some finite bbox but return infinite bbox because "it's hard work to
+    // calculate". (see PlasticDeformerFx::doGetBBox() and the issue
+    // opentoonz#1330) NOTE: No fx returns half-planes or similar (ie if any
+    // coordinate is either (std::numeric_limits<double>::max)() or its
+    // opposite, then the rect IS THE infiniteRectD)
+    if (bbox.isEmpty())
+      return;
+    else if (bbox == TConsts::infiniteRectD)
+      bbox *= TRectD(tile->m_pos, TDimensionD(tile->getRaster()->getLx(),
+                                              tile->getRaster()->getLy()));
   }
 
   // Now, these are the particle rendering specifications

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -1141,7 +1141,7 @@ void EditTool::drawMainHandle() {
   TAffine parentAff    = xsh->getParentPlacement(objId, frame);
   TAffine aff          = xsh->getPlacement(objId, frame);
   TPointD center       = Stage::inch * xsh->getCenter(objId, frame);
-  int devPixRatio      = getDevPixRatio();
+  int devPixRatio      = getDevicePixelRatio(m_viewer->viewerWidget());
   // the gadget appears on the center of the level. orientation and dimension
   // are independent of the movement of the level
   glPushMatrix();

--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -17,6 +17,7 @@
 #include "tparamuiconcept.h"
 
 #include "historytypes.h"
+#include "toonzqt/gutil.h"
 
 #include <QApplication>
 #include <QDesktopWidget>
@@ -26,11 +27,6 @@ using namespace EditToolGadgets;
 GLdouble FxGadget::m_selectedColor[3] = {0.2, 0.8, 0.1};
 
 namespace {
-int getDevPixRatio() {
-  static int devPixRatio = QApplication::desktop()->devicePixelRatio();
-  return devPixRatio;
-}
-
 TPointD hadamard(const TPointD &v1, const TPointD &v2) {
   return TPointD(v1.x * v2.x, v1.y * v2.y);
 }
@@ -199,14 +195,14 @@ void FxGadget::setValue(const TPointParamP &param, const TPointD &pos) {
 //---------------------------------------------------------------------------
 
 void FxGadget::setPixelSize() {
-  setPixelSize(sqrt(tglGetPixelSize2()) * getDevPixRatio());
+  setPixelSize(sqrt(tglGetPixelSize2()) * m_controller->getDevPixRatio());
 }
 
 //---------------------------------------------------------------------------
 
 void FxGadget::drawTooltip(const TPointD &tooltipPos,
                            std::string tooltipPosText) {
-  double unit = sqrt(tglGetPixelSize2()) * getDevPixRatio();
+  double unit = sqrt(tglGetPixelSize2()) * m_controller->getDevPixRatio();
   glPushMatrix();
   glTranslated(tooltipPos.x, tooltipPos.y, 0.0);
   double sc = unit * 1.6;
@@ -494,7 +490,7 @@ void AngleFxGadget::draw(bool picking) {
   else
     glColor3d(0, 0, 1);
   glPushName(getId());
-  double pixelSize = sqrt(tglGetPixelSize2()) * getDevPixRatio();
+  double pixelSize = sqrt(tglGetPixelSize2()) * m_controller->getDevPixRatio();
   double r         = pixelSize * 40;
   double a = pixelSize * 10, b = pixelSize * 5;
   tglDrawCircle(m_pos, r);
@@ -579,7 +575,7 @@ void AngleRangeFxGadget::draw(bool picking) {
       glColor3d(0, 0, 1);
   };
 
-  double pixelSize = sqrt(tglGetPixelSize2()) * getDevPixRatio();
+  double pixelSize = sqrt(tglGetPixelSize2()) * m_controller->getDevPixRatio();
   double r         = pixelSize * 200;
   double a         = pixelSize * 30;
 
@@ -2063,3 +2059,7 @@ int FxGadgetController::getCurrentFrame() const { return m_tool->getFrame(); }
 //---------------------------------------------------------------------------
 
 void FxGadgetController::invalidateViewer() { m_tool->invalidate(); }
+
+int FxGadgetController::getDevPixRatio() {
+  return getDevicePixelRatio(m_tool->getViewer()->viewerWidget());
+}

--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -1831,15 +1831,16 @@ void FxGadgetController::draw(bool picking) {
 //---------------------------------------------------------------------------
 
 void FxGadgetController::selectById(unsigned int id) {
-  std::map<GLuint, FxGadget *>::iterator it;
-  it                       = m_idTable.find(id);
-  FxGadget *selectedGadget = it != m_idTable.end() ? it->second : 0;
+  std::map<GLuint, FxGadget *>::iterator it = m_idTable.find(id);
+  FxGadget *selectedGadget = it != m_idTable.end() ? it->second : nullptr;
   if (selectedGadget != m_selectedGadget) {
     if (m_selectedGadget) m_selectedGadget->select(-1);
     m_selectedGadget = selectedGadget;
-    if (m_selectedGadget)
-      m_selectedGadget->select(id - m_selectedGadget->getId());
   }
+  if (!m_selectedGadget) return;
+  int handleId = id - m_selectedGadget->getId();
+  if (!m_selectedGadget->isSelected(handleId))
+    m_selectedGadget->select(handleId);
 }
 
 //---------------------------------------------------------------------------

--- a/toonz/sources/tnztools/edittoolgadgets.h
+++ b/toonz/sources/tnztools/edittoolgadgets.h
@@ -151,6 +151,8 @@ public:
 
   bool hasGadget() { return m_gadgets.size() != 0; }
 
+  int getDevPixRatio();
+
 public slots:
 
   void onFxSwitched();

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2578,7 +2578,7 @@ int FillTool::pick(const TImageP &image, const TPointD &pos, const int frame) {
   TVectorImageP vi = image;
   if (!ti && !vi) return 0;
 
-  StylePicker picker(image);
+  StylePicker picker(getViewer()->viewerWidget(), image);
   double scale2 = 1.0;
   if (vi) {
     TAffine aff = getViewer()->getViewMatrix() * getCurrentColumnMatrix(frame);

--- a/toonz/sources/tnztools/fingertool.cpp
+++ b/toonz/sources/tnztools/fingertool.cpp
@@ -561,7 +561,7 @@ void FingerTool::pick(const TPointD &pos) {
 
   int subsampling = level->getImageSubsampling(getCurrentFid());
 
-  StylePicker picker(image);
+  StylePicker picker(getViewer()->viewerWidget(), image);
 
   int styleId =
       picker.pickStyleId(TScale(1.0 / subsampling) * pos + TPointD(-0.5, -0.5),

--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -705,7 +705,7 @@ int PaintBrushTool::getStyleUnderCursor(const TPointD &pos) {
 
   int subsampling = level->getImageSubsampling(getCurrentFid());
 
-  StylePicker picker(image);
+  StylePicker picker(getViewer()->viewerWidget(), image);
 
   int styleId =
       picker.pickStyleId(TScale(1.0 / subsampling) * pos,

--- a/toonz/sources/tnztools/perspectivetool.cpp
+++ b/toonz/sources/tnztools/perspectivetool.cpp
@@ -331,12 +331,12 @@ void PerspectivePresetManager::deletePreset(TFilePath presetPath) {
 
 //----------------------------------------------------------------------------------------------------------
 
-void PerspectiveControls::drawControls() {
+void PerspectiveControls::drawControls(SceneViewer *viewer) {
   if (!m_perspective) return;
 
   TPointD centerPoint = m_perspective->getCenterPoint();
 
-  m_unit = sqrt(tglGetPixelSize2()) * getDevPixRatio();
+  m_unit = sqrt(tglGetPixelSize2()) * viewer->getDevPixRatio();
 
   double circleRadius = m_handleRadius * m_unit;
   double diskRadius   = (m_handleRadius - 2) * m_unit;
@@ -707,7 +707,7 @@ void PerspectiveTool::draw(SceneViewer *viewer) {
   bool drawControls = getApplication()->getCurrentTool()->getTool() == this;
   if (drawControls) {
     for (int i = 0; i < m_perspectiveObjs.size(); i++)
-      m_perspectiveObjs[i]->drawControls();
+      m_perspectiveObjs[i]->drawControls(viewer);
   }
 
   if (m_selecting) {

--- a/toonz/sources/tnztools/perspectivetool.h
+++ b/toonz/sources/tnztools/perspectivetool.h
@@ -145,7 +145,7 @@ public:
 
   void shiftPerspectiveObject(TPointD delta);
 
-  void drawControls();
+  void drawControls(SceneViewer *viewer);
 
   bool isOverCenterPoint() {
     TPointD centerPoint = m_perspective->getCenterPoint();

--- a/toonz/sources/tnztools/rgbpickertool.cpp
+++ b/toonz/sources/tnztools/rgbpickertool.cpp
@@ -430,7 +430,7 @@ void RGBPickerTool::passivePick() {
   TRectD area = TRectD(m_mousePixelPosition.x, m_mousePixelPosition.y,
                        m_mousePixelPosition.x, m_mousePixelPosition.y);
 
-  StylePicker picker(image);
+  StylePicker picker(getViewer()->viewerWidget(), image);
 
   if (LutManager::instance()->isValid()) m_viewer->bindFBO();
 
@@ -458,7 +458,7 @@ void RGBPickerTool::pick() {
 
   TRectD area = TRectD(m_mousePixelPosition.x - 1, m_mousePixelPosition.y - 1,
                        m_mousePixelPosition.x + 1, m_mousePixelPosition.y + 1);
-  StylePicker picker(image, palette);
+  StylePicker picker(getViewer()->viewerWidget(), image, palette);
 
   if (LutManager::instance()->isValid()) m_viewer->bindFBO();
 
@@ -491,7 +491,7 @@ void RGBPickerTool::pickRect() {
   }
   m_selectingRect.empty();
   if (area.getLx() <= 1 || area.getLy() <= 1) return;
-  StylePicker picker(image, palette);
+  StylePicker picker(getViewer()->viewerWidget(), image, palette);
 
   if (LutManager::instance()->isValid()) m_viewer->bindFBO();
 
@@ -511,7 +511,7 @@ void RGBPickerTool::pickStroke() {
   TPalette *palette       = ph->getPalette();
   if (!palette) return;
 
-  StylePicker picker(image, palette);
+  StylePicker picker(getViewer()->viewerWidget(), image, palette);
   TStroke *stroke = new TStroke(*m_stroke);
 
   if (LutManager::instance()->isValid()) m_viewer->bindFBO();

--- a/toonz/sources/tnztools/shifttracetool.cpp
+++ b/toonz/sources/tnztools/shifttracetool.cpp
@@ -245,7 +245,7 @@ void ShiftTraceTool::drawControlRect() {  // TODO
                                           inksOnly);
     color       = (m_ghostIndex == 0) ? backOniColor : frontOniColor;
     double unit = sqrt(tglGetPixelSize2());
-    unit *= getDevPixRatio();
+    unit *= getDevicePixelRatio(m_viewer->viewerWidget());
     TRectD coloredBox = box.enlarge(3.0 * unit);
     tglColor(color);
     glBegin(GL_LINE_STRIP);

--- a/toonz/sources/tnztools/stylepicker.cpp
+++ b/toonz/sources/tnztools/stylepicker.cpp
@@ -17,13 +17,14 @@
 
 //---------------------------------------------------------
 
-StylePicker::StylePicker(const TImageP &image)
-    : m_image(image), m_palette(image->getPalette()) {}
+StylePicker::StylePicker(const QWidget *parent, const TImageP &image)
+    : m_widget(parent), m_image(image), m_palette(image->getPalette()) {}
 
 //---------------------------------------------------------
 
-StylePicker::StylePicker(const TImageP &image, const TPaletteP &palette)
-    : m_image(image), m_palette(palette) {}
+StylePicker::StylePicker(const QWidget *parent, const TImageP &image,
+                         const TPaletteP &palette)
+    : m_widget(parent), m_image(image), m_palette(palette) {}
 
 //---------------------------------------------------------
 
@@ -86,7 +87,7 @@ int StylePicker::pickStyleId(const TPointD &pos, double radius, double scale2,
     // la thickness, cioe' la min distance dalla outline e non dalla centerLine
     strokeFound = vi->getNearestStroke(pos, w, index, dist2);
     if (strokeFound) {
-      int devPixRatio = getDevPixRatio();
+      int devPixRatio = getDevicePixelRatio(m_widget);
       dist2 *= scale2;
       TStroke *stroke = vi->getStroke(index);
       thick           = stroke->getThickPoint(w).thick;

--- a/toonz/sources/tnztools/stylepickertool.cpp
+++ b/toonz/sources/tnztools/stylepickertool.cpp
@@ -116,7 +116,7 @@ void StylePickerTool::pick(const TPointD &pos, const TMouseEvent &e,
         TAffine aff =
             getViewer()->getViewMatrix() * getColumnMatrix(superPickedColumnId);
         double scale2 = aff.det();
-        StylePicker superPicker(pickedImage);
+        StylePicker superPicker(getViewer()->viewerWidget(), pickedImage);
         int picked_subsampling =
             picked_level->getImageSubsampling(pickedCell.getFrameId());
         int superPicked_StyleId = superPicker.pickStyleId(
@@ -159,7 +159,7 @@ void StylePickerTool::pick(const TPointD &pos, const TMouseEvent &e,
   TAffine aff = getViewer()->getViewMatrix() * getCurrentColumnMatrix();
   double scale2 = aff.det();
   int subsampling = level->getImageSubsampling(getCurrentFid());
-  StylePicker picker(image);
+  StylePicker picker(getViewer()->viewerWidget(), image);
   int styleId =
       picker.pickStyleId(TScale(1.0 / subsampling) * pos + TPointD(-0.5, -0.5),
                          10.0, scale2, modeValue);
@@ -215,7 +215,7 @@ void StylePickerTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   TAffine aff = getViewer()->getViewMatrix() * getCurrentColumnMatrix();
   double scale2 = aff.det();
   int subsampling = level->getImageSubsampling(getCurrentFid());
-  StylePicker picker(image);
+  StylePicker picker(getViewer()->viewerWidget(), image);
   TPointD pickPos(TScale(1.0 / subsampling) * pos + TPointD(-0.5, -0.5));
   int inkStyleId = picker.pickStyleId(pickPos, 10.0, scale2, 1);
   int paintStyleId = picker.pickStyleId(pickPos, 10.0, scale2, 0);

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -447,6 +447,7 @@ ToolOptionPopupButton::ToolOptionPopupButton(TTool *tool,
     QAction *action = addItem(createQIcon(items[i].iconName.toUtf8()));
     // make the tooltip text
     action->setToolTip(items[i].UIName);
+    action->setIconVisibleInMenu(true);
   }
   setCurrentIndex(0);
   updateStatus();

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -1505,7 +1505,9 @@ void ToolUtils::drawBalloon(const TPointD &pos, std::string text,
                             const TPixel32 &color, TPoint delta,
                             double pixelSize, bool isPicking,
                             std::vector<TRectD> *otherBalloons) {
-  int devPixRatio = getDevPixRatio();
+  TTool::Viewer *viewer =
+      TTool::getApplication()->getCurrentTool()->getTool()->getViewer();
+  int devPixRatio = getDevicePixelRatio(viewer->viewerWidget());
   QString qText   = QString::fromStdString(text);
   QFont font("Arial");  // ,QFont::Bold);
   font.setPixelSize(13 * devPixRatio);
@@ -1558,9 +1560,6 @@ void ToolUtils::drawBalloon(const TPointD &pos, std::string text,
   int y1 = textRect.bottom() + mrg;
 
   if (isPicking) {
-    TTool::Viewer *viewer =
-        TTool::getApplication()->getCurrentTool()->getTool()->getViewer();
-
     if (viewer->is3DView()) {
       double x0 = pos.x + textRect.left() * pixelSize,
              y0 = pos.y + delta.y * pixelSize;
@@ -1650,7 +1649,9 @@ void ToolUtils::drawBalloon(const TPointD &pos, std::string text,
 
 void ToolUtils::drawHook(const TPointD &pos, ToolUtils::HookType type,
                          bool highlighted, bool onionSkin) {
-  int devPixRatio = getDevPixRatio();
+  TTool::Viewer *viewer =
+      TTool::getApplication()->getCurrentTool()->getTool()->getViewer();
+  int devPixRatio = getDevicePixelRatio(viewer->viewerWidget());
   int r = 10, d = r + r;
   QImage image(d * devPixRatio, d * devPixRatio, QImage::Format_ARGB32);
   image.fill(Qt::transparent);

--- a/toonz/sources/toonz/cleanuppopup.cpp
+++ b/toonz/sources/toonz/cleanuppopup.cpp
@@ -476,7 +476,7 @@ void CleanupPopup::buildCleanupList() {
         const TXshCell &cell = xsh->getCell(r, c);
         if (cell.isEmpty()) continue;
         TXshSimpleLevel *sl = cell.getSimpleLevel();
-        if (!sl && locals::supportsCleanup(sl)) continue;
+        if (!(sl && locals::supportsCleanup(sl))) continue;
         /*---もし新しいLevelなら、Levelのリストに登録---*/
         std::map<TXshSimpleLevel *, FramesList>::iterator it =
             cleanupList.find(sl);

--- a/toonz/sources/toonz/colormodelviewer.cpp
+++ b/toonz/sources/toonz/colormodelviewer.cpp
@@ -271,14 +271,16 @@ void ColorModelViewer::contextMenuEvent(QContextMenuEvent *event) {
 /*! If left button is pressed recall \b pick() in event pos.
  */
 void ColorModelViewer::mousePressEvent(QMouseEvent *event) {
-  if (event->button() == Qt::LeftButton) pick(event->pos() * getDevPixRatio());
+  if (event->button() == Qt::LeftButton)
+    pick(event->pos() * getDevicePixelRatio(this));
 }
 
 //-----------------------------------------------------------------------------
 /*! If left button is moved recall \b pick() in event pos.
  */
 void ColorModelViewer::mouseMoveEvent(QMouseEvent *event) {
-  if (event->buttons() & Qt::LeftButton) pick(event->pos() * getDevPixRatio());
+  if (event->buttons() & Qt::LeftButton)
+    pick(event->pos() * getDevicePixelRatio(this));
 }
 
 //-----------------------------------------------------------------------------
@@ -296,7 +298,7 @@ void ColorModelViewer::pick(const QPoint &p) {
   /*- 画面外ではPickできない -*/
   if (!m_imageViewer->rect().contains(p)) return;
 
-  StylePicker picker(img, currentPalette);
+  StylePicker picker(this, img, currentPalette);
 
   QPoint viewP = m_imageViewer->mapFrom(this, p);
   TPointD pos  = m_imageViewer->getViewAff().inv() *

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -204,7 +204,8 @@ DvDirModelFileFolderNode::DvDirModelFileFolderNode(DvDirModelNode *parent,
 //-----------------------------------------------------------------------------
 
 bool DvDirModelFileFolderNode::exists() {
-  return m_existsChecked ? m_exists : m_peeks
+  return m_existsChecked ? m_exists
+                         : m_peeks
              ? m_existsChecked = true,
                m_exists        = TFileStatus(m_path).doesExist() : true;
 }
@@ -1327,12 +1328,12 @@ void DvDirModelRootNode::updateSceneFolderNodeVisibility(bool forceHide) {
   bool show = (forceHide) ? false : !m_sceneFolderNode->getPath().isEmpty();
   if (show && m_sceneFolderNode->getRow() == -1) {
     int row = getChildCount();
-    DvDirModel::instance()->notifyBeginInsertRows(QModelIndex(), row, row + 1);
+    DvDirModel::instance()->notifyBeginInsertRows(QModelIndex(), row, row);
     addChild(m_sceneFolderNode);
     DvDirModel::instance()->notifyEndInsertRows();
   } else if (!show && m_sceneFolderNode->getRow() != -1) {
     int row = m_sceneFolderNode->getRow();
-    DvDirModel::instance()->notifyBeginRemoveRows(QModelIndex(), row, row + 1);
+    DvDirModel::instance()->notifyBeginRemoveRows(QModelIndex(), row, row);
     // remove the last child of the root node
     m_children.erase(m_children.begin() + row, m_children.begin() + row + 1);
     DvDirModel::instance()->notifyEndRemoveRows();
@@ -1435,7 +1436,7 @@ DvDirModelNode *DvDirModel::getNode(const QModelIndex &index) const {
 QModelIndex DvDirModel::index(int row, int column,
                               const QModelIndex &parent) const {
   if (column != 0) return QModelIndex();
-  DvDirModelNode *parentNode       = m_root;
+  DvDirModelNode *parentNode = m_root;
   if (parent.isValid()) parentNode = getNode(parent);
   if (row < 0 || row >= parentNode->getChildCount()) return QModelIndex();
   DvDirModelNode *node = parentNode->getChild(row);

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -2116,8 +2116,8 @@ void FlipBook::onDoubleClick(QMouseEvent *me) {
   if (!img) return;
 
   TAffine toWidgetRef(m_imageViewer->getImgToWidgetAffine());
-  TRectD pixGeomD(TScale(1.0 / (double)getDevPixRatio()) * toWidgetRef *
-                  getImageBoundsD(img));
+  TRectD pixGeomD(TScale(1.0 / (double)getDevicePixelRatio(this)) *
+                  toWidgetRef * getImageBoundsD(img));
   // TRectD pixGeomD(toWidgetRef  * getImageBoundsD(img));
   TRect pixGeom(tceil(pixGeomD.x0), tceil(pixGeomD.y0), tfloor(pixGeomD.x1) - 1,
                 tfloor(pixGeomD.y1) - 1);

--- a/toonz/sources/toonz/formatsettingspopups.cpp
+++ b/toonz/sources/toonz/formatsettingspopups.cpp
@@ -75,17 +75,17 @@ FormatSettingsPopup::FormatSettingsPopup(QWidget *parent,
   if (m_props) {
     int i = 0;
     for (i = 0; i < m_props->getPropertyCount(); i++) {
-      if (dynamic_cast<TEnumProperty *>(m_props->getProperty(i)))
+      TProperty *prop = m_props->getProperty(i);
+      if (prop && !prop->getVisible()) continue;
+      if (dynamic_cast<TEnumProperty *>(prop))
         buildPropertyComboBox(i, m_props);
-      else if (dynamic_cast<TIntProperty *>(m_props->getProperty(i)))
+      else if (dynamic_cast<TIntProperty *>(prop))
         buildValueField(i, m_props);
-      else if (dynamic_cast<TDoubleProperty *>(m_props->getProperty(i)))
+      else if (dynamic_cast<TDoubleProperty *>(prop))
         buildDoubleField(i, m_props);
-      else if (dynamic_cast<TBoolProperty*>(m_props->getProperty(i))) {
-        if (m_props->getProperty(i)->getName() !=
-            "Generate Palette")  // Hide. Not using but still needed here
+      else if (dynamic_cast<TBoolProperty *>(prop))
         buildPropertyCheckBox(i, m_props);
-      } else if (dynamic_cast<TStringProperty*>(m_props->getProperty(i)))
+      else if (dynamic_cast<TStringProperty *>(prop))
         buildPropertyLineEdit(i, m_props);
       else
         assert(false);

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -973,7 +973,7 @@ void ImageViewer::pickColor(QMouseEvent *event, bool putValueToStyleEditor) {
     return;
   }
 
-  StylePicker picker(img);
+  StylePicker picker(this, img);
 
   TPointD pos =
       getViewAff().inv() * TPointD(curPos.x() - (qreal)(width()) / 2,
@@ -1042,7 +1042,7 @@ void ImageViewer::rectPickColor(bool putValueToStyleEditor) {
     return;
   }
 
-  StylePicker picker(img);
+  StylePicker picker(this, img);
 
   if (!img->raster()) {  // vector image
     TPointD pressedWinPos = convert(m_pressedMousePos) + m_winPosMousePosOffset;

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1319,6 +1319,10 @@ void IoCmd::newScene() {
 
   if (!saveSceneIfNeeded(QApplication::tr("New Scene"))) return;
 
+  // temporary clear the current level to prevent UI to access deleted level
+  // while switching scenes
+  app->getCurrentLevel()->setLevel(nullptr);
+
   IconGenerator::instance()->clearRequests();
   IconGenerator::instance()->clearSceneIcons();
   ImageManager::instance()->clear();
@@ -1921,6 +1925,11 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   }
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
+  TApp *app = TApp::instance();
+  // temporary clear the current level to prevent UI to access deleted level
+  // while switching scenes
+  app->getCurrentLevel()->setLevel(nullptr);
+
   TUndoManager::manager()->reset();
   IconGenerator::instance()->clearRequests();
   IconGenerator::instance()->clearSceneIcons();
@@ -1976,7 +1985,6 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
     project->setFolder("project", scenePath);
     scene->setProject(project);
   }
-  TApp *app = TApp::instance();
   app->getCurrentScene()->setScene(scene);
   app->getCurrentScene()->notifyNameSceneChange();
   app->getCurrentFrame()->setFrame(0);

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -453,7 +453,7 @@ int main(int argc, char *argv[]) {
   // qDebug() << "All icon theme search paths:" << QIcon::themeSearchPaths();
 
   // Set show icons in menus flag (use iconVisibleInMenu to disable selectively)
-  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, false);
+  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
 
   TEnv::setApplicationFileName(argv[0]);
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -460,9 +460,7 @@ int main(int argc, char *argv[]) {
   // splash screen
   QPixmap splashPixmap =
       QIcon(":Resources/splash2.svg").pixmap(QSize(344, 344));
-  splashPixmap.setDevicePixelRatio(QApplication::desktop()->devicePixelRatio());
 
-// QPixmap splashPixmap(":Resources/splash.png");
 #ifdef _WIN32
   QFont font("Segoe UI", -1);
 #else

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1231,6 +1231,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {expandFunctionHeader,
        tr("Expand Function Editor Header to Match Quick Toolbar Height*")},
       {showColumnNumbers, tr("Show Column Numbers in Column Headers")},
+      {parentColorsInXsheetColumn,
+       tr("Show Column Parent's Color in the Xsheet")},
       {syncLevelRenumberWithXsheet,
        tr("Sync Level Strip Drawing Number Changes with the Scene")},
       {currentTimelineEnabled,
@@ -1924,6 +1926,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   QGridLayout* xshToolbarLay = insertGroupBoxUI(showQuickToolbar, lay);
   { insertUI(expandFunctionHeader, xshToolbarLay); }
   insertUI(showColumnNumbers, lay);
+  insertUI(parentColorsInXsheetColumn, lay);
   // insertUI(syncLevelRenumberWithXsheet, lay);
   // insertUI(currentTimelineEnabled, lay);
   // insertUI(currentColumnColor, lay);

--- a/toonz/sources/toonz/ruler.cpp
+++ b/toonz/sources/toonz/ruler.cpp
@@ -107,10 +107,10 @@ double Ruler::getPan() const {
     if (m_viewer->is3DView())  // Vertical   3D
       return m_viewer->getPan3D().y;
     else  // Vertical   2D
-      return aff.a23 / getDevPixRatio();
+      return aff.a23 / m_viewer->getDevPixRatio();
   else if (m_viewer->is3DView())  // Horizontal 3D
     return m_viewer->getPan3D().x;
-  return aff.a13 / getDevPixRatio();  // Horizontal 2D
+  return aff.a13 / m_viewer->getDevPixRatio();  // Horizontal 2D
 }
 
 //-----------------------------------------------------------------------------
@@ -137,7 +137,7 @@ void Ruler::drawVertical(QPainter &p) {
   for (i = 0; i < count; i++) {
     QColor color = (m_moving && count - 1 == i ? QColor(getHandleDragColor())
                                                : QColor(getHandleColor()));
-    double v = guides[i] / (double)getDevPixRatio();
+    double v     = guides[i] / (double)m_viewer->getDevPixRatio();
     int y    = (int)(origin - zoom * v);
     p.fillRect(QRect(x0, y - 1, x1 - x0, 2), QBrush(color));
   }
@@ -192,7 +192,7 @@ void Ruler::drawHorizontal(QPainter &p) {
   for (i = 0; i < count; i++) {
     QColor color = (m_moving && count - 1 == i ? QColor(getHandleDragColor())
                                                : QColor(getHandleColor()));
-    double v = guides[i] / (double)getDevPixRatio();
+    double v     = guides[i] / (double)m_viewer->getDevPixRatio();
     int x    = (int)(origin + zoom * v);
     p.fillRect(QRect(x - 1, y0, 2, y1 - y0), QBrush(color));
   }
@@ -258,7 +258,7 @@ void Ruler::mousePressEvent(QMouseEvent *e) {
   int i;
   int count = guides.size();
   for (i = 0; i < count; i++) {
-    double g     = guides[i] / (double)getDevPixRatio();
+    double g     = guides[i] / (double)m_viewer->getDevPixRatio();
     double dist2 = (g - v) * (g - v);
     if (selected < 0 || dist2 < minDist2) {
       minDist2 = dist2;
@@ -268,7 +268,7 @@ void Ruler::mousePressEvent(QMouseEvent *e) {
   if (e->button() == Qt::LeftButton) {
     if (selected < 0 || minDist2 > 25) {
       // crea una nuova guida
-      guides.push_back(v * getDevPixRatio());
+      guides.push_back(v * m_viewer->getDevPixRatio());
       m_viewer->update();
       // aggiorna sprop!!!!
     } else if (selected < count - 1)
@@ -294,7 +294,7 @@ void Ruler::mousePressEvent(QMouseEvent *e) {
 void Ruler::mouseMoveEvent(QMouseEvent *e) {
   if (m_moving) {
     m_hiding           = m_vertical ? (e->pos().x() < 0) : (e->pos().y() < 0);
-    getGuides().back() = posToValue(e->pos()) * getDevPixRatio();
+    getGuides().back() = posToValue(e->pos()) * m_viewer->getDevPixRatio();
     // aggiorna sprop!!!!
     update();
     m_viewer->update();
@@ -308,7 +308,7 @@ void Ruler::mouseMoveEvent(QMouseEvent *e) {
 
   int count = guides.size();
   for (int i = 0; i < count; i++) {
-    double g     = guides[i] / (double)getDevPixRatio();
+    double g     = guides[i] / (double)m_viewer->getDevPixRatio();
     double dist2 = (g - v) * (g - v);
     if (dist2 < 25) {
       setToolTip(tr(

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -757,6 +757,7 @@ public:
 
 SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
     : GLWidgetForHighDpi(parent)
+    , TTool::Viewer(this)
     , m_pressure(0)
     , m_lastMousePos(0, 0)
     , m_mouseButton(Qt::NoButton)

--- a/toonz/sources/toonz/subcameramanager.cpp
+++ b/toonz/sources/toonz/subcameramanager.cpp
@@ -31,7 +31,7 @@ inline bool bitwiseContains(UCHAR flag, UCHAR state) {
 inline bool bitwiseExclude(UCHAR flag, UCHAR state) {
   return bitwiseContains(~state, flag);
 }
-}
+}  // namespace
 
 //********************************************************************************
 //    Classes implementation
@@ -119,7 +119,7 @@ bool PreviewSubCameraManager::mousePressEvent(SceneViewer *viewer,
   if (viewer->is3DView()) return true;
 
   m_mousePressed  = true;
-  m_mousePressPos = event.mousePos() * getDevPixRatio();
+  m_mousePressPos = event.mousePos() * viewer->getDevPixRatio();
   m_dragType      = getSubCameraDragEnum(viewer, m_mousePressPos);
 
   if (bitwiseExclude(m_dragType, OUTER))
@@ -133,7 +133,7 @@ bool PreviewSubCameraManager::mousePressEvent(SceneViewer *viewer,
 bool PreviewSubCameraManager::mouseMoveEvent(SceneViewer *viewer,
                                              const TMouseEvent &event) {
   if (viewer->is3DView()) return true;
-  QPointF curPos(event.mousePos() * getDevPixRatio());
+  QPointF curPos(event.mousePos() * viewer->getDevPixRatio());
   if (event.buttons() == Qt::LeftButton) {
     if (!bitwiseContains(m_dragType, INNER)) {
       if (std::abs(curPos.x() - m_mousePressPos.x()) > 10 ||
@@ -334,7 +334,7 @@ TPoint PreviewSubCameraManager::getSubCameraDragDistance(
 
 //-----------------------------------------------------------------------------
 /*! Delete sub camera frame. Executed from context menu of the viewer.
-*/
+ */
 void PreviewSubCameraManager::deleteSubCamera(SceneViewer *viewer) {
   TCamera *camera =
       TApp::instance()->getCurrentScene()->getScene()->getCurrentCamera();

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -321,10 +321,14 @@ void MotionPathMenu::leaveEvent(QEvent *event) { hide(); }
 //-----------------------------------------------------------------------------
 
 ChangeObjectWidget::ChangeObjectWidget(QWidget *parent)
-    : QListWidget(parent), m_width(40) {
+    : QListWidget(parent), m_width(40), m_objectHandle(0), m_xsheetHandle(0) {
   setMouseTracking(true);
   setObjectName("XshColumnChangeObjectWidget");
   setAutoFillBackground(true);
+
+  bool ret = connect(this, SIGNAL(itemClicked(QListWidgetItem *)), this,
+                     SLOT(onItemSelected(QListWidgetItem *)));
+  assert(ret);
 }
 
 //-----------------------------------------------------------------------------
@@ -335,12 +339,16 @@ ChangeObjectWidget::~ChangeObjectWidget() {}
 
 void ChangeObjectWidget::show(const QPoint &pos) {
   refresh();
+  int scrollbarW = qApp->style()->pixelMetric(QStyle::PM_ScrollBarExtent);
   int itemNumber = count();
   if (itemNumber > 10) {
     itemNumber = 10;
-    m_width += 15;
+    m_width += scrollbarW;
   }
-  setGeometry(pos.x(), pos.y(), m_width, itemNumber * 16 + 2);
+  int height = 0;
+  for (int i = 0; i < itemNumber; i++)
+    height += sizeHintForRow(i);
+  setGeometry(pos.x(), pos.y(), m_width, height + 2);
   QListWidget::show();
   setFocus();
   scrollToItem(currentItem());
@@ -387,11 +395,55 @@ void ChangeObjectWidget::focusOutEvent(QFocusEvent *e) {
 //-----------------------------------------------------------------------------
 
 void ChangeObjectWidget::selectCurrent(const QString &text) {
-  QList<QListWidgetItem *> itemList = findItems(text, Qt::MatchExactly);
   clearSelection();
-  if (itemList.size() < 1) return;
-  QListWidgetItem *currentWidgetItem = itemList.at(0);
-  setCurrentItem(currentWidgetItem);
+  int numRows = count();
+  for (int row = 0; row < numRows; row++) {
+    QListWidgetItem *it = item(row);
+    QVariant display    = it->data(Qt::UserRole);
+    if (text == (display.isValid() ? display.toString() : it->text())) {
+      setCurrentItem(it);
+      return;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::addText(const QString &text, const QString &display) {
+  QListWidgetItem *item = new QListWidgetItem(display);
+  item->setData(Qt::UserRole, text);
+  addItem(item);
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::addText(const QString &text, const QColor &textColor) {
+  QListWidgetItem *item = new QListWidgetItem(text);
+  item->setForeground(textColor);
+  addItem(item);
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::addText(const QString &text, const QString &display,
+                                 const QColor &identColor) {
+  QListWidgetItem *item = new QListWidgetItem(display);
+  QPixmap pixmap(4, 8);
+  pixmap.fill(identColor);
+  QIcon icon(pixmap);
+  item->setIcon(icon);
+  item->setData(Qt::UserRole, text);
+  addItem(item);
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::onItemSelected(QListWidgetItem *item) {
+  QVariant display = item->data(Qt::UserRole);
+  if (display.isValid())
+    onTextSelected(display.toString());
+  else
+    onTextSelected(item->text());
 }
 
 //=============================================================================
@@ -399,11 +451,7 @@ void ChangeObjectWidget::selectCurrent(const QString &text) {
 //-----------------------------------------------------------------------------
 
 ChangeObjectParent::ChangeObjectParent(QWidget *parent)
-    : ChangeObjectWidget(parent) {
-  bool ret = connect(this, SIGNAL(currentTextChanged(const QString &)), this,
-                     SLOT(onTextChanged(const QString &)));
-  assert(ret);
-}
+    : ChangeObjectWidget(parent) {}
 
 //-----------------------------------------------------------------------------
 
@@ -415,6 +463,7 @@ void ChangeObjectParent::refresh() {
   clear();
   assert(m_xsheetHandle);
   assert(m_objectHandle);
+  XsheetViewer *viewer           = TApp::instance()->getCurrentXsheetViewer();
   TXsheet *xsh                   = m_xsheetHandle->getXsheet();
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   TStageObjectId parentId = xsh->getStageObject(currentObjectId)->getParent();
@@ -422,9 +471,10 @@ void ChangeObjectParent::refresh() {
   std::list<TStageObject *> children = currentObject->getChildren();
   TStageObjectTree *tree             = xsh->getStageObjectTree();
   int objectCount                    = tree->getStageObjectCount();
-  QString text;
-  QList<QString> pegbarList;
-  QList<QString> columnList;
+  QList<QString> pegbarListID, pegbarListTr;
+  QList<QString> columnListID, columnListTr;
+  QList<QColor> pegbarListColor, columnListColor;
+  QString currentText;
   QString theLongestTxt;
   int i;
   for (i = 0; i < objectCount; i++) {
@@ -432,52 +482,68 @@ void ChangeObjectParent::refresh() {
     if (id == tree->getMotionPathViewerId()) continue;
     int index = id.getIndex();
     QString indexStr(std::to_string(id.getIndex() + 1).c_str());
-    QString newText;
-    if (id == parentId) {
-      if (parentId.isTable())
-        text = QString("Table");
-      else if (parentId.isPegbar())
-        text = QString("Peg ") + indexStr;
-      else if (parentId.isColumn()) {
-        text             = QString("Col ") + indexStr;
-        QString tempText = newText;
-        std::string name = tree->getStageObject(i)->getName();
-        if (name != tempText.replace(" ", "").toStdString()) {
-          text += " (" + QString::fromStdString(name) + " )";
-        }
-      }
-    }
+    QString newTextID, newTextTr;
+    QColor newTextBG;
 
+    // Remove childs from parent list
     bool found = (std::find(children.begin(), children.end(),
                             xsh->getStageObject(id)) != children.end());
-
     if (id == currentObjectId || found) continue;
+
     if (id.isTable()) {
-      newText = QString("Table");
-      pegbarList.append(newText);
+      newTextID = QString("Table");
+      newTextTr = tr("Table");
+      newTextBG = viewer->getTableColor();
     }
     if (id.isPegbar()) {
-      newText = QString("Peg ") + indexStr;
-      pegbarList.append(newText);
+      newTextID = QString("Peg ") + indexStr;
+      newTextTr = QString("Peg") + indexStr;
+      newTextBG = viewer->getPegColor();
+      //
+      std::string name = tree->getStageObject(i)->getName();
+      if (name.length() > 0) newTextTr = QString::fromStdString(name);
     }
-    if (id.isColumn() && !xsh->isColumnEmpty(index)) {
-      newText          = QString("Col ") + indexStr;
-      QString tempText = newText;
-      if (xsh->getColumn(index)->getColumnType() !=
-              TXshColumn::eSoundTextType &&
-          xsh->getColumn(index)->getColumnType() != TXshColumn::eSoundType) {
+    if (id.isCamera()) {
+      bool isActive =
+          (id == xsh->getStageObjectTree()->getCurrentCameraId());
+      newTextID = QString("Cam ") + indexStr;
+      newTextTr = QString("Camera") + indexStr;
+      newTextBG = isActive ? viewer->getActiveCameraColor()
+                           : viewer->getOtherCameraColor();
+      //
+      std::string name = tree->getStageObject(i)->getName();
+      if (name.length() > 0) newTextTr = QString::fromStdString(name);
+    }
+    if (id.isColumn() && (!xsh->isColumnEmpty(index))) {
+      TXshColumn *colx = xsh->getColumn(index);
+      if (colx->getColumnType() != TXshColumn::eSoundTextType &&
+          colx->getColumnType() != TXshColumn::eSoundType) {
+        newTextID = QString("Col ") + indexStr;
+        newTextTr = QString("Col") + indexStr;
+        QColor unused;
+        viewer->getColumnColor(newTextBG, unused, id.getIndex(), xsh);
         std::string name = tree->getStageObject(i)->getName();
-        if (name.length() > 0 &&
-            name != tempText.replace(" ", "").toStdString()) {
-          newText += " (" + QString::fromStdString(name) + " )";
-        }
-        columnList.append(newText);
+        if (name.length() > 0) newTextTr = QString::fromStdString(name);
       }
     }
-    if (newText.length() > theLongestTxt.length()) theLongestTxt = newText;
+    if (id == parentId) currentText = newTextID;
+    if (newTextTr.length() > theLongestTxt.length()) theLongestTxt = newTextTr;
+    if (!newTextID.isEmpty()) {
+      if (id.isColumn()) {
+        columnListID.append(newTextID);
+        columnListTr.append(newTextTr);
+        columnListColor.append(newTextBG);
+      } else {
+        pegbarListID.append(newTextID);
+        pegbarListTr.append(newTextTr);
+        pegbarListColor.append(newTextBG);
+      }
+    }
   }
-  for (i = 0; i < columnList.size(); i++) addItem(columnList.at(i));
-  for (i = 0; i < pegbarList.size(); i++) addItem(pegbarList.at(i));
+  for (i = 0; i < columnListID.size(); i++)
+    addText(columnListID.at(i), columnListTr.at(i), columnListColor.at(i));
+  for (i = 0; i < pegbarListID.size(); i++)
+    addText(pegbarListID.at(i), pegbarListTr.at(i), pegbarListColor.at(i));
 
   QString fontName = Preferences::instance()->getInterfaceFont();
   if (fontName == "") {
@@ -491,14 +557,13 @@ void ChangeObjectParent::refresh() {
   // set font size in pixel
   font.setPixelSize(XSHEET_FONT_PX_SIZE);
 
-  m_width = std::max(QFontMetrics(font).width(theLongestTxt) + 22, 71);
-  std::string strText = text.toStdString();
-  selectCurrent(text);
+  m_width = QFontMetrics(font).width(theLongestTxt) + 32;
+  selectCurrent(currentText);
 }
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectParent::onTextChanged(const QString &text) {
+void ChangeObjectParent::onTextSelected(const QString &text) {
   assert(m_xsheetHandle);
   assert(m_objectHandle);
   if (text.isEmpty()) {
@@ -507,6 +572,8 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
   }
   bool isPegbar                        = false;
   if (text.startsWith("Peg")) isPegbar = true;
+  bool isCamera = false;
+  if (text.startsWith("Cam")) isCamera = true;
   bool isTable                         = false;
   if (text == "Table") isTable         = true;
   QString number                       = text;
@@ -526,6 +593,8 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
   TStageObjectId newStageObjectId;
   if (isPegbar)
     newStageObjectId = TStageObjectId::PegbarId(index);
+  else if (isCamera)
+    newStageObjectId = TStageObjectId::CameraId(index);
   else if (isTable)
     newStageObjectId = TStageObjectId::TableId;
   else
@@ -533,7 +602,10 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
 
   if (newStageObjectId == currentObjectId) return;
 
-  if (newStageObjectId == currentParentId) return;
+  if (newStageObjectId == currentParentId) {
+    hide();
+    return;
+  }
 
   TStageObject *stageObject =
       m_xsheetHandle->getXsheet()->getStageObject(currentObjectId);
@@ -550,11 +622,7 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
 //-----------------------------------------------------------------------------
 
 ChangeObjectHandle::ChangeObjectHandle(QWidget *parent)
-    : ChangeObjectWidget(parent) {
-  bool ret = connect(this, SIGNAL(currentTextChanged(const QString &)), this,
-                     SLOT(onTextChanged(const QString &)));
-  assert(ret);
-}
+    : ChangeObjectWidget(parent) {}
 
 //-----------------------------------------------------------------------------
 
@@ -566,38 +634,41 @@ void ChangeObjectHandle::refresh() {
   clear();
   assert(m_xsheetHandle);
   assert(m_objectHandle);
-  TXsheet *xsh = m_xsheetHandle->getXsheet();
+  XsheetViewer *viewer = TApp::instance()->getCurrentXsheetViewer();
+  TXsheet *xsh         = m_xsheetHandle->getXsheet();
   assert(xsh);
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   TStageObject *stageObject      = xsh->getStageObject(currentObjectId);
-  m_width                        = 55;
+  m_width                        = 28;
 
   int i;
   QString str;
+  QColor colorHndHook = viewer->getPreviewFrameTextColor();
+  QColor colorHndDef  = viewer->getSelectedColumnTextColor();
+  QColor colorHndNone = viewer->getTextColor();
   if (stageObject->getParent().isColumn()) {
-    for (i = 0; i < 20; i++) addItem(str.number(20 - i));
+    for (i = 0; i < 20; i++) addText(str.number(20 - i), colorHndHook);
   }
-  // for (i = 0; i < 26; i++) addItem(QString(char('A' + i)));
-  addItem(QString("Base"));
+  for (i = 0; i < 26; i++) {
+    if (i == 1)
+      addText(QString("B"), colorHndDef);
+    else
+      addText(QString(char('A' + i)), colorHndNone);
+  }
+
   std::string handle = stageObject->getParentHandle();
-  if (handle[0] == 'H' && handle.length() > 1)
-    handle = handle.substr(1);
-  else
-    (handle = "Base");
+  if (handle[0] == 'H' && handle.length() > 1) handle = handle.substr(1);
   selectCurrent(QString::fromStdString(handle));
 }
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectHandle::onTextChanged(const QString &text) {
+void ChangeObjectHandle::onTextSelected(const QString &text) {
   assert(m_xsheetHandle);
   assert(m_objectHandle);
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   QString handle                 = text;
-  if (text.toInt() != 0)
-    handle = QString("H") + handle;
-  else if (text == "Base")
-    handle = "B";
+  if (text.toInt() != 0) handle = QString("H") + handle;
   if (handle.isEmpty()) return;
   std::vector<TStageObjectId> ids;
   ids.push_back(currentObjectId);
@@ -1214,9 +1285,13 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   // set font size in pixel
   font.setPixelSize(XSHEET_FONT_PX_SIZE);
 
+  int handleWidth = 20;
+  std::string handle = xsh->getStageObject(columnId)->getParentHandle();
+  if (handle == "B") handleWidth = 0; // Default handle
+
   int width = QFontMetrics(font).width(name);
 
-  while (width > o->rect(PredefinedRect::PEGBAR_NAME).width() - 20) {
+  while (width > o->rect(PredefinedRect::PEGBAR_NAME).width() - handleWidth) {
     name.remove(-1, 1000);
     width = QFontMetrics(font).width(name);
   }
@@ -1229,10 +1304,15 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   if (column->getSoundColumn() || column->getSoundTextColumn() ||
       column->getPaletteColumn())
     return;
-  if (ShowParentColorsInXsheet == 1) {
-    QColor parentColor = Qt::black;
+
+  if (Preferences::instance()->isParentColorsInXsheetColumnEnabled() &&
+      column->isPreviewVisible()) {
+    QColor parentColor = Qt::transparent;
     if (parentId.isCamera()) {
-      parentColor = m_viewer->getActiveCameraColor();
+      bool isActive =
+          (parentId == xsh->getStageObjectTree()->getCurrentCameraId());
+      parentColor = isActive ? m_viewer->getActiveCameraColor()
+                             : m_viewer->getOtherCameraColor();
     } else if (parentId.isPegbar()) {
       parentColor = m_viewer->getPegColor();
     } else if (parentId.isTable()) {
@@ -1242,11 +1322,13 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
       QColor unused;
       m_viewer->getColumnColor(parentColor, unused, columnIndex, xsh);
     }
-    if (parentColor != Qt::black) {
-      p.fillRect(pegbarnamerect, parentColor);
-      p.drawRect(pegbarnamerect);
+    if (parentColor != Qt::transparent) {
+      QRect parentrect = pegbarnamerect;
+      parentrect.adjust(1, 1, 0, 0);
+      p.fillRect(parentrect, parentColor);
     }
   }
+
   p.setPen(m_viewer->getTextColor());
   p.drawText(pegbarnamerect.adjusted(3, 0, 0, 0),
              Qt::AlignLeft | Qt::AlignVCenter | Qt::TextSingleLine, name);
@@ -1269,13 +1351,22 @@ void ColumnArea::DrawHeader::drawParentHandleName() const {
   if (o->flag(PredefinedFlag::PARENT_HANDLE_NAME_BORDER))
     p.drawRect(parenthandleRect);
 
-  p.setPen(m_viewer->getVerticalLineColor());
-  p.drawRect(parenthandleRect.adjusted(2, 0, 0, 0));
-  p.setPen(m_viewer->getTextColor());
-
   std::string handle = xsh->getStageObject(columnId)->getParentHandle();
   if (handle[0] == 'H' && handle.length() > 1) handle = handle.substr(1);
-  // if (parentId != TStageObjectId::TableId)
+
+  if (handle == "B") { // Default handle
+    QPen pen(m_viewer->getVerticalLineColor());
+    pen.setStyle(Qt::PenStyle::DotLine);
+    p.setPen(pen);
+    int offset = parenthandleRect.x() + 2;
+    p.drawLine(offset, parenthandleRect.y(), offset, parenthandleRect.bottom());
+    return;
+  }
+
+  p.setPen(m_viewer->getVerticalLineColor());
+  p.drawRect(parenthandleRect.adjusted(2, 0, 0, 0));
+
+  p.setPen(m_viewer->getTextColor());
   p.drawText(parenthandleRect,
              Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextSingleLine,
              QString::fromStdString(handle));
@@ -2315,17 +2406,13 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     if (m_col < 0) {
       if (o->rect(PredefinedRect::CAMERA_LOCK_AREA).contains(mouseInCell)) {
         // lock button
-        if (event->button() == Qt::LeftButton)
-          m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
-        else
-          return;
+        if (event->button() != Qt::LeftButton) return;
+        m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
       } else if (o->rect(PredefinedRect::CAMERA_CONFIG_AREA)
                      .contains(mouseInCell)) {
         // config button
-        if (event->button() == Qt::LeftButton)
-          m_doOnRelease = OpenSettings;
-        else
-          return;
+        if (event->button() != Qt::LeftButton) return;
+        m_doOnRelease = OpenSettings;
       } else {
         // clicking another area means column selection
         m_viewer->setCurrentColumn(m_col);
@@ -2348,51 +2435,43 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
         setDragTool(XsheetGUI::DragTool::makeColumnMoveTool(m_viewer));
       } else if (o->rect(PredefinedRect::LOCK_AREA).contains(mouseInCell)) {
         // lock button
-        if (event->button() == Qt::LeftButton)
-          m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
-        else
-          return;
+        if (event->button() != Qt::LeftButton) return;
+        m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
       } else if (o->rect(PredefinedRect::EYE_AREA).contains(mouseInCell)) {
         // preview button
-        if (event->button() == Qt::LeftButton) {
-          if (column->getSoundTextColumn()) {
-            // do nothing
-          } else {
-            m_doOnRelease =
-                isCtrlPressed ? ToggleAllPreviewVisible : TogglePreviewVisible;
-            if (column->getSoundColumn())
-              TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
-          }
-        } else
-          return;
+        if (event->button() != Qt::LeftButton) return;
+        if (column->getSoundTextColumn()) {
+          // do nothing
+        } else {
+          m_doOnRelease =
+              isCtrlPressed ? ToggleAllPreviewVisible : TogglePreviewVisible;
+          if (column->getSoundColumn())
+            TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
+        }
       } else if (o->rect(PredefinedRect::PREVIEW_LAYER_AREA)
                      .contains(mouseInCell)) {
         // camstand button
-        if (event->button() == Qt::LeftButton) {
-          if (column->getPaletteColumn() || column->getSoundTextColumn()) {
-            // do nothing
-          } else {
-            m_doOnRelease =
-                isCtrlPressed ? ToggleAllTransparency : ToggleTransparency;
-            if (!o->flag(PredefinedFlag::CONFIG_AREA_VISIBLE) &&
-                !column->getSoundColumn())
-              startTransparencyPopupTimer(event);
-          }
-        } else
-          return;
+        if (event->button() != Qt::LeftButton) return;
+        if (column->getPaletteColumn() || column->getSoundTextColumn()) {
+          // do nothing
+        } else {
+          m_doOnRelease =
+              isCtrlPressed ? ToggleAllTransparency : ToggleTransparency;
+          if (!o->flag(PredefinedFlag::CONFIG_AREA_VISIBLE) &&
+              !column->getSoundColumn())
+            startTransparencyPopupTimer(event);
+        }
       } else if (o->rect(PredefinedRect::CONFIG_AREA).contains(mouseInCell)) {
         // config button
-        if (event->button() == Qt::LeftButton) {
-          TXshZeraryFxColumn *zColumn =
-              dynamic_cast<TXshZeraryFxColumn *>(column);
+        if (event->button() != Qt::LeftButton) return;
+        TXshZeraryFxColumn *zColumn =
+            dynamic_cast<TXshZeraryFxColumn *>(column);
 
-          if (column && (zColumn || column->getPaletteColumn() ||
-                         column->getSoundTextColumn())) {
-            // do nothing
-          } else
-            m_doOnRelease = OpenSettings;
+        if (column && (zColumn || column->getPaletteColumn() ||
+                       column->getSoundTextColumn())) {
+          // do nothing
         } else
-          return;
+          m_doOnRelease = OpenSettings;
       } else if (column && column->getSoundColumn()) {
         // sound column
         if (o->rect(PredefinedRect::SOUND_ICON).contains(mouseInCell)) {
@@ -2427,39 +2506,36 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
       } else {
         // clicking another area means column selection
         m_viewer->setCurrentColumn(m_col);
-        if (m_viewer->getColumnSelection()->isColumnSelected(m_col) &&
-            event->button() == Qt::RightButton)
+        if (event->button() != Qt::LeftButton) return;
+        if (xsh->getColumn(m_col)->getSoundTextColumn()) return;
+ 
+        int y = Preferences::instance()->isShowQuickToolbarEnabled() ? 30 : 0;
+        TStageObjectId columnId = m_viewer->getObjectId(m_col);
+        bool isColumn = xsh->getStageObject(columnId)->getParent().isColumn();
+        bool clickChangeParent =
+            isColumn
+                ? o->rect(PredefinedRect::PEGBAR_NAME)
+                      .adjusted(0, 0, -20, 0)
+                      .contains(mouseInCell)
+                : o->rect(PredefinedRect::PEGBAR_NAME).contains(mouseInCell);
+        if (clickChangeParent) {
+          m_changeObjectParent->refresh();
+          m_changeObjectParent->show(QPoint(
+              o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
+                      QPoint(o->rect(PredefinedRect::CAMERA_CELL).width(), 0) +
+                      m_viewer->positionToXY(CellPosition(0, m_col)) +
+                      QPoint(-m_viewer->getColumnScrollValue(), y)));
           return;
-        if (!xsh->getColumn(m_col)->getSoundTextColumn()) {
-          int x = 0;
-          x     = Preferences::instance()->isShowQuickToolbarEnabled() ? 30 : 0;
-          TStageObjectId columnId = m_viewer->getObjectId(m_col);
-          bool isColumn = xsh->getStageObject(columnId)->getParent().isColumn();
-          bool clickChangeParent =
-              isColumn
-                  ? o->rect(PredefinedRect::PEGBAR_NAME)
-                        .adjusted(0, 0, -20, 0)
-                        .contains(mouseInCell)
-                  : o->rect(PredefinedRect::PEGBAR_NAME).contains(mouseInCell);
-          if (clickChangeParent) {
-            m_changeObjectParent->refresh();
-            m_changeObjectParent->show(QPoint(
-                o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
-                m_viewer->positionToXY(CellPosition(0, m_col)) + QPoint(0, x) +
-                QPoint(o->rect(PredefinedRect::CAMERA_CELL).width(), 4) -
-                QPoint(m_viewer->getColumnScrollValue(), 0)));
-            return;
-          }
-          if (isColumn &&
-              o->rect(PredefinedRect::PARENT_HANDLE_NAME)
-                  .contains(mouseInCell)) {
-            m_changeObjectHandle->refresh();
-            m_changeObjectHandle->show(QPoint(
-                o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
-                m_viewer->positionToXY(CellPosition(0, m_col + 1)) +
-                QPoint(2, x) - QPoint(m_viewer->getColumnScrollValue(), 0)));
-            return;
-          }
+        }
+        if (isColumn &&
+            o->rect(PredefinedRect::PARENT_HANDLE_NAME)
+                .contains(mouseInCell)) {
+          m_changeObjectHandle->refresh();
+          m_changeObjectHandle->show(QPoint(
+              o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
+                      m_viewer->positionToXY(CellPosition(0, m_col + 1)) +
+                      QPoint(-m_viewer->getColumnScrollValue(), y)));
+          return;
         }
 
         setDragTool(XsheetGUI::DragTool::makeColumnSelectionTool(m_viewer));
@@ -2726,17 +2802,21 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
     // signal XsheetChanged will invoke PreviewFxManager to all rendered frames,
     // if necessary. it causes slowness when opening preview flipbook of large
     // scene.
+    // KNOWN BUG: Side effect, transparency doesn't sync in schematic if false.
     bool isTransparencyRendered = app->getCurrentScene()
                                       ->getScene()
                                       ->getProperties()
                                       ->isColumnColorFilterOnRenderEnabled();
-    if ((isTransparencyRendered && (m_doOnRelease == ToggleTransparency ||
+    bool isStateChanged = m_doOnRelease == TogglePreviewVisible ||
+                          m_doOnRelease == ToggleAllPreviewVisible ||
+                          m_doOnRelease == ToggleLock ||
+                          m_doOnRelease == ToggleAllLock;
+    if (isStateChanged ||
+        (isTransparencyRendered && (m_doOnRelease == ToggleTransparency ||
                                     m_doOnRelease == ToggleAllTransparency ||
-                                    m_doOnRelease == OpenSettings)) ||
-        m_doOnRelease == TogglePreviewVisible ||
-        m_doOnRelease == ToggleAllPreviewVisible ||
-        m_doOnRelease == ToggleLock || m_doOnRelease == ToggleAllLock)
+                                    m_doOnRelease == OpenSettings))) {
       app->getCurrentXsheet()->notifyXsheetChanged();
+    }
     update();
     m_doOnRelease = 0;
   }

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -95,8 +95,14 @@ protected:
   void focusInEvent(QFocusEvent *e) override {}
   void selectCurrent(const QString &text);
 
+  void addText(const QString &text, const QString &display);
+  void addText(const QString &text, const QColor &textColor);
+  void addText(const QString &text, const QString &display,
+               const QColor &identColor);
+  virtual void onTextSelected(const QString &) = 0;
+
 protected slots:
-  virtual void onTextChanged(const QString &) = 0;
+  void onItemSelected(QListWidgetItem *);
 };
 
 //=============================================================================
@@ -113,7 +119,7 @@ public:
   void refresh() override;
 
 protected slots:
-  void onTextChanged(const QString &) override;
+  void onTextSelected(const QString &) override;
 };
 
 //=============================================================================
@@ -130,7 +136,7 @@ public:
   void refresh() override;
 
 protected slots:
-  void onTextChanged(const QString &) override;
+  void onTextSelected(const QString &) override;
 };
 
 //=============================================================================

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -519,7 +519,7 @@ TStageObjectId XsheetViewer::getObjectId(int col) const {
 
 void XsheetViewer::setCurrentColumn(int col) {
   TColumnHandle *columnHandle = TApp::instance()->getCurrentColumn();
-  if (col != columnHandle->getColumnIndex()) {
+  if (col != columnHandle->getColumnIndex() || !columnHandle->getColumn()) {
     columnHandle->setColumnIndex(col);
     // E' necessario per il caso in cui si passa da colonna di camera a altra
     // colonna
@@ -600,6 +600,12 @@ void XsheetViewer::scroll(QPoint delta) {
 
   m_cellScrollArea->horizontalScrollBar()->setValue(valueH);
   m_cellScrollArea->verticalScrollBar()->setValue(valueV);
+}
+
+//-----------------------------------------------------------------------------
+
+int XsheetViewer::getColumnScrollValue() {
+  return m_columnScrollArea->horizontalScrollBar()->value();
 }
 
 //-----------------------------------------------------------------------------
@@ -1538,12 +1544,6 @@ void XsheetViewer::scrollToVerticalRange(int y0, int y1) {
     updateCellRowAree();
   else
     updateCellColumnAree();
-}
-
-//-----------------------------------------------------------------------------
-
-int XsheetViewer::getColumnScrollValue() {
-  return m_columnScrollArea->horizontalScrollBar()->value();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -357,12 +357,9 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   // Table color
   QColor m_tableColor;
   Q_PROPERTY(QColor TableColor READ getTableColor WRITE setTableColor)
-
   // Peg node
   QColor m_pegColor;
   Q_PROPERTY(QColor PegColor READ getPegColor WRITE setPegColor)
-
-  // Peg color
   // SoundText column
   QColor m_soundTextColumnColor;
   QColor m_soundTextColumnBorderColor;
@@ -961,11 +958,9 @@ public:
   // Table node
   void setTableColor(const QColor &color) { m_tableColor = color; }
   QColor getTableColor() const { return m_tableColor; }
-
   // Peg node
   void setPegColor(const QColor &color) { m_pegColor = color; }
   QColor getPegColor() const { return m_pegColor; }
-
   // SoundText column
   void setSoundTextColumnColor(const QColor &color) {
     m_soundTextColumnColor = color;

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -576,6 +576,8 @@ void Preferences::definePreferenceItems() {
   define(showQuickToolbar, "showQuickToolbar", QMetaType::Bool, false);
   define(expandFunctionHeader, "expandFunctionHeader", QMetaType::Bool, false);
   define(showColumnNumbers, "showColumnNumbers", QMetaType::Bool, false);
+  define(parentColorsInXsheetColumn, "parentColorsInXsheetColumn",
+         QMetaType::Bool, true);
   define(syncLevelRenumberWithXsheet, "syncLevelRenumberWithXsheet",
          QMetaType::Bool, true);
   define(currentTimelineEnabled, "currentTimelineEnabled", QMetaType::Bool,

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -23,21 +23,22 @@
 #include "tiio.h"
 
 namespace {
-const TSceneProperties::CellMark cellMarkDefault[12] = {
-    {QObject::tr("Red"), TPixel32(167, 55, 55)},
-    {QObject::tr("Orange"), TPixel32(195, 115, 40)},
-    {QObject::tr("Yellow"), TPixel32(214, 183, 22)},
-    {QObject::tr("Light Green"), TPixel32(165, 179, 57)},
-    {QObject::tr("Green"), TPixel32(82, 157, 79)},
-    {QObject::tr("Light Blue"), TPixel32(71, 142, 165)},
-    {QObject::tr("Blue"), TPixel32(64, 103, 172)},
-    {QObject::tr("Dark Blue"), TPixel32(60, 49, 187)},
-    {QObject::tr("Purple"), TPixel32(108, 66, 170)},
-    {QObject::tr("Pink"), TPixel32(161, 75, 140)},
-    {QObject::tr("Dark Pink"), TPixel32(111, 29, 108)},
-    {QObject::tr("White"), TPixel32(255, 255, 255)}};
-
+const QList<TSceneProperties::CellMark> getDefaultCellMarks() {
+  return QList<TSceneProperties::CellMark>{
+      {QObject::tr("Red"), TPixel32(167, 55, 55)},
+      {QObject::tr("Orange"), TPixel32(195, 115, 40)},
+      {QObject::tr("Yellow"), TPixel32(214, 183, 22)},
+      {QObject::tr("Light Green"), TPixel32(165, 179, 57)},
+      {QObject::tr("Green"), TPixel32(82, 157, 79)},
+      {QObject::tr("Light Blue"), TPixel32(71, 142, 165)},
+      {QObject::tr("Blue"), TPixel32(64, 103, 172)},
+      {QObject::tr("Dark Blue"), TPixel32(60, 49, 187)},
+      {QObject::tr("Purple"), TPixel32(108, 66, 170)},
+      {QObject::tr("Pink"), TPixel32(161, 75, 140)},
+      {QObject::tr("Dark Pink"), TPixel32(111, 29, 108)},
+      {QObject::tr("White"), TPixel32(255, 255, 255)}};
 }
+}  // namespace
 
 //=============================================================================
 
@@ -66,7 +67,7 @@ TSceneProperties::TSceneProperties()
   m_notesColor.push_back(TPixel32(150, 245, 255));
 
   // Default Cell Marks
-  for (int i = 0; i < 12; i++) m_cellMarks.push_back(cellMarkDefault[i]);
+  m_cellMarks = getDefaultCellMarks();
 }
 
 //-----------------------------------------------------------------------------
@@ -853,12 +854,7 @@ void TSceneProperties::setCellMark(const TSceneProperties::CellMark &mark,
 // check if the cell mark settings are modified
 bool TSceneProperties::hasDefaultCellMarks() const {
   if (m_cellMarks.size() != 12) return false;
-  for (int i = 0; i < 12; i++) {
-    if (m_cellMarks.at(i).name != cellMarkDefault[i].name ||
-        m_cellMarks.at(i).color != cellMarkDefault[i].color)
-      return false;
-  }
-  return true;
+  return m_cellMarks == getDefaultCellMarks();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -1239,7 +1239,6 @@ void FxSchematicPort::paint(QPainter *painter,
                             const QStyleOptionGraphicsItem *option,
                             QWidget *widget) {
   if (m_isPassThrough && getLinkCount() > 0) return;
-  int devicePixelRatio = getDevicePixelRatio(widget);
   // large scaled
   if (getDock()->getNode()->isNormalIconView()) {
     switch (getType()) {

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -1239,22 +1239,20 @@ void FxSchematicPort::paint(QPainter *painter,
                             const QStyleOptionGraphicsItem *option,
                             QWidget *widget) {
   if (m_isPassThrough && getLinkCount() > 0) return;
-
+  int devicePixelRatio = getDevicePixelRatio(widget);
   // large scaled
   if (getDock()->getNode()->isNormalIconView()) {
     switch (getType()) {
     case eFxInputPort:
     case eFxGroupedInPort: {
-      QRect sourceRect =
+      QRect targetRect =
           scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
       static QIcon fxPortRedIcon(":Resources/fxport_red.svg");
       static QIcon fxPortPassThroughRedIcon(":Resources/fxport_pt_red.svg");
       QPixmap redPm = (m_isPassThrough)
-                          ? fxPortPassThroughRedIcon.pixmap(sourceRect.size())
-                          : fxPortRedIcon.pixmap(sourceRect.size());
-      sourceRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                         sourceRect.height() * getDevPixRatio());
-      painter->drawPixmap(boundingRect(), redPm, sourceRect);
+                          ? fxPortPassThroughRedIcon.pixmap(targetRect.size())
+                          : fxPortRedIcon.pixmap(targetRect.size());
+      painter->drawPixmap(boundingRect().toRect(), redPm);
     } break;
 
     case eFxOutputPort:
@@ -1263,8 +1261,7 @@ void FxSchematicPort::paint(QPainter *painter,
           scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
       static QIcon fxPortBlueIcon(":Resources/fxport_blue.svg");
       QPixmap bluePm = fxPortBlueIcon.pixmap(sourceRect.size());
-      sourceRect     = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                         sourceRect.height() * getDevPixRatio());
+      sourceRect     = QRect(0, 0, bluePm.width(), bluePm.height());
       painter->drawPixmap(boundingRect(), bluePm, sourceRect);
       FxSchematicDock *parentDock =
           dynamic_cast<FxSchematicDock *>(parentItem());
@@ -1288,9 +1285,7 @@ void FxSchematicPort::paint(QPainter *painter,
           scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
       QPixmap linkPm =
           QIcon(":Resources/schematic_link.svg").pixmap(sourceRect.size());
-      sourceRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                         sourceRect.height() * getDevPixRatio());
-      painter->drawPixmap(boundingRect(), linkPm, sourceRect);
+      painter->drawPixmap(boundingRect().toRect(), linkPm);
     } break;
     }
   }
@@ -1314,9 +1309,7 @@ void FxSchematicPort::paint(QPainter *painter,
           scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
       QPixmap linkPm = QIcon(":Resources/schematic_link_small.svg")
                            .pixmap(sourceRect.size());
-      sourceRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                         sourceRect.height() * getDevPixRatio());
-      painter->drawPixmap(boundingRect(), linkPm, sourceRect);
+      painter->drawPixmap(boundingRect().toRect(), linkPm);
     } break;
     }
     painter->drawRect(boundingRect());
@@ -3924,9 +3917,9 @@ QRectF FxSchematicPassThroughNode::boundingRect() const {
   qreal width = m_width;
   QRectF recF = m_nameItem->boundingRect();
   if (m_showName) {
-    width                     = recF.width();
+    width = recF.width();
     if (width > m_width) xAdj = (width - m_width) / 2;
-    yAdj                      = 30;
+    yAdj = 30;
   }
   return QRectF(-5 - xAdj, -5 - yAdj, std::max(m_width, width) + 10,
                 m_height + 10 + yAdj);

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -31,9 +31,38 @@
 #include <QFileInfo>
 #include <QDesktopWidget>
 #include <QSvgRenderer>
+#include <QScreen>
+#include <QWindow>
 
 using namespace DVGui;
 
+namespace {
+inline bool hasScreensWithDifferentDevPixRatio() {
+  static bool ret     = false;
+  static bool checked = false;
+  if (!checked) {  // check once
+    int dpr = QApplication::desktop()->devicePixelRatio();
+    for (auto screen : QGuiApplication::screens()) {
+      if ((int)screen->devicePixelRatio() != dpr) {
+        ret = true;
+        break;
+      }
+    }
+    checked = true;
+  }
+  return ret;
+}
+
+int getHighestDevicePixelRatio() {
+  static int highestDevPixRatio = 0;
+  if (highestDevPixRatio == 0) {
+    for (auto screen : QGuiApplication::screens())
+      highestDevPixRatio =
+          std::max(highestDevPixRatio, (int)screen->devicePixelRatio());
+  }
+  return highestDevPixRatio;
+}
+}  // namespace
 //-----------------------------------------------------------------------------
 
 QString fileSizeString(qint64 size, int precision) {
@@ -78,7 +107,7 @@ QPixmap rasterToQPixmap(const TRaster32P &ras, bool premultiplied,
                         bool setDevPixRatio) {
   QPixmap pixmap = QPixmap::fromImage(rasterToQImage(ras, premultiplied));
   if (setDevPixRatio) {
-    pixmap.setDevicePixelRatio(getDevPixRatio());
+    pixmap.setDevicePixelRatio(getDevicePixelRatio());
   }
   return pixmap;
 }
@@ -158,7 +187,7 @@ QPixmap scalePixmapKeepingAspectRatio(QPixmap pixmap, QSize size,
 
 QPixmap svgToPixmap(const QString &svgFilePath, const QSize &size,
                     Qt::AspectRatioMode aspectRatioMode, QColor bgColor) {
-  static int devPixRatio = getDevPixRatio();
+  static int devPixRatio = getHighestDevicePixelRatio();
   QSvgRenderer svgRenderer(svgFilePath);
   QSize pixmapSize;
   QRectF renderRect;
@@ -197,7 +226,16 @@ QPixmap svgToPixmap(const QString &svgFilePath, const QSize &size,
 
 //-----------------------------------------------------------------------------
 
-int getDevPixRatio() {
+int getDevicePixelRatio(const QWidget *widget) {
+  if (hasScreensWithDifferentDevPixRatio() && widget) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    return widget->screen()->devicePixelRatio();
+#else
+    if (!widget->windowHandle()) widget->winId();
+    if (widget->windowHandle())
+      return widget->windowHandle()->devicePixelRatio();
+#endif
+  }
   static int devPixRatio = QApplication::desktop()->devicePixelRatio();
   return devPixRatio;
 }
@@ -224,7 +262,7 @@ QString getIconThemePath(const QString &fileSVGPath) {
 
 QPixmap compositePixmap(QPixmap pixmap, const qreal &opacity, const QSize &size,
                         const int leftAdj, const int topAdj, QColor bgColor) {
-  static int devPixRatio = getDevPixRatio();
+  static int devPixRatio = getHighestDevicePixelRatio();
 
   // Sets size of destination pixmap for source to be drawn onto, if size is
   // empty use source pixmap size, else use custom size.
@@ -269,7 +307,7 @@ QPixmap recolorPixmap(QPixmap pixmap, QColor color) {
 
 QIcon createQIcon(const char *iconSVGName, bool useFullOpacity,
                   bool isForMenuItem) {
-  static int devPixRatio = getDevPixRatio();
+  static int devPixRatio = getHighestDevicePixelRatio();
 
   QIcon themeIcon = QIcon::fromTheme(iconSVGName);
 

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -405,41 +405,51 @@ QIcon createQIcon(const char *iconSVGName, bool useFullOpacity,
   // them for use in toolbars that are set for 20x20 we want to draw them onto a
   // 20x20 pixmap so they don't get resized in the GUI, they will be loaded into
   // the icon along with the original 16x16 pixmap.
-
+  // In case of multiple monitors with different resolutions, let's create icons
+  // for those also
   if (themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio)) {
-    const QSize drawOnSize(20, 20);
-    const int x = (drawOnSize.width() - 16) / 2;   // left adjust
-    const int y = (drawOnSize.height() - 16) / 2;  // top adjust
+    for (auto screen : QApplication::screens()) {
+      QSize drawOnSize(20, 20);
+      int otherDevPixRatio = screen->devicePixelRatio();
+      if (otherDevPixRatio != devPixRatio) {
+        drawOnSize.setWidth(16 * otherDevPixRatio);
+        drawOnSize.setHeight(16 * otherDevPixRatio);
+      }
+      int x = (drawOnSize.width() - 16) / 2;   // left adjust
+      int y = (drawOnSize.height() - 16) / 2;  // top adjust
 
-    // Base icon
-    icon.addPixmap(
-        compositePixmap(themeIconPixmap, baseOpacity, drawOnSize, x, y),
-        QIcon::Normal, QIcon::Off);
-    icon.addPixmap(
-        compositePixmap(themeIconPixmap, disabledOpacity, drawOnSize, x, y),
-        QIcon::Disabled, QIcon::Off);
-
-    // Over icon
-    icon.addPixmap(
-        !overPixmap.isNull()
-            ? compositePixmap(overPixmap, activeOpacity, drawOnSize, x, y)
-            : compositePixmap(themeIconPixmap, activeOpacity, drawOnSize, x, y),
-        QIcon::Active);
-
-    // On icon
-    if (!onPixmap.isNull()) {
-      icon.addPixmap(compositePixmap(onPixmap, activeOpacity, drawOnSize, x, y),
-                     QIcon::Normal, QIcon::On);
+      // Base icon
       icon.addPixmap(
-          compositePixmap(onPixmap, disabledOpacity, drawOnSize, x, y),
-          QIcon::Disabled, QIcon::On);
-    } else {
-      icon.addPixmap(
-          compositePixmap(themeIconPixmap, activeOpacity, drawOnSize, x, y),
-          QIcon::Normal, QIcon::On);
+          compositePixmap(themeIconPixmap, baseOpacity, drawOnSize, x, y),
+          QIcon::Normal, QIcon::Off);
       icon.addPixmap(
           compositePixmap(themeIconPixmap, disabledOpacity, drawOnSize, x, y),
-          QIcon::Disabled, QIcon::On);
+          QIcon::Disabled, QIcon::Off);
+
+      // Over icon
+      icon.addPixmap(
+          !overPixmap.isNull()
+              ? compositePixmap(overPixmap, activeOpacity, drawOnSize, x, y)
+              : compositePixmap(themeIconPixmap, activeOpacity, drawOnSize, x,
+                                y),
+          QIcon::Active);
+
+      // On icon
+      if (!onPixmap.isNull()) {
+        icon.addPixmap(
+            compositePixmap(onPixmap, activeOpacity, drawOnSize, x, y),
+            QIcon::Normal, QIcon::On);
+        icon.addPixmap(
+            compositePixmap(onPixmap, disabledOpacity, drawOnSize, x, y),
+            QIcon::Disabled, QIcon::On);
+      } else {
+        icon.addPixmap(
+            compositePixmap(themeIconPixmap, activeOpacity, drawOnSize, x, y),
+            QIcon::Normal, QIcon::On);
+        icon.addPixmap(
+            compositePixmap(themeIconPixmap, disabledOpacity, drawOnSize, x, y),
+            QIcon::Disabled, QIcon::On);
+      }
     }
   }
 

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -103,6 +103,10 @@ void SchematicName::focusInEvent(QFocusEvent *fe) {
   setTextCursor(cursor);
 }
 
+//--------------------------------------------------------
+
+void SchematicName::contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) {}
+
 //========================================================
 //
 // class SchematicThumbnailToggle

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -89,7 +89,8 @@ void SchematicName::setName(const QString &name) {
 
 void SchematicName::acceptName(const QString &name) {
   m_curName = name;
-  setPlainText(name);
+  m_curName.remove(QRegExp("[\\n\\r]"));  // remove all newlines
+  setPlainText(m_curName);
 }
 
 //--------------------------------------------------------

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -33,7 +33,10 @@
 //========================================================
 
 SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
-    : QGraphicsTextItem("", parent), m_width(width), m_height(height) {
+    : QGraphicsTextItem("", parent)
+    , m_width(width)
+    , m_height(height)
+    , m_noAllSelect(false) {
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   setFlag(QGraphicsItem::ItemIsFocusable, true);
   setTextInteractionFlags(Qt::TextEditorInteraction);

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -49,16 +49,16 @@ SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
   popup = new QMenu();
   popup->setObjectName(QLatin1String("qt_edit_menu"));
 
-  actionCut = popup->addAction(tr("Cu&t") + ACCEL_KEY(QKeySequence::Cut),
-                                 this, SLOT(onCut()));
+  actionCut = popup->addAction(tr("Cu&t") + ACCEL_KEY(QKeySequence::Cut), this,
+                               SLOT(onCut()));
   actionCut->setObjectName(QStringLiteral("edit-cut"));
 
   actionCopy = popup->addAction(tr("&Copy") + ACCEL_KEY(QKeySequence::Copy),
-                                  this, SLOT(onCopy()));
+                                this, SLOT(onCopy()));
   actionCopy->setObjectName(QStringLiteral("edit-copy"));
 
-  actionPaste = popup->addAction(
-      tr("&Paste") + ACCEL_KEY(QKeySequence::Paste), this, SLOT(onPaste()));
+  actionPaste = popup->addAction(tr("&Paste") + ACCEL_KEY(QKeySequence::Paste),
+                                 this, SLOT(onPaste()));
   actionPaste->setObjectName(QStringLiteral("edit-paste"));
 
   actionDelete = popup->addAction(
@@ -69,7 +69,7 @@ SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
 
   actionSelectAll =
       popup->addAction(tr("Select &All") + ACCEL_KEY(QKeySequence::SelectAll),
-                      this, SLOT(onSelectAll()));
+                       this, SLOT(onSelectAll()));
   actionSelectAll->setObjectName(QStringLiteral("select-all"));
 
   connect(popup, SIGNAL(aboutToHide()), this, SLOT(onPopupHide()));
@@ -210,8 +210,8 @@ void SchematicName::onCut() {
   QString plainText     = toPlainText();
 
   if (cursor.hasSelection()) {
-    int p = cursor.selectionStart();
-    int n = cursor.selectionEnd() - p;
+    int p             = cursor.selectionStart();
+    int n             = cursor.selectionEnd() - p;
     QString selection = plainText.mid(p, n);
     clipboard->setText(selection);
     plainText.remove(p, n);
@@ -244,7 +244,7 @@ void SchematicName::onPaste() {
   QTextCursor cursor    = textCursor();
   QString plainText     = toPlainText();
   QString clipboardText = clipboard->text();
-  clipboardText.remove(QRegExp("[\\n\\r]")); // remove all newlines
+  clipboardText.remove(QRegExp("[\\n\\r]"));  // remove all newlines
 
   int n, p = cursor.position();
   if (cursor.hasSelection()) {
@@ -268,8 +268,8 @@ void SchematicName::onDelete() {
   QString plainText     = toPlainText();
 
   if (cursor.hasSelection()) {
-    int p             = cursor.selectionStart();
-    int n             = cursor.selectionEnd() - p;
+    int p = cursor.selectionStart();
+    int n = cursor.selectionEnd() - p;
     plainText.remove(p, n);
     acceptName(plainText);
     cursor.setPosition(p);
@@ -320,10 +320,8 @@ void SchematicThumbnailToggle::paint(QPainter *painter,
   if (m_isDown)
     pixmap = offIcon.pixmap(sourceRect.size());
   else
-    pixmap   = onIcon.pixmap(sourceRect.size());
-  sourceRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                     sourceRect.height() * getDevPixRatio());
-  painter->drawPixmap(rect, pixmap, sourceRect);
+    pixmap = onIcon.pixmap(sourceRect.size());
+  painter->drawPixmap(rect, pixmap);
 }
 
 //--------------------------------------------------------
@@ -441,9 +439,7 @@ void SchematicToggle::paint(QPainter *painter,
     QRect sourceRect =
         scene()->views()[0]->matrix().mapRect(QRect(0, 0, 18, 17));
     QPixmap redPm = pix.pixmap(sourceRect.size());
-    QRect newRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                          sourceRect.height() * getDevPixRatio());
-    painter->drawPixmap(rect, redPm, newRect);
+    painter->drawPixmap(rect, redPm);
   } else if (!m_imageOff.isNull()) {
     QPen pen(m_colorOn);
     pen.setWidthF(0.5);
@@ -454,9 +450,7 @@ void SchematicToggle::paint(QPainter *painter,
     QRect sourceRect =
         scene()->views()[0]->matrix().mapRect(QRect(0, 0, 18, 17));
     QPixmap redPm = m_imageOff.pixmap(sourceRect.size());
-    QRect newRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                          sourceRect.height() * getDevPixRatio());
-    painter->drawPixmap(rect, redPm, newRect);
+    painter->drawPixmap(rect, redPm);
   }
 }
 
@@ -510,7 +504,7 @@ void SchematicToggle::contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) {
 
 //--------------------------------------------------------
 /*! for Spline Aim and CP toggles
-*/
+ */
 void SchematicToggle_SplineOptions::paint(
     QPainter *painter, const QStyleOptionGraphicsItem *option,
     QWidget *widget) {
@@ -521,9 +515,7 @@ void SchematicToggle_SplineOptions::paint(
         (m_state == 2 && !m_imageOn2.isNull()) ? m_imageOn2 : m_imageOn;
     QRect sourceRect = scene()->views()[0]->matrix().mapRect(rect.toRect());
     QPixmap redPm    = pix.pixmap(sourceRect.size());
-    QRect newRect    = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                          sourceRect.height() * getDevPixRatio());
-    painter->drawPixmap(rect, redPm, newRect);
+    painter->drawPixmap(rect.toRect(), redPm);
   }
   painter->setBrush(Qt::NoBrush);
   painter->setPen(QColor(180, 180, 180, 255));
@@ -532,7 +524,7 @@ void SchematicToggle_SplineOptions::paint(
 
 //--------------------------------------------------------
 /*! for Spline Aim and CP toggles
-*/
+ */
 void SchematicToggle_SplineOptions::mousePressEvent(
     QGraphicsSceneMouseEvent *me) {
   SchematicToggle::mousePressEvent(me);
@@ -578,8 +570,8 @@ void SchematicHandleSpinBox::paint(QPainter *painter,
 
 void SchematicHandleSpinBox::mouseMoveEvent(QGraphicsSceneMouseEvent *me) {
   if (m_buttonState == Qt::LeftButton) {
-    bool increase           = false;
-    int delta               = me->screenPos().y() - me->lastScreenPos().y();
+    bool increase = false;
+    int delta     = me->screenPos().y() - me->lastScreenPos().y();
     if (delta < 0) increase = true;
     m_delta += abs(delta);
     if (m_delta > 5) {
@@ -1100,13 +1092,13 @@ SchematicNode::~SchematicNode() {}
 //--------------------------------------------------------
 
 /*!Reimplements the pure virtual QGraphicsItem::boundingRect() method.
-*/
+ */
 QRectF SchematicNode::boundingRect() const { return QRectF(0, 0, 1, 1); }
 
 //--------------------------------------------------------
 
 /*! Reimplements the pure virtual QGraphicsItem::paint() method.
-*/
+ */
 void SchematicNode::paint(QPainter *painter,
                           const QStyleOptionGraphicsItem *option,
                           QWidget *widget) {
@@ -1140,7 +1132,7 @@ void SchematicNode::paint(QPainter *painter,
 //--------------------------------------------------------
 
 /*! Reimplements the QGraphicsItem::mouseMoveEvent() method.
-*/
+ */
 void SchematicNode::mouseMoveEvent(QGraphicsSceneMouseEvent *me) {
   QList<QGraphicsItem *> items = scene()->selectedItems();
   if (items.empty()) return;
@@ -1183,7 +1175,7 @@ void SchematicNode::mouseReleaseEvent(QGraphicsSceneMouseEvent *me) {
 
 //--------------------------------------------------------
 /* Add a pair (portId, SchematicPort*port) in the mapping
-*/
+ */
 SchematicPort *SchematicNode::addPort(int portId, SchematicPort *port) {
   QMap<int, SchematicPort *>::iterator it;
   it = m_ports.find(portId);
@@ -1223,7 +1215,7 @@ SchematicPort *SchematicNode::getPort(int portId) const {
 
 /*! Returns a list of all node connected by links to a SchematicPort identified
  * by \b portId.
-*/
+ */
 QList<SchematicNode *> SchematicNode::getLinkedNodes(int portId) const {
   QList<SchematicNode *> list;
   SchematicPort *port = getPort(portId);

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -20,11 +20,13 @@
 #include "toonzqt/menubarcommand.h"
 #include "toonzqt/gutil.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #define ACCEL_KEY(k)                                                           \
   (!QCoreApplication::testAttribute(Qt::AA_DontShowShortcutsInContextMenus)    \
        ? QLatin1Char('\t') +                                                   \
              QKeySequence(k).toString(QKeySequence::NativeText)                \
        : QString())
+#endif
 
 //========================================================
 //
@@ -43,6 +45,7 @@ SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
   setFlag(QGraphicsItem::ItemIsFocusable, true);
   setTextInteractionFlags(Qt::TextEditorInteraction);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   popup = new QMenu();
   popup->setObjectName(QLatin1String("qt_edit_menu"));
 
@@ -69,14 +72,20 @@ SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
                       this, SLOT(onSelectAll()));
   actionSelectAll->setObjectName(QStringLiteral("select-all"));
 
+  connect(popup, SIGNAL(aboutToHide()), this, SLOT(onPopupHide()));
+#endif
+
   connect(document(), SIGNAL(contentsChanged()), this,
           SLOT(onContentsChanged()));
-  connect(popup, SIGNAL(aboutToHide()), this, SLOT(onPopupHide()));
 }
 
 //--------------------------------------------------------
 
-SchematicName::~SchematicName() { delete popup; }
+SchematicName::~SchematicName() {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+  delete popup;
+#endif
+}
 
 //--------------------------------------------------------
 
@@ -154,6 +163,7 @@ bool SchematicName::eventFilter(QObject *object, QEvent *event) {
 void SchematicName::focusInEvent(QFocusEvent *fe) {
   QGraphicsTextItem::focusInEvent(fe);
   qApp->installEventFilter(this);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (!m_refocus) {
     QTextDocument *doc = document();
     QTextCursor cursor(doc->begin());
@@ -161,10 +171,16 @@ void SchematicName::focusInEvent(QFocusEvent *fe) {
     setTextCursor(cursor);
     m_curName = toPlainText();
   }
+#else
+  QTextDocument *doc = document();
+  QTextCursor cursor(doc->begin());
+  cursor.select(QTextCursor::Document);
+#endif
 }
 
 //--------------------------------------------------------
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 void SchematicName::contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) {
   QClipboard *clipboard = QApplication::clipboard();
   QTextCursor cursor    = textCursor();
@@ -269,6 +285,7 @@ void SchematicName::onSelectAll() {
   cursor.select(QTextCursor::Document);
   setTextCursor(cursor);
 }
+#endif
 
 //========================================================
 //

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -245,8 +245,8 @@ void SchematicSceneViewer::mousePressEvent(QMouseEvent *me) {
   if (m_buttonState == Qt::LeftButton) {
     if (m_cursorMode == CursorMode::Hand || m_panningArmed) {
       m_mousePanPoint = m_touchDevice == QTouchDevice::TouchScreen
-        ? mapToScene(me->pos())
-        : me->pos() * getDevPixRatio();
+                            ? mapToScene(me->pos())
+                            : me->pos() * getDevicePixelRatio(this);
       m_panning = true;
       return;
     } else if (m_cursorMode == CursorMode::Zoom) {
@@ -257,7 +257,7 @@ void SchematicSceneViewer::mousePressEvent(QMouseEvent *me) {
   } else if (m_buttonState == Qt::MidButton) {
     m_mousePanPoint = m_touchDevice == QTouchDevice::TouchScreen
                           ? mapToScene(me->pos())
-                          : me->pos() * getDevPixRatio();
+                          : me->pos() * getDevicePixelRatio(this);
   }
   bool drawRect                       = true;
   QList<QGraphicsItem *> pointedItems = items(me->pos());
@@ -292,12 +292,12 @@ void SchematicSceneViewer::mouseMoveEvent(QMouseEvent *me) {
       m_buttonState == Qt::MidButton) {
     QPointF usePos = m_touchDevice == QTouchDevice::TouchScreen
                          ? mapToScene(me->pos())
-                         : me->pos() * getDevPixRatio();
+                         : me->pos() * getDevicePixelRatio(this);
     QPointF deltaPoint = usePos - m_mousePanPoint;
     panQt(deltaPoint);
     m_mousePanPoint = m_touchDevice == QTouchDevice::TouchScreen
                           ? mapToScene(me->pos())
-                          : me->pos() * getDevPixRatio();
+                          : me->pos() * getDevicePixelRatio(this);
   } else {
     if (m_cursorMode == CursorMode::Zoom && m_zooming) {
       int deltaY     = (m_oldWinPos.y() - me->pos().y()) * 10;
@@ -605,8 +605,9 @@ void SchematicSceneViewer::gestureEvent(QGestureEvent *e) {
       }
 
       if (changeFlags & QPinchGesture::CenterPointChanged) {
-        QPointF centerDelta = (gesture->centerPoint() * getDevPixRatio()) -
-                              (gesture->lastCenterPoint() * getDevPixRatio());
+        QPointF centerDelta =
+            (gesture->centerPoint() * getDevicePixelRatio(this)) -
+            (gesture->lastCenterPoint() * getDevicePixelRatio(this));
         if (centerDelta.manhattanLength() > 1) {
           // panQt(centerDelta.toPoint());
         }
@@ -641,14 +642,14 @@ void SchematicSceneViewer::touchEvent(QTouchEvent *e, int type) {
         }
       }
       if (m_panning) {
-        QPointF curPos =
-            m_touchDevice == QTouchDevice::TouchScreen
-                ? mapToScene(panPoint.pos().toPoint())
-                : mapToScene(panPoint.pos().toPoint()) * getDevPixRatio();
-        QPointF lastPos =
-            m_touchDevice == QTouchDevice::TouchScreen
-                ? mapToScene(panPoint.lastPos().toPoint())
-                : mapToScene(panPoint.lastPos().toPoint()) * getDevPixRatio();
+        QPointF curPos = m_touchDevice == QTouchDevice::TouchScreen
+                             ? mapToScene(panPoint.pos().toPoint())
+                             : mapToScene(panPoint.pos().toPoint()) *
+                                   getDevicePixelRatio(this);
+        QPointF lastPos = m_touchDevice == QTouchDevice::TouchScreen
+                              ? mapToScene(panPoint.lastPos().toPoint())
+                              : mapToScene(panPoint.lastPos().toPoint()) *
+                                    getDevicePixelRatio(this);
         QPointF centerDelta = curPos - lastPos;
         panQt(centerDelta);
       }

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -769,9 +769,7 @@ void StageSchematicNodePort::paint(QPainter *painter,
       else
         pixmap = QIcon(":Resources/port_red.svg").pixmap(sourceRect.size());
     }
-    sourceRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                       sourceRect.height() * getDevPixRatio());
-    painter->drawPixmap(imgRect, pixmap, sourceRect);
+    painter->drawPixmap(imgRect, pixmap);
   }
 }
 
@@ -910,8 +908,8 @@ QRectF StageSchematicSplinePort::boundingRect() const {
 void StageSchematicSplinePort::paint(QPainter *painter,
                                      const QStyleOptionGraphicsItem *option,
                                      QWidget *widget) {
-  QRect rect(0, 0, 16, 8);
-  QRect sourceRect = scene()->views()[0]->matrix().mapRect(rect);
+  QRect sourceRect =
+      scene()->views()[0]->matrix().mapRect(boundingRect().toRect());
   QPixmap pixmap;
 
   if (!m_parent->isParentPort()) {
@@ -927,9 +925,7 @@ void StageSchematicSplinePort::paint(QPainter *painter,
     static QIcon splineParentIcon(":Resources/spline_parent_port.svg");
     pixmap = splineParentIcon.pixmap(sourceRect.size());
   }
-  sourceRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
-                     sourceRect.height() * getDevPixRatio());
-  painter->drawPixmap(rect, pixmap, sourceRect);
+  painter->drawPixmap(boundingRect().toRect(), pixmap);
 }
 
 //--------------------------------------------------------
@@ -1584,11 +1580,10 @@ StageSchematicPegbarNode::StageSchematicPegbarNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
     : StageSchematicNode(scene, pegbar, 90, 18, false, false) {
   SchematicViewer *viewer = scene->getSchematicViewer();
-
-  std::string name = m_stageObject->getFullName();
-  std::string id   = m_stageObject->getId().toString();
-  m_name           = QString::fromStdString(name);
-  m_nameItem       = new SchematicName(this, 72, 20);
+  std::string name        = m_stageObject->getFullName();
+  std::string id          = m_stageObject->getId().toString();
+  m_name                  = QString::fromStdString(name);
+  m_nameItem              = new SchematicName(this, 72, 20);
   m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->setPos(16, -1);
@@ -2032,9 +2027,8 @@ StageSchematicCameraNode::StageSchematicCameraNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
     : StageSchematicNode(scene, pegbar, 90, 18, false, false) {
   SchematicViewer *viewer = scene->getSchematicViewer();
-
-  std::string name = m_stageObject->getFullName();
-  m_name           = QString::fromStdString(name);
+  std::string name        = m_stageObject->getFullName();
+  m_name                  = QString::fromStdString(name);
 
   m_nameItem = new SchematicName(this, 54, 20);
   m_nameItem->setDefaultTextColor(viewer->getTextColor());
@@ -2114,9 +2108,8 @@ StageSchematicSplineNode::StageSchematicSplineNode(StageSchematicScene *scene,
                                                    TStageObjectSpline *spline)
     : SchematicNode(scene), m_spline(spline), m_isOpened(false) {
   SchematicViewer *viewer = scene->getSchematicViewer();
-
-  m_width  = 90;
-  m_height = 18;
+  m_width                 = 90;
+  m_height                = 18;
   assert(spline);
 
   m_dock = new StageSchematicSplineDock(this, true, eStageSplinePort);


### PR DESCRIPTION
Ported the following PRs from OT:

### Fixes
#4256 - Fix Stage Schematic Column (Right click) crash  by @justburner
#4265 - Fix fx gadget picking by @shun-iwasawa
#4268 - Fix GIF rendering on older versions by @justburner
#4269 - Fix Stage Schematic Column (Right click) now w/Context Menu  by @justburner**
#4271 - Initializing a missing member  by @justburner
#4276 - fix cell mark default names to be translatable  by @shun-iwasawa
#4277 - Fix crash on switching scenes while selecting raster level frame  by @shun-iwasawa
#4278 - Fix file browser assertion failure  by @shun-iwasawa
#4280 - Fix crash on cleaning up zerary column  by @shun-iwasawa
#4281 - Fix crash on rendering PaletteFilter Fx (and other fxs) with hyphen  by @shun-iwasawa
#4282 - Fixes toward Xsheet parenting + enhancements  by @justburner
#4283 - Fix crash on rendering ArtContour fx  by @shun-iwasawa
#4284 - Fix crashes with preview in Fx Settings popup  by @shun-iwasawa
#4285 - Fix Particles Fx using plastic-deformed source  by @shun-iwasawa
#4292 - Fix high dpi multimonitor glitch by @shun-iwasawa***
#4320 - Fix crash on Fx Schematic by @shun-iwasawa

--------------
** - Added commit changing fix for Qt 5.9
*** - Modified for T2D changes; Added commit fixing missing icon in 2ndary monitor issue























































