### PR TITLE
Fix ffmpeg builds on macOS Catalina

### DIFF
--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -25,6 +25,30 @@ sudo make install
 
 cd ../..
 
+echo ">>> Cloning dav1d"
+git clone https://github.com/videolan/dav1d
+
+cd dav1d
+
+git checkout tags/0.9.2
+
+if [ ! -d build ] 
+then
+   mkdir build
+fi
+cd build
+
+echo ">>> Configuring dav1d (meson)"
+meson ..
+
+echo ">>> Building dav1d"
+ninja
+
+echo ">>> Installing dav1d"
+ninja install
+
+cd ../..
+
 echo ">>> Cloning ffmpeg"
 git clone -b v4.3.1 https://github.com/tahoma2d/FFmpeg ffmpeg
 

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -4,4 +4,7 @@ brew update
 rm -f '/usr/local/bin/2to3'
 # Remove synlink to nghttp2 in order for latest curl to install
 brew unlink nghttp2
-brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
+brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
+#brew install dav1d
+brew install meson ninja
+ 


### PR DESCRIPTION
Ffmpeg builds on macOS needed for opencv builds for Tahoma2D are failing because Homebrew upgraded libdav1d from 0.9.2 to 1.0.

Cannot compile a higher version of ffmpeg that allows for the newer version of libdav1d because that would also force a higher version of opencv which I cannot get to compile on Catalina.

To fix this issue and resume with the current versions of ffmpeg/opencv, this PR will build libdav1d 0.9.2 from source instead of using the brew version.
