### PR TITLE
Fix cell selection resizing with Ctrl+Arrows

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -610,6 +610,8 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
 
   int m_frameZoomFactor;
 
+  CellPosition m_ctrlSelectRef;
+
 public:
   enum FrameDisplayStyle { Frame = 0, SecAndFrame, SixSecSheet, ThreeSecSheet };
 


### PR DESCRIPTION
This PR fixes #589 

Revised the logic to modify cell selection area with CTRL+Arrows using the Current Frame as a reference point.  If the Current Frame is not in an active selection, which can happen when using Next/Previous Drawing, it will use the upper-left corner of the active selection as reference.