### PR TITLE
Allow tag actions on non-current frame

### DIFF
--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2755,7 +2755,8 @@ public:
   ToggleTaggedFrame() : MenuItemHandler(MI_ToggleTaggedFrame) {}
   void execute() override {
     TApp *app = TApp::instance();
-    int frame = app->getCurrentFrame()->getFrame();
+    int frame = app->getCurrentXsheetViewer()->getContextMenuRow();
+    if (frame < 0) frame = app->getCurrentFrame()->getFrame();
     assert(frame >= 0);
     TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
 
@@ -2777,7 +2778,8 @@ public:
   EditTaggedFrame() : MenuItemHandler(MI_EditTaggedFrame) {}
   void execute() override {
     TApp *app = TApp::instance();
-    int frame = app->getCurrentFrame()->getFrame();
+    int frame = app->getCurrentXsheetViewer()->getContextMenuRow();
+    if (frame < 0) frame = app->getCurrentFrame()->getFrame();
     assert(frame >= 0);
     TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
 

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -1285,6 +1285,8 @@ public:
   QList<int> availableFramesPerPage();
   void zoomToFramesPerPage(int frames);
 
+  int getContextMenuRow() { return m_rowArea->getContextMenuRow(); }
+
 protected:
   void scrollToColumn(int col);
   void scrollToHorizontalRange(int x0, int x1);

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1297,6 +1297,9 @@ void RowArea::mouseReleaseEvent(QMouseEvent *event) {
 //-----------------------------------------------------------------------------
 
 void RowArea::contextMenuEvent(QContextMenuEvent *event) {
+  TPoint pos(event->pos().x(), event->pos().y());
+  m_contextMenuRow = m_viewer->xyToPosition(pos).frame();
+
   OnionSkinMask osMask =
       TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
 

--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -44,6 +44,8 @@ class RowArea final : public QWidget {
   // panning by middle-drag
   bool m_isPanning;
 
+  int m_contextMenuRow;
+
   void drawRows(QPainter &p, int r0, int r1);
   void drawPlayRangeBackground(QPainter &p, int r0, int r1);
   void drawPlayRange(QPainter &p, int r0, int r1);
@@ -70,6 +72,8 @@ public:
   RowArea(XsheetViewer *parent, Qt::WFlags flags = 0);
 #endif
   ~RowArea();
+
+  int getContextMenuRow() { return m_contextMenuRow; }
 
 protected:
   void paintEvent(QPaintEvent *) override;


### PR DESCRIPTION
This allows you to `Toggle Navigation Tag` and `Edit Tag` by right-clicking on the frame you want to perform this on without having to first switch to that frame.