### PR TITLE
Individualized Command Bar definitions

### DIFF
--- a/toonz/sources/include/saveloadqsettings.h
+++ b/toonz/sources/include/saveloadqsettings.h
@@ -11,7 +11,7 @@ class QSettings;
 //! into / from provided qsettings
 class SaveLoadQSettings {
 public:
-  virtual void save(QSettings &settings) const = 0;
+  virtual void save(QSettings &settings, bool forPopupIni = false) const = 0;
   virtual void load(QSettings &settings)       = 0;
 };
 

--- a/toonz/sources/include/toonzqt/functionviewer.h
+++ b/toonz/sources/include/toonzqt/functionviewer.h
@@ -124,7 +124,8 @@ public:
   TXsheetHandle *getXsheetHandle() const { return m_xshHandle; }
 
   // SaveLoadQSettings
-  virtual void save(QSettings &settings) const override;
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
   virtual void load(QSettings &settings) override;
 
   // refer to the preferences' "Current Column Color"

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -892,7 +892,8 @@ public:
   }
 
   // SaveLoadQSettings
-  virtual void save(QSettings &settings) const override;
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
   virtual void load(QSettings &settings) override;
 
   void updateColorCalibration();

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -914,7 +914,7 @@ void ComboViewerPanel::setVisiblePartsFlag(UINT flag) {
 }
 
 // SaveLoadQSettings
