### PR TITLE
Update displaying of Column/Pegbar Number

### DIFF
--- a/toonz/sources/include/toonzqt/fxschematicnode.h
+++ b/toonz/sources/include/toonzqt/fxschematicnode.h
@@ -264,6 +264,8 @@ public:
 class FxSchematicNode : public SchematicNode {
   Q_OBJECT
 
+  int m_columnIndex;
+
 protected:
   enum eDropActionMode { eShift, eNone };
 
@@ -346,6 +348,9 @@ public:
 
   void toggleNormalIconView() { m_isNormalIconView = !m_isNormalIconView; }
   bool isNormalIconView() { return m_isNormalIconView; }
+
+  void setColumnIndex(int columnIndex) { m_columnIndex = columnIndex; }
+  int getColumnIndex() { return m_columnIndex; }
 signals:
 
   void switchCurrentFx(TFx *fx);
@@ -436,7 +441,6 @@ class FxSchematicZeraryNode final : public FxSchematicNode {
   Q_OBJECT
 
   FxPainter *m_painter;
-  int m_columnIndex;
   SchematicToggle *m_renderToggle, *m_cameraStandToggle;
 
 public:
@@ -449,7 +453,6 @@ public:
 
   void resize(bool maximizeNode) override;
 
-  int getColumnIndex() { return m_columnIndex; }
   bool isCached() const override;
 
 protected:
@@ -473,7 +476,6 @@ class FxSchematicColumnNode final : public FxSchematicNode {
   SchematicThumbnailToggle *m_resizeItem;
   SchematicToggle *m_renderToggle, *m_cameraStandToggle;
   FxColumnPainter *m_columnPainter;
-  int m_columnIndex;
   bool m_isOpened;
 
 public:
@@ -489,7 +491,6 @@ public:
   void getLevelTypeAndName(int &, QString &);
 
   void resize(bool maximizeNode) override;
-  int getColumnIndex() { return m_columnIndex; }
 
 protected:
   void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *me) override;
@@ -515,7 +516,6 @@ class FxSchematicPaletteNode final : public FxSchematicNode {
 
   SchematicToggle *m_renderToggle;
   FxPalettePainter *m_palettePainter;
-  int m_columnIndex;
 
 public:
   FxSchematicPaletteNode(FxSchematicScene *scene, TPaletteColumnFx *fx);
@@ -526,7 +526,6 @@ public:
              QWidget *widget = 0) override;
   QPixmap getPixmap();
   bool isOpened() override { return false; }
-  int getColumnIndex() { return m_columnIndex; }
 
   QString getPaletteName();
 

--- a/toonz/sources/include/toonzqt/stageschematicnode.h
+++ b/toonz/sources/include/toonzqt/stageschematicnode.h
@@ -484,6 +484,7 @@ public:
   void resize(bool maximized);
 
   void getLevelTypeAndName(int &, QString &);
+  int getColumnNumber();
 
 private:
   void updatePortsPosition();

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -1242,8 +1242,7 @@ glPopMatrix();
     std::string name;
     name = (m_parentProbeEnabled ? "Linking " : "Link ") +
            removeTrailingH(magicLink.m_h0.getHandle()) + " to " +
-           obj->getName() + " (Col " + std::to_string(h1.m_columnIndex + 1) +
-           ")/" + removeTrailingH(h1.getHandle());
+           obj->getFullName() + "/" + removeTrailingH(h1.getHandle());
 
     int code = TD_MagicLink + i;
     glPushName(code);

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -413,6 +413,8 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
 
   // enable to choose target pegbar with combobox
   m_currentStageObjectCombo = new QComboBox(this);
+  m_currentStageObjectCombo->setSizeAdjustPolicy(
+      QComboBox::SizeAdjustPolicy::AdjustToContents);
 
   TEnumProperty *activeAxisProp =
       dynamic_cast<TEnumProperty *>(m_pg->getProperty("Active Axis"));
@@ -989,7 +991,7 @@ void ArrowToolOptionsBox::updateStageObjectComboItems() {
     TStageObject *pegbar = xsh->getStageObject(id);
     QString itemName     = (id.isTable())
                            ? tr("Table")
-                           : QString::fromStdString(pegbar->getName());
+                           : QString::fromStdString(pegbar->getFullName());
     // store the item with ObjectId data
     m_currentStageObjectCombo->addItem(itemName, (int)id.getCode());
   }
@@ -1016,7 +1018,7 @@ void ArrowToolOptionsBox::syncCurrentStageObjectComboItem() {
   // column.)
   else {
     TStageObject *pegbar = m_xshHandle->getXsheet()->getStageObject(curObjId);
-    QString itemName     = QString::fromStdString(pegbar->getName());
+    QString itemName     = QString::fromStdString(pegbar->getFullName());
     std::string itemNameString = itemName.toStdString();
     // store the item with ObjectId data
     if (itemName == "Peg10000") itemName = "Path";

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1306,7 +1306,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {showQuickToolbar, tr("Show Quick Toolbar")},
       {expandFunctionHeader,
        tr("Expand Function Editor Header to Match Quick Toolbar Height*")},
-      {showColumnNumbers, tr("Show Column Numbers in Column Headers")},
+      {showColumnNumbers, tr("Show Column Numbers")},
       {parentColorsInXsheetColumn,
        tr("Show Column Parent's Color in the Xsheet")},
       {highlightLineEverySecond, tr("Highlight Line Every Second")},

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -467,7 +467,8 @@ void ChangeObjectParent::refresh() {
     TStageObjectId newTextID = id;
     QString newTextTr;
     if (tree->getStageObject(i)->hasSpecifiedName())
-      newTextTr = QString::fromStdString(tree->getStageObject(i)->getName());
+      newTextTr =
+          QString::fromStdString(tree->getStageObject(i)->getFullName());
     else
       newTextTr = getNameTr(id);
 
@@ -486,7 +487,7 @@ void ChangeObjectParent::refresh() {
         continue;
 
       QColor unused;
-        viewer->getColumnColor(newTextBG, unused, id.getIndex(), xsh);
+      viewer->getColumnColor(newTextBG, unused, id.getIndex(), xsh);
     } else
       continue;
 
@@ -682,8 +683,10 @@ void RenameColumnField::show(const QRect &rect, int col) {
                      ->getName();
   TXshColumn *column          = xsh->getColumn(col);
   TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(column);
+/*
   if (zColumn)
     name = ::to_string(zColumn->getZeraryColumnFx()->getZeraryFx()->getName());
+*/
   setText(QString(name.c_str()));
   selectAll();
 
@@ -705,8 +708,7 @@ void RenameColumnField::renameColumn() {
   if (zColumn)
     TFxCommand::renameFx(zColumn->getZeraryColumnFx(), ::to_wstring(newName),
                          m_xsheetHandle);
-  else
-    TStageObjectCmd::rename(columnId, newName, m_xsheetHandle);
+  TStageObjectCmd::rename(columnId, newName, m_xsheetHandle);
   m_xsheetHandle->notifyXsheetChanged();
   m_col = -1;
   setText("");
@@ -1080,12 +1082,12 @@ void ColumnArea::DrawHeader::drawColumnName() const {
     if (levels.size() == 1) name = to_string((*levels.begin())->getName());
   }
   //  if (col < 0) name = std::string("Camera");
-
+/*
   // ZeraryFx columns store name elsewhere
   TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(column);
   if (zColumn && !isEmpty)
     name = ::to_string(zColumn->getZeraryColumnFx()->getZeraryFx()->getName());
-
+*/
   QRect columnName = o->rect((col < 0) ? PredefinedRect::CAMERA_LAYER_NAME
                                        : PredefinedRect::LAYER_NAME)
                          .translated(orig);

--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -9,6 +9,7 @@
 #include "toonz/tcolumnfxset.h"
 #include "toonz/txshzeraryfxcolumn.h"
 #include "toonz/tstageobjecttree.h"
+#include "toonz/tstageobjectcmd.h"
 #include "toonz/txshlevelcolumn.h"
 #include "toonz/txshpalettecolumn.h"
 #include "toonz/toonzscene.h"
@@ -843,6 +844,14 @@ void InsertFxUndo::redo() const {
   if (m_insertedColumn) {
     FxCommandUndo::insertColumn(xsh, m_insertedColumn.getPointer(), m_colIdx,
                                 m_columnReplacesHole, true);
+
+    TStageObjectId columnId = TStageObjectId::ColumnId(m_colIdx);
+    std::wstring wname =
+        m_insertedColumn->getZeraryColumnFx()->getZeraryFx()->getName();
+    std::string str(wname.begin(), wname.end());
+
+    TStageObjectCmd::rename(columnId, str, m_app->getCurrentXsheet());
+
     return;
   }
 

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -13,6 +13,7 @@
 #include "toonz/tcamera.h"
 #include "toonz/doubleparamcmd.h"
 #include "toonz/tpinnedrangeset.h"
+#include "toonz/preferences.h"
 
 // TnzExt includes
 #include "ext/plasticskeleton.h"
@@ -557,13 +558,20 @@ string TStageObject::getName() const {
 string TStageObject::getFullName() const {
   string name = getName();
   if (m_id.isColumn()) {
-    if (name.find("Col") == 0 && name.length() > 3 &&
-        name.find_first_not_of("0123456789", 3) == string::npos)
-      return name;
-    else
-      return name + " (" + std::to_string(m_id.getIndex() + 1) + ")";
-  } else
-    return name;
+    if (!Preferences::instance()->isShowColumnNumbersEnabled()) return name;
+
+    if (name.find("Col") != 0 ||
+        (name.length() > 3 &&
+         name.find_first_not_of("0123456789", 3) != string::npos))
+      return name + " (Col" + std::to_string(m_id.getIndex() + 1) + ")";
+  } else if (m_id.isPegbar()) {
+    if (name.find("Peg") != 0 ||
+        (name.length() > 3 &&
+         name.find_first_not_of("0123456789", 3) != string::npos))
+      return name + " (Peg" + std::to_string(m_id.getIndex() + 1) + ")";
+  }
+
+  return name;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -343,6 +343,8 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
     painter.fillRect(x0, y0, width, y3 - y0, getViewer()->getBGColor());
   }
 
+  int groupChannelCount = 0;
+  int firstX0           = 0;
   for (int c = c0; c <= c1; ++c) {
     FunctionTreeModel::Channel *channel = m_sheet->getChannel(c);
     if (!channel) {
@@ -363,14 +365,21 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
 
     /*---- If the group is different from the before and after, flags are set
      * respectively ---*/
-    bool firstGroupColumn = prevGroup != group;
-    bool lastGroupColumn  = nextGroup != group;
+    bool firstGroupColumn = prevGroup != group || c == 0;
+    bool lastGroupColumn  = nextGroup != group || c == c1;
 
     /*--- The left and right coordinates of the current column ---*/
     int x0 = getViewer()->columnToX(c);
     int x1 = getViewer()->columnToX(c + 1) - 1;
     // Column width
     int width = x1 - x0 + 1;
+
+    if (firstGroupColumn) {
+      groupChannelCount = 0;
+      firstX0           = x0;
+    }
+
+    groupChannelCount++;
 
     QRect selectedRect = m_sheet->getSelectedCells();
     bool isSelected =
@@ -414,13 +423,13 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
     }
 
     // group name
-    if (firstGroupColumn) {
-      int tmpwidth = (lastGroupColumn) ? width : width * 2;
+    if (lastGroupColumn) {
+      int tmpwidth = width * groupChannelCount;
       painter.setPen(getViewer()->getTextColor());
       if (group == currentGroup)
         painter.setPen(m_sheet->getViewer()->getCurrentTextColor());
-      text = group->getShortName();
-      painter.drawText(x0 + d, y0, tmpwidth - d, y1 - y0 + 1,
+      text = group->getLongName();
+      painter.drawText(firstX0 + d, y0, tmpwidth - d, y1 - y0 + 1,
                        Qt::AlignLeft | Qt::AlignVCenter, text);
     }
   }

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -272,12 +272,9 @@ QVariant StageObjectChannelGroup::data(int role) const {
   if (role == Qt::DisplayRole) {
     std::string name = (m_stageObject->getId().isTable())
                            ? FunctionTreeView::tr("Table").toStdString()
-                           : m_stageObject->getName();
-    std::string id = m_stageObject->getId().toString();
+                           : m_stageObject->getFullName();
 
-    return (name == id) ? QString::fromStdString(name)
-                        : QString::fromStdString(name + " (" + id + ")");
-
+    return QString::fromStdString(name);
   } else if (role == Qt::ForegroundRole) {
     FunctionTreeModel *model = dynamic_cast<FunctionTreeModel *>(getModel());
     if (!model)
@@ -345,7 +342,9 @@ QString FxChannelGroup::getShortName() const {
 //-----------------------------------------------------------------------------
 
 QString FxChannelGroup::getLongName() const {
-  return QString::fromStdWString(m_fx->getFxId());
+  std::wstring name = m_fx->getName();
+  std::wstring id   = m_fx->getFxId();
+  return QString::fromStdWString(id + L" (" + name + L")");
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -204,15 +204,21 @@ void FxColumnPainter::paint(QPainter *painter,
   painter->setPen(viewer->getTextColor());
   painter->setBrush(Qt::NoBrush);
 
+  bool showColumnNumber = Preferences::instance()->isShowColumnNumbersEnabled();
+  int rectAdj           = 0;
+  if (showColumnNumber) rectAdj = -20;
+
   QRectF columnNameRect;
   QRectF levelNameRect;
+  QRectF colNumberRect;
   if (m_parent->isNormalIconView()) {
-    columnNameRect = QRect(18, 2, 54, 14);
-    levelNameRect  = QRectF(18, 16, 54, 14);
+    columnNameRect = QRect(18, 2, 74 + rectAdj, 14);
+    levelNameRect  = QRectF(18, 16, 74, 14);
+    colNumberRect  = QRectF(72, 2, 20, 14);
   } else {
-    columnNameRect = QRect(4, 2, 78, 22);
-    levelNameRect  = QRectF(4, 26, 78, 22);
-
+    columnNameRect = QRect(4, 2, 94 + rectAdj, 22);
+    levelNameRect  = QRectF(4, 26, 94, 22);
+    colNumberRect  = QRectF(76, 2, 24, 22);
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
     painter->setFont(fnt);
@@ -227,6 +233,12 @@ void FxColumnPainter::paint(QPainter *painter,
         elideText(m_name, painter->font(), columnNameRect.width());
     painter->drawText(columnNameRect, Qt::AlignLeft | Qt::AlignVCenter,
                       elidedName);
+
+    // column number
+    if (showColumnNumber) {
+      QString colNumber = QString::number(m_parent->getColumnIndex() + 1);
+      painter->drawText(colNumberRect, Qt::AlignCenter, colNumber);
+    }
   }
 
   // level name
@@ -429,18 +441,25 @@ void FxPalettePainter::paint(QPainter *painter,
   else
     painter->drawRoundRect(QRectF(0, 0, m_width, m_height), 10, 30);
 
+  bool showColumnNumber = Preferences::instance()->isShowColumnNumbersEnabled();
+  int rectAdj           = 0;
+  if (showColumnNumber) rectAdj = -20;
+
   // draw icon
   QRect paletteRect;
   QRectF idRect;
   QRectF palNameRect;
+  QRectF colNumberRect;
   if (m_parent->isNormalIconView()) {
-    paletteRect = QRect(-3, -1, 20, 16);
-    idRect      = QRectF(18, 2, 54, 14);
-    palNameRect = QRectF(18, 16, 54, 14);
+    paletteRect   = QRect(-3, -1, 20, 16);
+    idRect        = QRectF(18, 2, 74 + rectAdj, 14);
+    palNameRect   = QRectF(18, 16, 74, 14);
+    colNumberRect = QRectF(72, 2, 20, 14);
   } else {
-    paletteRect = QRect(4, -6, 35, 28);
-    idRect      = QRectF(25, 2, 49, 22);
-    palNameRect = QRectF(4, 26, 78, 22);
+    paletteRect   = QRect(4, -6, 35, 28);
+    idRect        = QRectF(25, 2, 69 + rectAdj, 22);
+    palNameRect   = QRectF(4, 26, 98, 22);
+    colNumberRect = QRectF(76, 2, 24, 22);
 
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
@@ -461,9 +480,13 @@ void FxPalettePainter::paint(QPainter *painter,
     if (m_parent->isNormalIconView()) {
       QString elidedName = elideText(m_name, painter->font(), w);
       painter->drawText(idRect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
-    } else
-      painter->drawText(idRect, Qt::AlignRight | Qt::AlignVCenter,
-                        QString::number(m_parent->getColumnIndex() + 1));
+    }
+
+    // column number
+    if (showColumnNumber) {
+      QString colNumber = QString::number(m_parent->getColumnIndex() + 1);
+      painter->drawText(colNumberRect, Qt::AlignCenter, colNumber);
+    }
   }
 
   // level name
@@ -618,6 +641,10 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
   columnFont.setPixelSize(columnFont.pixelSize() - 1);
   painter->setFont(columnFont);
 
+  bool showColumnNumber = Preferences::instance()->isShowColumnNumbersEnabled();
+  int rectAdj           = 0;
+  if (showColumnNumber && m_type == eZeraryFx) rectAdj = -20;
+
   // draw fxId in the bottom part
   painter->setPen(viewer->getTextColor());
   QString label;
@@ -648,7 +675,7 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
     if (!sceneFx) return;
     if (sceneFx->getCurrentFx() == m_parent->getFx())
       painter->setPen(viewer->getSelectedNodeTextColor());
-    QRectF rect(3, 2, m_width - 21, 14);
+    QRectF rect(3, 2, m_width + rectAdj - 21, 14);
     int w = rect.width();
     if (label == m_name) {
       rect.adjust(0, 0, 0, 14);
@@ -656,6 +683,13 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
     }
     QString elidedName = elideText(m_name, painter->font(), w);
     painter->drawText(rect, Qt::TextWrapAnywhere, elidedName);
+
+    // column number
+    if (showColumnNumber && m_type == eZeraryFx) {
+      QString colNumber = QString::number(m_parent->getColumnIndex() + 1);
+      QRectF colNumberRect(72, 2, 20, 14);
+      painter->drawText(colNumberRect, Qt::AlignCenter, colNumber);
+    }
   }
 }
 
@@ -865,20 +899,21 @@ void FxPainter::paint_small(QPainter *painter) {
       QRectF rect(14, 2, 68, 22);
       int w              = rect.width();
       QString elidedName = elideText(m_name, painter->font(), w);
-      painter->drawText(rect, elidedName);
+      painter->drawText(rect, elidedName, Qt::AlignLeft | Qt::AlignVCenter);
     }
   } else {
-    painter->drawPixmap(16, 6, 38, 38,
+    painter->drawPixmap(22, 6, 44, 38,
                         FxIconPixmapManager::instance()->getFxIconPm(m_fxType));
   }
 
   // show column number on the right side of icon
-  if (m_type == eZeraryFx) {
+  if (Preferences::instance()->isShowColumnNumbersEnabled() &&
+      m_type == eZeraryFx) {
     FxSchematicZeraryNode *zeraryNode =
         dynamic_cast<FxSchematicZeraryNode *>(m_parent);
     if (zeraryNode) {
-      QRect idRect(30, 10, 46, 38);
-      painter->drawText(idRect, Qt::AlignRight | Qt::AlignBottom,
+      QRectF idRect(76, 2, 24, 22);
+      painter->drawText(idRect, Qt::AlignCenter,
                         QString::number(zeraryNode->getColumnIndex() + 1));
     }
   }
@@ -2412,14 +2447,14 @@ bool isMatteFx(std::string id) {
 
 FxSchematicNormalFxNode::FxSchematicNormalFxNode(FxSchematicScene *scene,
                                                  TFx *fx)
-    : FxSchematicNode(scene, fx, 90, 32, eNormalFx) {
+    : FxSchematicNode(scene, fx, 110, 32, eNormalFx) {
   SchematicViewer *viewer = scene->getSchematicViewer();
 
   checkDynamicInputPortSize();
 
   // resize if small scaled
   if (!m_isNormalIconView) {
-    setWidth(70);
+    setWidth(90);
     setHeight(50);
   }
 
@@ -2480,7 +2515,7 @@ FxSchematicNormalFxNode::FxSchematicNormalFxNode(FxSchematicScene *scene,
     break;
   }
 
-  m_nameItem = new SchematicName(this, 72, 20);  // for rename
+  m_nameItem = new SchematicName(this, 92, 20);  // for rename
   m_outDock  = new FxSchematicDock(this, "", 0, eFxOutputPort);
   m_linkDock = new FxSchematicDock(this, "", 0, eFxLinkPort);
 
@@ -2504,18 +2539,18 @@ FxSchematicNormalFxNode::FxSchematicNormalFxNode(FxSchematicScene *scene,
 
   if (m_isNormalIconView) {
     m_nameItem->setPos(1, -1);
-    m_outDock->setPos(72, 14);
-    m_linkDock->setPos(72, 7);
-    m_renderToggle->setPos(72, 0);
+    m_outDock->setPos(92, 14);
+    m_linkDock->setPos(92, 7);
+    m_renderToggle->setPos(92, 0);
   } else {
     QFont fnt = m_nameItem->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
     m_nameItem->setFont(fnt);
 
     m_nameItem->setPos(-1, 0);
-    m_outDock->setPos(60, 0);
-    m_linkDock->setPos(60, -5);
-    m_renderToggle->setPos(30, -5);
+    m_outDock->setPos(80, 0);
+    m_linkDock->setPos(80, -5);
+    m_renderToggle->setPos(50, -5);
   }
 
   m_nameItem->setZValue(3);
@@ -2721,24 +2756,24 @@ void FxSchematicNormalFxNode::resize(bool maximized) {}
 
 FxSchematicZeraryNode::FxSchematicZeraryNode(FxSchematicScene *scene,
                                              TZeraryColumnFx *fx)
-    : FxSchematicNode(scene, fx, 90, 32, eZeraryFx) {
+    : FxSchematicNode(scene, fx, 110, 32, eZeraryFx) {
   SchematicViewer *viewer = scene->getSchematicViewer();
 
   checkDynamicInputPortSize();
 
   if (!m_isNormalIconView) {
-    setWidth(90);
+    setWidth(110);
     setHeight(50);
   }
 
-  m_columnIndex = fx->getColumnIndex();
+  setColumnIndex(fx->getColumnIndex());
 
-  TXshColumn *column = scene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = scene->getXsheet()->getColumn(getColumnIndex());
 
   TFx *zeraryFx     = fx->getZeraryFx();
-  TStageObjectId id = TStageObjectId::ColumnId(m_columnIndex);
+  TStageObjectId id = TStageObjectId::ColumnId(getColumnIndex());
   std::string name  = scene->getXsheet()->getStageObject(id)->getName();
-
+/*
   if (column) {
     // ZeraryFx columns store name elsewhere
     TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(column);
@@ -2746,13 +2781,13 @@ FxSchematicZeraryNode::FxSchematicZeraryNode(FxSchematicScene *scene,
       name =
           ::to_string(zColumn->getZeraryColumnFx()->getZeraryFx()->getName());
   }
-
+*/
   m_name = QString::fromStdString(name);
 
   setToolTip(QString("%1 : %2").arg(
       m_name, QString::fromStdWString(zeraryFx->getFxId())));
 
-  m_nameItem = new SchematicName(this, 72, 20);  // for rename
+  m_nameItem = new SchematicName(this, 92, 20);  // for rename
   m_outDock  = new FxSchematicDock(this, "", 0, eFxOutputPort);
   m_linkDock = new FxSchematicDock(this, "", 0, eFxLinkPort);
   m_renderToggle =
@@ -2794,10 +2829,10 @@ FxSchematicZeraryNode::FxSchematicZeraryNode(FxSchematicScene *scene,
   // define positions
   if (m_isNormalIconView) {
     m_nameItem->setPos(1, -1);
-    m_outDock->setPos(72, 14);
-    m_linkDock->setPos(72, m_height);
-    m_renderToggle->setPos(72, 0);
-    m_cameraStandToggle->setPos(72, 7);
+    m_outDock->setPos(92, 14);
+    m_linkDock->setPos(92, m_height);
+    m_renderToggle->setPos(92, 0);
+    m_cameraStandToggle->setPos(92, 7);
 
   } else {
     QFont fnt = m_nameItem->font();
@@ -2805,10 +2840,10 @@ FxSchematicZeraryNode::FxSchematicZeraryNode(FxSchematicScene *scene,
     m_nameItem->setFont(fnt);
 
     m_nameItem->setPos(-1, 0);
-    m_outDock->setPos(80, 0);
-    m_linkDock->setPos(80, -5);
-    m_renderToggle->setPos(50, -5);
-    m_cameraStandToggle->setPos(20, -5);
+    m_outDock->setPos(100, 0);
+    m_linkDock->setPos(100, -5);
+    m_renderToggle->setPos(70, -5);
+    m_cameraStandToggle->setPos(40, -5);
   }
 
   m_nameItem->setZValue(3);
@@ -2875,7 +2910,7 @@ void FxSchematicZeraryNode::paint(QPainter *painter,
 void FxSchematicZeraryNode::onRenderToggleClicked(bool toggled) {
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TXshColumn *column = fxScene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = fxScene->getXsheet()->getColumn(getColumnIndex());
   if (column) {
     column->setPreviewVisible(toggled);
     emit sceneChanged();
@@ -2888,7 +2923,7 @@ void FxSchematicZeraryNode::onRenderToggleClicked(bool toggled) {
 void FxSchematicZeraryNode::onCameraStandToggleClicked(int state) {
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TXshColumn *column = fxScene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = fxScene->getXsheet()->getColumn(getColumnIndex());
   if (column) {
     column->setCamstandVisible(!column->isCamstandVisible());
     // column->setCamstandVisible(toggled);
@@ -2918,10 +2953,10 @@ void FxSchematicZeraryNode::mouseDoubleClickEvent(
   QRectF nameArea(0, 0, m_width, 14);
   if (nameArea.contains(me->pos()) && me->modifiers() == Qt::ControlModifier) {
     FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
-    TXshColumn *column        = fxScene->getXsheet()->getColumn(m_columnIndex);
-    TStageObjectId id         = TStageObjectId::ColumnId(m_columnIndex);
-    std::string name = fxScene->getXsheet()->getStageObject(id)->getName();
-
+    TXshColumn *column = fxScene->getXsheet()->getColumn(getColumnIndex());
+    TStageObjectId id  = TStageObjectId::ColumnId(getColumnIndex());
+    std::string name   = fxScene->getXsheet()->getStageObject(id)->getName();
+    /*
     if (column) {
       // ZeraryFx columns store name elsewhere
       TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(column);
@@ -2929,7 +2964,7 @@ void FxSchematicZeraryNode::mouseDoubleClickEvent(
         name =
             ::to_string(zColumn->getZeraryColumnFx()->getZeraryFx()->getName());
     }
-
+*/
     m_name = QString::fromStdString(name);
 
     m_nameItem->setPlainText(m_name);
@@ -2969,15 +3004,17 @@ void FxSchematicZeraryNode::onNameChanged() {
   if (!fxScene) return;
 
   TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(
-      fxScene->getXsheet()->getColumn(m_columnIndex));
+      fxScene->getXsheet()->getColumn(getColumnIndex()));
   if (zColumn) {
     TFx *fx = zColumn->getZeraryColumnFx()->getZeraryFx();
     setToolTip(
         QString("%1 : %2").arg(m_name, QString::fromStdWString(fx->getFxId())));
   }
 
+  TStageObjectId id = TStageObjectId::ColumnId(getColumnIndex());
   TFxCommand::renameFx(m_fx.getPointer(), m_name.toStdWString(),
                        fxScene->getXsheetHandle());
+  TStageObjectCmd::rename(id, m_name.toStdString(), fxScene->getXsheetHandle());
   updateOutputDockToolTips(m_name);
   emit sceneChanged();
   update();
@@ -2995,23 +3032,23 @@ void FxSchematicZeraryNode::resize(bool maximized) {}
 
 FxSchematicColumnNode::FxSchematicColumnNode(FxSchematicScene *scene,
                                              TLevelColumnFx *fx)
-    : FxSchematicNode(scene, fx, 90, 32, eColumnFx)
+    : FxSchematicNode(scene, fx, 110, 32, eColumnFx)
     , m_isOpened(false)  // iwasawa
 {
   SchematicViewer *viewer = scene->getSchematicViewer();
 
   if (!m_isNormalIconView) {
-    setWidth(90);
+    setWidth(110);
     setHeight(50);
   }
-  m_columnIndex     = fx->getColumnIndex();
-  TStageObjectId id = TStageObjectId::ColumnId(m_columnIndex);
+  setColumnIndex(fx->getColumnIndex());
+  TStageObjectId id = TStageObjectId::ColumnId(getColumnIndex());
   std::string name  = scene->getXsheet()->getStageObject(id)->getName();
   m_name            = QString::fromStdString(name);
 
   m_resizeItem = new SchematicThumbnailToggle(
       this, fx->getAttributes()->isOpened());    //サムネイル矢印
-  m_nameItem = new SchematicName(this, 54, 20);  //リネーム部分
+  m_nameItem = new SchematicName(this, 74, 20);  //リネーム部分
   m_outDock  = new FxSchematicDock(this, "", 0, eFxOutputPort);  // Outポート
   m_renderToggle =
       new SchematicToggle(this, viewer->getSchematicPreviewButtonOnImage(),
@@ -3045,7 +3082,7 @@ FxSchematicColumnNode::FxSchematicColumnNode(FxSchematicScene *scene,
   addPort(0, m_outDock->getPort());
 
   m_nameItem->hide();
-  TXshColumn *column = scene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = scene->getXsheet()->getColumn(getColumnIndex());
   if (column) {
     m_renderToggle->setIsActive(column->isPreviewVisible());
     m_cameraStandToggle->setState(
@@ -3059,15 +3096,15 @@ FxSchematicColumnNode::FxSchematicColumnNode(FxSchematicScene *scene,
   if (m_isNormalIconView) {
     m_resizeItem->setPos(2, 0);
     m_nameItem->setPos(16, -1);
-    m_outDock->setPos(72, 14);
-    m_renderToggle->setPos(72, 0);
-    m_cameraStandToggle->setPos(72, 7);
+    m_outDock->setPos(92, 14);
+    m_renderToggle->setPos(92, 0);
+    m_cameraStandToggle->setPos(92, 7);
   } else {
     m_resizeItem->hide();
     m_nameItem->setPos(0, 0);
-    m_outDock->setPos(80, 0);
-    m_renderToggle->setPos(60, -5);
-    m_cameraStandToggle->setPos(30, -5);
+    m_outDock->setPos(100, 0);
+    m_renderToggle->setPos(80, -5);
+    m_cameraStandToggle->setPos(50, -5);
   }
 
   m_resizeItem->setZValue(2);
@@ -3118,7 +3155,7 @@ void FxSchematicColumnNode::paint(QPainter *painter,
 void FxSchematicColumnNode::onRenderToggleClicked(bool toggled) {
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TXshColumn *column = fxScene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = fxScene->getXsheet()->getColumn(getColumnIndex());
   if (column) {
     column->setPreviewVisible(toggled);
     emit sceneChanged();
@@ -3131,7 +3168,7 @@ void FxSchematicColumnNode::onRenderToggleClicked(bool toggled) {
 void FxSchematicColumnNode::onCameraStandToggleClicked(int state) {
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TXshColumn *column = fxScene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = fxScene->getXsheet()->getColumn(getColumnIndex());
   if (column) {
     column->setCamstandVisible(!column->isCamstandVisible());
     // column->setCamstandVisible(toggled);
@@ -3146,11 +3183,11 @@ QPixmap FxSchematicColumnNode::getPixmap() {
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return QPixmap();
   TXsheet *xsh = fxScene->getXsheet();
-  if (xsh && !xsh->isColumnEmpty(m_columnIndex)) {
+  if (xsh && !xsh->isColumnEmpty(getColumnIndex())) {
     int r0, r1;
-    xsh->getCellRange(m_columnIndex, r0, r1);
+    xsh->getCellRange(getColumnIndex(), r0, r1);
     if (r1 >= r0) {
-      TXshCell cell = xsh->getCell(r0, m_columnIndex);
+      TXshCell cell = xsh->getCell(r0, getColumnIndex());
       TXshLevel *xl = cell.m_level.getPointer();
       if (xl)
         return IconGenerator::instance()->getIcon(xl, cell.m_frameId, false);
@@ -3171,19 +3208,19 @@ void FxSchematicColumnNode::getLevelTypeAndName(int &ltype,
   }
 
   TXsheet *xsh = fxScene->getXsheet();
-  if (xsh && !xsh->isColumnEmpty(m_columnIndex)) {
+  if (xsh && !xsh->isColumnEmpty(getColumnIndex())) {
     int r0, r1;
-    xsh->getCellRange(m_columnIndex, r0, r1);
+    xsh->getCellRange(getColumnIndex(), r0, r1);
     if (r1 >= r0) {
-      TXshCell cell = xsh->getCell(r0, m_columnIndex);
+      TXshCell cell = xsh->getCell(r0, getColumnIndex());
       TXshLevel *xl = cell.m_level.getPointer();
       if (xl) {
         ltype = cell.m_level->getType();
 
         // for Zerary Fx, display FxId
         if (ltype == ZERARYFX_XSHLEVEL) {
-          TXshZeraryFxColumn *zColumn =
-              dynamic_cast<TXshZeraryFxColumn *>(xsh->getColumn(m_columnIndex));
+          TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(
+              xsh->getColumn(getColumnIndex()));
           if (zColumn) {
             TFx *fx   = zColumn->getZeraryColumnFx()->getZeraryFx();
             levelName = QString::fromStdWString(fx->getFxId());
@@ -3229,7 +3266,7 @@ void FxSchematicColumnNode::onNameChanged() {
 
   setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-  TStageObjectId id = TStageObjectId::ColumnId(m_columnIndex);
+  TStageObjectId id = TStageObjectId::ColumnId(getColumnIndex());
   renameObject(id, m_name.toStdString());
   updateOutputDockToolTips(m_name);
   emit sceneChanged();
@@ -3248,7 +3285,7 @@ void FxSchematicColumnNode::mouseDoubleClickEvent(
     QGraphicsSceneMouseEvent *me) {
   QRectF nameArea(14, 0, m_width - 15, 14);
   if (nameArea.contains(me->pos()) && me->modifiers() == Qt::ControlModifier) {
-    TStageObjectId id         = TStageObjectId::ColumnId(m_columnIndex);
+    TStageObjectId id         = TStageObjectId::ColumnId(getColumnIndex());
     FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
     if (!fxScene) return;
     TStageObject *pegbar = fxScene->getXsheet()->getStageObject(id);
@@ -3295,21 +3332,21 @@ void FxSchematicColumnNode::renameObject(const TStageObjectId &id,
 
 FxSchematicPaletteNode::FxSchematicPaletteNode(FxSchematicScene *scene,
                                                TPaletteColumnFx *fx)
-    : FxSchematicNode(scene, fx, 90, 32, eColumnFx) {
+    : FxSchematicNode(scene, fx, 110, 32, eColumnFx) {
   SchematicViewer *viewer = scene->getSchematicViewer();
 
   if (!m_isNormalIconView) {
-    setWidth(90);
+    setWidth(110);
     setHeight(50);
   }
-  m_columnIndex     = fx->getColumnIndex();
-  TStageObjectId id = TStageObjectId::ColumnId(m_columnIndex);
+  setColumnIndex(fx->getColumnIndex());
+  TStageObjectId id = TStageObjectId::ColumnId(getColumnIndex());
   std::string name  = scene->getXsheet()->getStageObject(id)->getName();
   m_name            = QString::fromStdString(name);
 
   m_linkedNode = 0;
   m_linkDock   = 0;
-  m_nameItem   = new SchematicName(this, 54, 20);  // for rename
+  m_nameItem   = new SchematicName(this, 74, 20);  // for rename
   m_outDock    = new FxSchematicDock(this, "", 0, eFxOutputPort);
   m_renderToggle =
       new SchematicToggle(this, viewer->getSchematicPreviewButtonOnImage(),
@@ -3328,22 +3365,22 @@ FxSchematicPaletteNode::FxSchematicPaletteNode(FxSchematicScene *scene,
 
   addPort(0, m_outDock->getPort());
 
-  TXshColumn *column = scene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = scene->getXsheet()->getColumn(getColumnIndex());
   if (column) m_renderToggle->setIsActive(column->isPreviewVisible());
 
   // set geometry
   if (m_isNormalIconView) {
     m_nameItem->setPos(19, -1);
-    m_outDock->setPos(72, 14);
-    m_renderToggle->setPos(72, 0);
+    m_outDock->setPos(92, 14);
+    m_renderToggle->setPos(92, 0);
   } else {
     QFont fnt = m_nameItem->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
     m_nameItem->setFont(fnt);
 
     m_nameItem->setPos(-1, 0);
-    m_outDock->setPos(80, 0);
-    m_renderToggle->setPos(60, -5);
+    m_outDock->setPos(100, 0);
+    m_renderToggle->setPos(80, -5);
   }
 
   m_nameItem->setZValue(2);
@@ -3369,11 +3406,11 @@ QString FxSchematicPaletteNode::getPaletteName() {
   }
 
   TXsheet *xsh = fxScene->getXsheet();
-  if (xsh && !xsh->isColumnEmpty(m_columnIndex)) {
+  if (xsh && !xsh->isColumnEmpty(getColumnIndex())) {
     int r0, r1;
-    xsh->getCellRange(m_columnIndex, r0, r1);
+    xsh->getCellRange(getColumnIndex(), r0, r1);
     if (r1 >= r0) {
-      TXshCell cell = xsh->getCell(r0, m_columnIndex);
+      TXshCell cell = xsh->getCell(r0, getColumnIndex());
       TXshLevel *xl = cell.m_level.getPointer();
       if (xl) {
         return QString::fromStdWString(xl->getName());
@@ -3407,7 +3444,7 @@ void FxSchematicPaletteNode::paint(QPainter *painter,
 void FxSchematicPaletteNode::onRenderToggleClicked(bool toggled) {
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TXshColumn *column = fxScene->getXsheet()->getColumn(m_columnIndex);
+  TXshColumn *column = fxScene->getXsheet()->getColumn(getColumnIndex());
   if (column) {
     column->setPreviewVisible(toggled);
     emit sceneChanged();
@@ -3429,7 +3466,7 @@ void FxSchematicPaletteNode::onNameChanged() {
   setToolTip(QString("%1 : %2").arg(m_name, paletteName));
   setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-  TStageObjectId id = TStageObjectId::ColumnId(m_columnIndex);
+  TStageObjectId id = TStageObjectId::ColumnId(getColumnIndex());
   renameObject(id, m_name.toStdString());
   updateOutputDockToolTips(m_name);
   emit sceneChanged();

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -1205,6 +1205,7 @@ void FxSchematicScene::onSelectionChanged() {
 
 void FxSchematicScene::reorderScene() {
   int step = m_gridDimension == eLarge ? 100 : 50;
+  if (!m_isNormalIconView) step += 10;
   m_placedFxs.clear();
   QPointF sceneCenter = sceneRect().center();
   double minY         = sceneCenter.y();
@@ -1297,7 +1298,7 @@ void FxSchematicScene::reorderScene() {
     TFx *fx = fxSet->getFx(i);
     if (m_placedFxs.contains(fx)) continue;
 
-    placeNodeAndParents(fx, (sceneCenter.x() + 120), maxX, minY);
+    placeNodeAndParents(fx, (sceneCenter.x() + 140), maxX, minY);
     y -= step;
     minY = std::min(y, minY);
   }
@@ -1315,8 +1316,8 @@ void FxSchematicScene::removeRetroLinks(TFx *fx, double &maxX) {
     TPointD fxPos   = fx->getAttributes()->getDagNodePos();
     if (inFxPos != TConst::nowhere && fxPos != TConst::nowhere &&
         fxPos.x <= inFxPos.x) {
-      while (fxPos.x <= inFxPos.x) fxPos.x += 150;
-      maxX = std::max(fxPos.x + 150, maxX);
+      while (fxPos.x <= inFxPos.x) fxPos.x += 170;
+      maxX = std::max(fxPos.x + 170, maxX);
       fx->getAttributes()->setDagNodePos(fxPos);
       for (int j = 0; j < fx->getOutputConnectionCount(); j++) {
         TFx *outFx = fx->getOutputConnection(j)->getOwnerFx();
@@ -1331,6 +1332,7 @@ void FxSchematicScene::removeRetroLinks(TFx *fx, double &maxX) {
 void FxSchematicScene::placeNodeAndParents(TFx *fx, double x, double &maxX,
                                            double &minY) {
   int step = m_gridDimension == eLarge ? 100 : 50;
+  if (!m_isNormalIconView) step += 10;
   if (!fx) return;
   m_placedFxs.append(fx);
   if (fx->getFxType() == "STD_particlesFx" ||
@@ -1364,7 +1366,7 @@ void FxSchematicScene::placeNodeAndParents(TFx *fx, double x, double &maxX,
   } else
     fx->getAttributes()->setDagNodePos(TPointD(x, y));
   if (fx->getOutputConnectionCount() == 0) minY -= step;
-  x += 120;
+  x += 140;
   maxX = std::max(maxX, x);
   int i;
   for (i = 0; i < fx->getOutputConnectionCount(); i++) {

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -727,7 +727,7 @@ void StageSchematicScene::placeNodes() {
   for (i = 0; i < pegTree->getSplineCount(); i++) {
     TStageObjectSpline *spline = pegTree->getSpline(i);
     spline->setDagNodePos(TPointD(maxXPos, yFirstPos + step));
-    maxXPos += (m_showLetterOnPortFlag) ? 150 : 120;
+    maxXPos += (m_showLetterOnPortFlag) ? 170 : 140;
   }
 
   // delete the tree
@@ -783,7 +783,7 @@ void StageSchematicScene::makeTree(TreeStageNode *treeNode) {
 void StageSchematicScene::placeChildren(TreeStageNode *treeNode, double &xPos,
                                         double &yPos, bool isCameraTree) {
   int i;
-  xPos += (m_showLetterOnPortFlag) ? 150 : 120;
+  xPos += (m_showLetterOnPortFlag) ? 170 : 140;
   double xChildPos = xPos;
   double xRefPos   = xPos;
   bool firstChild  = true;
@@ -815,7 +815,7 @@ void StageSchematicScene::placeNode(StageSchematicNode *node) {
   double xPos      = xFirstPos;
   double yPos      = yFirstPos;
   int step         = m_gridDimension == eLarge ? 100 : 50;
-  int hStep        = (m_showLetterOnPortFlag) ? 150 : 120;
+  int hStep        = (m_showLetterOnPortFlag) ? 170 : 140;
 
   TStageObjectTree *pegTree = m_xshHandle->getXsheet()->getStageObjectTree();
   QRectF nodeRect           = node->boundingRect();
@@ -923,7 +923,7 @@ void StageSchematicScene::placeSplineNode(
     StageSchematicSplineNode *splineNode) {
   double xFirstPos           = m_firstPos.x - 500;
   double yFirstPos           = m_firstPos.y + 500;
-  int hStep                  = (m_showLetterOnPortFlag) ? 150 : 120;
+  int hStep                  = (m_showLetterOnPortFlag) ? 170 : 140;
   double xPos                = xFirstPos + (hStep * 2);
   int step                   = m_gridDimension == eLarge ? 100 : 50;
   double yPos                = yFirstPos + step;


### PR DESCRIPTION
This revises how Column Numbers (and Pegbar Numbers) are displayed throughout T2D. 

- Column numbers are no longer shown unless you enable `Preferences` -> `Scene` -> `Show Column Numbers` (formally `Show Column Numbers in Column Header`)
- When displayed, the column number will be displaued as `(Col#)` after the column name.
- Column number would show in the following existing and new areas:
   - Timeline/Xsheet Column Headers (existing - # only)
   - Function Editor tree pane (existing)
   - Viewer indicator when using Animate Tool (existing)
   - Viewer indicator when linking using Skeleton Tool (existing)
   - Viewer `Select Column` context menu (existing)
   - Xsheet's Parent dropdown list (new)
   - Animate Tool's object dropdown list (new)
   - Function Editor's column headers in spreadsheet pane (new)
   - Stage Schematic nodes (new, # only - nodes widened)
   - FX Schematic nodes (new, # only - nodes widened)
	
The following fixes were made in relation to displaying column numbers:
- Fixed Pegbar to show `(Peg#)` if pegbar name is changed
- Fixed ZeraryFx column name change to update stageobject of column
   - For existing scenes, this change will cause the ZeraryFx column name to show as `Col#` even if it had a specified name. Rename to correct going forward
- Fixed display of ZeraryFX column name which always displayed `Col#` instead of specified column name in the following areas
   - Animate Tool object dropdown list
   - Xsheet's Parent dropdown list
   - Function Editor tree pane
   - Function Editor column header
   - Scene Viewer `Select Column` context menu
- Fixes vertical spacing when reordering FX Schematic nodes in Icon view.
