### PR TITLE
Fix software version check

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1314,7 +1314,7 @@ extern const char *applicationVersion;
 void MainWindow::checkForUpdates() {
   // Since there is only a single version of Tahoma, we can do a simple check
   // against a string
-  QString updateUrl("https://tahoma2d.org/files/tahoma-version.txt");
+  QString updateUrl("http://tahoma2d.org/files/tahoma-version.txt");
 
   m_updateChecker = new UpdateChecker(updateUrl);
   connect(m_updateChecker, SIGNAL(done(bool)), this,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2169,7 +2169,7 @@ QWidget* PreferencesPopup::createVersionControlPage() {
 
   insertUI(SVNEnabled, lay);
   insertUI(automaticSVNFolderRefreshEnabled, lay);
-//  insertUI(latestVersionCheckEnabled, lay);
+  insertUI(latestVersionCheckEnabled, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);


### PR DESCRIPTION
This fixes an issue where the software version check is not working.

Although I was able to locally test it we won't really be able to test this for a while.  Soonest we can verify this is when using a v1.3 nightly and v1.4 has been released.