### PR TITLE
Fix column name displays

### DIFF
--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -1237,11 +1237,13 @@ glPopMatrix();
   for (int i = 0; i < (int)m_magicLinks.size(); i++) {
     const MagicLink &magicLink = m_magicLinks[i];
     const HookData &h1         = magicLink.m_h1;
+    TStageObjectId id          = TStageObjectId::ColumnId(h1.m_columnIndex);
+    TStageObject *obj          = xsh->getStageObject(id);
     std::string name;
     name = (m_parentProbeEnabled ? "Linking " : "Link ") +
-           removeTrailingH(magicLink.m_h0.getHandle()) + " to Col " +
-           std::to_string(h1.m_columnIndex + 1) + "/" +
-           removeTrailingH(h1.getHandle());
+           removeTrailingH(magicLink.m_h0.getHandle()) + " to " +
+           obj->getName() + " (Col " + std::to_string(h1.m_columnIndex + 1) +
+           ")/" + removeTrailingH(h1.getHandle());
 
     int code = TD_MagicLink + i;
     glPushName(code);

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -276,7 +276,7 @@ QVariant StageObjectChannelGroup::data(int role) const {
     std::string id = m_stageObject->getId().toString();
 
     return (name == id) ? QString::fromStdString(name)
-                        : QString::fromStdString(id + " (" + name + ")");
+                        : QString::fromStdString(name + " (" + id + ")");
 
   } else if (role == Qt::ForegroundRole) {
     FunctionTreeModel *model = dynamic_cast<FunctionTreeModel *>(getModel());


### PR DESCRIPTION
This PR is a minor UI enhancement to update the display of column names to use name instead of Col# in the following places:

- Skeleton in build mode now shows `Linking B to name (Col#)/B` when connecting 1 bone to another. (fixes #944) 
- Function Editor changed from `Col# (name)` to `name (Col#)`