### PR TITLE
OpenToonz Patches thru 4/1/2022

### DIFF
--- a/toonz/sources/common/psdlib/psd.cpp
+++ b/toonz/sources/common/psdlib/psd.cpp
@@ -176,7 +176,7 @@ bool TPSDReader::doImageResources() {
       hresd = FIXDPI(hres = read4Bytes(m_file));
       read2Bytes(m_file);
       read2Bytes(m_file);
-      vresd = FIXDPI(vres = read4Bytes(m_file));
+      vresd             = FIXDPI(vres = read4Bytes(m_file));
       m_headerInfo.vres = vresd;
       m_headerInfo.hres = hresd;
       fseek(m_file, savepos, SEEK_SET);
@@ -248,7 +248,7 @@ bool TPSDReader::readLayerInfo(int i) {
     fseek(m_file, 6 * li->channels + 12, SEEK_CUR);
     skipBlock(m_file);  // skip  "layer info: extra data";
   } else {
-    li->chan = (TPSDChannelInfo *)mymalloc(li->channels *
+    li->chan    = (TPSDChannelInfo *)mymalloc(li->channels *
                                            sizeof(struct TPSDChannelInfo));
     li->chindex = (int *)mymalloc((li->channels + 2) * sizeof(int));
     li->chindex += 2;  //
@@ -558,7 +558,7 @@ void TPSDReader::readImageData(TRasterP &rasP, TPSDLayerInfo *li,
     x1 = x0 + m_region.getLx() - 1;
     // controllo che x1 rimanga all'interno dell'immagine
     if (x1 >= m_headerInfo.cols) x1 = m_headerInfo.cols - 1;
-    y0                              = m_region.getP00().y;
+    y0 = m_region.getP00().y;
     // se y0 è fuori dalle dimensioni dell'immagine ritorna un'immagine vuota
     if (y0 >= m_headerInfo.rows) {
       free(rledata);
@@ -640,7 +640,7 @@ void TPSDReader::readImageData(TRasterP &rasP, TPSDLayerInfo *li,
     m_layersSavebox[li->layerId] = layerSaveBox2;
   else
     m_layersSavebox[0] = layerSaveBox2;
-  TRasterP smallRas    = rasP->extract(layerSaveBox2);
+  TRasterP smallRas = rasP->extract(layerSaveBox2);
   assert(smallRas);
   if (!smallRas) return;
   // Trovo l'indice di colonna del primo pixel del livello che deve essere letto
@@ -1005,11 +1005,11 @@ void readChannel(FILE *f, TPSDLayerInfo *li,
 
   for (ch = 0; ch < channels; ++ch) {
     if (!li) chan[ch].id = ch;
-    chan[ch].rowbytes    = rb;
-    chan[ch].comptype    = comp;
-    chan[ch].rows        = chan->rows;
-    chan[ch].cols        = chan->cols;
-    chan[ch].filepos     = pos;
+    chan[ch].rowbytes = rb;
+    chan[ch].comptype = comp;
+    chan[ch].rows     = chan->rows;
+    chan[ch].cols     = chan->cols;
+    chan[ch].filepos  = pos;
 
     if (!chan->rows) continue;
 
@@ -1030,7 +1030,7 @@ void readChannel(FILE *f, TPSDLayerInfo *li,
 
         if (count > 2 * chan[ch].rowbytes)  // this would be impossible
           count = last;                     // make a guess, to help recover
-        last    = count;
+        last = count;
 
         chan[ch].rowpos[j] = pos;
         pos += count;
@@ -1294,9 +1294,8 @@ int TPSDParser::getLevelIdByName(std::string levelName) {
       levelNameCount++;
     }
   }
-  if (lyid == 0 && lyid < 0) lyid = 0;
-  if (lyid < 0 && lyid != 0)
-    throw TImageException(m_path, "Layer ID not exists");
+
+  if (lyid < 0) throw TImageException(m_path, "Layer ID not exists");
   return lyid;
 }
 int TPSDParser::getFramesCount(int levelId) {

--- a/toonz/sources/common/tvrender/tstrokeprop.cpp
+++ b/toonz/sources/common/tvrender/tstrokeprop.cpp
@@ -247,7 +247,10 @@ void OutlineStrokeProp::draw(const TVectorRenderData &rd) {
       m_styleVersionNumber = m_colorStyle->getVersionNumber();
     }
 
-    m_colorStyle->drawStroke(rd.m_cf, &m_outline, m_stroke);
+    if (rd.m_antiAliasing)
+      m_colorStyle->drawStroke(rd.m_cf, &m_outline, m_stroke);
+    else
+      m_colorStyle->drawAliasedStroke(rd.m_cf, &m_outline, m_stroke);
   }
 
   glPopMatrix();

--- a/toonz/sources/include/tsimplecolorstyles.h
+++ b/toonz/sources/include/tsimplecolorstyles.h
@@ -118,6 +118,12 @@ public:
 
   virtual void drawStroke(const TColorFunction *cf, TStrokeOutline *outline,
                           const TStroke *stroke) const = 0;
+  // draw aliased stroke. currently reimplemented by TSolidColorStyle only
+  virtual void drawAliasedStroke(const TColorFunction *cf,
+                                 TStrokeOutline *outline,
+                                 const TStroke *stroke) const {
+    drawStroke(cf, outline, stroke);
+  };
 
 protected:
   // Not assignable
@@ -158,8 +164,17 @@ public:
   void drawRegion(const TColorFunction *cf, const bool antiAliasing,
                   TRegionOutline &outline) const override;
 
+  void doDrawStroke(const TColorFunction *cf, TStrokeOutline *outline,
+                    const TStroke *s, bool antialias) const;
+
   void drawStroke(const TColorFunction *cf, TStrokeOutline *outline,
-                  const TStroke *s) const override;
+                  const TStroke *s) const override {
+    doDrawStroke(cf, outline, s, true);
+  }
+  void drawAliasedStroke(const TColorFunction *cf, TStrokeOutline *outline,
+                         const TStroke *s) const override {
+    doDrawStroke(cf, outline, s, false);
+  }
 
   int getTagId() const override;
 

--- a/toonz/sources/stdfx/iwa_tilefx.cpp
+++ b/toonz/sources/stdfx/iwa_tilefx.cpp
@@ -134,6 +134,11 @@ void Iwa_TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
                            TRectD &rectOnInput, TRenderSettings &infoOnInput) {
   infoOnInput = infoOnOutput;
 
+  if (!m_input.isConnected()) {
+    rectOnInput.empty();
+    return;
+  }
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, infoOnOutput);
 
@@ -161,6 +166,8 @@ void Iwa_TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
 
 int Iwa_TileFx::getMemoryRequirement(const TRectD &rect, double frame,
                                      const TRenderSettings &info) {
+  if (!m_input.isConnected()) return 0;
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, info);
 

--- a/toonz/sources/stdfx/rgbkeyfx.cpp
+++ b/toonz/sources/stdfx/rgbkeyfx.cpp
@@ -51,7 +51,7 @@ public:
   void doCompute(TTile &tile, double frame, const TRenderSettings &) override;
 
   bool canHandle(const TRenderSettings &info, double frame) override {
-    return true;
+    return false;
   }
 };
 

--- a/toonz/sources/stdfx/tilefx.cpp
+++ b/toonz/sources/stdfx/tilefx.cpp
@@ -90,6 +90,11 @@ void TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
                        TRenderSettings &infoOnInput) {
   infoOnInput = infoOnOutput;
 
+  if (!m_input.isConnected()) {
+    rectOnInput.empty();
+    return;
+  }
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, infoOnOutput);
 
@@ -116,6 +121,8 @@ void TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
 
 int TileFx::getMemoryRequirement(const TRectD &rect, double frame,
                                  const TRenderSettings &info) {
+  if (!m_input.isConnected()) return 0;
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, info);
 
@@ -157,7 +164,7 @@ void TileFx::doCompute(TTile &tile, double frame, const TRenderSettings &ri) {
 //------------------------------------------------------------------------------
 //! Make the tile of the image contained in \b inputTile in \b tile
 /*
-*/
+ */
 void TileFx::makeTile(const TTile &inputTile, const TTile &tile) const {
   // Build the mirroring pattern. It obviously repeats itself out of 2x2 tile
   // blocks.

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -541,8 +541,11 @@ TAffine TRasterFx::handledAffine(const TRenderSettings &info, double frame) {
 bool TRasterFx::getBBox(double frame, TRectD &bBox,
                         const TRenderSettings &info) {
   bool ret = doGetBBox(frame, bBox, info);
-  bBox     = info.m_affine * bBox;
-  enlargeToI(bBox);
+  if (!bBox.isEmpty()) {  // TODO: check if bbox can always be empty when ret ==
+                          // false
+    bBox = info.m_affine * bBox;
+    enlargeToI(bBox);
+  }
   return ret;
 }
 

--- a/toonz/sources/tnztools/hookselection.cpp
+++ b/toonz/sources/tnztools/hookselection.cpp
@@ -96,7 +96,7 @@ void HooksData::storeHookPositions(const std::vector<int> &ids) {
   if (ids.empty()) return;
   TTool::Application *app = TTool::getApplication();
   TXshLevelP level        = app->getCurrentLevel()->getLevel();
-  assert(level = m_level);
+  assert(level == m_level);
   if (level != m_level || !m_level || m_level->getSimpleLevel()->isReadOnly())
     return;
   HookSet *hookSet = m_level->getHookSet();

--- a/toonz/sources/tnztools/shifttracetool.cpp
+++ b/toonz/sources/tnztools/shifttracetool.cpp
@@ -348,6 +348,10 @@ void ShiftTraceTool::onActivate() {
 }
 
 void ShiftTraceTool::onDeactivate() {
+  // Deactivating Shift and Trace mode resets the pseudo tool with keeping the
+  // Edit Shift checkbox unchanged
+  QAction *shiftTrace = CommandManager::instance()->getAction("MI_ShiftTrace");
+  if (!shiftTrace->isChecked()) return;
   QAction *action = CommandManager::instance()->getAction("MI_EditShift");
   action->setChecked(false);
 }

--- a/toonz/sources/toonz/cameracapturelevelcontrol.cpp
+++ b/toonz/sources/toonz/cameracapturelevelcontrol.cpp
@@ -148,7 +148,7 @@ void CameraCaptureLevelHistogram::mousePressEvent(QMouseEvent* event) {
     m_offset = pos.x() - SIDE_MARGIN - m_black;
   else if (m_currentItem == GammaSlider)
     m_offset = pos.x() - SIDE_MARGIN - gammaToHPos(m_gamma, m_black, m_white);
-  else if (m_currentItem == BlackSlider)
+  else if (m_currentItem == WhiteSlider)
     m_offset = pos.x() - SIDE_MARGIN - m_white;
   else if (m_currentItem == ThresholdSlider)
     m_offset = pos.x() - SIDE_MARGIN - m_threshold;

--- a/toonz/sources/toonz/cameracapturelevelcontrol_qt.cpp
+++ b/toonz/sources/toonz/cameracapturelevelcontrol_qt.cpp
@@ -157,7 +157,7 @@ void CameraCaptureLevelHistogram::mousePressEvent(QMouseEvent* event) {
     m_offset = pos.x() - SIDE_MARGIN - m_black;
   else if (m_currentItem == GammaSlider)
     m_offset = pos.x() - SIDE_MARGIN - gammaToHPos(m_gamma, m_black, m_white);
-  else if (m_currentItem == BlackSlider)
+  else if (m_currentItem == WhiteSlider)
     m_offset = pos.x() - SIDE_MARGIN - m_white;
   else if (m_currentItem == ThresholdSlider)
     m_offset = pos.x() - SIDE_MARGIN - m_threshold;

--- a/toonz/sources/toonz/canvassizepopup.cpp
+++ b/toonz/sources/toonz/canvassizepopup.cpp
@@ -137,7 +137,7 @@ int getPixelLength(double measuredLength, TMeasure *measure, double dpi,
   double inchValue = measure->getCurrentUnit()->convertFrom(measuredLength);
   return tround(inchValue * dpi);
 }
-}
+}  // namespace
 //=============================================================================
 // PeggingWidget
 //-----------------------------------------------------------------------------
@@ -266,7 +266,7 @@ void PeggingWidget::on00() {
   m_01->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
   m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLx ? -90 : 90),
+      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
   m_10->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
@@ -601,7 +601,7 @@ void CanvasSizePopup::showEvent(QShowEvent *e) {
   TPointD dpi    = m_sl->getDpi();
   double dimLx   = getMeasuredLength(dim.lx, m_xMeasure, dpi.x,
                                    "pixel");
-  double dimLy = getMeasuredLength(dim.ly, m_yMeasure, dpi.y,
+  double dimLy   = getMeasuredLength(dim.ly, m_yMeasure, dpi.y,
       "pixel");
   m_currentXSize->setText(QString::number(dimLx));
   m_currentYSize->setText(QString::number(dimLy));

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -689,13 +689,12 @@ void ComboViewerPanel::changeWindowTitle() {
     name = name + tr("   ::   Level: ") + imageName;
 
     if (!m_sceneViewer->is3DView()) {
-      TAffine aff = m_sceneViewer->getViewMatrix();
+      TAffine aff = m_sceneViewer->getViewMatrix() *
+                    m_sceneViewer->getNormalZoomScale().inv();
       if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
       if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
       name = name + "  ::  Zoom : " +
-             QString::number((int)(100.0 * sqrt(aff.det()) *
-                                   m_sceneViewer->getDpiFactor())) +
-             "%";
+             QString::number(tround(100.0 * sqrt(aff.det()))) + "%";
     }
 
     // If the current level exists and some option is set in the preference,
@@ -709,13 +708,12 @@ void ComboViewerPanel::changeWindowTitle() {
                                               // neither
                      ->isEnabled() &&
              !m_sceneViewer->is3DView()) {
-      TAffine aff = m_sceneViewer->getViewMatrix();
+      TAffine aff = m_sceneViewer->getViewMatrix() *
+                    m_sceneViewer->getNormalZoomScale().inv();
       if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
       if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
       name = name + "  ::  Zoom : " +
-             QString::number((int)(100.0 * sqrt(aff.det()) *
-                                   m_sceneViewer->getDpiFactor())) +
-             "%";
+             QString::number(tround(100.0 * sqrt(aff.det()))) + "%";
     }
 
   }
@@ -729,13 +727,12 @@ void ComboViewerPanel::changeWindowTitle() {
 
       name = name + tr("Level: ") + imageName;
       if (!m_sceneViewer->is3DView()) {
-        TAffine aff = m_sceneViewer->getViewMatrix();
+        TAffine aff = m_sceneViewer->getViewMatrix() *
+                      m_sceneViewer->getNormalZoomScale().inv();
         if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
         if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
         name = name + "  ::  Zoom : " +
-               QString::number((int)(100.0 * sqrt(aff.det()) *
-                                     m_sceneViewer->getDpiFactor())) +
-               "%";
+               QString::number(tround(100.0 * sqrt(aff.det()))) + "%";
       }
     }
   }

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1616,6 +1616,9 @@ QWidget* PreferencesPopup::createInterfacePage() {
   insertUI(CurrentLanguageName, lay, languageItemList);
   // insertUI(interfaceFont, lay);  // creates QFontComboBox
   // insertUI(interfaceFontStyle, lay, buildFontStyleList());
+  //qobject_cast<QComboBox*>(m_controlIdMap.key(interfaceFontStyle))
+  //    ->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+
   QGridLayout* colorCalibLay = insertGroupBoxUI(colorCalibrationEnabled, lay);
   { insertUI(colorCalibrationLutPaths, colorCalibLay); }
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
@@ -1676,7 +1679,8 @@ QWidget* PreferencesPopup::createVisualizationPage() {
 
 QWidget* PreferencesPopup::createLoadingPage() {
   m_levelFormatNames = new QComboBox;
-  m_editLevelFormat  = new QPushButton(tr("Edit"));
+  m_levelFormatNames->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+  m_editLevelFormat = new QPushButton(tr("Edit"));
 
   QPushButton* addLevelFormat    = new QPushButton("+");
   QPushButton* removeLevelFormat = new QPushButton("-");

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -420,7 +420,17 @@ public:
     if (std::string(m_cmdId) == MI_ShiftTrace) {
       cm->enable(MI_EditShift, checked);
       cm->enable(MI_NoShift, checked);
-      if (checked) OnioniSkinMaskGUI::resetShiftTraceFrameOffset();
+      if (checked) {
+        OnioniSkinMaskGUI::resetShiftTraceFrameOffset();
+        // activate edit shift
+        if (isChecked(MI_EditShift))
+          TApp::instance()->getCurrentTool()->setPseudoTool("T_ShiftTrace");
+      } else {
+        // deactivate edit shift
+        if (isChecked(MI_EditShift))
+          TApp::instance()->getCurrentTool()->unsetPseudoTool();
+      }
+
       //     cm->getAction(MI_NoShift)->setChecked(false);
       TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
     } else if (std::string(m_cmdId) == MI_EditShift) {

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -514,6 +514,14 @@ void SceneViewer::mouseMoveEvent(QMouseEvent *event) {
 void SceneViewer::onMove(const TMouseEvent &event) {
   if (m_freezedStatus != NO_FREEZED) return;
 
+  // in case mouseReleaseEvent is not called, finish the action for the previous
+  // button first.
+  if (m_mouseButton != Qt::NoButton && event.m_buttons == Qt::NoButton) {
+    TMouseEvent preEvent = event;
+    preEvent.m_button    = m_mouseButton;
+    onRelease(preEvent);
+  }
+
   int devPixRatio = getDevPixRatio();
   QPointF curPos  = event.mousePos() * devPixRatio;
   bool cursorSet  = false;

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -346,8 +346,7 @@ void ChangeObjectWidget::show(const QPoint &pos) {
     m_width += scrollbarW;
   }
   int height = 0;
-  for (int i = 0; i < itemNumber; i++)
-    height += sizeHintForRow(i);
+  for (int i = 0; i < itemNumber; i++) height += sizeHintForRow(i);
   setGeometry(pos.x(), pos.y(), m_width, height + 2);
   QListWidget::show();
   setFocus();
@@ -482,7 +481,6 @@ void ChangeObjectParent::refresh() {
     if (id == tree->getMotionPathViewerId()) continue;
     int index = id.getIndex();
     QString indexStr(std::to_string(id.getIndex() + 1).c_str());
-    QString newTextID, newTextTr;
     QColor newTextBG;
 
     // Remove childs from parent list
@@ -490,54 +488,41 @@ void ChangeObjectParent::refresh() {
                             xsh->getStageObject(id)) != children.end());
     if (id == currentObjectId || found) continue;
 
-    if (id.isTable()) {
-      newTextID = QString("Table");
-      newTextTr = tr("Table");
+    QString newTextID = QString::fromStdString(id.toString());
+    QString newTextTr;
+    if (tree->getStageObject(i)->hasSpecifiedName())
+      newTextTr = QString::fromStdString(tree->getStageObject(i)->getName());
+    else
+      newTextTr = getNameTr(id);
+
+    if (id.isTable())
       newTextBG = viewer->getTableColor();
-    }
-    if (id.isPegbar()) {
-      newTextID = QString("Peg ") + indexStr;
-      newTextTr = QString("Peg") + indexStr;
+    else if (id.isPegbar())
       newTextBG = viewer->getPegColor();
-      //
-      std::string name = tree->getStageObject(i)->getName();
-      if (name.length() > 0) newTextTr = QString::fromStdString(name);
-    }
-    if (id.isCamera()) {
-      bool isActive =
-          (id == xsh->getStageObjectTree()->getCurrentCameraId());
-      newTextID = QString("Cam ") + indexStr;
-      newTextTr = QString("Camera") + indexStr;
-      newTextBG = isActive ? viewer->getActiveCameraColor()
+    else if (id.isCamera()) {
+      bool isActive = (id == xsh->getStageObjectTree()->getCurrentCameraId());
+      newTextBG     = isActive ? viewer->getActiveCameraColor()
                            : viewer->getOtherCameraColor();
-      //
-      std::string name = tree->getStageObject(i)->getName();
-      if (name.length() > 0) newTextTr = QString::fromStdString(name);
-    }
-    if (id.isColumn() && (!xsh->isColumnEmpty(index))) {
+    } else if (id.isColumn() && (!xsh->isColumnEmpty(index))) {
       TXshColumn *colx = xsh->getColumn(index);
       if (colx->getColumnType() != TXshColumn::eSoundTextType &&
           colx->getColumnType() != TXshColumn::eSoundType) {
-        newTextID = QString("Col ") + indexStr;
-        newTextTr = QString("Col") + indexStr;
         QColor unused;
         viewer->getColumnColor(newTextBG, unused, id.getIndex(), xsh);
-        std::string name = tree->getStageObject(i)->getName();
-        if (name.length() > 0) newTextTr = QString::fromStdString(name);
       }
-    }
+    } else
+      continue;
+
     if (id == parentId) currentText = newTextID;
     if (newTextTr.length() > theLongestTxt.length()) theLongestTxt = newTextTr;
-    if (!newTextID.isEmpty()) {
-      if (id.isColumn()) {
-        columnListID.append(newTextID);
-        columnListTr.append(newTextTr);
-        columnListColor.append(newTextBG);
-      } else {
-        pegbarListID.append(newTextID);
-        pegbarListTr.append(newTextTr);
-        pegbarListColor.append(newTextBG);
-      }
+    if (id.isColumn()) {
+      columnListID.append(newTextID);
+      columnListTr.append(newTextTr);
+      columnListColor.append(newTextBG);
+    } else {
+      pegbarListID.append(newTextID);
+      pegbarListTr.append(newTextTr);
+      pegbarListColor.append(newTextBG);
     }
   }
   for (i = 0; i < columnListID.size(); i++)
@@ -545,20 +530,17 @@ void ChangeObjectParent::refresh() {
   for (i = 0; i < pegbarListID.size(); i++)
     addText(pegbarListID.at(i), pegbarListTr.at(i), pegbarListColor.at(i));
 
-  QString fontName = Preferences::instance()->getInterfaceFont();
-  if (fontName == "") {
-#ifdef _WIN32
-    fontName = "Arial";
-#else
-    fontName = "Helvetica";
-#endif
-  }
-  static QFont font(fontName, -1, QFont::Normal);
-  // set font size in pixel
-  font.setPixelSize(XSHEET_FONT_PX_SIZE);
-
-  m_width = QFontMetrics(font).width(theLongestTxt) + 32;
+  m_width = fontMetrics().width(theLongestTxt) + 32;
   selectCurrent(currentText);
+}
+
+//-----------------------------------------------------------------------------
+
+QString ChangeObjectParent::getNameTr(const TStageObjectId id) {
+  if (id.isTable()) return tr("Table");
+  // return untranslated string for other types
+  else
+    return QString::fromStdString(id.toString());
 }
 
 //-----------------------------------------------------------------------------
@@ -577,7 +559,7 @@ void ChangeObjectParent::onTextSelected(const QString &text) {
   bool isTable                         = false;
   if (text == "Table") isTable         = true;
   QString number                       = text;
-  number.remove(0, 4);
+  number.remove(0, 3);
   // Remove names from the index
   int spaceIndex = number.indexOf(" ");
   if (spaceIndex > -1) number.remove(spaceIndex, 1000);
@@ -1267,11 +1249,12 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
 
   TStageObjectId columnId = m_viewer->getObjectId(col);
   TStageObjectId parentId = xsh->getStageObjectParent(columnId);
-  std::string strName     = xsh->getStageObject(parentId)->getName();
-  QString name            = QString(parentId.toString().c_str());
-  if (strName.length() > 0 && parentId.toString() != strName) {
-    name = QString::fromStdString(strName);
-  }
+
+  QString name;
+  if (xsh->getStageObject(parentId)->hasSpecifiedName())
+    name = QString::fromStdString(xsh->getStageObject(parentId)->getName());
+  else
+    name = ChangeObjectParent::getNameTr(parentId);
 
   QString fontName = Preferences::instance()->getInterfaceFont();
   if (fontName == "") {
@@ -1285,9 +1268,9 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   // set font size in pixel
   font.setPixelSize(XSHEET_FONT_PX_SIZE);
 
-  int handleWidth = 20;
+  int handleWidth    = 20;
   std::string handle = xsh->getStageObject(columnId)->getParentHandle();
-  if (handle == "B") handleWidth = 0; // Default handle
+  if (handle == "B") handleWidth = 0;  // Default handle
 
   int width = QFontMetrics(font).width(name);
 
@@ -1351,10 +1334,10 @@ void ColumnArea::DrawHeader::drawParentHandleName() const {
   if (o->flag(PredefinedFlag::PARENT_HANDLE_NAME_BORDER))
     p.drawRect(parenthandleRect);
 
-  std::string handle = xsh->getStageObject(columnId)->getParentHandle();
+  std::string handle      = xsh->getStageObject(columnId)->getParentHandle();
   if (handle[0] == 'H' && handle.length() > 1) handle = handle.substr(1);
 
-  if (handle == "B") { // Default handle
+  if (handle == "B") {  // Default handle
     QPen pen(m_viewer->getVerticalLineColor());
     pen.setStyle(Qt::PenStyle::DotLine);
     p.setPen(pen);
@@ -2408,7 +2391,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
         if (event->button() != Qt::LeftButton) return;
         m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
       } else if (o->rect(PredefinedRect::CAMERA_CONFIG_AREA)
-                     .contains(mouseInCell)) {
+                   .contains(mouseInCell)) {
         // config button
         if (event->button() != Qt::LeftButton) return;
         m_doOnRelease = OpenSettings;

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -118,6 +118,8 @@ public:
 
   void refresh() override;
 
+  static QString getNameTr(const TStageObjectId id);
+
 protected slots:
   void onTextSelected(const QString &) override;
 };

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -93,16 +93,14 @@ protected:
   void wheelEvent(QWheelEvent *event) override;
   void focusOutEvent(QFocusEvent *e) override;
   void focusInEvent(QFocusEvent *e) override {}
-  void selectCurrent(const QString &text);
 
   void addText(const QString &text, const QString &display);
   void addText(const QString &text, const QColor &textColor);
-  void addText(const QString &text, const QString &display,
+  void addText(const TStageObjectId &id, const QString &display,
                const QColor &identColor);
-  virtual void onTextSelected(const QString &) = 0;
 
 protected slots:
-  void onItemSelected(QListWidgetItem *);
+  virtual void onItemSelected(QListWidgetItem *) = 0;
 };
 
 //=============================================================================
@@ -119,9 +117,10 @@ public:
   void refresh() override;
 
   static QString getNameTr(const TStageObjectId id);
+  void selectCurrent(const TStageObjectId &id);
 
 protected slots:
-  void onTextSelected(const QString &) override;
+  void onItemSelected(QListWidgetItem *) override;
 };
 
 //=============================================================================
@@ -136,9 +135,10 @@ public:
   ~ChangeObjectHandle();
 
   void refresh() override;
+  void selectCurrent(const QString &text);
 
 protected slots:
-  void onTextSelected(const QString &) override;
+  void onItemSelected(QListWidgetItem *) override;
 };
 
 //=============================================================================

--- a/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
+++ b/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
@@ -119,7 +119,8 @@ TFilePath getLocalRoot() {
 #else
   // set path to something suitable for most linux (Unix?) systems
 #ifdef FREEBSD
-  std::string unixpath = "/usr/local/etc/" + tver.getAppName() + "/tahoma.conf";
+  std::string unixpath =
+      "/usr/local/etc/" + tver.getAppName() + "/tahoma.conf";
 #else
   std::string unixpath = "/etc/" + tver.getAppName() + "/tahoma.conf";
 #endif
@@ -767,7 +768,7 @@ inline QString toString(const TFarmTask &task, int ver) {
     ss += ",";
     ss += QString::number(task.m_platform) + ",";
 
-    int depCount                      = 0;
+    int depCount = 0;
     if (task.m_dependencies) depCount = task.m_dependencies->getTaskCount();
 
     ss += QString::number(depCount);
@@ -1320,7 +1321,7 @@ bool FarmController::tryToStartTask(CtrlFarmTask *task) {
       map<TaskId, CtrlFarmTask *>::iterator itSubTask =
           m_tasks.find(TaskId(*itSubTaskId));
       if (itSubTask != m_tasks.end()) {
-        CtrlFarmTask *subTask                = itSubTask->second;
+        CtrlFarmTask *subTask = itSubTask->second;
         if (tryToStartTask(subTask)) started = true;
       }
     }
@@ -1776,8 +1777,7 @@ void FarmController::taskSubmissionError(const QString &taskId, int errCode) {
         }
 
         parentTask->m_status = parentTaskState;
-        if (parentTask->m_status == Aborted ||
-            parentTask->m_status == Aborted) {
+        if (parentTask->m_status == Aborted) {
           parentTask->m_completionDate = task->m_completionDate;
           if (parentTask->m_toBeDeleted) m_tasks.erase(itParent);
         }
@@ -1861,7 +1861,7 @@ void FarmController::taskCompleted(const QString &taskId, int exitCode) {
     } else {
       switch (exitCode) {
       case 0:
-        task->m_status                                = Completed;
+        task->m_status = Completed;
         if (isAScript(task)) task->m_successfullSteps = task->m_stepCount;
         break;
       case RENDER_LICENSE_NOT_FOUND:
@@ -2343,7 +2343,7 @@ void ControllerService::onStart(int argc, char *argv[]) {
   msg += "\n";
   m_userLog->info(msg);
 
-// std::cout << msg;
+  // std::cout << msg;
 
 #ifdef __sgi
   { remove("/tmp/.tfarmcontroller.dat"); }

--- a/toonz/sources/toonzlib/plasticdeformerfx.cpp
+++ b/toonz/sources/toonzlib/plasticdeformerfx.cpp
@@ -149,7 +149,7 @@ std::string PlasticDeformerFx::getAlias(double frame,
       meshColumnObj->getPlasticSkeletonDeformation();
   if (sd) alias += ", " + toString(sd, meshColumnObj->paramsTime(frame));
 
-  alias + "]";
+  alias += "]";
 
   return alias;
 }

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1041,6 +1041,10 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
       TVectorRenderData rd(TVectorRenderData::ProductionSettings(), aff,
                            TRect(size), vpalette);
 
+      // obtain jaggy image when the Closest Pixel is set
+      if (info.m_quality == TRenderSettings::ClosestPixel_FilterResampleQuality)
+        rd.m_antiAliasing = false;
+
       if (!m_offlineContext || m_offlineContext->getLx() < size.lx ||
           m_offlineContext->getLy() < size.ly) {
         if (m_offlineContext) delete m_offlineContext;

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -1000,11 +1000,6 @@ void FunctionPanel::drawCurrentCurve(QPainter &painter) {
                        p.y() + easeHeight + easeTick);
       break;
 
-      painter.setBrush(
-          Qt::NoBrush);  // isSelected ? QColor(255,126,0) : Qt::white);
-      painter.setPen(isHighlighted ? QColor(255, 126, 0) : m_selectedColor);
-      painter.drawLine(p.x(), p.y() - 15, p.x(), p.y() + 15);
-      break;
     default:
       break;
     }

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -853,6 +853,7 @@ void SchematicPort::mouseMoveEvent(QGraphicsSceneMouseEvent *me) {
 
   // Snapping
   SchematicPort *linkingTo = searchPort(me->scenePos());
+
   if (!linkingTo) {
     for (SchematicLink *ghostLink : m_ghostLinks) {
       ghostLink->updateEndPos(me->scenePos());
@@ -864,8 +865,12 @@ void SchematicPort::mouseMoveEvent(QGraphicsSceneMouseEvent *me) {
       m_linkingTo = nullptr;
     }
   }
-  // if to be connected something
-  else if (linkingTo != this) {
+  // if to be connected something new
+  else if (linkingTo != this && m_linkingTo != linkingTo) {
+    if (m_linkingTo) {
+      m_linkingTo->highLight(false);
+      m_linkingTo->update();
+    }
     m_linkingTo = linkingTo;
     for (SchematicLink *ghostLink : m_ghostLinks) {
       ghostLink->updatePath(ghostLink->getStartPort(), linkingTo);

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -2183,7 +2183,6 @@ void StageSchematicSplineNode::setSchematicNodePos(const QPointF &pos) const {
 
 QPixmap StageSchematicSplineNode::getPixmap() {
   return IconGenerator::instance()->getIcon(m_spline);
-  return QPixmap();
 }
 
 //--------------------------------------------------------


### PR DESCRIPTION
Ported the following PRs from OT:

## Fixes
opentoonz/opentoonz/#4322 - Fix tile fxs & bounding box handling  by @shun-iwasawa
opentoonz/opentoonz/#4323 - Deactivate Edit Shift mode when deactivating Shift and Trace  by @shun-iwasawa
opentoonz/opentoonz/#4332 - Fix maddin200 pointed problems  by @shun-iwasawa
opentoonz/opentoonz/#4331 - Fix Fx Schematic links disappear  by @shun-iwasawa
opentoonz/opentoonz/#4333 - Fix vector levels to render aliased line  by @shun-iwasawa
opentoonz/opentoonz/#4351 - Fix RGB key fx affine transformation handling  by @shun-iwasawa
opentoonz/opentoonz/#4353 - Fix maddin200 pointed problems part2  by @shun-iwasawa
opentoonz/opentoonz/#4363 - Fix Preferences popup combobox size adjustment  by @shun-iwasawa
opentoonz/opentoonz/#4362 - Fix the parent object label in xsheet column header translatable  by @shun-iwasawa
opentoonz/opentoonz/#4360 - Fix zoom scale display of ComboViewer's titlebar  by @shun-iwasawa
opentoonz/opentoonz/#4374 - Fix parent object field in the xsheet column header  by @shun-iwasawa
opentoonz/opentoonz/#4380 - Fix missing mouse release  by @shun-iwasawa
opentoonz/opentoonz/#4382 - Fix maddin200 pointed problems part3  by @shun-iwasawa
