### PR TITLE
Fix column renaming when editing frame

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -659,7 +659,8 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   if (m_tileSet->getTileCount() > 0) {
     delete m_tileSaver;
     bool isEditingLevel = m_application->getCurrentFrame()->isEditingLevel();
-    if (!isEditingLevel) TUndoManager::manager()->beginBlock();
+    bool renameColumn   = m_isFrameCreated;
+    if (!isEditingLevel && renameColumn) TUndoManager::manager()->beginBlock();
     TTool::Application *app   = TTool::getApplication();
     TXshLevel *level          = app->getCurrentLevel()->getLevel();
     TXshSimpleLevelP simLevel = level->getSimpleLevel();
@@ -670,7 +671,7 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
         m_strokeRect.getP00()));
 
     // Column name renamed to level name only if was originally empty
-    if (!isEditingLevel) {
+    if (!isEditingLevel && renameColumn) {
       int col            = app->getCurrentColumn()->getColumnIndex();
       TXshColumn *column = app->getCurrentXsheet()->getXsheet()->getColumn(col);
       int r0, r1;

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -1260,12 +1260,13 @@ public:
     if (!m_active) return;
 
     bool isEditingLevel = m_application->getCurrentFrame()->isEditingLevel();
-    if (!isEditingLevel) TUndoManager::manager()->beginBlock();
+    bool renameColumn   = m_isFrameCreated;
+    if (!isEditingLevel && renameColumn) TUndoManager::manager()->beginBlock();
 
     if (m_primitive) m_primitive->leftButtonUp(p, e);
 
     // Column name renamed to level name only if was originally empty
-    if (!isEditingLevel) {
+    if (!isEditingLevel && renameColumn) {
       int col = m_application->getCurrentColumn()->getColumnIndex();
       TXshColumn *column =
           m_application->getCurrentXsheet()->getXsheet()->getColumn(col);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1861,7 +1861,8 @@ void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
   TXshSimpleLevelP simLevel = level->getSimpleLevel();
 
   bool isEditingLevel = m_application->getCurrentFrame()->isEditingLevel();
-  if (!isEditingLevel) TUndoManager::manager()->beginBlock();
+  bool renameColumn   = m_isFrameCreated;
+  if (!isEditingLevel && renameColumn) TUndoManager::manager()->beginBlock();
 
   /*--
    * 描画中にカレントフレームが変わっても、描画開始時のFidに対してUndoを記録する
@@ -2087,7 +2088,7 @@ void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
   }
 
   // Column name renamed to level name only if was originally empty
-  if (!isEditingLevel) {
+  if (!isEditingLevel && renameColumn) {
     int col            = app->getCurrentColumn()->getColumnIndex();
     TXshColumn *column = app->getCurrentXsheet()->getXsheet()->getColumn(col);
     int r0, r1;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1148,7 +1148,8 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
     stroke->insertControlPoints(0.5);
 
   bool isEditingLevel = m_application->getCurrentFrame()->isEditingLevel();
-  if (!isEditingLevel) TUndoManager::manager()->beginBlock();
+  bool renameColumn   = m_isFrameCreated;
+  if (!isEditingLevel && renameColumn) TUndoManager::manager()->beginBlock();
 
   if (m_frameRange.getIndex()) {
     if (m_firstFrameId == -1) {
@@ -1257,7 +1258,7 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
   }
 
   // Column name renamed to level name only if was originally empty
-  if (!isEditingLevel) {
+  if (!isEditingLevel && renameColumn) {
     int col = getApplication()->getCurrentColumn()->getColumnIndex();
     TXshColumn *column =
         getApplication()->getCurrentXsheet()->getXsheet()->getColumn(col);

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -733,13 +733,14 @@ void TypeTool::stopEditing() {
   invalidate();
   if (m_undo) {
     bool isEditingLevel = getApplication()->getCurrentFrame()->isEditingLevel();
-    if (!isEditingLevel) TUndoManager::manager()->beginBlock();
+    bool renameColumn   = m_isFrameCreated;
+    if (!isEditingLevel && renameColumn) TUndoManager::manager()->beginBlock();
 
     TUndoManager::manager()->add(m_undo);
     m_undo = 0;
 
     // Column name renamed to level name only if was originally empty
-    if (!isEditingLevel) {
+    if (!isEditingLevel && renameColumn) {
       int col = getApplication()->getCurrentColumn()->getColumnIndex();
       TXshColumn *column =
           getApplication()->getCurrentXsheet()->getXsheet()->getColumn(col);


### PR DESCRIPTION
This PR fixes an issue when you add a new level (column is named for level), rename the column to something else, then draw in the frame  the column name is renamed back to match the level name.