### PR TITLE
Fix Implicit Hold issues

### DIFF
--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1714,6 +1714,9 @@ void CloneLevelUndo::insertCells() const {
     TXshLevelP lastLevel = 0;
     for (int r = m_range.m_r0; r <= m_range.m_r1; ++r) {
       TXshCell srcCell = xsh->getCell(r, c, false);
+      if (srcCell.isEmpty() && useImplicitHold &&
+          xsh->isColumnEmpty(c + m_range.getColCount()))
+        srcCell = xsh->getCell(r, c, true);
       if (TXshSimpleLevel *srcSl = srcCell.getSimpleLevel()) {
         std::map<TXshSimpleLevel *, TXshLevelP>::iterator lt =
             m_insertedLevels.find(srcSl);
@@ -1809,6 +1812,7 @@ void TCellSelection::cloneLevel() {
       TStageObjectId columnId = TStageObjectId::ColumnId(newCol);
       TXsheet *xsh            = app->getCurrentXsheet()->getXsheet();
       TXshCell cell           = xsh->getCell(m_range.m_r0, newCol);
+      if (cell.isEmpty()) continue;
       TXshSimpleLevel *level  = cell.getSimpleLevel();
       std::string columnName =
           QString::fromStdWString(level->getName()).toStdString();

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -136,7 +136,12 @@ public:
       f++;
       xsh->setCell(i, m_columnIndex, cell);
       int appo = i++;
-      while (i < m_step + appo) xsh->setCell(i++, m_columnIndex, cell);
+      while (i < m_step + appo) {
+        if (i > 0 && Preferences::instance()->isImplicitHoldEnabled())
+          xsh->setCell(i++, m_columnIndex, TXshCell(0, TFrameId::EMPTY_FRAME));
+        else
+          xsh->setCell(i++, m_columnIndex, cell);
+      }
     }
     app->getCurrentScene()->notifySceneChanged();
     app->getCurrentScene()->notifyCastChange();
@@ -679,7 +684,12 @@ bool LevelCreatePopup::apply() {
       sl->setFrame(fid, ri);
     }
     TXshCell cell(sl, fid);
-    for (j = 0; j < step; j++) xsh->setCell(row++, col, cell);
+    for (j = 0; j < step; j++) {
+      if (j > 0 && Preferences::instance()->isImplicitHoldEnabled())
+        xsh->setCell(row++, col, TXshCell(0, TFrameId::EMPTY_FRAME));
+      else
+        xsh->setCell(row++, col, cell);
+    }
   }
 
   //  if (lType == TZP_XSHLEVEL || lType == OVL_XSHLEVEL) {

--- a/toonz/sources/toonz/matchlinecommand.cpp
+++ b/toonz/sources/toonz/matchlinecommand.cpp
@@ -378,23 +378,26 @@ void doCloneLevelNoSave(const TCellSelection::Range &range,
 
       TXshCell oldCell(cell);
       cell.m_level = xl;
-      int k;
-      for (k = range.m_r0; k < r; k++) {
-        if (xsh->getCell(k, c, false).getImage(true).getPointer() ==
-            img.getPointer()) {
-          TFrameId oldFid = xsh->getCell(k, c, false).getFrameId();
-          assert(fid == oldFid);
-          sl->setFrame(fid,
-                       xsh->getCell(k, c + range.getColCount(), false).getImage(true));
-          break;
+      if (!fid.isStopFrame()) {
+        int k;
+        for (k = range.m_r0; k < r; k++) {
+          if (xsh->getCell(k, c, false).getImage(true).getPointer() ==
+              img.getPointer()) {
+            TFrameId oldFid = xsh->getCell(k, c, false).getFrameId();
+            assert(fid == oldFid);
+            sl->setFrame(
+                fid,
+                xsh->getCell(k, c + range.getColCount(), false).getImage(true));
+            break;
+          }
         }
-      }
 
-      if (!keepOldLevel && k >= r) {
-        TImageP newImg(img->cloneImage());
-        assert(newImg);
+        if (!keepOldLevel && k >= r) {
+          TImageP newImg(img->cloneImage());
+          assert(newImg);
 
-        sl->setFrame(fid, newImg);
+          sl->setFrame(fid, newImg);
+        }
       }
 
       cell.m_frameId = fid;

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -31,6 +31,7 @@
 #include "toonz/tstageobjectspline.h"
 #include "toonz/tcamera.h"
 #include "toonz/expressionreferencemonitor.h"
+#include "toonz/preferences.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -1282,6 +1283,39 @@ void removeFx(TXsheet *xsh, TFx *fx) {
 
 //-----------------------------------------------------------------------------
 
+int getChildFrameCount(TXsheet *childXsh) {
+  if (!childXsh) return 0;
+
+  int frameCount = childXsh->getFrameCount();
+
+  // For implicit holds, use last Stop Frame marker or last Key frame marker as
+  // frame count
+  if (Preferences::instance()->isImplicitHoldEnabled()) {
+    for (int c = 0; c < childXsh->getColumnCount(); c++) {
+      int r0, r1;
+
+      r1            = childXsh->getMaxFrame(c);
+      TXshCell cell = childXsh->getCell(r1, c);
+      // If last frame is a stop frame, don't check for keyframe in the same
+      // column in case of overshoot
+      if (cell.getFrameId().isStopFrame()) {
+        frameCount = std::max(frameCount, (r1 + 1));
+        continue;
+      }
+
+      TStageObject *pegbar =
+          childXsh->getStageObject(TStageObjectId::ColumnId(c));
+      if (!pegbar) continue;
+      if (!pegbar->getKeyframeRange(r0, r1)) continue;
+      frameCount = std::max(frameCount, (r1 + 1));
+    }
+  }
+
+  return frameCount;
+}
+
+//-----------------------------------------------------------------------------
+
 void collapseColumns(std::set<int> indices, bool columnsOnly) {
   // return if there is no selected columns
   if (indices.empty()) return;
@@ -1337,7 +1371,7 @@ void collapseColumns(std::set<int> indices, bool columnsOnly) {
   xsh->insertColumn(index);
 
   // set subxsheet cells in the parent xhseet
-  int r, rowCount = childXsh->getFrameCount();
+  int r, rowCount = getChildFrameCount(childXsh);
   for (r = 0; r < rowCount; ++r)
     xsh->setCell(r, index, TXshCell(xl, TFrameId(r + 1)));
 
@@ -1440,7 +1474,7 @@ void collapseColumns(std::set<int> indices,
 
   xsh->insertColumn(index);
 
-  int r, rowCount = childXsh->getFrameCount();
+  int r, rowCount = getChildFrameCount(childXsh);
   for (r = 0; r < rowCount; r++)
     xsh->setCell(r, index, TXshCell(xl, TFrameId(r + 1)));
 
@@ -1514,7 +1548,7 @@ void collapseColumns(std::set<int> indices, const std::set<TFx *> &fxs,
     if (output) xsh->getFxDag()->removeOutputFx(output);
   }
 
-  int rowCount = childXsh->getFrameCount();
+  int rowCount = getChildFrameCount(childXsh);
   int r;
   for (r = 0; r < rowCount; r++)
     xsh->setCell(r, index, TXshCell(xl, TFrameId(r + 1)));

--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -107,7 +107,7 @@ void CellsMover::getImplicitCellInfo() {
       column->getRange(r0, r1);
       TXshCell currentCell;
       for (int r = r0; r <= r1 + 1; r++) {
-        TXshCell tmpCell = cellCol->getCell(r);
+        TXshCell tmpCell = cellCol->getCell(r, false);
         if (tmpCell != currentCell) {
           if (m_qualifiers & eCopyCells)
             cellInfo.insert(r, tmpCell);
@@ -208,10 +208,13 @@ void CellsMover::moveCells(const TPoint &pos) const {
           continue;
         }
         // a cell at the bottom of the inserted cells
-        TXshCell bottomCell = xsh->getCell(r + m_rowCount - 1, c + i);
+        TXshCell bottomCell = xsh->getCell(r + m_rowCount - 1, c + i, false);
         for (int tmp_r = r + m_rowCount; tmp_r <= itr.key() - 1 + m_rowCount;
              tmp_r++)
-          xsh->setCell(tmp_r, c + i, bottomCell);
+          if (Preferences::instance()->isImplicitHoldEnabled())
+            xsh->setCell(tmp_r, c + i, TXshCell(0, TFrameId::EMPTY_FRAME));
+          else
+            xsh->setCell(tmp_r, c + i, bottomCell);
 
         infoId++;
       }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2243,7 +2243,8 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     isRed            = true;
   TXshChildLevel *cl = cell.getChildLevel();
   if (cl && !cell.getFrameId().isStopFrame() &&
-      cell.getFrameId().getNumber() - 1 >= cl->getFrameCount())
+      cell.getFrameId().getNumber() - 1 >= cl->getFrameCount() &&
+      !Preferences::instance()->isImplicitHoldEnabled())
     isRed = true;
   QColor penColor =
       isRed ? QColor(m_viewer->getErrorTextColor()) : m_viewer->getTextColor();


### PR DESCRIPTION
This fixes the following Implicit Hold issues

1. Fixes #1011 
2. Fixes #1023
3. Fixes #1041
4. Fixes a reported issue of New Level creation with Step > 1 creating explicit cells
5. Fixes a Subscene issue mentioned in #1055
       - In this case, the initial frames exposed when Collapsing levels into a Subscene is based on the last keyframe or the  last stop frame, whichever is first. If neither are present, then it's at the last drawing..