### PR TITLE
Fix Navigation Tag color

### DIFF
--- a/toonz/sources/include/toonz/navigationtags.h
+++ b/toonz/sources/include/toonz/navigationtags.h
@@ -41,7 +41,9 @@ public:
   };
   std::vector<Tag> m_tags;
 
-  NavigationTags() {}
+  QColor m_lastTagColorUsed;
+
+  NavigationTags();
   ~NavigationTags() {}
 
   std::vector<Tag> getTags() { return m_tags; }

--- a/toonz/sources/toonz/navtageditorpopup.cpp
+++ b/toonz/sources/toonz/navtageditorpopup.cpp
@@ -44,22 +44,51 @@ NavTagEditorPopup::NavTagEditorPopup(int frame, QString label, QColor color)
   m_colorCB->addItem(getColorChipIcon(Qt::cyan), tr("Cyan"), TagColors::Cyan);
   m_colorCB->addItem(getColorChipIcon(Qt::white), tr("White"),
                      TagColors::White);
+  m_colorCB->addItem(getColorChipIcon(Qt::darkMagenta), tr("Dark Magenta"),
+                     TagColors::DarkMagenta);
+  m_colorCB->addItem(getColorChipIcon(Qt::darkRed), tr("Dark Red"),
+                     TagColors::DarkRed);
+  m_colorCB->addItem(getColorChipIcon(Qt::darkGreen), tr("Dark Green"),
+                     TagColors::DarkGreen);
+  m_colorCB->addItem(getColorChipIcon(Qt::darkBlue), tr("Dark Blue"),
+                     TagColors::DarkBlue);
+  m_colorCB->addItem(getColorChipIcon(Qt::darkYellow), tr("Dark Yellow"),
+                     TagColors::DarkYellow);
+  m_colorCB->addItem(getColorChipIcon(Qt::darkCyan), tr("Dark Cyan"),
+                     TagColors::DarkCyan);
+  m_colorCB->addItem(getColorChipIcon(Qt::darkGray), tr("Dark Gray"),
+                     TagColors::DarkGray);
+
   addWidget(tr("Color:"), m_colorCB);
 
   if (color == Qt::magenta)
-    m_colorCB->setCurrentIndex(0);
+    m_colorCB->setCurrentIndex(TagColors::Magenta);
   else if (color == Qt::red)
-    m_colorCB->setCurrentIndex(1);
+    m_colorCB->setCurrentIndex(TagColors::Red);
   else if (color == Qt::green)
-    m_colorCB->setCurrentIndex(2);
+    m_colorCB->setCurrentIndex(TagColors::Green);
   else if (color == Qt::blue)
-    m_colorCB->setCurrentIndex(3);
+    m_colorCB->setCurrentIndex(TagColors::Blue);
   else if (color == Qt::yellow)
-    m_colorCB->setCurrentIndex(4);
+    m_colorCB->setCurrentIndex(TagColors::Yellow);
   else if (color == Qt::cyan)
-    m_colorCB->setCurrentIndex(5);
+    m_colorCB->setCurrentIndex(TagColors::Cyan);
   else if (color == Qt::white)
-    m_colorCB->setCurrentIndex(6);
+    m_colorCB->setCurrentIndex(TagColors::White);
+  else if (color == Qt::darkMagenta)
+    m_colorCB->setCurrentIndex(TagColors::DarkMagenta);
+  else if (color == Qt::darkRed)
+    m_colorCB->setCurrentIndex(TagColors::DarkRed);
+  else if (color == Qt::darkGreen)
+    m_colorCB->setCurrentIndex(TagColors::DarkGreen);
+  else if (color == Qt::darkBlue)
+    m_colorCB->setCurrentIndex(TagColors::DarkBlue);
+  else if (color == Qt::darkYellow)
+    m_colorCB->setCurrentIndex(TagColors::DarkYellow);
+  else if (color == Qt::darkCyan)
+    m_colorCB->setCurrentIndex(TagColors::DarkCyan);
+  else if (color == Qt::darkGray)
+    m_colorCB->setCurrentIndex(TagColors::DarkGray);
 
   ret = ret &&
         connect(m_labelFld, SIGNAL(editingFinished()), SLOT(onLabelChanged()));
