### PR TITLE
Fix crash when adding to task list from browser

### DIFF
--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -239,6 +239,11 @@ void FileSelection::enableCommands() {
 //------------------------------------------------------------------------
 
 void FileSelection::addToBatchRenderList() {
+  if (!BatchesController::instance()->getTasksTree()) {
+    QAction *taskPopup = CommandManager::instance()->getAction(MI_OpenTasks);
+    taskPopup->trigger();
+  }
+
   std::vector<TFilePath> files;
   getSelectedFiles(files);
   int i;
@@ -251,6 +256,11 @@ void FileSelection::addToBatchRenderList() {
 //------------------------------------------------------------------------
 
 void FileSelection::addToBatchCleanupList() {
+  if (!BatchesController::instance()->getTasksTree()) {
+    QAction *taskPopup = CommandManager::instance()->getAction(MI_OpenTasks);
+    taskPopup->trigger();
+  }
+
   std::vector<TFilePath> files;
   getSelectedFiles(files);
   int i;


### PR DESCRIPTION
This PR fixes #850.

A crash occurs when using `Add as Render Task` or `Add as Cleanup Task` from `File Browser`, but never once opened a `Tasks` panel.  Adding tasks like this does not properly initialize the Task manager causing a crash when you try to add something to it. The only way to properly initialize it is to open a `Tasks` panel.

Updated the commands to check if the Task manager was initialize properly and if not, it will open a `Tasks` Panel first.