### PR TITLE
Fix parent column indicators

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2903,9 +2903,10 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
                              : m_viewer->getReferenceColumnColor();
     sideColor = m_viewer->getReferenceColumnBorderColor();
   } else {
-    cellColor = (isSelected) ? m_viewer->getSelectedPaletteColumnColor()
-                             : m_viewer->getPaletteColumnColor();
-    sideColor = m_viewer->getPaletteColumnBorderColor();
+    int levelType;
+    m_viewer->getCellTypeAndColors(levelType, cellColor, sideColor, cell,
+                                   isSelected);
+
     if (isImplicitCell) cellColor.setAlpha(m_viewer->getImplicitCellAlpha());
     if (isStopFrame) {
       cellColorAlpha = cellColor.alpha();

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1270,8 +1270,7 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   p.setPen(m_viewer->getVerticalLineColor());
   if (o->flag(PredefinedFlag::PEGBAR_NAME_BORDER)) p.drawRect(pegbarnamerect);
 
-  if (column->getSoundColumn() || column->getSoundTextColumn() ||
-      column->getPaletteColumn())
+  if (column->getSoundColumn() || column->getSoundTextColumn())
     return;
 
   if (Preferences::instance()->isParentColorsInXsheetColumnEnabled() &&
@@ -1306,8 +1305,7 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
 void ColumnArea::DrawHeader::drawParentHandleName() const {
   if (col < 0 || isEmpty ||
       !o->flag(PredefinedFlag::PARENT_HANDLE_NAME_VISIBILE) ||
-      column->getSoundColumn() || column->getSoundTextColumn() ||
-      column->getPaletteColumn())
+      column->getSoundColumn() || column->getSoundTextColumn())
     return;
 
   TStageObjectId columnId = m_viewer->getObjectId(col);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -481,11 +481,12 @@ void ChangeObjectParent::refresh() {
                            : viewer->getOtherCameraColor();
     } else if (id.isColumn() && (!xsh->isColumnEmpty(index))) {
       TXshColumn *colx = xsh->getColumn(index);
-      if (colx->getColumnType() != TXshColumn::eSoundTextType &&
-          colx->getColumnType() != TXshColumn::eSoundType) {
-        QColor unused;
+      if (colx->getColumnType() == TXshColumn::eSoundTextType ||
+          colx->getColumnType() == TXshColumn::eSoundType)
+        continue;
+
+      QColor unused;
         viewer->getColumnColor(newTextBG, unused, id.getIndex(), xsh);
-      }
     } else
       continue;
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -116,6 +116,11 @@ void XsheetViewer::getCellTypeAndColors(int &ltype, QColor &cellColor,
           (isSelected) ? getSelectedMeshColumnColor() : getMeshColumnColor();
       sideColor = getMeshColumnBorderColor();
       break;
+    case PLT_XSHLEVEL:
+      cellColor =
+          (isSelected) ? getSelectedPaletteColumnColor() : getPaletteColumnColor();
+      sideColor = getPaletteColumnBorderColor();
+      break;
     case UNKNOWN_XSHLEVEL:
     case NO_XSHLEVEL:
     default:


### PR DESCRIPTION
This PR fixes some minor things with the Xsheet's Parent Column dropdown

- Removes Sound and Note columns from the list since you cannot parent columns to these in the Schematic
- Shows parent for Palette columns since it is changable in the Schematic and from the Xsheet.
- Corrects the Palette column color. It was using the default column color (gray-ish) instead of the color assigned to palette columns.