### PR TITLE
Fix small text on high res monitors

### DIFF
--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -30,6 +30,7 @@
 // TnzQt includes
 #include "toonzqt/selection.h"
 #include "toonzqt/selectioncommandids.h"
+#include "toonzqt/gutil.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -1263,7 +1264,8 @@ void SkeletonTool::drawDrawingBrowser(const TXshCell &cell,
                      std::to_string(cell.m_frameId.getNumber());
 
   QString qText = QString::fromStdString(name);
-  QFont font("Arial", 10);  // ,QFont::Bold);
+  int devPixRatio = getDevicePixelRatio(getViewer()->viewerWidget());
+  QFont font("Arial", 10 * devPixRatio);  // ,QFont::Bold);
   QFontMetrics fm(font);
   QSize textSize   = fm.boundingRect(qText).size();
   int arrowHeight  = 10;

--- a/toonz/sources/tnztools/trackertool.cpp
+++ b/toonz/sources/tnztools/trackertool.cpp
@@ -8,6 +8,7 @@
 #include "toonz/txshlevelhandle.h"
 #include "toonz/tscenehandle.h"
 #include "toonzqt/selectioncommandids.h"
+#include "toonzqt/gutil.h"
 
 #include "toonzqt/selection.h"
 #include "tproperty.h"
@@ -287,6 +288,7 @@ void TrackerTool::draw() {
     selectedObjectId = -1;
   int i              = 0;
   double pixelSize   = getPixelSize();
+  int devPixRatio    = getDevicePixelRatio(m_viewer->viewerWidget());
 
   std::vector<TRectD> balloons;  // this is used to avoid balloons overlapping
   // draw hooks
@@ -324,7 +326,7 @@ void TrackerTool::draw() {
       tglColor(textColor);
       glPushMatrix();
       glTranslated(hook->getPos(fid).x, hook->getPos(fid).y, 0);
-      glScaled(pixelSize, pixelSize, 1);
+      glScaled(pixelSize * devPixRatio, pixelSize * devPixRatio, 1);
       int objectId = hook->getTrackerObjectId();
       std::string text({static_cast<char>('A' + objectId)});
       tglDrawText(TPointD(-15, 10), text);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1891,13 +1891,15 @@ void SceneViewer::drawViewerIndicators() {
 
   if (!checkTexts.size()) return;
 
+  int devPixRatio = getDevPixRatio();
+
   int x0, x1, y0, y1;
   rect().getCoords(&x0, &y0, &x1, &y1);
-  x0 = (-(x1 / 2)) + 15;
-  y0 = ((y1 / 2)) - 25;
+  x0 = (-(x1 / (2 * devPixRatio))) + 15;
+  y0 = ((y1 / (2 * devPixRatio))) - 25;
 
   glPushMatrix();
-  glScaled(2, 2, 2);
+  glScaled(2 * devPixRatio, 2 * devPixRatio, 2 * devPixRatio);
   glColor3d(1.0, 0.0, 0.0);
   for (int i = 0; i < checkTexts.size(); i++) {
     int y = (y0 / 2) - (i * 10);


### PR DESCRIPTION
This PR scales the size of the text in the Viewer for high res monitors otherway they appear too small and are hard to read.

The following will be fixed:
- Viewer check indicators (i.e. Transparency Check, etc) 
- Tracker tool object label
- Skeleton tool frame indicator