### PR TITLE
Update labels to Guided Tweening

### DIFF
--- a/toonz/sources/common/tvrender/tglregions.cpp
+++ b/toonz/sources/common/tvrender/tglregions.cpp
@@ -178,7 +178,7 @@ static void drawArrows(TStroke *stroke, bool onlyFirstPoint) {
 }
 
 //-----------------------------------------------------------------------------
-// Used for Guided Drawing
+// Used for Guided Tweening
 static void drawFirstControlPoint(const TVectorRenderData &rd,
                                   TStroke *stroke) {
   TPointD p          = stroke->getPoint(0.0);
@@ -601,7 +601,7 @@ static bool tglDoDraw(const TVectorRenderData &rd, const TStroke *s) {
   bool ret = false;
 
   if (visible) {
-    // Change stroke color to blue if guided drawing
+    // Change stroke color to blue if guided tweening
     if (rd.m_showGuidedDrawing && rd.m_highLightNow) {
       TVectorRenderData *newRd = new TVectorRenderData(
           rd, rd.m_aff, rd.m_clippingRect, rd.m_palette, rd.m_guidedCf);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2208,7 +2208,7 @@ void MainWindow::defineActions() {
   CommandManager::instance()->enable(MI_NoShift, false);
   createAction(MI_ResetShift, QT_TR_NOOP("Reset Shift"), "", "",
                MenuViewCommandType, "shift_and_trace_reset");
-  createToggle(MI_VectorGuidedDrawing, QT_TR_NOOP("Vector Guided Drawing"), "",
+  createToggle(MI_VectorGuidedDrawing, QT_TR_NOOP("Vector Guided Tweening"), "",
                Preferences::instance()->isGuidedDrawingEnabled(),
                MenuViewCommandType, "view_guided_drawing");
   if (QGLPixelBuffer::hasOpenGLPbuffers())
@@ -2279,7 +2279,7 @@ void MainWindow::defineActions() {
   createMenuWindowsAction(MI_StartupPopup, QT_TR_NOOP("&Startup Popup..."),
                           "Alt+S" /*, "opentoonz"*/);
   createMenuWindowsAction(MI_OpenGuidedDrawingControls,
-                          QT_TR_NOOP("Guided Drawing Controls"), "",
+                          QT_TR_NOOP("Guided Tweening Controls"), "",
                           "guided_drawing");
   // menuAct = createToggle(MI_DockingCheck, QT_TR_NOOP("&Lock Room Panes"), "",
   //                        DockingCheckToggleAction ? 1 : 0, MenuWindowsCommandType);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2071,7 +2071,7 @@ void SceneViewer::drawScene() {
   bool fillFullColorRaster = TXshSimpleLevel::m_fillFullColorRaster;
   TXshSimpleLevel::m_fillFullColorRaster = false;
 
-  // Guided Drawing Check
+  // Guided Tweening Check
   int useGuidedDrawing  = Preferences::instance()->getGuidedDrawingType();
   TTool *tool           = app->getCurrentTool()->getTool();
   int guidedFrontStroke = tool ? tool->getViewer()->getGuidedFrontStroke() : -1;

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -148,17 +148,17 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
       action->setChecked(data == currentData);
       group->addAction(action);
     };
-    QMenu *guidedDrawingMenu = addMenu(tr("Vector Guided Drawing"));
+    QMenu *guidedDrawingMenu = addMenu(tr("Vector Guided Tweening"));
     int guidedDrawingStatus  = Preferences::instance()->getGuidedDrawingType();
 
     QActionGroup *guidedDrawingGroup = new QActionGroup(this);
     addOptionAction(tr("Off"), 0, guidedDrawingStatus, guidedDrawingMenu,
                     guidedDrawingGroup);
-    addOptionAction(tr("Closest Drawing"), 1, guidedDrawingStatus,
+    addOptionAction(tr("Closest Onion Skin Drawing"), 1, guidedDrawingStatus,
                     guidedDrawingMenu, guidedDrawingGroup);
-    addOptionAction(tr("Farthest Drawing"), 2, guidedDrawingStatus,
+    addOptionAction(tr("Farthest Onion Skin Drawing"), 2, guidedDrawingStatus,
                     guidedDrawingMenu, guidedDrawingGroup);
-    addOptionAction(tr("All Drawings"), 3, guidedDrawingStatus,
+    addOptionAction(tr("All Onion Skin Drawings"), 3, guidedDrawingStatus,
                     guidedDrawingMenu, guidedDrawingGroup);
     ret = ret &&
           parent->connect(guidedDrawingGroup, SIGNAL(triggered(QAction *)),

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1631,8 +1631,8 @@ public:
   TPanel *createPanel(QWidget *parent) override {
     TPanel *panel = new VectorGuidedDrawingPanel(parent);
     panel->setObjectName(getPanelType());
-    panel->setWindowTitle(QObject::tr("Vector Guided Drawing Controls"));
-    panel->setMinimumSize(387, 265);
+    panel->setWindowTitle(QObject::tr("Vector Guided Tweening Controls"));
+    panel->setMinimumSize(405, 265);
     panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
     connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
             SLOT(showTitleBar(bool)));
@@ -1645,4 +1645,4 @@ public:
 //=============================================================================
 OpenFloatingPanel openVectorGuidedDrawingPanelCommand(
     MI_OpenGuidedDrawingControls, "VectorGuidedDrawingPanel",
-    QObject::tr("Vector Guided Drawing"));
+    QObject::tr("Vector Guided Tweening Controls"));

--- a/toonz/sources/toonz/vectorguideddrawingpane.cpp
+++ b/toonz/sources/toonz/vectorguideddrawingpane.cpp
@@ -112,12 +112,12 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
   mainlayout->setSpacing(2);
   {
     QLabel *guideFrameLabel = new QLabel(this);
-    guideFrameLabel->setText(tr("Guide Frames:"));
+    guideFrameLabel->setText(tr("Use Onion Skin Frames:"));
     mainlayout->addWidget(guideFrameLabel, 0, 0, Qt::AlignRight);
     mainlayout->addWidget(m_guidedTypeCB, 0, 1);
 
     QLabel *selectGuideStrokeLabel = new QLabel(this);
-    selectGuideStrokeLabel->setText(tr("Select Guide Stroke:"));
+    selectGuideStrokeLabel->setText(tr("Select Stroke:"));
     mainlayout->addWidget(selectGuideStrokeLabel, 1, 0, Qt::AlignRight);
     QHBoxLayout *selectBtnLayout = new QHBoxLayout();
     selectBtnLayout->setMargin(0);
@@ -131,7 +131,7 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
     mainlayout->addLayout(selectBtnLayout, 1, 1);
 
     QLabel *flipGuideStrokeLabel = new QLabel(this);
-    flipGuideStrokeLabel->setText(tr("Flip Guide Stroke:"));
+    flipGuideStrokeLabel->setText(tr("Flip Stroke Direction:"));
     mainlayout->addWidget(flipGuideStrokeLabel, 2, 0, Qt::AlignRight);
     QHBoxLayout *flipBtnLayout = new QHBoxLayout();
     flipBtnLayout->setMargin(0);

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -203,7 +203,7 @@ public:
   int m_currentXsheetLevel;   // level of the current xsheet, see: editInPlace
   int m_xsheetLevel;          // xsheet-level of the column being processed
 
-  // for guided drawing
+  // for guided tweening
   TFrameId m_currentFrameId;
   int m_isGuidedDrawingEnabled;
   int m_guidedFrontStroke = -1;


### PR DESCRIPTION
This PR relabels `Guided Drawing Controls` to `Guided Tweening Controls` in an attempt to make this feature more discoverable for those looking to use Vector inbetweening.

Also updated the label in the popup to indicate it uses Onion Skin.

Aside: Will work on documenting this feature in the manual since it isn't quite intuitive to use....yet
