### PR TITLE
Fix popups appearing behind other popups

### DIFF
--- a/toonz/sources/toonz/filebrowserversioncontrol.cpp
+++ b/toonz/sources/toonz/filebrowserversioncontrol.cpp
@@ -495,6 +495,7 @@ void FileBrowser::getRevisionHistory() {
 
   timelineDialog->show();
   timelineDialog->raise();
+  timelineDialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -573,6 +574,7 @@ void FileBrowser::showLockInformation() {
   SVNLockInfoDialog *dialog = new SVNLockInfoDialog(this, status);
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -522,6 +522,7 @@ void FileSelection::separateFilesByColors() {
   popup->setFiles(files);
   popup->show();
   popup->raise();
+  popup->activateWindow();
   // popup->exec();
 }
 

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -901,8 +901,9 @@ FlipBook *FlipBookPool::pop() {
 
   // The panel need to be added to currentRoom's layout control.
   currentRoom->addDockWidget(panel);
-  panel->raise();
   panel->show();
+  panel->raise();
+  panel->activateWindow();
 
   return flipbook;
 }

--- a/toonz/sources/toonz/floatingpanelcommand.cpp
+++ b/toonz/sources/toonz/floatingpanelcommand.cpp
@@ -126,6 +126,7 @@ TPanel *OpenFloatingPanel::getOrOpenFloatingPanel(
         currentRoom->addDockWidget(panel);
         panel->show();
         panel->raise();
+        panel->activateWindow();
         return panel;
       } else
         lastFloatingPos = panel->pos();
@@ -141,6 +142,7 @@ TPanel *OpenFloatingPanel::getOrOpenFloatingPanel(
   panel->setFloating(true);
   panel->show();
   panel->raise();
+  panel->activateWindow();
   if (!lastFloatingPos.isNull())
     panel->move(QPoint(lastFloatingPos.x() + 30, lastFloatingPos.y() + 30));
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -12,6 +12,7 @@
 #include "cleanupsettingspopup.h"
 #include "filebrowsermodel.h"
 #include "expressionreferencemanager.h"
+#include "startuppopup.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -811,6 +812,13 @@ int main(int argc, char *argv[]) {
 
   // Show floating panels only after the main window has been shown
   w.startupFloatingPanels();
+
+  if (Preferences::instance()->isStartupPopupEnabled()) {
+    StartupPopup *startupPopup = new StartupPopup();
+    startupPopup->show();
+    startupPopup->raise();
+    startupPopup->activateWindow();
+  }
 
   CommandManager::instance()->execute(T_Hand);
   if (!loadFilePath.isEmpty()) {

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -12,7 +12,6 @@
 #include "iocommand.h"
 #include "tapp.h"
 #include "viewerpane.h"
-#include "startuppopup.h"
 #include "tooloptionsshortcutinvoker.h"
 #include "statusbar.h"
 #include "aboutpopup.h"
@@ -1308,12 +1307,6 @@ void MainWindow::onMenuCheckboxChanged() {
 void MainWindow::showEvent(QShowEvent *event) {
   getCurrentRoom()->layout()->setEnabled(true);  // See main function in
                                                  // main.cpp
-  if (Preferences::instance()->isStartupPopupEnabled() &&
-      !m_startupPopupShown) {
-    StartupPopup *startupPopup = new StartupPopup();
-    startupPopup->show();
-    m_startupPopupShown = true;
-  }
 }
 extern const char *applicationName;
 extern const char *applicationVersion;

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -60,7 +60,6 @@ class MainWindow final : public QMainWindow {
   Q_OBJECT
 
   bool m_saveSettingsOnQuit;
-  bool m_startupPopupShown = false;
   bool m_shownOnce         = false;
   int m_oldRoomIndex;
   QString m_currentRoomsChoice;

--- a/toonz/sources/toonz/meshifypopup.cpp
+++ b/toonz/sources/toonz/meshifypopup.cpp
@@ -1322,8 +1322,9 @@ public:
     static MeshifyPopup *thePopup = 0;
     if (!thePopup) thePopup = new MeshifyPopup;
 
-    thePopup->raise();
     thePopup->show();
+    thePopup->raise();
+    thePopup->activateWindow();
   }
 
 } meshifyCommand;

--- a/toonz/sources/toonz/messagepanel.cpp
+++ b/toonz/sources/toonz/messagepanel.cpp
@@ -172,6 +172,7 @@ public:
             pane->getPanelType() == "Message") {
           pane->show();
           pane->raise();
+          pane->activateWindow();
           return;
         }
       }
@@ -180,6 +181,7 @@ public:
       pane->setFloating(true);
       pane->show();
       pane->raise();
+      pane->activateWindow();
     }
   }
 } openFloatingLogPanelCommand;

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -546,6 +546,7 @@ void SceneSettingsPopup::onEditCellMarksButtonClicked() {
   if (!m_cellMarksPopup) m_cellMarksPopup = new CellMarksPopup(this);
   m_cellMarksPopup->show();
   m_cellMarksPopup->raise();
+  m_cellMarksPopup->activateWindow();
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/testpanel.cpp
+++ b/toonz/sources/toonz/testpanel.cpp
@@ -127,6 +127,7 @@ public:
             pane->getPanelType() == "Test") {
           pane->show();
           pane->raise();
+          pane->activateWindow();
           return;
         }
       }