-void ComboViewerPanel::save(QSettings &settings) const {
+void ComboViewerPanel::save(QSettings &settings, bool forPopupIni) const {
   settings.setValue("visibleParts", m_visiblePartsFlag);
 }
 

--- a/toonz/sources/toonz/comboviewerpane.h
+++ b/toonz/sources/toonz/comboviewerpane.h
@@ -99,7 +99,8 @@ public:
   void onLeavePanel() { m_sceneViewer->clearFocus(); }
 
   // SaveLoadQSettings
-  virtual void save(QSettings &settings) const override;
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
   virtual void load(QSettings &settings) override;
 
   void initializeTitleBar(TPanelTitleBar *titleBar);

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+#include "saveloadqsettings.h"
+
 #include "toonz/txsheet.h"
 #include "toonzqt/keyframenavigator.h"
 
@@ -19,10 +21,12 @@ class QAction;
 // CommandBar
 //-----------------------------------------------------------------------------
 
-class CommandBar : public QToolBar {
+class CommandBar : public QToolBar, public SaveLoadQSettings {
   Q_OBJECT
 protected:
   bool m_isCollapsible;
+  bool m_isQuickToolbar;
+  QString m_barId;
 
 public:
 #if QT_VERSION >= 0x050500
@@ -32,16 +36,25 @@ public:
   CommandBar(QWidget *parent = 0, Qt::WFlags flags = 0);
 #endif
 
+  QString getBarId() { return m_barId; }
+
+  // SaveLoadQSettings
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
+  virtual void load(QSettings &settings) override;
+
 signals:
   void updateVisibility();
 
 protected:
-  static void fillToolbar(CommandBar *toolbar, bool isQuickToolbar = false);
+  static void fillToolbar(CommandBar *toolbar, bool isQuickToolbar = false,
+                          QString barId = "");
   static void buildDefaultToolbar(CommandBar *toolbar);
   void contextMenuEvent(QContextMenuEvent *event) override;
 
 protected slots:
   void doCustomizeCommandBar();
+  void onCloseButtonPressed();
 };
 
 #endif  // COMMANDBAR_H

--- a/toonz/sources/toonz/commandbarpopup.h
+++ b/toonz/sources/toonz/commandbarpopup.h
@@ -6,6 +6,7 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QAction>
+#include <QCheckBox>
 
 #include "toonzqt/dvdialog.h"
 #include "tfilepath.h"
@@ -25,7 +26,7 @@ class CommandBarTree final : public QTreeWidget {
   void saveMenuRecursive(QXmlStreamWriter& writer, QTreeWidgetItem* parentItem);
 
 public:
-  CommandBarTree(TFilePath& path, QWidget* parent = 0);
+  CommandBarTree(TFilePath& path, TFilePath& defaultPath, QWidget* parent = 0);
   void saveMenuTree(TFilePath& path);
 
 protected:
@@ -71,10 +72,11 @@ class CommandBarPopup final : public DVGui::Dialog {
   Q_OBJECT
   CommandBarListTree* m_commandListTree;
   CommandBarTree* m_menuBarTree;
-  TFilePath m_path;
+  QCheckBox* m_saveAsDefaultCB;
+  TFilePath m_path, m_defaultPath;
 
 public:
-  CommandBarPopup(bool isQuickToolbar = false);
+  CommandBarPopup(QString barId, bool isQuickToolbar = false);
 protected slots:
   void onOkPressed();
   void onSearchTextChanged(const QString& text);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1949,7 +1949,7 @@ void Filmstrip::setOrientation(bool isVertical) {
 }
 
 // SaveLoadQSettings
-void Filmstrip::save(QSettings &settings) const {
+void Filmstrip::save(QSettings &settings, bool forPopupIni) const {
   UINT orientation = 0;
   orientation      = m_isVertical ? 1 : 0;
   settings.setValue("vertical", orientation);

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -247,7 +247,8 @@ public:
   ~Filmstrip();
 
   // SaveLoadQSettings
-  virtual void save(QSettings &settings) const override;
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
   virtual void load(QSettings &settings) override;
 
 protected:

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -91,7 +91,7 @@ TPanel::~TPanel() {
     settings.setValue("geometry", geometry());
     if (SaveLoadQSettings *persistent =
             dynamic_cast<SaveLoadQSettings *>(widget()))
-      persistent->save(settings);
+      persistent->save(settings, true);
   }
 }
 

--- a/toonz/sources/toonz/quicktoolbar.cpp
+++ b/toonz/sources/toonz/quicktoolbar.cpp
@@ -75,7 +75,7 @@ void QuickToolbar::contextMenuEvent(QContextMenuEvent *event) {
 //-----------------------------------------------------------------------------
 
 void QuickToolbar::doCustomizeCommandBar() {
-  CommandBarPopup *cbPopup = new CommandBarPopup(true);
+  CommandBarPopup *cbPopup = new CommandBarPopup("", true);
 
   if (cbPopup->exec()) {
     fillToolbar(this, true);

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1033,7 +1033,7 @@ public:
 //-----------------------------------------------------------------------------
 CommandBarPanel::CommandBarPanel(QWidget *parent)
     : TPanel(parent, 0, TDockWidget::horizontal) {
-  CommandBar *xsheetToolbar = new CommandBar();
+  CommandBar *xsheetToolbar = new CommandBar(this);
   setWidget(xsheetToolbar);
   setIsMaximizable(false);
   setFixedHeight(36);

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -900,7 +900,7 @@ void SceneViewerPanel::setVisiblePartsFlag(UINT flag) {
 //-----------------------------------------------------------------------------
 
 // SaveLoadQSettings
-void SceneViewerPanel::save(QSettings &settings) const {
+void SceneViewerPanel::save(QSettings &settings, bool forPopupIni) const {
   settings.setValue("visibleParts", m_visiblePartsFlag);
   settings.setValue("consoleParts", m_flipConsole->getCustomizeMask());
 }

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -75,7 +75,8 @@ public:
   void onLeavePanel() { m_sceneViewer->clearFocus(); }
 
   // SaveLoadQSettings
-  virtual void save(QSettings &settings) const override;
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
   virtual void load(QSettings &settings) override;
 
   void initializeTitleBar(TPanelTitleBar *titleBar);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1855,7 +1855,7 @@ void XsheetViewer::setFrameDisplayStyle(FrameDisplayStyle style) {
 
 //-----------------------------------------------------------------------------
 
-void XsheetViewer::save(QSettings &settings) const {
+void XsheetViewer::save(QSettings &settings, bool forPopupIni) const {
   settings.setValue("orientation", orientation()->name());
   settings.setValue("frameZoomFactor", m_frameZoomFactor);
 }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -1277,7 +1277,8 @@ public:
   FrameDisplayStyle getFrameDisplayStyle() { return m_frameDisplayStyle; }
 
   // SaveLoadQSettings
-  virtual void save(QSettings &settings) const override;
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
   virtual void load(QSettings &settings) override;
 
   QString getXsheetLayout() const { return m_xsheetLayout; }

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -803,7 +803,7 @@ bool FunctionViewer::isExpressionPageActive() {
 
 //----------------------------------------------------------------------------
 
-void FunctionViewer::save(QSettings &settings) const {
+void FunctionViewer::save(QSettings &settings, bool forPopupIni) const {
   FunctionEditorToggleStatus = m_toggleStatus;
   settings.setValue("toggleStatus", m_toggleStatus);
   settings.setValue("showIbtwnValuesInSheet",

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -5411,7 +5411,7 @@ void StyleEditor::loadPageStates(StylePageType pageType,
   }
 }
 
-void StyleEditor::save(QSettings &settings) const {
+void StyleEditor::save(QSettings &settings, bool forPopupIni) const {
   settings.setValue("isVertical", m_plainColorPage->getIsVertical());
   int visibleParts = 0;
   if (m_wheelAction->isChecked()) visibleParts |= 0x01;


### PR DESCRIPTION
This PR will allow you to set up each `Command Bar` instance with different button lists.

When saving a Command Bar configuration, you can opt to `Save as Default`, instead.  This will cause all command bars without   individualized configurations to be updated with the new definition on restart.

Load priority of Command Bar definitions
- Command bar specific definition (profiles/users/xxx/commandbars/commandbar_####.xml)
- User defined default command bar definition (profiles/users/xxx/commandbar.xml) 
- T2D default command bar definition (profiles/layouts/settings/commandbar.xml)
