### PR TITLE
Update to use CrashRpt built in MSVC 2019

### DIFF
--- a/ci-scripts/windows/tahoma-get3rdpartyapps.bat
+++ b/ci-scripts/windows/tahoma-get3rdpartyapps.bat
@@ -8,9 +8,9 @@ echo * > .gitignore
 echo ">>> Getting CrashRpt"
 
 IF EXIST crashrpt rmdir /S /Q crashrpt
-curl -fsSL -o crashrpt-tahoma2d-win.zip https://github.com/tahoma2d/crashrpt2/releases/download/v1.5.0.0/crashrpt-tahoma2d-win.zip
-7z x crashrpt-tahoma2d-win.zip
-rename crashrpt-tahoma2d-win crashrpt
+curl -fsSL -o crashrpt-tahoma2d-win_2019.zip https://github.com/tahoma2d/crashrpt2/releases/download/v1.5.0.0/crashrpt-tahoma2d-win_2019.zip
+7z x crashrpt-tahoma2d-win_2019.zip
+rename crashrpt-tahoma2d-win_2019 crashrpt
 IF EXIST ..\crashrpt\include rmdir /S /Q ..\crashrpt\include
 IF EXIST ..\crashrpt\CrashRpt1500.lib del ..\crashrpt\CrashRpt1500.lib
 move crashrpt\include ..\crashrpt


### PR DESCRIPTION
The CrashRpt currently being used was built with MSVC 2017 and doesn't appear to be working correctly since T2D now builds with MSVC 2019.

I've added a version of CrashRpt built using MSVC 2019 to the [tahoma2d\crashrpt2](https://github.com/tahoma2d/crashrpt2) repo.  Modifying the build packing scripts to use it.