### PR TITLE
Fix Particle Control Port handling

### DIFF
--- a/toonz/sources/stdfx/particlesengine.cpp
+++ b/toonz/sources/stdfx/particlesengine.cpp
@@ -526,6 +526,7 @@ void Particles_Engine::render_particles(
     TRectD bboxForInifiniteSource = ri.m_affine.inv() * outTileBBox;
     TRectD sourceBbox;
     if (values.source_ctrl_val &&
+        (ctrl_ports.find(values.source_ctrl_val) != ctrl_ports.end()) &&
         ctrl_ports.at(values.source_ctrl_val)->isConnected()) {
       (*(ctrl_ports.at(values.source_ctrl_val)))
           ->getBBox(r_frame, sourceBbox, riAux);


### PR DESCRIPTION
Fixes #1030

Added missing logic to test for the existence of the selected control port before checking to see if it was connected.  This missing test was causing the render to fail and reattempt to render repeatedly.