### PR TITLE
tahoma2d/tahoma2d#1030 : Change grass preset default

### DIFF
--- a/stuff/fxs/presets/STD_particlesFx/Grass.fx
+++ b/stuff/fxs/presets/STD_particlesFx/Grass.fx
@@ -1,7 +1,7 @@
 <dvpreset fxId="STD_particlesFx" ver="1.0">
   <params>
     <source_ctrl>
-      0 
+      -1 
     </source_ctrl>
     <multi_source>
       0 0 


### PR DESCRIPTION
As mentionned here: https://github.com/tahoma2d/tahoma2d/discussions/1030

This resolves the issue by setting the default value to -1 .