### PR TITLE
Copy missing libopencv dylib needed for plugin support

### DIFF
--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -70,6 +70,9 @@ $QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -verbose=0 -always-overwrite \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/tfarmcontroller \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/tfarmserver 
 
+echo ">>> Manually copying missing dylib needed for plugins"
+cp /usr/local/lib/libopencv_dnn.4.5.dylib $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+
 echo ">>> Correcting library paths"
 for X in `find $TOONZDIR/Tahoma2D.app/Contents -type f -name *.dylib -exec otool -l {} \; | grep -e "^toonz" -e"name \/usr\/local" | sed -e"s/://" -e"s/ (.*$//" -e"s/^ *name //"`
 do


### PR DESCRIPTION
This PR only impacts macOS build packaging to correct a missing dylib needed by Tahoma2D plugins.

Currently modifying the Tahoma2D plugin builds for OSX so that it uses the opencv library included with T2D rather than looking for opencv installed on the system.  This would eliminate the need for users to install opencv manually.  

It was discovered not all opencv libraries used by the plugins are included with T2D so I've updated the build scripts to manually include the missing library.