### PR TITLE
Fix rendered sound starting too soon

### DIFF
--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -81,6 +81,12 @@ void getRange(ToonzScene *scene, bool isPreview, int &from, int &to) {
       int r0, r1;
       xs->getCellRange(k, r0, r1);
 
+      // Sound columns should be based on frame 0 for timing purposes
+      TXshColumn *col         = xs->getColumn(k);
+      TXshSoundColumn *sndCol = col ? col->getSoundColumn() : 0;
+
+      if (sndCol) r0  = 0;
+
       from = std::min(from, r0), to = std::max(to, r1);
     }
   }


### PR DESCRIPTION
This PR fixes an issue where sound in a rendered scene starts too early.

When rendering the entire animation, not a snippet, the audio portion is generated after the 1st frame that has a populated cell, image or audio.  For example, if the 1st scene frame to have a populated cell is in Frame 72 (3 seconds in) but the audio doesn't start until Frame 120 ( 5 seconds in), the entire audio will start at Frame 72.

Modified the logic such that when audio is generated, it will generate it based on Frame 1.

