### PR TITLE
Fix xsheet/timeline starting with wrong orientation

### DIFF
--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -95,38 +95,76 @@
 #include <QAction>
 
 //=============================================================================
-// XsheetViewer
+// XsheetViewerFactory
 //-----------------------------------------------------------------------------
 
-class XsheetViewerFactory final : public TPanelFactory {
+class XsheetViewerFactory : public TPanelFactory {
 public:
   XsheetViewerFactory() : TPanelFactory("Xsheet") {}
-  void initialize(TPanel *panel) override {
-    panel->setWidget(new XsheetViewer(panel));
+
+  TPanel *createPanel(QWidget *parent) override {
+    XsheetViewerPanel *panel = new XsheetViewerPanel(parent);
+    panel->setObjectName(getPanelType());
+    panel->reset();
     panel->resize(500, 300);
     panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
     connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
             SLOT(showTitleBar(bool)));
+    return panel;
   }
+
+  void initialize(TPanel *panel) override {}
 } xsheetViewerFactory;
 
 //=============================================================================
-// XsheetViewer - Timeline mode
+// XsheetViewer
+//-----------------------------------------------------------------------------
+
+XsheetViewerPanel::XsheetViewerPanel(QWidget *parent) : TPanel(parent) {
+  m_xsheetViewer = new XsheetViewer(this);
+  setWidget(m_xsheetViewer);
+}
+
+void XsheetViewerPanel::reset() {
+  if (!m_xsheetViewer->orientation()->isVerticalTimeline())
+    m_xsheetViewer->flipOrientation();
+}
+
+//=============================================================================
+// TimelineViewerFactory
 //-----------------------------------------------------------------------------
 
 class TimelineViewerFactory final : public TPanelFactory {
 public:
   TimelineViewerFactory() : TPanelFactory("Timeline") {}
-  void initialize(TPanel *panel) override {
-    panel->setWidget(new XsheetViewer(panel));
-    XsheetViewer *xsh = (XsheetViewer *)panel->widget();
-    xsh->flipOrientation();
+
+  TPanel *createPanel(QWidget *parent) override {
+    TimelineViewerPanel *panel = new TimelineViewerPanel(parent);
+    panel->setObjectName(getPanelType());
+    panel->reset();
     panel->resize(500, 300);
     panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
     connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
             SLOT(showTitleBar(bool)));
+    return panel;
   }
+
+  void initialize(TPanel *panel) override {}
 } timelineViewerFactory;
+
+//=============================================================================
+// TimelineViewer
+//-----------------------------------------------------------------------------
+
+TimelineViewerPanel::TimelineViewerPanel(QWidget *parent) : TPanel(parent) {
+  m_timelineViewer = new XsheetViewer(this);
+  setWidget(m_timelineViewer);
+}
+
+void TimelineViewerPanel::reset() {
+  if (m_timelineViewer->orientation()->isVerticalTimeline())
+    m_timelineViewer->flipOrientation();
+}
 
 //=============================================================================
 // SchematicSceneViewer

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -32,6 +32,7 @@ class FxSettings;
 class VectorGuidedDrawingPane;
 class FxSelection;
 class StageObjectSelection;
+class XsheetViewer;
 
 //=========================================================
 // PaletteViewerPanel
@@ -336,6 +337,36 @@ class VectorGuidedDrawingPanel final : public TPanel {
 
 public:
   VectorGuidedDrawingPanel(QWidget *parent);
+};
+
+//=========================================================
+// XsheetViewerPanel
+//---------------------------------------------------------
+
+class XsheetViewerPanel final : public TPanel {
+  Q_OBJECT
+
+  XsheetViewer *m_xsheetViewer;
+
+public:
+  XsheetViewerPanel(QWidget *parent = 0);
+
+  void reset() override;
+};
+
+//=========================================================
+// TimelineViewerPanel
+//---------------------------------------------------------
+
+class TimelineViewerPanel final : public TPanel {
+  Q_OBJECT
+
+  XsheetViewer *m_timelineViewer;
+
+public:
+  TimelineViewerPanel(QWidget *parent = 0);
+
+  void reset() override;
 };
 
 #endif


### PR DESCRIPTION
This PR fixes a reported issue where the Xsheet/Timeline starts in the wrong orientation when you bring up a new xsheet/timeline from the `Panels` menu.

This happens when you bring up a xsheet/timeline, use `Toggle Orientation` on it at some point, close the panel, then ask for a new one.  

When these panels are closed, they are merely hidden, not destroyed, so when you ask for a new one, it restores the hidden one in whatever orientation it was in last.  Interestingly, the last orientation is also saved so even after restarting T2D, it can still start in the wrong orientation. 

Modified the logic such that when a hidden xsheet/timeline is restored, it will check the orientation and fix it if needed.
