### PR TITLE
Fix reappearing deleted style

### DIFF
--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -209,6 +209,8 @@ void TPalette::Page::removeStyle(int indexInPage) {
   assert(0 <= styleId && styleId < m_palette->getStyleCount());
   assert(m_palette->m_styles[styleId].first == this);
   m_palette->m_styles[styleId].first = 0;
+  m_palette->m_styles[styleId].second =
+      TColorStyleP(new TSolidColorStyle(TPixel32::Black));
   m_styleIds.erase(m_styleIds.begin() + indexInPage);
 }
 


### PR DESCRIPTION
This PR fixes #836 

Internally, deleted styles are not completely removed.   Instead, it's storage is marked as being empty but style information remains.

When a new style is added to the palette, it will search for a deleted style slot and reuse one if found.  The problem is when it reuses a deleted style slot, it only changes the main color of the style that was there previously.  If he style was a  texture, vector brush, mypaint brush, etc, then that style was restored.

Added logic when deleting a style, it will change the deleted style slot's style to the basic Color Style (black) so that will be restored instead of the previous style.
