### PR TITLE
Fix deprecated issues in Github Actions environment

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         compiler: [ gcc, clang ]
@@ -16,12 +16,12 @@ jobs:
             cc: clang
             cxx: clang++
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Dependencies
         run: |
           ci-scripts/linux/tahoma-install.sh
           sudo apt-get install ccache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             /home/runner/.ccache

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -4,15 +4,15 @@ on: [push, pull_request]
 
 jobs:
   macOS:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Dependencies
         run: |
           ci-scripts/osx/tahoma-install.sh
           brew install ccache
           mkdir /Users/runner/.ccache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             /Users/runner/.ccache

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -6,7 +6,7 @@ jobs:
   Windows:
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: true
       - name: Install Dependencies
@@ -24,7 +24,7 @@ jobs:
         run: |
           ci-scripts\windows\tahoma-get3rdpartyapps.bat
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1
       - name: Build Tahoma2D
         run: |
           ci-scripts\windows\tahoma-build.bat

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo add-apt-repository --yes ppa:beineri/opt-qt-5.15.2-bionic
+sudo add-apt-repository --yes ppa:beineri/opt-qt-5.15.2-focal
 sudo apt-get update
 sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt515script libsuperlu-dev qt515svg qt515tools qt515multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg-turbo8-dev libturbojpeg0-dev libglib2.0-dev qt515serialport
 # Removed: libopenjpeg-dev 


### PR DESCRIPTION
Due to deprecated components in Github Action builds, the following has been updated:

### Windows Builds
- Update actions/checkout to v3
- Update microsoft/setup-msbuild to v1.1

### macOS Builds
- Update build environment to macos-11 (Big Sur)
- Update actions/checkout to v3
- Update actions/cache to v3

### Linux Builds
- Update build environment to ubuntu-20.04 (Focal Fossa)
- Update actions/checkout to v3
- Update actions/cache to v3