@@ -136,6 +137,7 @@ public:
       pane->setFloating(true);
       pane->show();
       pane->raise();
+      pane->activateWindow();
     }
   }
 } openFloatingTestPanelCommand;

--- a/toonz/sources/toonz/versioncontrol.cpp
+++ b/toonz/sources/toonz/versioncontrol.cpp
@@ -652,6 +652,7 @@ void VersionControl::commit(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -665,6 +666,7 @@ void VersionControl::revert(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -680,6 +682,7 @@ void VersionControl::update(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -693,6 +696,7 @@ void VersionControl::updateAndLock(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -705,6 +709,7 @@ void VersionControl::lock(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -718,6 +723,7 @@ void VersionControl::unlock(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -730,6 +736,7 @@ void VersionControl::lockFrameRange(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -742,6 +749,7 @@ void VersionControl::lockFrameRange(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -755,6 +763,7 @@ void VersionControl::unlockFrameRange(QWidget *parent,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -768,6 +777,7 @@ void VersionControl::unlockFrameRange(QWidget *parent,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -779,6 +789,7 @@ void VersionControl::showFrameRangeLockInfo(QWidget *parent,
       new SVNFrameRangeLockInfoDialog(parent, workingDir, file);
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -790,6 +801,7 @@ void VersionControl::showFrameRangeLockInfo(QWidget *parent,
       new SVNMultiFrameRangeLockInfoDialog(parent, workingDir, files);
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -803,6 +815,7 @@ void VersionControl::commitFrameRange(QWidget *parent,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -817,6 +830,7 @@ void VersionControl::revertFrameRange(QWidget *parent,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -830,6 +844,7 @@ void VersionControl::deleteFiles(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -842,6 +857,7 @@ void VersionControl::deleteFolder(QWidget *parent, const QString &workingDir,
           SIGNAL(commandDone(const QStringList &)));
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -850,6 +866,7 @@ void VersionControl::cleanupFolder(QWidget *parent, const QString &workingDir) {
   SVNCleanupDialog *dialog = new SVNCleanupDialog(parent, workingDir);
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------
@@ -858,6 +875,7 @@ void VersionControl::purgeFolder(QWidget *parent, const QString &workingDir) {
   SVNPurgeDialog *dialog = new SVNPurgeDialog(parent, workingDir);
   dialog->show();
   dialog->raise();
+  dialog->activateWindow();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR attempts to fix an issue where sometimes popups appear behind other popups.

- For the Startup dialog, I moved the startup popup to be displayed after displaying room popups that were open at the time of closing T2D otherwise it appeared behind it.
- Anywhere there was a show() + raise() action on a dialog/pane, I followed that with an activateWindow() where it was not already being called to 