### PR TITLE
Fix palette converting to Smart Raster

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -4019,7 +4019,7 @@ void TCellSelection::convertToToonzRaster() {
     firstImage->setSavebox(TRect(0, 0, xres - 1, yres - 1));
   }
 
-  bool keepOriginalPalette;
+  bool keepOriginalPalette = false;
   bool success = data->getLevelFrames(
       sl, newFrameIds, DrawingData::OVER_SELECTION, true, keepOriginalPalette,
       true);  // setting is redo = true skips the


### PR DESCRIPTION
This PR fixes #915 by changing a parameter that will force the default palette created with the new Smart Raster level to be replaced with a copy of the Vector's palette.