### PR TITLE
Fix Autofill toggle command crash

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1088,7 +1088,7 @@ void MainWindow::onOpenReportABug() {
 
 void MainWindow::autofillToggle() {
   TPaletteHandle *h = TApp::instance()->getCurrentPalette();
-  h->toggleAutopaint();
+  if (h->getPalette()) h->toggleAutopaint();
 }
 
 void MainWindow::resetRoomsLayout() {


### PR DESCRIPTION
This fixes #1070 a reported crash caused when toggling Autofill (`Shift+A`) while on the Camera column.