### PR TITLE
Fix cell selection issues

### DIFF
--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1025,6 +1025,10 @@ void IncreaseStepUndo::redo() const {
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection) cellSelection->selectCells(m_r0, m_c0, m_newR1, m_c1);
 }
 
 //-----------------------------------------------------------------------------
@@ -1043,6 +1047,11 @@ void IncreaseStepUndo::undo() const {
 
   app->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection)
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + (m_rowsCount - 1)), m_c1);
 }
 
 }  // namespace
@@ -1069,11 +1078,6 @@ void TCellSelection::increaseStepCells() {
   TUndoManager::manager()->add(undo);
 
   undo->redo();
-
-  if (undo->m_newR1 != m_range.m_r1) {
-    m_range.m_r1 = undo->m_newR1;
-    TApp::instance()->getCurrentSelection()->notifySelectionChanged();
-  }
 }
 
 //*********************************************************************************

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -524,6 +524,13 @@ void EachUndo::redo() const {
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection) {
+    int newR = m_r0 + (m_r1 - m_r0 + m_each) / m_each - 1;
+    cellSelection->selectCells(m_r0, m_c0, newR, m_c1);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -549,6 +556,11 @@ void EachUndo::undo() const {
 
   app->getCurrentXsheet()->notifyXsheetChanged();
   app->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection)
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + (m_rowsCount - 1)), m_c1);
 }
 
 }  // namespace
@@ -566,7 +578,6 @@ void TCellSelection::eachCells(int each) {
   TUndoManager::manager()->add(undo);
 
   undo->redo();
-  m_range.m_r1 = m_range.m_r0 + (m_range.m_r1 - m_range.m_r0 + each) / each - 1;
 }
 
 //*********************************************************************************

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -410,6 +410,12 @@ void StepUndo::redo() const {
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection)
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + (m_rowsCount * m_step) - 1),
+                               m_c1);
 }
 
 //-----------------------------------------------------------------------------
@@ -433,6 +439,11 @@ void StepUndo::undo() const {
     }
   app->getCurrentXsheet()->notifyXsheetChanged();
   app->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection)
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + (m_rowsCount - 1)), m_c1);
 }
 
 }  // namespace
@@ -447,7 +458,6 @@ void TCellSelection::stepCells(int step) {
   TUndoManager::manager()->add(undo);
 
   undo->redo();
-  m_range.m_r1 += (step - 1) * m_range.getRowCount();
 }
 
 //*********************************************************************************

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -130,6 +130,11 @@ void SwingUndo::redo() const {
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection)
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + ((m_r1 - m_r0) * 2)), m_c1);
 }
 
 //-----------------------------------------------------------------------------
@@ -143,6 +148,10 @@ void SwingUndo::undo() const {
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection) cellSelection->selectCells(m_r0, m_c0, m_r1, m_c1);
 }
 
 }  // namespace

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -937,6 +937,15 @@ void ResetStepUndo::redo() const {
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection) {
+    int newR = 1;
+    for (int c = m_c0; c <= m_c1; ++c)
+      newR = std::max(newR, m_insertedCells[c]);
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + newR - 1), m_c1);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -955,6 +964,11 @@ void ResetStepUndo::undo() const {
 
   app->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection)
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + (m_rowsCount - 1)), m_c1);
 }
 
 }  // namespace

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1153,6 +1153,10 @@ void DecreaseStepUndo::redo() const {
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection) cellSelection->selectCells(m_r0, m_c0, m_newR1, m_c1);
 }
 
 //-----------------------------------------------------------------------------
@@ -1171,6 +1175,11 @@ void DecreaseStepUndo::undo() const {
 
   app->getCurrentXsheet()->notifyXsheetChanged();
   app->getCurrentScene()->setDirtyFlag(true);
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection)
+    cellSelection->selectCells(m_r0, m_c0, (m_r0 + (m_rowsCount - 1)), m_c1);
 }
 
 }  // namespace
@@ -1202,18 +1211,12 @@ void TCellSelection::decreaseStepCells() {
     m_range.m_r1 = r1;
     m_range.m_c0 = col;
     m_range.m_c1 = col;
-    TApp::instance()->getCurrentSelection()->notifySelectionChanged();
   }
   DecreaseStepUndo *undo = new DecreaseStepUndo(m_range.m_r0, m_range.m_c0,
                                                 m_range.m_r1, m_range.m_c1);
   TUndoManager::manager()->add(undo);
 
   undo->redo();
-
-  if (undo->m_newR1 != m_range.m_r1) {
-    m_range.m_r1 = undo->m_newR1;
-    TApp::instance()->getCurrentSelection()->notifySelectionChanged();
-  }
 }
 
 //*********************************************************************************

--- a/toonz/sources/toonz/duplicatepopup.cpp
+++ b/toonz/sources/toonz/duplicatepopup.cpp
@@ -63,6 +63,10 @@ void DuplicateUndo::undo() const {
     app->getCurrentXsheet()->getXsheet()->removeCells(m_r1 + 1, j,
                                                       m_upTo - (m_r1 + 1) + 1);
   app->getCurrentXsheet()->notifyXsheetChanged();
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection) cellSelection->selectCells(m_r0, m_c0, m_r1, m_c1);
 }
 
 //-----------------------------------------------------------------------------
@@ -73,6 +77,10 @@ void DuplicateUndo::redo() const {
   app->getCurrentXsheet()->getXsheet()->duplicateCells(m_r0, m_c0, m_r1, m_c1,
                                                        m_upTo);
   app->getCurrentXsheet()->notifyXsheetChanged();
+
+  TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+      TApp::instance()->getCurrentSelection()->getSelection());
+  if (cellSelection) cellSelection->selectCells(m_r0, m_c0, m_upTo, m_c1);
 }
 
 //-----------------------------------------------------------------------------
@@ -166,6 +174,8 @@ void DuplicatePopup::onApplyPressed() {
     xsh->duplicateCells(r0, c0, r1, c1, (int)upTo - 1);
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+
+    selection->selectCells(r0, c0, ((int)upTo - 1), c1);
   } catch (...) {
     DVGui::error(("Cannot duplicate"));
   }


### PR DESCRIPTION
This PR fixes the cell selection after certain actions are performed so that the current cell selection will adjust based on cells added or removed by an action.

This was fixed for the following Cell actions, including their undo/redo actions
- Reframe (1's, 2's, 3's, 4's, Reframe with empty inbetweens)
- Step (2, 3, 4)
- Increase Step
- Decrease Step
- Reset Step
- Each (2, 3, 4)
- Swing
- Repeat
