### PR TITLE
Remove .gitkeep files from package

### DIFF
--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -35,6 +35,8 @@ mv appdir/usr/share/tahoma2d/stuff Tahoma2D/tahomastuff
 chmod -R 777 Tahoma2D/tahomastuff
 rmdir appdir/usr/share/tahoma2d
 
+find Tahoma2D/tahomastuff -name .gitkeep -exec rm -f {} \;
+
 if [ -d ../../thirdparty/apps/ffmpeg/bin ]
 then
    echo ">>> Copying FFmpeg to Tahoma2D/ffmpeg"

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -22,6 +22,8 @@ fi
 cp -R stuff $TOONZDIR/Tahoma2D.app/tahomastuff
 chmod -R 777 $TOONZDIR/Tahoma2D.app/tahomastuff
 
+find $TOONZDIR/Tahoma2D.app/tahomastuff -name .gitkeep -exec rm -f {} \;
+
 if [ -d thirdparty/apps/ffmpeg/bin ]
 then
    echo ">>> Copying FFmpeg to $TOONZDIR/Tahoma2D.app/ffmpeg"

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -43,6 +43,8 @@ echo ">>> Copying stuff to Tahoma2D\tahomastuff"
 mkdir Tahoma2D\tahomastuff
 xcopy /Y /E ..\..\stuff Tahoma2D\tahomastuff
 
+del /A- /S Tahoma2D\tahomastuff\*.gitkeep
+
 IF EXIST ..\..\thirdparty\apps\ffmpeg\bin (
    echo ">>> Copying FFmpeg to Tahoma2D\ffmpeg"
    IF EXIST Tahoma2D\ffmpeg rmdir /S /Q Tahoma2D\ffmpeg


### PR DESCRIPTION
This fixes #1079 caused by the presence of .gitkeep files.

Updated packaging scripts to remove .gitkeep files that are normally needed to keep empty stuff sub-folders in git but not needed in the final package.