### PR TITLE
Replace DEL with Backspace for OSX

### DIFF
--- a/toonz/sources/toonz/graphwidget.cpp
+++ b/toonz/sources/toonz/graphwidget.cpp
@@ -828,7 +828,11 @@ void GraphWidget::mouseReleaseEvent(QMouseEvent* e) {
 void GraphWidget::keyPressEvent(QKeyEvent* e) {
   if (m_currentControlPointIndex == -1) return;
 
+#ifdef MACOSX
+  if (e->key() == Qt::Key_Backspace) {
+#else
   if (e->key() == Qt::Key_Delete) {
+#endif
     removeCurrentControlPoint();
     return;
   }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1833,7 +1833,12 @@ void MainWindow::defineActions() {
                        "paste_duplicate");
   createMenuEditAction(MI_PasteInto, QT_TR_NOOP("&Paste Into"), "",
                        "paste_into");
-  createMenuEditAction(MI_Clear, QT_TR_NOOP("&Delete"), "Del", "delete");
+#ifdef MACOSX
+  QString delKey = "Backspace";
+#else
+  QString delKey = "Del";
+#endif
+  createMenuEditAction(MI_Clear, QT_TR_NOOP("&Delete"), delKey, "delete");
   createMenuEditAction(MI_Insert, QT_TR_NOOP("&Insert"), "Ins", "insert");
   createMenuEditAction(MI_InsertBelow, QT_TR_NOOP("&Insert Below/Before"),
                        "Shift+Ins", "insert_above_after");

--- a/toonz/sources/toonzqt/hexcolornames.cpp
+++ b/toonz/sources/toonzqt/hexcolornames.cpp
@@ -700,7 +700,11 @@ void HexColorNamesEditor::keyPressEvent(QKeyEvent *event) {
   case Qt::Key_Escape:
     deselectItem(true);
     break;
+#ifdef MACOSX
+  case Qt::Key_Backspace:
+#else
   case Qt::Key_Delete:
+#endif
     deleteCurrentItem(false);
     break;
   case Qt::Key_Insert:

--- a/toonz/sources/toonzqt/tonecurvefield.cpp
+++ b/toonz/sources/toonzqt/tonecurvefield.cpp
@@ -762,7 +762,11 @@ void ChennelCurveEditor::mouseReleaseEvent(QMouseEvent *e) {
 void ChennelCurveEditor::keyPressEvent(QKeyEvent *e) {
   if (m_currentControlPointIndex == -1) return;
 
+#ifdef MACOSX
+  if (e->key() == Qt::Key_Backspace) {
+#else
   if (e->key() == Qt::Key_Delete) {
+#endif
     removeCurrentControlPoint();
     return;
   }


### PR DESCRIPTION
This addresses an issue for MacOS users where the `Delete` key on mac keyboard does nothing because it is internally identified as `Backspace` and actions are not typically defined against it.

The following changes were made **for macOS builds only**:

- Replaced the default `Delete` keyboard shortcut `DEL` with `Backspace`
  - This generally impacts wherever a menu shortcut command or action uses the T2D delete command option.

- Anywhere `DEL` is hardcoded for a particular action and there is no `Backspace` action defined, the logic has been switched to work with `Backspace` instead
  - Hex Color Name Editor - Removing entries
  - Motion Path Panel  - Graph widget - Removing curve points
  - CurvesFx - Removing curve point

- Anywhere the `Backspace` is hardcoded for a particular action and there is no `DEL` action defined, the logic will remain the same
  - Script console - removing text
  - Stop Motion Panel - Numpad shortcuts active option switches `Backspace` shortcut to Stop Motion Remove Frame command

- Anywhere a `DEL` action and a `Backspace` action is hardcoded with different actions, the logic will remain the same
  - Type Tool - text edit box
