### PR TITLE
Fix scene switching flipbook crash

### DIFF
--- a/toonz/sources/include/toonz/tscenehandle.h
+++ b/toonz/sources/include/toonz/tscenehandle.h
@@ -42,6 +42,7 @@ public:
     emit sceneChanged();
     if (setDirty) setDirtyFlag(true);
   }
+  void notifySceneSwitching() { emit sceneSwitching(); }
   void notifySceneSwitched() {
     emit sceneSwitched();
     setDirtyFlag(false);
@@ -76,6 +77,7 @@ public slots:
   }
 
 signals:
+  void sceneSwitching();
   void sceneSwitched();
   void sceneChanged();
   void castChanged();

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -236,6 +236,10 @@ FlipBook::FlipBook(QWidget *parent, QString viewerTitle,
 
   m_previewUpdateTimer.setSingleShot(true);
 
+  TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
+
+  ret = ret && connect(sceneHandle, SIGNAL(sceneSwitching()), this,
+                       SLOT(onSceneSwitching()));
   ret = ret && connect(parentWidget(), SIGNAL(closeButtonPressed()), this,
                        SLOT(onCloseButtonPressed()));
   ret = ret && connect(parentWidget(), SIGNAL(doubleClick(QMouseEvent *)), this,
@@ -546,6 +550,10 @@ void FlipBook::loadImages() {
   m_loadPopup->raise();
   m_loadPopup->activateWindow();
 }
+
+//=============================================================================
+
+void FlipBook::clearImages() { reset(); }
 
 //=============================================================================
 
@@ -1862,6 +1870,9 @@ void FlipBook::reset() {
   else
     PreviewFxManager::instance()->detach(this);
 
+  m_snd = 0;
+  m_xl  = 0;
+
   m_levelNames.clear();
   m_levels.clear();
   m_framesCount = 0;
@@ -2264,3 +2275,7 @@ FlipBook *viewFile(const TFilePath &path, int from, int to, int step,
 }
 
 //-----------------------------------------------------------------------------
+
+void FlipBook::onSceneSwitching() {
+  if (m_xl || m_isPreviewFx) reset();
+}

--- a/toonz/sources/toonz/flipbook.h
+++ b/toonz/sources/toonz/flipbook.h
@@ -299,6 +299,7 @@ public slots:
 
   void saveImages();
   void loadImages();
+  void clearImages();
 
   void performFxUpdate();
   void regenerate();
@@ -306,6 +307,8 @@ public slots:
   void clonePreview();
   void freezePreview();
   void unfreezePreview();
+
+  void onSceneSwitching();
 };
 
 // utility

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -307,6 +307,9 @@ void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
     menu->addAction(action);
     action->setParent(m_flipbook);
 
+    action = menu->addAction(tr("Clear Images"));
+    connect(action, SIGNAL(triggered()), m_flipbook, SLOT(clearImages()));
+
     menu->addSeparator();
   }
 

--- a/toonz/sources/toonzlib/tscenehandle.cpp
+++ b/toonz/sources/toonzlib/tscenehandle.cpp
@@ -23,6 +23,7 @@ ToonzScene *TSceneHandle::getScene() const { return m_scene; }
 
 void TSceneHandle::setScene(ToonzScene *scene) {
   if (m_scene == scene) return;
+  emit sceneSwitching();
   delete m_scene;
   m_scene = scene;
   if (m_scene) emit sceneSwitched();


### PR DESCRIPTION
This PR fixes #859 

When a level from the current scene is dragged from the Scene Cast to a Flipbook, there is a link maintained between the level in the flipbook with the scene.  When switching scenes, the link isn't properly cleared beforehand so when setting up for the new scene it crashes or leaves the images in the flipbook in an odd state when it cannot locate the deleted level.

This issue does not apply to levels dragged from Browser or external source.

Added logic it so that just before a scene switch occurs any flipbooks that contain a level linked to the current scene are cleared and reset.

Also added a `Clear Images` option to the Context menu of the flipbook viewer.