### PR TITLE
Add Default Projects Folder to Browser

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -126,6 +126,13 @@ void DvDirModelNode::addChild(DvDirModelNode *child) {
 
 //-----------------------------------------------------------------------------
 
+void DvDirModelNode::insertChild(int row, DvDirModelNode *child) {
+  child->setRow(row);
+  m_children.insert(m_children.begin() + row, child);
+}
+
+//-----------------------------------------------------------------------------
+
 int DvDirModelNode::getChildCount() {
   if (!m_childrenValid) refreshChildren();
   return (int)m_children.size();
@@ -1108,6 +1115,34 @@ void DvDirModelRootNode::add(std::wstring name, const TFilePath &path) {
 
 //-----------------------------------------------------------------------------
 
+void DvDirModelRootNode::refreshDefaultProjectPath() {
+  removeChildren(8, m_projectDirNodes.size());
+  m_projectDirNodes.clear();
+
+  QString defaultProjectPaths =
+      Preferences::instance()->getDefaultProjectPath();
+  if (!defaultProjectPaths.isEmpty()) {
+    QStringList projectRoots =
+        defaultProjectPaths.split(";", QString::SkipEmptyParts);
+    for (int i = 0; i < projectRoots.size(); i++) {
+      TFilePath projectRootDir(projectRoots.at(i));
+      if (!TFileStatus(projectRootDir).isDirectory()) continue;
+      std::wstring folderName = L"Projects";
+      if (projectRoots.size() > 1)
+        folderName +=
+            L" (" + projectRootDir.withoutParentDir().getWideString() + L")";
+      DvDirModelSpecialFileFolderNode *projectFolderNode =
+          new DvDirModelSpecialFileFolderNode(this, folderName, projectRootDir);
+      projectFolderNode->setPixmap(recolorPixmap(
+          svgToPixmap(getIconThemePath("actions/16/projects_folder.svg"))));
+      m_projectDirNodes.push_back(projectFolderNode);
+      insertChild(8 + i, projectFolderNode);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
 void DvDirModelRootNode::refreshChildren() {
   m_childrenValid = true;
   if (m_children.empty()) {
@@ -1155,6 +1190,28 @@ void DvDirModelRootNode::refreshChildren() {
     addChild(child);
 
     addChild(new DvDirModelHistoryNode(this));
+
+    QString defaultProjectPaths =
+        Preferences::instance()->getDefaultProjectPath();
+    if (!defaultProjectPaths.isEmpty()) {
+      QStringList projectRoots =
+          defaultProjectPaths.split(";", QString::SkipEmptyParts);
+      for (int i = 0; i < projectRoots.size(); i++) {
+        TFilePath projectRootDir(projectRoots.at(i));
+        if (!TFileStatus(projectRootDir).isDirectory()) continue;
+        std::wstring folderName = L"Projects";
+        if (projectRoots.size() > 1)
+          folderName +=
+              L" (" + projectRootDir.withoutParentDir().getWideString() + L")";
+        DvDirModelSpecialFileFolderNode *projectFolderNode =
+            new DvDirModelSpecialFileFolderNode(this, folderName,
+                                                projectRootDir);
+        projectFolderNode->setPixmap(recolorPixmap(
+            svgToPixmap(getIconThemePath("actions/16/projects_folder.svg"))));
+        m_projectDirNodes.push_back(projectFolderNode);
+        addChild(projectFolderNode);
+      }
+    }
 
     TProjectManager *pm          = TProjectManager::instance();
     TFilePath sandboxProjectPath = pm->getSandboxProjectFolder();
@@ -1286,6 +1343,12 @@ DvDirModelNode *DvDirModelRootNode::getNodeByPath(const TFilePath &path) {
   // check for the special folders (My Documents / Desktop / Library)
   for (DvDirModelSpecialFileFolderNode *specialNode : m_specialNodes) {
     DvDirModelNode *node = specialNode->getNodeByPath(path);
+    if (node) return node;
+  }
+
+  // check for the project root folders
+  for (DvDirModelSpecialFileFolderNode *projectDirNode : m_projectDirNodes) {
+    DvDirModelNode *node = projectDirNode->getNodeByPath(path);
     if (node) return node;
   }
 
@@ -1593,12 +1656,15 @@ void DvDirModel::onSceneSwitched() {
 //-----------------------------------------------------------------------------
 
 void DvDirModel::onPreferenceChanged(const QString &prefName) {
-  if (prefName != "PathAliasPriority") return;
-
-  Preferences::PathAliasPriority priority =
-      Preferences::instance()->getPathAliasPriority();
   DvDirModelRootNode *rootNode = dynamic_cast<DvDirModelRootNode *>(m_root);
-  if (rootNode)
+  if (!rootNode) return;
+  if (prefName == "PathAliasPriority") {
+    Preferences::PathAliasPriority priority =
+        Preferences::instance()->getPathAliasPriority();
     rootNode->updateSceneFolderNodeVisibility(priority ==
                                               Preferences::ProjectFolderOnly);
+  } else if (prefName == "DefaultProjectPath") {
+    rootNode->refreshDefaultProjectPath();
+    emit layoutChanged();
+  }
 }

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -1116,8 +1116,17 @@ void DvDirModelRootNode::add(std::wstring name, const TFilePath &path) {
 //-----------------------------------------------------------------------------
 
 void DvDirModelRootNode::refreshDefaultProjectPath() {
-  removeChildren(8, m_projectDirNodes.size());
-  m_projectDirNodes.clear();
+// Windows has 1 more entry (Network) than macOS/Linux
+#ifdef WIN32
+  int row = 8;
+#else
+  int row = 7;
+#endif
+
+  if (m_projectDirNodes.size() > 0) {
+    removeChildren(row, m_projectDirNodes.size());
+    m_projectDirNodes.clear();
+  }
 
   QString defaultProjectPaths =
       Preferences::instance()->getDefaultProjectPath();
@@ -1136,7 +1145,7 @@ void DvDirModelRootNode::refreshDefaultProjectPath() {
       projectFolderNode->setPixmap(recolorPixmap(
           svgToPixmap(getIconThemePath("actions/16/projects_folder.svg"))));
       m_projectDirNodes.push_back(projectFolderNode);
-      insertChild(8 + i, projectFolderNode);
+      insertChild(row + i, projectFolderNode);
     }
   }
 }

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -1133,6 +1133,7 @@ void DvDirModelRootNode::refreshDefaultProjectPath() {
   if (!defaultProjectPaths.isEmpty()) {
     QStringList projectRoots =
         defaultProjectPaths.split(";", QString::SkipEmptyParts);
+    int folderCount = 0;
     for (int i = 0; i < projectRoots.size(); i++) {
       TFilePath projectRootDir(projectRoots.at(i));
       if (!TFileStatus(projectRootDir).isDirectory()) continue;
@@ -1145,7 +1146,8 @@ void DvDirModelRootNode::refreshDefaultProjectPath() {
       projectFolderNode->setPixmap(recolorPixmap(
           svgToPixmap(getIconThemePath("actions/16/projects_folder.svg"))));
       m_projectDirNodes.push_back(projectFolderNode);
-      insertChild(row + i, projectFolderNode);
+      insertChild(row + folderCount, projectFolderNode);
+      folderCount++;
     }
   }
 }

--- a/toonz/sources/toonz/filebrowsermodel.h
+++ b/toonz/sources/toonz/filebrowsermodel.h
@@ -44,6 +44,7 @@ public:
 
   void removeChildren(int row, int count);
   void addChild(DvDirModelNode *child);
+  void insertChild(int row, DvDirModelNode *child);
   virtual void visualizeContent(FileBrowser *browser) {}  // ?????????????
 
   virtual QPixmap getPixmap(bool isOpen) const;
@@ -324,11 +325,13 @@ class DvDirModelRootNode final : public DvDirModelNode {
   std::set<TFilePath> m_projectPaths;
   DvDirModelSceneFolderNode *m_sceneFolderNode;
   std::vector<DvDirModelSpecialFileFolderNode *> m_specialNodes;
+  std::vector<DvDirModelSpecialFileFolderNode *> m_projectDirNodes;
 
   void add(std::wstring name, const TFilePath &path);
 
 public:
   DvDirModelRootNode();
+  void refreshDefaultProjectPath();
   void refreshChildren() override;
   int getProjectPathsSize() { return m_projectPaths.size(); }
 

--- a/toonz/sources/toonz/icons/dark/actions/16/projects_folder.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/projects_folder.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg10"
+   sodipodi:docname="projects_folder.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata
+   id="metadata16"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs14" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   id="namedview12"
+   showgrid="true"
+   inkscape:zoom="45.6875"
+   inkscape:cx="8"
+   inkscape:cy="9.4555404"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg10"
+   inkscape:pagecheckerboard="0"><inkscape:grid
+     type="xygrid"
+     id="grid823" /></sodipodi:namedview>
+    
+    
+<path
+   style="color:#000000;clip-rule:nonzero;fill:#000000;fill-opacity:0.8;fill-rule:nonzero;stroke-linejoin:miter;-inkscape-stroke:none"
+   d="M 3,9.5 A 0.50005,0.50005 0 0 0 2.5,10 v 1 A 0.50005,0.50005 0 0 0 3,11.5 H 4 A 0.50005,0.50005 0 0 0 4.5,11 V 10 A 0.50005,0.50005 0 0 0 4,9.5 Z"
+   id="path3773" /><path
+   style="color:#000000;clip-rule:nonzero;fill:#000000;fill-opacity:0.8;fill-rule:nonzero;stroke-linejoin:miter;-inkscape-stroke:none"
+   d="M 3,5.5 A 0.50005,0.50005 0 0 0 2.5,6 V 7 A 0.50005,0.50005 0 0 0 3,7.5 H 4 A 0.50005,0.50005 0 0 0 4.5,7 V 6 A 0.50005,0.50005 0 0 0 4,5.5 Z"
+   id="path3668" /><g
+   id="rect1031"><path
+     style="color:#000000;clip-rule:nonzero;fill:#ffffff;fill-opacity:0;fill-rule:nonzero;stroke-linejoin:miter;-inkscape-stroke:none"
+     d="M 1,2 V 4 14 H 15 V 4 H 7 L 5,2 Z"
+     id="path2560" /><path
+     style="color:#000000;clip-rule:nonzero;fill:#000000;fill-opacity:0.8;fill-rule:nonzero;stroke-linejoin:miter;-inkscape-stroke:none"
+     d="M 1,1.5 C 0.72386906,1.5000276 0.50002761,1.7238691 0.5,2 v 2 10 c 2.761e-5,0.276131 0.22386906,0.499972 0.5,0.5 h 14 c 0.276131,-2.8e-5 0.499972,-0.223869 0.5,-0.5 V 4 C 15.499972,3.7238691 15.276131,3.5000276 15,3.5 H 7.2070312 L 5.3535156,1.6464844 C 5.2597597,1.5527163 5.1325995,1.5000255 5,1.5 Z m 6,3 h 7.5 v 9 h -13 v -9 c 1.6556381,-0.080228 4.4346962,0.026255 5.5,0 z"
+     id="path2562"
+     sodipodi:nodetypes="ccccccccccccccccccc" /></g><path
+   style="color:#000000;clip-rule:nonzero;fill:#000000;fill-opacity:0.8;fill-rule:nonzero;stroke-linejoin:miter;-inkscape-stroke:none"
+   d="M 13,5.5 A 0.50005,0.50005 0 0 1 13.5,6 V 7 A 0.50005,0.50005 0 0 1 13,7.5 H 6 A 0.50005,0.50005 0 0 1 5.5,7 V 6 A 0.50005,0.50005 0 0 1 6,5.5 Z"
+   id="path3785" /><path
+   style="color:#000000;clip-rule:nonzero;fill:#000000;fill-opacity:0.8;fill-rule:nonzero;stroke-linejoin:miter;-inkscape-stroke:none"
+   d="M 6,9.5 C 5.7238691,9.5000276 5.5000276,9.7238691 5.5,10 v 1 c 2.76e-5,0.276131 0.2238691,0.499972 0.5,0.5 h 7 c 0.276131,-2.8e-5 0.499972,-0.223869 0.5,-0.5 V 10 C 13.499972,9.7238691 13.276131,9.5000276 13,9.5 Z"
+   id="path3779"
+   sodipodi:nodetypes="ccccccccc" /></svg>

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -443,6 +443,14 @@ QList<ComboBoxItem> PreferencesPopup::buildFontStyleList() const {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onDefaultProjectPathChanged() {
+  // emit signal to update behavior of the File browser
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
+      "DefaultProjectPath");
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onAutoSaveChanged() {
   bool on = getUI<QGroupBox*>(autosaveEnabled)->isChecked();
   if (!on) return;
@@ -1604,6 +1612,8 @@ QWidget* PreferencesPopup::createGeneralPage() {
   pathAliasPriorityCB->setItemData(1, scenefolderTooltip, Qt::ToolTipRole);
   pathAliasPriorityCB->setItemData(2, QString(" "), Qt::ToolTipRole);
 
+  m_onEditedFuncMap.insert(defaultProjectPath,
+                           &PreferencesPopup::onDefaultProjectPathChanged);
   m_onEditedFuncMap.insert(autosaveEnabled,
                            &PreferencesPopup::onAutoSaveChanged);
   m_onEditedFuncMap.insert(autosaveSceneEnabled,

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -135,6 +135,7 @@ private:
 
   //--- callbacks ---
   // General
+  void onDefaultProjectPathChanged();
   void onAutoSaveChanged();
   void onAutoSaveOptionsChanged();
   void onWatchFileSystemClicked();

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -138,6 +138,7 @@
 		<file>icons/dark/actions/16/fb_down.svg</file>
 		<file>icons/dark/actions/16/viewlist.svg</file>
 		<file>icons/dark/actions/16/viewicon.svg</file>
+		<file>icons/dark/actions/16/projects_folder.svg</file>
     <file>icons/dark/actions/16/favorites.svg</file>
 
     <file>icons/dark/actions/18/folder_project_root.svg</file>


### PR DESCRIPTION
This PR fixes #996 by adding an entry for `Projects` in the `File Browser` if a `Default Project Path` is set.  In case of multiple paths (separated by `;`), multiple entries will be created with the base path name appended to `Projects`.

![image](https://user-images.githubusercontent.com/19245851/168453739-58b93d18-5b7c-47df-a41d-d44cf07bcfb3.png)

![image](https://user-images.githubusercontent.com/19245851/168453780-e524462c-af25-433b-8371-046114d53f5d.png)
