### PR TITLE
Change default minimum fill depth

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -61,7 +61,7 @@ using namespace ToolUtils;
 #define FREEHANDFILL L"Freehand"
 #define POLYLINEFILL L"Polyline"
 
-TEnv::IntVar MinFillDepth("InknpaintMinFillDepth", 0);
+TEnv::IntVar MinFillDepth("InknpaintMinFillDepth", 1);
 TEnv::IntVar MaxFillDepth("InknpaintMaxFillDepth", 10);
 TEnv::StringVar FillType("InknpaintFillType", "Normal");
 TEnv::StringVar FillColorType("InknpaintFillColorType", "Areas");
@@ -2034,7 +2034,7 @@ FillTool::FillTool(int targetType)
     , m_selective("Selective", false)
     , m_colorType("Mode:")
     , m_onion("Onion Skin", false)
-    , m_fillDepth("Fill Depth", 0, 15, 0, 15)
+    , m_fillDepth("Fill Depth", 0, 15, 1, 15)
     , m_segment("Segment", false)
     , m_onionStyleId(0)
     , m_currCell(-1, -1)


### PR DESCRIPTION
This PR addresses and issue with Smart Raster fills sometimes jumping lines resulting in strange fill bands.

I found that this is prone to happen when the minimum fill depth is < 1.  To help resolve this issue, I am changing the default minimum from 0 to 1.  I still allow setting to 0 if needed, but felt starting with 1 was a good place to start.  

![image](https://user-images.githubusercontent.com/19245851/163425210-3e23057b-c949-4b13-bc81-67750a745ea5.png)


Side Note: Raster level fill have a default minimum fill depth = 4.

This would impact new installations when you do not import preferences from prior installations.

