### PR TITLE
Fix undo delete level strip mesh frame

### DIFF
--- a/toonz/sources/toonz/drawingdata.cpp
+++ b/toonz/sources/toonz/drawingdata.cpp
@@ -307,8 +307,9 @@ bool DrawingData::getLevelFrames(TXshSimpleLevel *sl,
   TPalette *slPlt = sl->getPalette();
   bool styleAdded = mergePalette_Overlap(slPlt, imgPlt, keepOriginalPalette);
 
+  int styleCount = slPlt ? slPlt->getStyleCount() : 0;
   std::map<int, int> styleTable;
-  for (int s = 0; s < slPlt->getStyleCount(); s++) styleTable[s] = s;
+  for (int s = 0; s < styleCount; s++) styleTable[s] = s;
 
   // Merge Image
   for (auto const &image : usedImageSet) {


### PR DESCRIPTION
This PR fixes #899

When restoring the mesh frame in the level strip, it was trying to restore the palette associated with the level, however mesh levels do not have palettes and would crash as a result. 

Updated logic to account for mesh levels not having a palette.