### PR TITLE
Fix missing CurrentCellColor entry in stylesheets

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2245,6 +2245,7 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(237, 220, 233, 0.3);
   qproperty-PlayRangeColor: #383838;
+  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #4a4a4a;
   qproperty-FoldedColumnLineColor: #232323;
   qproperty-EmptyCellColor: #282828;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -2245,6 +2245,7 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(237, 220, 233, 0.3);
   qproperty-PlayRangeColor: #202020;
+  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #3a3a3a;
   qproperty-FoldedColumnLineColor: #131313;
   qproperty-EmptyCellColor: #202020;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2245,6 +2245,7 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(0, 0, 0, 0.15);
   qproperty-PlayRangeColor: #DBDBDB;
+  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #a8a8a8;
   qproperty-FoldedColumnLineColor: #757575;
   qproperty-EmptyCellColor: #c2c2c2;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -2245,6 +2245,7 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(237, 220, 233, 0.3);
   qproperty-PlayRangeColor: #484848;
+  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #626262;
   qproperty-FoldedColumnLineColor: #3b3b3b;
   qproperty-EmptyCellColor: #393939;

--- a/stuff/config/qss/Medium/less/Medium.less
+++ b/stuff/config/qss/Medium/less/Medium.less
@@ -408,6 +408,7 @@
 @xsheet-DarkBG-color:                       lighten(@bg, 60.0000);
 @xsheet-DarkLine-color:                     lighten(@bg, 30.5882);
 @xsheet-ColumnIconLine-color:               @accent;
+@xsheet-CurrentCellColor-color:             rgb(0, 255, 255);
 
 @xsheet-CellArea-bg-color-focus:            rgb(0, 0, 0);
 @xsheet-CellFocus-color:                    #000;

--- a/stuff/config/qss/Medium/less/layouts/xsheet.less
+++ b/stuff/config/qss/Medium/less/layouts/xsheet.less
@@ -89,6 +89,7 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: @xsheet-ColumnHeadPastelizer-color;
   qproperty-SelectedColumnHead: @xsheet-SelectedColumnHead-color;
   qproperty-PlayRangeColor: @xsheet-PlayRange-Color;
+  qproperty-CurrentCellColor: @xsheet-CurrentCellColor-color;
 
   qproperty-FoldedColumnBGColor: @xsheet-FoldedColumnBG-color;
   qproperty-FoldedColumnLineColor: @xsheet-FoldedColumnLine-color;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2245,6 +2245,7 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(243, 223, 235, 0.3);
   qproperty-PlayRangeColor: #808080;
+  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #9a9a9a;
   qproperty-FoldedColumnLineColor: #737373;
   qproperty-EmptyCellColor: #6c6c6c;


### PR DESCRIPTION
This PR adds missing `qproperty-CurrentCellColor` entry in stylesheets.
