### PR TITLE
Fix pen issues

### DIFF
--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -1740,7 +1740,9 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
 //----------------------------------------------------------------------
 
 void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
+#if (!defined(LINUX) && !defined(FREEBSD)) || QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+#endif
 
   struct Locals {
     EraserTool *m_this;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2124,7 +2124,9 @@ void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
 //---------------------------------------------------------------------------------------------------------------
 // 明日はここをMyPaintのときにカーソルを消せるように修正する！！！！！！
 void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
+#if (!defined(LINUX) && !defined(FREEBSD)) || QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+#endif
 
   struct Locals {
     ToonzRasterBrushTool *m_this;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1526,7 +1526,9 @@ void ToonzVectorBrushTool::flushTrackPoint() {
 //---------------------------------------------------------------------------------------------------------------
 
 void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
+#if (!defined(LINUX) && !defined(FREEBSD)) || QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+#endif
 
   struct Locals {
     ToonzVectorBrushTool *m_this;

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -281,6 +281,7 @@ void SchematicSceneViewer::mousePressEvent(QMouseEvent *me) {
 /*! Reimplemets the QGraphicsView::mouseMoveEvent()
  */
 void SchematicSceneViewer::mouseMoveEvent(QMouseEvent *me) {
+  // qDebug() << "[mouseMoveEvent]";
   if (m_gestureActive && m_touchDevice == QTouchDevice::TouchScreen &&
       !m_stylusUsed) {
     return;
@@ -550,7 +551,7 @@ void SchematicSceneViewer::tabletEvent(QTabletEvent *e) {
     m_stylusUsed = false;
   }
 
-  e->accept();
+  QGraphicsView::tabletEvent(e);
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following pen issues on Linux

- Fixes #1007 (Linux issue)

When the pen is hovering while using the Brush or Eraser tool on Smart Raster and Vector levels, there was constant `QPaint()` calls while the pen cursor was moving to the new location causing a significant amount of lag.  Oddly, this was not an issue while drawing if you pressed down, waited for the cursor to catch up then started drawing.

This issue appears to be caused by some unknown QT 5.15 bug on Linux systems with calls to `processEvents(QEventLoop::ExcludeUserInputEvents)` that was not an issue when T2D was being built using Qt 5.9.7.

Not sure what QT version this might have started with so I only I blocked execution of this statement for Linux builds using QT 5.15 or later.

- Pen doesn't work in Schematic Viewer. (macOS/Linux issue)

The Schematic Viewer expects pen events to create both Tablet and Mouse events.  Mouse events are actually what drives pen interaction with the schematic viewer.

`QGraphicsView::tabletEvent()` is shadowed in the schematic viewer which forces acceptance of the Tablet event instead of calling the base class function to finish handling it. For Windows this does not prevent the creation of the Mouse event, but it does block it for other builds. To fix, I simply replaced the forced event acceptance with a call to the base class function so the Tablet event is handled normally and creates the Mouse event.
