### PR TITLE
Set Start/Stop Markers enhancement

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2033,6 +2033,8 @@ void MainWindow::defineActions() {
   createMenuXsheetAction(MI_SetAutoMarkers, QT_TR_NOOP("Set Auto Markers"), "");
   createMenuXsheetAction(MI_PreviewThis,
                          QT_TR_NOOP("Set Markers to Current Frame"), "");
+  createMenuXsheetAction(MI_PreviewSelected,
+                         QT_TR_NOOP("Set Markers to Selected Range"), "");
   createMenuXsheetAction(MI_ToggleTaggedFrame,
                          QT_TR_NOOP("Toggle Navigation Tag"), "",
                          "toggle_nav_tag");

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -152,6 +152,7 @@
 #define MI_ClearMarkers "MI_ClearMarkers"
 #define MI_SetAutoMarkers "MI_SetAutoMarkers"
 #define MI_PreviewThis "MI_PreviewThis"
+#define MI_PreviewSelected "MI_PreviewSelected"
 
 #define MI_PasteNew "MI_PasteNew"
 #define MI_Autorenumber "MI_Autorenumber"

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2729,6 +2729,27 @@ public:
 
 //============================================================
 
+class PreviewSelected final : public MenuItemHandler {
+public:
+  PreviewSelected() : MenuItemHandler(MI_PreviewSelected) {}
+
+  void execute() override {
+    TApp *app             = TApp::instance();
+    TSelection *selection = app->getCurrentSelection()->getSelection();
+    if (!selection) return;
+    TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(selection);
+    if (!cellSelection) return;
+    int row0, col0, row1, col1;
+    cellSelection->getSelectedCells(row0, col0, row1, col1);
+    int r0, r1, step;
+    XsheetGUI::getPlayRange(r0, r1, step);
+    XsheetGUI::setPlayRange(row0, row1, step);
+    TApp::instance()->getCurrentXsheetViewer()->update();
+  }
+} PreviewSelected;
+
+//============================================================
+
 class ToggleTaggedFrame final : public MenuItemHandler {
 public:
   ToggleTaggedFrame() : MenuItemHandler(MI_ToggleTaggedFrame) {}

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1297,6 +1297,8 @@ void RowArea::contextMenuEvent(QContextMenuEvent *event) {
 
   menu->addAction(CommandManager::instance()->getAction(MI_PreviewThis));
 
+  menu->addAction(CommandManager::instance()->getAction(MI_PreviewSelected));
+
   menu->addSeparator();
 
   if (Preferences::instance()->isOnionSkinEnabled()) {

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1240,9 +1240,9 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
                .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
                .contains(mouseInCell) &&
            xsh->isFrameTagged(m_row)) {
-    QString label = xsh->getNavigationTags()->getTagLabel(m_row);
+    QString label              = xsh->getNavigationTags()->getTagLabel(m_row);
     if (label.isEmpty()) label = "-";
-    m_tooltip = tr("Tag: %1").arg(label);
+    m_tooltip                  = tr("Tag: %1").arg(label);
   } else if (row == currentRow) {
     if (Preferences::instance()->isOnionSkinEnabled() &&
         o->rect(PredefinedRect::ONION)
@@ -1256,10 +1256,11 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
   else if (m_showOnionToSet == Mos)
     m_tooltip = tr("Relative Onion Skin Toggle");
   else
-    m_tooltip = tr("%1+Click - Set Playback Start Marker\n%2+Click - Set "
-                   "Playback End Marker")
+    m_tooltip = tr("%1+Click\t- Set Playback Start Marker\n%2+Click \t- Set "
+                   "Playback End Marker\n%3+Click\t- Remove Playback Markers")
                     .arg(trModKey("Ctrl"))
-                    .arg(trModKey("Alt"));
+                    .arg(trModKey("Alt"))
+                    .arg(trModKey("Ctrl+Alt"));
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1225,6 +1225,9 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
       o->path(PredefinedPath::END_PLAY_RANGE).translated(base1);
 
   if (!m_tooltip.isEmpty()) return;
+
+  TXsheet *xsh = m_viewer->getXsheet();
+
   if (startArrow.contains(m_pos))
     m_tooltip = tr("Playback Start Marker");
   else if (endArrow.contains(m_pos))
@@ -1235,11 +1238,11 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
                     .arg((isRootBonePinned) ? " (Root)" : "");
   else if (o->rect(PredefinedRect::NAVIGATION_TAG_AREA)
                .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
-               .contains(mouseInCell)) {
-    TXsheet *xsh = m_viewer->getXsheet();
+               .contains(mouseInCell) &&
+           xsh->isFrameTagged(m_row)) {
     QString label = xsh->getNavigationTags()->getTagLabel(m_row);
     if (label.isEmpty()) label = "-";
-    if (xsh->isFrameTagged(m_row)) m_tooltip = tr("Tag: %1").arg(label);
+    m_tooltip = tr("Tag: %1").arg(label);
   } else if (row == currentRow) {
     if (Preferences::instance()->isOnionSkinEnabled() &&
         o->rect(PredefinedRect::ONION)
@@ -1252,6 +1255,11 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
     m_tooltip = tr("Fixed Onion Skin Toggle");
   else if (m_showOnionToSet == Mos)
     m_tooltip = tr("Relative Onion Skin Toggle");
+  else
+    m_tooltip = tr("%1+Click - Set Playback Start Marker\n%2+Click - Set "
+                   "Playback End Marker")
+                    .arg(trModKey("Ctrl"))
+                    .arg(trModKey("Alt"));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the following:

- A new option to set the start and stop markers on a selected frame range by selecting a range of cells in the timeline/xsheet, right-click the start/stop marker area and then choosing `Set Markers to Selected Range`.
- A tool tip for setting start/stop markers using CTRL/ALT + click when hovering over frames area