### PR TITLE
Fix incorrect QT_VERSION checks

### DIFF
--- a/toonz/sources/common/tvrender/tfont_qt.cpp
+++ b/toonz/sources/common/tvrender/tfont_qt.cpp
@@ -179,7 +179,7 @@ TPoint TFont::drawChar(QImage &outImage, TPoint &unused, wchar_t charcode,
   // (21/1/2022) Use this workaround for all platforms as the crash also occured
   // in windows when the display is scaled up.
   if (chars[0].isSpace()) {
-#if QT_VERSION >= 0x051100
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     int w = QFontMetrics(m_pimpl->m_font).horizontalAdvance(chars[0]);
 #else
     int w = raw.averageCharWidth();

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -249,7 +249,7 @@ AudioRecordingPopup::~AudioRecordingPopup() {}
 //-----------------------------------------------------------------------------
 
 void AudioRecordingPopup::onRecordButtonPressed() {
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (m_audioInput->state() == QAudio::InterruptedState) {
     DVGui::warning(
         tr("The microphone is not available: "

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -995,7 +995,7 @@ void XSheetPDFTemplate::drawCellNumber(QPainter& painter, QRect rect,
       circlePen.setWidth(mm2px(0.3));
       painter.setPen(circlePen);
       QFontMetrics fm(font);
-#if QT_VERSION >= 0x051100
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
       int keyR_width =
         std::max(param(RowHeight), fm.horizontalAdvance(str) + mm2px(1));
 #else

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -246,7 +246,7 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
   if (Preferences::instance()->isColorCalibrationEnabled())
     m_lutCalibrator = new LutCalibrator();
 
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (Preferences::instance()->is30bitDisplayEnabled())
     setTextureFormat(TGL_TexFmt10);
 #endif

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -280,7 +280,7 @@ PreferencesPopup::Display30bitChecker::GLView::GLView(QWidget* parent,
                                                       bool is30bit)
     : QOpenGLWidget(parent), m_is30bit(is30bit) {
   setFixedSize(500, 100);
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (m_is30bit) setTextureFormat(TGL_TexFmt10);
 #endif
 }
@@ -1616,7 +1616,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   // insertUI(interfaceFontStyle, lay, buildFontStyleList());
   QGridLayout* colorCalibLay = insertGroupBoxUI(colorCalibrationEnabled, lay);
   { insertUI(colorCalibrationLutPaths, colorCalibLay); }
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   insertUI(displayIn30bit, lay);
   row = lay->rowCount();
   lay->addWidget(check30bitBtn, row - 1, 2, Qt::AlignRight);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -835,7 +835,7 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
 
   if (Preferences::instance()->isColorCalibrationEnabled())
     m_lutCalibrator = new LutCalibrator();
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (Preferences::instance()->is30bitDisplayEnabled())
     setTextureFormat(TGL_TexFmt10);
 #endif


### PR DESCRIPTION
This PR fixes the checks for QT_VERSION 5.10 and later to use the correct format.

I was using an older syntax for QT version 5.10 and later which was incorrect.  When compiled on those versions or later, the code would never become active since the check always failed.  This replaces those checks to use the proper method so the code will be enabled when compiled with the right version or later

This will only impact macOS/Linux builds as they are currently building on 5.15 whereas Windows builds still [stubbornly] use Qt 5.9.

With this change, the following will now be activated for macOS/Linux builds:
- 30bit Display Support 
- Spacing of key when exporting xsheet to PDF
- Font spacing on Type tool
- Different error messages in Record Audio