### PR TITLE
Fix fx swatch not displaying initially

### DIFF
--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -1602,23 +1602,21 @@ void FxSettings::onViewModeChanged(QAction *triggeredAct) {
   QList<QAction *> actions = m_toolBar->actions();
   QAction *cameraAct       = actions[0];
   QAction *previewAct      = actions[1];
+  m_viewer->setEnable(actIsChecked);
   if (name == previewAct->text()) {
     if (cameraAct->isChecked()) cameraAct->setChecked(false);
     if (actIsChecked) {
       m_isCameraModeView = false;
       m_paramViewer->setIsCameraViewMode(false);
-      setCurrentFx();
     }
-    m_viewer->setEnable(actIsChecked);
   } else if (name == cameraAct->text()) {
     if (previewAct->isChecked()) previewAct->setChecked(false);
     if (actIsChecked) {
       m_isCameraModeView = true;
       m_paramViewer->setIsCameraViewMode(true);
-      setCurrentFx();
     }
-    m_viewer->setEnable(actIsChecked);
   }
+  setCurrentFx();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes an issue with Fx Settings swatch not showing anything initially when the viewer is enabled after clicking on the `Camera Preview` or `Preview` button. 

Corrected the logic as it was enabling the viewer at the wrong time so the swatch would not get any updates.
