### PR TITLE
Style sheet processing changes

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -310,7 +310,6 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #a35293;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -310,7 +310,6 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #a35293;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -310,7 +310,6 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #d97fbe;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -310,7 +310,6 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #a35293;

--- a/stuff/config/qss/Medium/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Medium/less/layouts/mainwindow.less
@@ -140,7 +140,6 @@ QMenu {
   padding: 2 0;
   &::item {
     border: 0;
-    padding: 3 28 3 8;
     &:selected {
       background-color: @menu-item-bg-color-selected;
       color: @menu-item-text-color-selected;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -310,7 +310,6 @@ QMenu {
 }
 QMenu::item {
   border: 0;
-  padding: 3 28 3 8;
 }
 QMenu::item:selected {
   background-color: #c16099;

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1664,7 +1664,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
 
   insertUI(CurrentStyleSheetName, lay, styleSheetItemList);
   int row = lay->rowCount();
-  // lay->addWidget(additionalStyleSheetBtn, row - 1, 3);
+  lay->addWidget(additionalStyleSheetBtn, row - 1, 3);
 
   // lay->addWidget(new QLabel(tr("Icon Theme*:"), this), 2, 0,
   //               Qt::AlignRight | Qt::AlignVCenter);


### PR DESCRIPTION
This PR is mostly due to address additional font scaling issues on Linux builds, but have made changes that will impact all 3 build platforms.  The changes are as follows:

- Enable `Edit Additional Style Sheet...` button for all build platforms
- Internally construct and use working style sheet as follows 
  - Initialize working style sheet with base style sheet setting to handle QT issues that are correctable via style sheet settings
  - Append theme style sheets to the working style sheet.  Theme style sheets can override base style sheet settings with this.
  - Append Additional Style Sheet, if any, to the working style sheet. Additional style sheet can override base and theme style sheet settings with this.
- Remove the QMenu::Item padding from the .LESS/.QSS files. Now controlled programmatically in base style sheet.