### PR TITLE
Fix temp fillgap indicators not disappearing

### DIFF
--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -646,7 +646,8 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
     for (int tempY = 0; tempY < tempRaster->getLy(); tempY++) {
       for (int tempX = 0; tempX < tempRaster->getLx();
            tempX++, tempPix++, keepPix++) {
-        keepPix->setPaint(tempPix->getPaint());
+        if (tempPix->getInk() != styleIndex)
+          keepPix->setPaint(tempPix->getPaint());
         // This next line takes care of autopaint lines
         if (tempPix->getInk() != styleIndex) {
           if (closeGaps && tempPix->getInk() == fakeStyleIndex) {


### PR DESCRIPTION
This PR fixes #925 

When `Fill Gap` is used for Smart Raster fills, temporary fill gap indicators are created in a separate area.  The process was incorrectly translating indicators not touched by the actual fill operation to the final image. Fixed it by ignoring any temp indicators that were not hit by the fill operation.