@@ -79,6 +108,10 @@ void NavTagEditorPopup::onColorChanged(int index) {
   QColor color;
 
   switch (index) {
+  case TagColors::Magenta:
+  default:
+    color = Qt::magenta;
+    break;
   case TagColors::Red:
     color = Qt::red;
     break;
@@ -94,9 +127,29 @@ void NavTagEditorPopup::onColorChanged(int index) {
   case TagColors::Cyan:
     color = Qt::cyan;
     break;
-  case TagColors::Magenta:
-  default:
-    color = Qt::magenta;
+  case TagColors::White:
+    color = Qt::white;
+    break;
+  case TagColors::DarkMagenta:
+    color = Qt::darkMagenta;
+    break;
+  case TagColors::DarkRed:
+    color = Qt::darkRed;
+    break;
+  case TagColors::DarkGreen:
+    color = Qt::darkGreen;
+    break;
+  case TagColors::DarkBlue:
+    color = Qt::darkBlue;
+    break;
+  case TagColors::DarkYellow:
+    color = Qt::darkYellow;
+    break;
+  case TagColors::DarkCyan:
+    color = Qt::darkCyan;
+    break;
+  case TagColors::DarkGray:
+    color = Qt::darkGray;
     break;
   }
 

--- a/toonz/sources/toonz/navtageditorpopup.h
+++ b/toonz/sources/toonz/navtageditorpopup.h
@@ -21,7 +21,22 @@ class NavTagEditorPopup final : public DVGui::Dialog {
   QColor m_color;
 
 public:
-  enum TagColors { Magenta = 0, Red, Green, Blue, Yellow, Cyan, White };
+  enum TagColors {
+    Magenta = 0,
+    Red,
+    Green,
+    Blue,
+    Yellow,
+    Cyan,
+    White,
+    DarkMagenta,
+    DarkRed,
+    DarkGreen,
+    DarkBlue,
+    DarkYellow,
+    DarkCyan,
+    DarkGray
+  };
 
 public:
   NavTagEditorPopup(int frame, QString label, QColor color);

--- a/toonz/sources/toonzlib/navigationtags.cpp
+++ b/toonz/sources/toonzlib/navigationtags.cpp
@@ -2,10 +2,20 @@
 
 #include "tstream.h"
 #include "texception.h"
+#include "tenv.h"
 
 #ifndef _WIN32
 #include <limits.h>
 #endif
+
+TEnv::IntVar NavigationTagLastColorR("NavigationTagLastColorR", 255);
+TEnv::IntVar NavigationTagLastColorG("NavigationTagLastColorG", 0);
+TEnv::IntVar NavigationTagLastColorB("NavigationTagLastColorB", 255);
+
+NavigationTags::NavigationTags() {
+  m_lastTagColorUsed = QColor(NavigationTagLastColorR, NavigationTagLastColorG,
+                              NavigationTagLastColorB);
+}
 
 //-----------------------------------------------------------------------------
 
@@ -28,7 +38,7 @@ NavigationTags::Tag NavigationTags::getTag(int frame) {
 void NavigationTags::addTag(int frame, QString label) {
   if (frame < 0 || isTagged(frame)) return;
 
-  m_tags.push_back(Tag(frame, label));
+  m_tags.push_back(Tag(frame, label, m_lastTagColorUsed));
 
   std::sort(m_tags.begin(), m_tags.end());
 }
@@ -146,7 +156,7 @@ void NavigationTags::setTagLabel(int frame, QString label) {
 QColor NavigationTags::getTagColor(int frame) {
   Tag tag = getTag(frame);
 
-  return tag.m_color;
+  return (tag.m_frame == -1) ? m_lastTagColorUsed : tag.m_color;
 }
 
 //-----------------------------------------------------------------------------
@@ -159,6 +169,11 @@ void NavigationTags::setTagColor(int frame, QColor color) {
       m_tags[i].m_color = color;
       break;
     }
+
+  m_lastTagColorUsed      = color;
+  NavigationTagLastColorR = color.red();
+  NavigationTagLastColorG = color.green();
+  NavigationTagLastColorB = color.blue();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR does the following for Navigation Tag colors

- Fixes a bug where selecting `White` would color the tag with magenta instead 
- Added additional colors: Dark Magenta, Dark Red, Dark Green, Dark Blue, Dark Yellow, Dark Cyan, Dark Gray