### PR TITLE
Fix starting panel resizing issues

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -807,10 +807,6 @@ int main(int argc, char *argv[]) {
     w.checkForUpdates();
   DvDirModel::instance()->forceRefresh();
 
-  // Disable the layout temporarily to avoid redistribution of panes that is
-  // executed during resizeEvents that are being called. It will reenable when
-  // the resizeEvent() is called
-  w.getCurrentRoom()->dockLayout()->setEnabled(false);
   w.show();
 
   // Show floating panels only after the main window has been shown
@@ -892,10 +888,6 @@ int main(int argc, char *argv[]) {
 
   a.installEventFilter(TApp::instance());
 
-  // Disable the layout temporarily to avoid redistribution of panes that is
-  // executed during resizeEvents that are being called. It will reenable when
-  // the resizeEvent() is called
-  w.getCurrentRoom()->dockLayout()->setEnabled(false);
   int ret = a.exec();
 
   TUndoManager::manager()->reset();

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -641,9 +641,12 @@ void PaletteViewer::updateSavePaletteToolBar() {
         if (levelType == PLT_XSHLEVEL) enable = false;
       }
       act->setEnabled(enable);
-    } else if (m_viewType != STUDIO_PALETTE && i == 1)  // move action
-      actions[i]->setVisible(enable);
-    else
+    } else if (m_viewType != STUDIO_PALETTE && i == 1) {  // move action
+      // Do not hide when palette is not visible otherwise it causes
+      // panel redistribution at startup
+      bool moveVisible = isVisible() ? enable : true;
+      actions[i]->setVisible(moveVisible);
+    } else
       actions[i]->setEnabled(true);
   }
 }

--- a/toonz/sources/toonzqt/tdockwindows.cpp
+++ b/toonz/sources/toonzqt/tdockwindows.cpp
@@ -106,11 +106,7 @@ void TMainWindow::setSeparatorsThickness(int thick) {
 
 //----------------------------------------
 
-void TMainWindow::resizeEvent(QResizeEvent *event) {
-  // see main.cpp for why we are doing this
-  if (m_layout->isEnabled()) m_layout->redistribute();
-  m_layout->setEnabled(true);
-}
+void TMainWindow::resizeEvent(QResizeEvent *event) { m_layout->redistribute(); }
 
 //========================================================================
 


### PR DESCRIPTION
This PR fixes a couple of reported panel sizing/display issues at startup.

Due to the logic implemented in #630...
- When restarting after closing T2D with a maximized viewer, the maximized viewer was not restored and the panels in the room did not have any controls.
- When starting a new installation of T2D, some monitor resolution/scale configurations would cause the panels to appear really small and not resize to fit the larger screen.

I reverted the logic that was blocking the panel resizing at startup to fix the issues noted above.

I found and fixed the root cause of #626: The Palette viewer's `Move Palette` widget is only visible when there is a palette. During startup the widget's visibility would toggle from OFF (no palette) to ON (default palette) resulting in panel redistribution with different sets of geometry ultimately causing the timeline to resize.  Forced visibility to ON when the panel is hidden.