### PR TITLE
Default column names to 1st level name

### DIFF
--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -37,6 +37,7 @@
 #include "toonz/tproject.h"
 #include "toonz/namebuilder.h"
 #include "toonz/childstack.h"
+#include "toonz/tstageobjectcmd.h"
 #include "toutputproperties.h"
 
 // TnzCore includes
@@ -638,6 +639,10 @@ bool LevelCreatePopup::apply() {
       scene->createNewLevel(lType, levelName, TDimension(), 0, fp);
   TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(level);
 
+  TStageObjectId columnId = TStageObjectId::ColumnId(col);
+  TXshColumn *column      = xsh->getColumn(columnId.getIndex());
+  bool wasColumnEmpty     = !column ? true : column->isEmpty();
+
   assert(sl);
   //  sl->setPath(fp, true);
   if (lType == TZP_XSHLEVEL || lType == OVL_XSHLEVEL) {
@@ -683,6 +688,12 @@ bool LevelCreatePopup::apply() {
   //  }
 
   undo->onAdd(sl);
+
+  // Column name renamed to level name only if was originally empty
+  if (wasColumnEmpty) {
+    std::string columnName = QString::fromStdWString(levelName).toStdString();
+    TStageObjectCmd::rename(columnId, columnName, app->getCurrentXsheet());
+  }
 
   TUndoManager::manager()->endBlock();
 


### PR DESCRIPTION
This PR will default an empty column's name to the name of the 1st level added to the column. (Resolves #114)

This should occur when adding a level to an empty column via...
- New Level popup (OK & Apply)
- Load Level popup
- Drag/drop levels from Scene Cast
- Drag/drop files from File Browser
- Drag/drop files from outside T2D (i.e. Windows File Explorer)
- Copy/paste of external image from another software
- Copy/paste of existing cell in the timeline
- Autocreation (brush tool, geometric tool, type tool)
- Create Blank Drawing
- Adding Zerary Fx (existing behavior)
- Adding Note level (existing behavior)
- Dragging existing cell (existing behavior)

If a column already has a level and a new level is added to it, the column name will not change
If a column has multiple levels and the 1st level is removed, the column name is not change