### PR TITLE
Fix Canon Import Image crash

### DIFF
--- a/toonz/sources/stopmotion/canon.cpp
+++ b/toonz/sources/stopmotion/canon.cpp
@@ -7,6 +7,7 @@
 #include "toonz/tscenehandle.h"
 #include "toonz/tcamera.h"
 #include "toonz/toonzscene.h"
+#include "tsystem.h"
 
 #include <QCoreApplication>
 #include <QFile>
@@ -968,12 +969,26 @@ bool Canon::downloadImage(EdsBaseRef object) {
 
   // write out the full res file
   if (!isRaw) {
+    TFilePath parentDir =
+        TApp::instance()->getCurrentScene()->getScene()->decodeFilePath(
+            TFilePath(StopMotion::instance()->m_filePath));
+    TFilePath tempFile = parentDir + "temp.jpg";
+
+    StopMotion::instance()->m_tempFile = tempFile.getQString();
+
     QFile fullImage(StopMotion::instance()->m_tempFile);
     fullImage.open(QIODevice::WriteOnly);
     QDataStream dataStream(&fullImage);
     dataStream.writeRawData((const char*)jpgStreamData, jpgStreamSize);
     fullImage.close();
   } else {
+    TFilePath parentDir =
+        TApp::instance()->getCurrentScene()->getScene()->decodeFilePath(
+            TFilePath(StopMotion::instance()->m_filePath));
+    TFilePath tempRaw = parentDir + "temp.cr2";
+
+    StopMotion::instance()->m_tempRaw = tempRaw.getQString();
+
     QFile fullImage(StopMotion::instance()->m_tempRaw);
     fullImage.open(QIODevice::WriteOnly);
     QDataStream dataStream(&fullImage);

--- a/toonz/sources/stopmotion/stopmotion.h
+++ b/toonz/sources/stopmotion/stopmotion.h
@@ -70,7 +70,6 @@ private:
   int m_captureNumberOfFrames = 1;
   QString m_levelName         = "";
   QString m_fileType          = "jpg";
-  QString m_filePath          = "+stopmotion";
   QString m_frameInfoText     = "";
   QString m_infoColorName     = "";
   QString m_frameInfoToolTip  = "";
@@ -110,6 +109,7 @@ public:
   bool m_isTimeLapse       = false;
   int m_reviewTimeDSec     = 20;
   bool m_isTestShot        = false;
+  QString m_filePath       = "+stopmotion";
   QString m_tempFile, m_tempRaw;
   TXshSimpleLevel* m_sl;
 


### PR DESCRIPTION
This PR fixes a crash that is caused when capturing image directly from a Canon camera without using Live View.

If you connect a Canon camera and never use Live View then take a picture using the camera directly, when the image is downloaded to T2D, it crashes because the temp file/path was never initialized.