### PR TITLE
Fix Linux plastic tool crash

### DIFF
--- a/ci-scripts/linux/tahoma-build.sh
+++ b/ci-scripts/linux/tahoma-build.sh
@@ -14,7 +14,6 @@ cd build
 source /opt/qt515/bin/qt515-env.sh
 
 cmake ../sources \
-    -DWITH_SYSTEM_SUPERLU:BOOL=OFF
+    -DWITH_SYSTEM_SUPERLU=ON
 
 make -j7
-


### PR DESCRIPTION
Fixes #1036 by switching the build to use the system SuperLU version 5.x.

T2D/OT was originally built using using a customized version of SuperLU 4.1 to make it thread-safe so it wouldn't crash. Since SuperLU 5, it is thread-safe and the customization is no longer needed.