### PR TITLE
v1.3.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.3.0{build}
+version: 1.3.1{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.3</string>
+	<string>1.3.1</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -19,7 +19,7 @@ public:
 private:
   const char *applicationName     = "Tahoma2D";
   const float applicationVersion  = 1.3;
-  const float applicationRevision = 0;
+  const float applicationRevision = 1;
   const char *applicationNote     = "";
 };
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(VERSION 1.3)
+set(VERSION 1.3.1)
 
 set(MOC_HEADERS
     aboutpopup.h

--- a/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
+++ b/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
@@ -26,6 +26,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.3.1" date="2022-12-09"/>
     <release version="1.3.0" date="2022-05-06"/>
     <release version="1.2.0" date="2021-05-03"/>
     <release version="1.1.0" date="2020-10-30"/>


### PR DESCRIPTION
This bumps up the version on the master branch to 1.3.1 in preparation of the fix release.

The actual 1.3.1 release will be built from the `v1.3.1` branch that will only contain fixes since `v1.3`. 