### PR TITLE
Remove Xsheet stylesheet cell focus colors

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2239,13 +2239,11 @@ XsheetViewer {
   qproperty-PreviewFrameTextColor: #9fdaff;
   qproperty-CurrentRowBgColor: rgba(163, 82, 147, 0.7);
   qproperty-OnionSkinAreaBgColor: #282828;
-  qproperty-CellFocusColor: #000;
   qproperty-ColumnIconLineColor: #111111;
   qproperty-EmptyColumnHeadColor: #303030;
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(237, 220, 233, 0.3);
   qproperty-PlayRangeColor: #383838;
-  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #4a4a4a;
   qproperty-FoldedColumnLineColor: #232323;
   qproperty-EmptyCellColor: #282828;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -2239,13 +2239,11 @@ XsheetViewer {
   qproperty-PreviewFrameTextColor: #9fdaff;
   qproperty-CurrentRowBgColor: rgba(163, 82, 147, 0.7);
   qproperty-OnionSkinAreaBgColor: #1b1b1b;
-  qproperty-CellFocusColor: #000;
   qproperty-ColumnIconLineColor: #060606;
   qproperty-EmptyColumnHeadColor: #343434;
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(237, 220, 233, 0.3);
   qproperty-PlayRangeColor: #202020;
-  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #3a3a3a;
   qproperty-FoldedColumnLineColor: #131313;
   qproperty-EmptyCellColor: #202020;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2239,13 +2239,11 @@ XsheetViewer {
   qproperty-PreviewFrameTextColor: #2d42b9;
   qproperty-CurrentRowBgColor: rgba(216, 87, 177, 0.7);
   qproperty-OnionSkinAreaBgColor: #c2c2c2;
-  qproperty-CellFocusColor: #000;
   qproperty-ColumnIconLineColor: #707070;
   qproperty-EmptyColumnHeadColor: #DBDBDB;
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(0, 0, 0, 0.15);
   qproperty-PlayRangeColor: #DBDBDB;
-  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #a8a8a8;
   qproperty-FoldedColumnLineColor: #757575;
   qproperty-EmptyCellColor: #c2c2c2;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -2239,13 +2239,11 @@ XsheetViewer {
   qproperty-PreviewFrameTextColor: #9fdaff;
   qproperty-CurrentRowBgColor: rgba(163, 82, 147, 0.7);
   qproperty-OnionSkinAreaBgColor: #393939;
-  qproperty-CellFocusColor: #000;
   qproperty-ColumnIconLineColor: #2c2c2c;
   qproperty-EmptyColumnHeadColor: #484848;
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(237, 220, 233, 0.3);
   qproperty-PlayRangeColor: #484848;
-  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #626262;
   qproperty-FoldedColumnLineColor: #3b3b3b;
   qproperty-EmptyCellColor: #393939;

--- a/stuff/config/qss/Medium/less/Medium.less
+++ b/stuff/config/qss/Medium/less/Medium.less
@@ -408,7 +408,6 @@
 @xsheet-DarkBG-color:                       lighten(@bg, 60.0000);
 @xsheet-DarkLine-color:                     lighten(@bg, 30.5882);
 @xsheet-ColumnIconLine-color:               @accent;
-@xsheet-CurrentCellColor-color:             rgb(0, 255, 255);
 
 @xsheet-CellArea-bg-color-focus:            rgb(0, 0, 0);
 @xsheet-CellFocus-color:                    #000;

--- a/stuff/config/qss/Medium/less/layouts/xsheet.less
+++ b/stuff/config/qss/Medium/less/layouts/xsheet.less
@@ -83,13 +83,11 @@ XsheetViewer {
   qproperty-PreviewFrameTextColor: @xsheet-PreviewFrameText-color;
   qproperty-CurrentRowBgColor: @xsheet-CurrentRowBG-color;
   qproperty-OnionSkinAreaBgColor: @xsheet-OnionSkinAreaBG-color;
-  qproperty-CellFocusColor: @xsheet-CellFocus-color;
   qproperty-ColumnIconLineColor: @xsheet-ColumnIconLine-color;
   qproperty-EmptyColumnHeadColor: @xsheet-EmptyColumnHead-color;
   qproperty-ColumnHeadPastelizer: @xsheet-ColumnHeadPastelizer-color;
   qproperty-SelectedColumnHead: @xsheet-SelectedColumnHead-color;
   qproperty-PlayRangeColor: @xsheet-PlayRange-Color;
-  qproperty-CurrentCellColor: @xsheet-CurrentCellColor-color;
 
   qproperty-FoldedColumnBGColor: @xsheet-FoldedColumnBG-color;
   qproperty-FoldedColumnLineColor: @xsheet-FoldedColumnLine-color;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2239,13 +2239,11 @@ XsheetViewer {
   qproperty-PreviewFrameTextColor: #17239c;
   qproperty-CurrentRowBgColor: rgba(251, 140, 205, 0.7);
   qproperty-OnionSkinAreaBgColor: #6c6c6c;
-  qproperty-CellFocusColor: #000;
   qproperty-ColumnIconLineColor: #4d4d4d;
   qproperty-EmptyColumnHeadColor: #808080;
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(243, 223, 235, 0.3);
   qproperty-PlayRangeColor: #808080;
-  qproperty-CurrentCellColor: #00ffff;
   qproperty-FoldedColumnBGColor: #9a9a9a;
   qproperty-FoldedColumnLineColor: #737373;
   qproperty-EmptyCellColor: #6c6c6c;


### PR DESCRIPTION
This PR actually reverses #983 as well as removes the original `CellFocusColor` from the XsheetViewer stylesheets since the cell focus color is no longer read from the stylesheet and controlled via preferences instead.