### PR TITLE
OpenToonz patches and Linux font size fix

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #a35293;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #a35293;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #d97fbe;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #a35293;

--- a/stuff/config/qss/Medium/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Medium/less/layouts/mainwindow.less
@@ -140,7 +140,7 @@ QMenu {
   padding: 2 0;
   &::item {
     border: 0;
-    padding: 3 28;
+    padding: 3 28 3 8;
     &:selected {
       background-color: @menu-item-bg-color-selected;
       color: @menu-item-text-color-selected;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -310,7 +310,7 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28;
+  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #c16099;

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -200,7 +200,10 @@ public:
   QStringList getLanguageList() const { return m_languageList; }
   QMap<int, QString> getRoomMap() const { return m_roomMaps; }
 
-  QString getCurrentStyleSheetPath() const;  // OK
+  QString getCurrentStyleSheet() const;
+  QString getAdditionalStyleSheet() const {
+    return getStringValue(additionalStyleSheet);
+  }
   bool getPixelsOnly() const { return getBoolValue(pixelsOnly); }
   QString getOldUnits() const { return getStringValue(oldUnits); }
   QString getOldCameraUnits() const { return getStringValue(oldCameraUnits); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -24,6 +24,7 @@ enum PreferencesItemId {
   //----------
   // Interface
   CurrentStyleSheetName,
+  additionalStyleSheet,
   iconTheme,
   pixelsOnly,
   oldUnits,

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -231,7 +231,7 @@ project->setUseScenePath(TProject::Extras, false);
   // Imposto la rootDir per ImageCache
 
   /*-- TOONZCACHEROOTの設定  --*/
-  TFilePath cacheDir               = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheDir = ToonzFolder::getCacheRootFolder();
   if (cacheDir.isEmpty()) cacheDir = TEnv::getStuffDir() + "cache";
   TImageCache::instance()->setRootDir(cacheDir);
 
@@ -339,10 +339,10 @@ int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
 
 #ifdef MACOSX
-// This workaround is to avoid missing left button problem on Qt5.6.0.
-// To invalidate m_rightButtonClicked in Qt/qnsview.mm, sending
-// NSLeftButtonDown event before NSLeftMouseDragged event propagated to
-// QApplication. See more details in ../mousedragfilter/mousedragfilter.mm.
+  // This workaround is to avoid missing left button problem on Qt5.6.0.
+  // To invalidate m_rightButtonClicked in Qt/qnsview.mm, sending
+  // NSLeftButtonDown event before NSLeftMouseDragged event propagated to
+  // QApplication. See more details in ../mousedragfilter/mousedragfilter.mm.
 
 #include "mousedragfilter.h"
 
@@ -762,7 +762,7 @@ int main(int argc, char *argv[]) {
   a.processEvents();
 
   // Carico lo styleSheet
-  QString currentStyle = Preferences::instance()->getCurrentStyleSheetPath();
+  QString currentStyle = Preferences::instance()->getCurrentStyleSheet();
   a.setStyleSheet(currentStyle);
 
   // Perspective grid tool - custom grid

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1263,7 +1263,7 @@ void MainWindow::onMenuCheckboxChanged() {
     FieldGuideToggleAction = isChecked;
   else if (cm->getAction(MI_RasterizePli) == action) {
     if (!QGLPixelBuffer::hasOpenGLPbuffers()) isChecked = 0;
-    RasterizePliToggleAction                            = isChecked;
+    RasterizePliToggleAction = isChecked;
   } else if (cm->getAction(MI_SafeArea) == action)
     SafeAreaToggleAction = isChecked;
   else if (cm->getAction(MI_ViewColorcard) == action)
@@ -3158,7 +3158,7 @@ void MainWindow::clearCacheFolder() {
   // 1. $CACHE/[Current ProcessID]
   // 2. $CACHE/temp/[Current scene folder] if the current scene is untitled
 
-  TFilePath cacheRoot                = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheRoot = ToonzFolder::getCacheRootFolder();
   if (cacheRoot.isEmpty()) cacheRoot = TEnv::getStuffDir() + "cache";
 
   TFilePathSet filesToBeRemoved;
@@ -3310,12 +3310,8 @@ class ReloadStyle final : public MenuItemHandler {
 public:
   ReloadStyle() : MenuItemHandler("MI_ReloadStyle") {}
   void execute() override {
-    QString currentStyle = Preferences::instance()->getCurrentStyleSheetPath();
-    QFile file(currentStyle);
-    file.open(QFile::ReadOnly);
-    QString styleSheet = QString(file.readAll());
-    qApp->setStyleSheet(styleSheet);
-    file.close();
+    QString currentStyle = Preferences::instance()->getCurrentStyleSheet();
+    qApp->setStyleSheet(currentStyle);
   }
 } reloadStyle;
 

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -17,6 +17,7 @@
 // Qt includes
 #include <QComboBox>
 #include <QFontComboBox>
+#include <QTextEdit>
 #include <QOpenGLWidget>
 #include <QSurfaceFormat>
 #include <QOpenGLFunctions>
@@ -68,11 +69,13 @@ public:
 
 private:
   class FormatProperties;
+  class AdditionalStyleEdit;
   class Display30bitChecker;
 
 private:
   Preferences* m_pref;
   FormatProperties* m_formatProperties;
+  AdditionalStyleEdit* m_additionalStyleEdit;
 
   // DVGui::CheckBox *m_projectRootDocuments, *m_projectRootDesktop,
   //    *m_projectRootCustom;
@@ -175,6 +178,9 @@ private slots:
   void onAutoSaveExternallyChanged();
   void onAutoSavePeriodExternallyChanged();
   // void onProjectRootChanged();
+
+  void onEditAdditionalStyleSheet();
+  void onAdditionalStyleSheetEdited();
   void onPixelUnitExternallySelected(bool on);
   void onInterfaceFontChanged(const QString& text);
   void onLutPathChanged();
@@ -249,6 +255,29 @@ protected:
   void initializeGL() override;
   void resizeGL(int width, int height) override;
   void paintGL() override;
+};
+
+//**********************************************************************************
+//   PreferencesPopup::AdditionalStyleEdit  definition
+//**********************************************************************************
+
+class PreferencesPopup::AdditionalStyleEdit final : public DVGui::Dialog {
+  Q_OBJECT
+
+public:
+  AdditionalStyleEdit(PreferencesPopup* parent);
+
+private:
+  QTextEdit* m_edit;
+
+protected:
+  void showEvent(QShowEvent* e) override;
+
+private slots:
+  void onOK();
+  void onApply();
+signals:
+  void additionalSheetEdited();
 };
 
 #endif  // PREFERENCESPOPUP_H

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -407,8 +407,9 @@ void Preferences::definePreferenceItems() {
   // (QTBUG-90242) Since the current OT is made to handle such issue, so we need
   // to apply an extra adjustment when it is run on the older versions (5.9.x)
   // of Qt
+  // Update: confirmed that the bug does not appear at least in Qt 5.12.8
   QString defaultAditionalSheet = "";
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 9)
   defaultAditionalSheet = "QMenu::Item{ padding: 3 28 3 28; }";
 #endif
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -413,6 +413,13 @@ void Preferences::definePreferenceItems() {
   defaultAditionalSheet = "QMenu::Item{ padding: 3 28 3 28; }";
 #endif
 
+  // Linux system font size appears a lot smaller than it should be despite
+  // setting QApplication's setPixelSize = 12 in main.cpp. We'll correct it using
+  // the additional stylesheet.
+#if defined(LINUX) || defined(FREEBSD)
+  defaultAditionalSheet = "QWidget { font: 12px; }" + defaultAditionalSheet;
+#endif
+
   define(additionalStyleSheet, "additionalStyleSheet", QMetaType::QString,
          defaultAditionalSheet);
   define(iconTheme, "iconTheme", QMetaType::Bool, false);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -402,7 +402,18 @@ void Preferences::definePreferenceItems() {
   // Interface
   define(CurrentStyleSheetName, "CurrentStyleSheetName", QMetaType::QString,
          "Dark");
-  define(additionalStyleSheet, "additionalStyleSheet", QMetaType::QString, "");
+
+  // Qt has a bug in recent versions that Menu item Does not show correctly
+  // (QTBUG-90242) Since the current OT is made to handle such issue, so we need
+  // to apply an extra adjustment when it is run on the older versions (5.9.x)
+  // of Qt
+  QString defaultAditionalSheet = "";
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+  defaultAditionalSheet = "QMenu::Item{ padding: 3 28 3 28; }";
+#endif
+
+  define(additionalStyleSheet, "additionalStyleSheet", QMetaType::QString,
+         defaultAditionalSheet);
   define(iconTheme, "iconTheme", QMetaType::Bool, false);
   define(pixelsOnly, "pixelsOnly", QMetaType::Bool, true);
   define(oldUnits, "oldUnits", QMetaType::QString, "mm");


### PR DESCRIPTION
This PR applies some older OT patches that were previously held back/skipped in order to use it to fix an issue with small font size on Linux builds.

### OT Patches applied: 
- opentoonz/opentoonz/#3487 - Additional Style Sheet  by @shun-iwasawa

  This PR is only being used internally and will not be visible to the user, for now.

- opentoonz/opentoonz/#3714 - Icons for all commands by  @shun-iwasawa

  This PR was already mostly applied to T2D but left out some changes related to PR 3487. This PR applies those changes previously left out.  Changes were slightly modified for T2D to fix menu item checkbox/icon-label spacing.

- opentoonz/opentoonz/#3779 - Fix Additional Style Sheet Condition  by @shun-iwasawa

### Linux fix:

For some reason, despite setting the default QApplication's font size = 12 using setPixelSize(), the Linux font displayed is still quite considerably small. It appears for most widgets, it was not using this value at all.  Windows/OSX builds used this value correctly.

Found the best way to fix this was to update the stylesheet to include `QWidget { font: 12px; }`.  I could have added this to the LESS/QSS files directly but, I wanted to limit the change to Linux builds only, hence the need to apply the Additional Stylesheets feature that was previously withheld.