### PR TITLE
Fix brower from startup not reopening

### DIFF
--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -453,7 +453,7 @@ void StartupPopup::updateProjectCB() {
   RecentFiles::instance()->addFilePath(currentProjectPath,
                                        RecentFiles::Project);
 
-  TFilePath sandboxFp = pm->getSandboxProjectFolder() + "sandbox_otprj.xml";
+  TFilePath sandboxFp = pm->getSandboxProjectFolder() + "tahomaproject.xml";
   m_projectPaths.push_back(sandboxFp);
   m_projectsCB->addItem("sandbox");
   m_projectsCB->setItemData(0, pm->getSandboxProjectFolder().getQString(),
@@ -503,12 +503,14 @@ void StartupPopup::onProjectComboChanged(int index) {
   // The last index is Browse. . .
   if (index == m_projectsCB->count() - 1) {
     m_projectsCB->blockSignals(true);
-    for (int i = 0; i < m_projectPaths.size(); i++) {
+    int i;
+    for (i = 0; i < m_projectPaths.size(); i++) {
       if (pm->getCurrentProjectPath() == m_projectPaths[i]) {
         m_projectsCB->setCurrentIndex(i);
         break;
       }
     }
+    if (i >= m_projectPaths.size()) m_projectsCB->setCurrentIndex(0);
     m_projectsCB->blockSignals(false);
     m_projectLocationFld->setPath(
         Preferences::instance()->getDefaultProjectPath());


### PR DESCRIPTION
This PR fixes #816

I found when you normally select `Browse...` from the Project list, the current project would normally stay as the current selection.  However, if it cannot find the project file for the project you started with, it selects `Browser...`.  When you cancel out of the browser window and then try to browse again, it won't let you since the dropdown thinks you've selected Browser already.  You'd need to switch to a different project in the dropdown and then switch back to the browser.

I additionally found this would happen if you started from the original `sandbox` project.

Corrected the issue as follows
- Internally, it had the wrong project file name for the `sandbox` project so it couldn't find it. Changed it from the name `sandbox_otprj.xml` to `tahomaproject.xml`
- If for whatever reason it can't find the project file for the currently selected project, it will force switching to the `sandbox` project when you choose `Browse...`

