### PR TITLE
Fix moving styles in palette

### DIFF
--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -202,15 +202,16 @@ void TPalette::Page::insertStyle(int indexInPage, TPixel32 color) {
 
 //-------------------------------------------------------------------
 
-void TPalette::Page::removeStyle(int indexInPage) {
+void TPalette::Page::removeStyle(int indexInPage, bool flagOnly) {
   if (indexInPage < 0 || indexInPage >= getStyleCount()) return;
   assert(m_palette);
   int styleId = getStyleId(indexInPage);
   assert(0 <= styleId && styleId < m_palette->getStyleCount());
   assert(m_palette->m_styles[styleId].first == this);
   m_palette->m_styles[styleId].first = 0;
-  m_palette->m_styles[styleId].second =
-      TColorStyleP(new TSolidColorStyle(TPixel32::Black));
+  if (!flagOnly)
+    m_palette->m_styles[styleId].second =
+        TColorStyleP(new TSolidColorStyle(TPixel32::Black));
   m_styleIds.erase(m_styleIds.begin() + indexInPage);
 }
 

--- a/toonz/sources/include/tpalette.h
+++ b/toonz/sources/include/tpalette.h
@@ -163,8 +163,10 @@ public:
     //! its
     //!  id at the specified position in the page.
 
-    void removeStyle(int indexInPage);  //!< Removes the style at the specified
-                                        //! position from this page.
+    void removeStyle(
+        int indexInPage,
+        bool flagOnly = false);  //!< Removes the style at the specified
+                                 //! position from this page.
     int search(int styleId)
         const;  //!< Returns the page position of the specified style id,
                 //!  or \p -1 if it cannot be found on the page.

--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -212,7 +212,7 @@ public:
     int k;
     for (k = 0; k < count; k++) {
       styles.push_back(dstPage->getStyleId(h));
-      dstPage->removeStyle(h);
+      dstPage->removeStyle(h, true);
     }
     k = 0;
     for (i = m_srcIndicesInPage.begin(); i != m_srcIndicesInPage.end();
@@ -235,7 +235,7 @@ public:
       int index = *i;
       if (m_dstPageIndex == m_srcPageIndex && index < k) k--;
       styles.push_back(srcPage->getStyleId(index));
-      srcPage->removeStyle(index);
+      srcPage->removeStyle(index, true);
     }
     for (j = styles.begin(); j != styles.end(); ++j)
       dstPage->insertStyle(k, *j);
@@ -300,7 +300,7 @@ public:
     assert(page);
     int indexInPage = page->search(m_styleId);
     assert(indexInPage >= 0);
-    page->removeStyle(indexInPage);
+    page->removeStyle(indexInPage, true);
     m_paletteHandle->notifyPaletteChanged();
   }
   void redo() const override {

--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -153,6 +153,7 @@ bool pasteStylesWithoutUndo(TPalette *palette, TPaletteHandle *pltHandle,
   // cerco il punto di inserimento (dopo lo stile corrente)
   int currentStyleIndex = pltHandle->getStyleIndex();
   int indexInPage       = page->search(currentStyleIndex) + 1;
+  if (pageIndex == 0 && indexInPage < 2) indexInPage = 2;
   const StyleData *data =
       dynamic_cast<const StyleData *>(QApplication::clipboard()->mimeData());
   if (!data) return false;
@@ -298,6 +299,7 @@ public:
     TPalette::Page *page = m_palette->getPage(m_pageIndex);
     assert(page);
     int indexInPage       = page->search(m_oldStyleIndex) + 1;
+    if (m_pageIndex == 0 && indexInPage < 2) indexInPage = 2;
     const StyleData *data = dynamic_cast<const StyleData *>(m_data);
     assert(data);
     std::set<int> styleIndicesInPage;


### PR DESCRIPTION
This PR does the following:

1. Fixes #1014 
   
This was caused by changes made in PR #966 which defaulted a deleted style to Solid black.  When styles are moved, it does a delete/insert so it caused a moved style to default to black.  Augmented logic to not default the deleted style when moving.

3. Fixes an issue when pasting a style into the 1st palette page and it pastes before Style 0.

This happens when you copy a style from a different page and paste it on the 1st page of the palette without first selecting a style.  When no style is selected, it puts the new style in the beginning and causes Style 0 and 1 to shift down.  Style 0 and 1 should never move, so I modified it to force it to paste in right afterwards.
