### PR TITLE
Fix Autopaint for Pencil lines

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -94,7 +94,8 @@ bool DVAPI inkSegment(const TRasterCM32P &r, const TPoint &p, int ink,
 void DVAPI rectFillInk(const TRasterCM32P &ras, const TRect &r, int color);
 
 void DVAPI fillautoInks(TRasterCM32P &r, TRect &rect,
-                        const TRasterCM32P &rbefore, TPalette *plt);
+                        const TRasterCM32P &rbefore, TPalette *plt,
+                        int fillIndex);
 
 void DVAPI fullColorFill(const TRaster32P &ras, const FillParameters &params,
                          TTileSaverFullColor *saver = 0, TXsheet *xsheet = 0,

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -631,7 +631,7 @@ public:
             m_tiles->getTile(m_tiles->getTileCount() - 1);
         TRasterCM32P rbefore;
         tile->getRaster(rbefore);
-        fillautoInks(ras, rect, rbefore, m_palette);
+        fillautoInks(ras, rect, rbefore, m_palette, m_closeStyleIndex);
       }
     }
     TTool::Application *app = TTool::getApplication();
@@ -1057,7 +1057,7 @@ void fillAreaWithUndo(const TImageP &img, const TRectD &area, TStroke *stroke,
             tileSet->getTile(tileSet->getTileCount() - 1);
         TRasterCM32P rbefore;
         tile->getRaster(rbefore);
-        fillautoInks(ras, rect, rbefore, plt);
+        fillautoInks(ras, rect, rbefore, plt, cs);
       }
     }
     ToolUtils::updateSaveBox(sl, fid);

--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -159,7 +159,7 @@ AreaFiller::~AreaFiller() { m_ras->unlock(); }
 // che confinano con le aree appena fillate con il rect. rbefore e' il rect del
 // raster prima del rectfill.
 void fillautoInks(TRasterCM32P &rin, TRect &rect, const TRasterCM32P &rbefore,
-                  TPalette *plt) {
+                  TPalette *plt, int fillIndex) {
   assert(plt);
   TRasterCM32P r = rin->extract(rect);
   assert(r->getSize() == rbefore->getSize());
@@ -172,7 +172,7 @@ void fillautoInks(TRasterCM32P &rin, TRect &rect, const TRasterCM32P &rbefore,
       int paint = pix->getPaint();
       int tone  = pix->getTone();
       int ink   = pix->getInk();
-      if (paint != pixb->getPaint() && tone > 0 && tone < 255 && ink != paint &&
+      if (paint != pixb->getPaint() && paint == fillIndex && ink != paint &&
           plt->getStyle(ink)->getFlags() != 0)
         inkFill(rin, TPoint(j, i) + rect.getP00(), paint, 0, NULL, &rect);
     }


### PR DESCRIPTION
This PR fixes #971 

The autopaint logic used by rectangle/freehand/polyline fills on Smart Raster levels was based on pixels not having extreme tones (0, 255).  Lines drawn with `Pencil` only use extreme tones so it would ignore those lines.

Updated logic to remove the tone requirement and work with colors being used.