### PR TITLE
Fix using favorite Vector Brush

### DIFF
--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -925,7 +925,7 @@ public:
   std::vector<StyleChooserPage *> *getStyleSetList(StylePageType pageType);
 
   void setUpdated(TFilePath setPath);
-  TFilePath getSetStyleFolder(QString setName);
+  TFilePath getSetStyleFolder(QString setName, StylePageType pageType);
 
   void updatePage(int pageIndex);
 


### PR DESCRIPTION
Fixes #1054 

Vector brushes were stored as vector styles when added to Favorites. As a result it behaved differently when used from Favorites.

In order to maintain a Vector brushes' drawing behavior, I store Vector brushes  in a separate group under My Favorites.

![image](https://user-images.githubusercontent.com/19245851/205219461-2061ee46-eee4-4fcb-88f3-b494c1a39d3a.png)

NOTE: If you migrate your favorites when upgrading and have a Vector brush in My Favorites grouped with Vector styles, you will need to remove it and re-add it back to correct the brush behavior.