### PR TITLE
Clipping Mask Column

### DIFF
--- a/toonz/sources/common/tgl/tstencilcontrol.cpp
+++ b/toonz/sources/common/tgl/tstencilcontrol.cpp
@@ -70,6 +70,9 @@ public:
 
   Imp();
 
+  void copy(Imp *src);
+  void resetMask();
+
   void updateOpenGlState();
 
   void pushMask();
@@ -121,6 +124,34 @@ TStencilControl::Imp::Imp()
 
 //---------------------------------------------------------
 
+void TStencilControl::Imp::copy(Imp *src) {
+  m_stencilBitCount  = src->m_stencilBitCount;
+  m_pushCount        = src->m_pushCount;
+  m_currentWriting   = src->m_currentWriting;
+  m_enabledMask      = src->m_enabledMask;
+  m_writingMask      = src->m_writingMask;
+  m_inOrOutMask      = src->m_inOrOutMask;
+  m_drawOnScreenMask = src->m_drawOnScreenMask;
+  m_drawOnlyOnceMask = src->m_drawOnlyOnceMask;
+  m_virtualState     = src->m_virtualState;
+}
+
+//---------------------------------------------------------
+
+void TStencilControl::Imp::resetMask() {
+  m_stencilBitCount  = 0;
+  m_pushCount        = 1;
+  m_currentWriting   = -1;
+  m_enabledMask      = 0;
+  m_writingMask      = 0;
+  m_inOrOutMask      = 0;
+  m_drawOnScreenMask = 0;
+  m_drawOnlyOnceMask = 0;
+  m_virtualState     = 0;
+}
+
+//---------------------------------------------------------
+
 TStencilControl *TStencilControl::instance() {
   StencilControlManager *instance = StencilControlManager::instance();
   return instance->getCurrentStencilControl();
@@ -128,7 +159,7 @@ TStencilControl *TStencilControl::instance() {
 
 //---------------------------------------------------------
 
-TStencilControl::TStencilControl() : m_imp(new Imp) {}
+TStencilControl::TStencilControl() : m_imp(new Imp) { m_impStack.empty(); }
 
 //---------------------------------------------------------
 
@@ -364,3 +395,36 @@ void TStencilControl::disableMask() {
 }
 
 //---------------------------------------------------------
+
+bool TStencilControl::isMaskEnabled() { return m_imp->m_virtualState > 0; }
+
+//---------------------------------------------------------
+
+void TStencilControl::stashMask() {
+  Imp *currentImp = new Imp;
+  currentImp->copy(m_imp.get());
+  m_impStack.push(currentImp);
+
+  if (m_imp->m_virtualState == 2)
+    endMask();
+  else if (m_imp->m_virtualState == 1) {
+    int masks = m_imp->m_pushCount;
+    for (int i = 0; i < masks; i++) disableMask();
+  }
+}
+
+//---------------------------------------------------------
+
+void TStencilControl::restoreMask() {
+  if (m_impStack.top()->m_virtualState == 2)
+    beginMask();
+  else if (m_impStack.top()->m_virtualState == 1) {
+    int masks = m_impStack.top()->m_pushCount;
+    for (int i = 0; i < masks; i++) beginMask();
+    enableMask(SHOW_INSIDE);
+  }
+
+  m_imp->copy(m_impStack.top());
+
+  m_impStack.pop();
+}

--- a/toonz/sources/common/tvrender/tofflinegl.cpp
+++ b/toonz/sources/common/tvrender/tofflinegl.cpp
@@ -685,6 +685,30 @@ void TOfflineGL::draw(TVectorImageP image, const TVectorRenderData &rd,
 
 //-----------------------------------------------------------------------------
 
+void TOfflineGL::drawMask(TVectorImageP image, const TVectorRenderData &rd,
+                          bool doInitMatrix) {
+  checkErrorsByGL;
+  makeCurrent();
+  checkErrorsByGL;
+
+  if (doInitMatrix) {
+    initMatrix();
+    checkErrorsByGL;
+  }
+
+  if (image) {
+    checkErrorsByGL;
+    tglDrawMask(rd, image.getPointer());
+    checkErrorsByGL;
+  }
+
+  checkErrorsByGL;
+  glFlush();
+  checkErrorsByGL;
+}
+
+//-----------------------------------------------------------------------------
+
 void TOfflineGL::draw(TRasterImageP ri, const TAffine &aff, bool doInitMatrix) {
   makeCurrent();
 

--- a/toonz/sources/common/tvrender/tregionprop.cpp
+++ b/toonz/sources/common/tvrender/tregionprop.cpp
@@ -123,6 +123,14 @@ bool computeOutline(const TRegion *region,
 //-------------------------------------------------------------------
 
 void OutlineRegionProp::computeRegionOutline() {
+  // Avoid overlapping calculations
+  if (!m_outline.setCalculating()) return;
+
+  // Drawing in progress. Hold calculation until it's done
+  while (m_outline.isInUse()) {
+     // Wait
+  }
+
   int subRegionNumber = getRegion()->getSubregionCount();
   TRegionOutline::PointVector app;
 
@@ -142,6 +150,7 @@ void OutlineRegionProp::computeRegionOutline() {
   }
 
   m_outline.m_bbox = getRegion()->getBBox();
+  m_outline.unsetCalculating();
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -140,7 +140,8 @@ enum class PredefinedRect {
   // ADD_LEVEL,
   FOOTER_NOTE_OBJ_AREA,
   FOOTER_NOTE_AREA,
-  NAVIGATION_TAG_AREA
+  NAVIGATION_TAG_AREA,
+  CLIPPING_MASK_AREA
 };
 enum class PredefinedLine {
   LOCKED,              //! dotted vertical line when cell is locked

--- a/toonz/sources/include/tfxutil.h
+++ b/toonz/sources/include/tfxutil.h
@@ -39,6 +39,9 @@ DVAPI void deleteKeyframes(const TFxP &fx, int frame);
 
 DVAPI void setKeyframe(const TFxP &dstFx, int dstFrame, const TFxP &srcFx,
                        int srcFrame, bool changedOnly = false);
+
+DVAPI TFxP makeMask(const TFxP &source, const TFxP &mask);
+
 }  // namespace TFxUtil
 
 #endif

--- a/toonz/sources/include/tofflinegl.h
+++ b/toonz/sources/include/tofflinegl.h
@@ -70,6 +70,9 @@ public:
   void draw(TVectorImageP image, const TVectorRenderData &rd,
             bool doInitMatrix = false);
 
+  void drawMask(TVectorImageP image, const TVectorRenderData &rd,
+                bool doInitMatrix = false);
+
   void draw(TRasterImageP image, const TAffine &aff, bool doInitMatrix = false);
 
   void flush();

--- a/toonz/sources/include/toonz/stage.h
+++ b/toonz/sources/include/toonz/stage.h
@@ -44,6 +44,20 @@ namespace Stage {
 DVVAR extern const double inch;
 DVVAR extern const double standardDpi;
 
+
+//=============================================================================
+/*! The ZPlacement class preserve camera position information.
+ */
+//=============================================================================
+
+class ZPlacement {
+public:
+  TAffine m_aff;
+  double m_z;
+  ZPlacement() : m_aff(), m_z(0) {}
+  ZPlacement(const TAffine &aff, double z) : m_aff(aff), m_z(z) {}
+};
+
 class Visitor;
 struct VisitArgs;
 

--- a/toonz/sources/include/toonz/stageplayer.h
+++ b/toonz/sources/include/toonz/stageplayer.h
@@ -118,6 +118,10 @@ public:
 
   bool m_currentDrawingOnTop;
 
+  bool m_isMask;
+  bool m_isInvertedMask;
+  bool m_canRenderMask;
+
 public:
   Player();
 

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -7,6 +7,7 @@
 #include "timage.h"
 #include "trastercm.h"
 #include "tgl.h"
+#include "tstencilcontrol.h"
 
 // TnzExt includes
 #include "ext/plasticvisualsettings.h"
@@ -106,7 +107,8 @@ public:
   // used in Toonz derivative works such as Tab or LineTest. They deal with
   // OpenGL stencil buffer.
 
-  virtual void enableMask()  = 0;
+  virtual void enableMask(
+      TStencilControl::MaskType maskType = TStencilControl::SHOW_INSIDE) = 0;
   virtual void disableMask() = 0;
 
   virtual void beginMask() = 0;
@@ -278,7 +280,8 @@ public:
 
   void beginMask() override;
   void endMask() override;
-  void enableMask() override;
+  void enableMask(TStencilControl::MaskType maskType =
+                      TStencilControl::SHOW_INSIDE) override;
   void disableMask() override;
 
   int getNodesCount();
@@ -319,7 +322,8 @@ public:
   void onRasterImage(TRasterImage *ri, const Stage::Player &data) override{};
   void beginMask() override;
   void endMask() override;
-  void enableMask() override;
+  void enableMask(TStencilControl::MaskType maskType =
+                      TStencilControl::SHOW_INSIDE) override;
   void disableMask() override;
 
   int getColumnIndex() const;
@@ -343,6 +347,8 @@ class DVAPI OpenGlPainter final : public Visitor  // Yep, the name sucks...
   bool m_isViewer, m_alphaEnabled, m_paletteHasChanged;
   double m_minZ;
 
+  bool m_singleColumnEnabled;
+
 public:
   OpenGlPainter(const TAffine &viewAff, const TRect &rect,
                 const ImagePainter::VisualSettings &vs, bool isViewer,
@@ -360,10 +366,14 @@ public:
 
   void beginMask() override;
   void endMask() override;
-  void enableMask() override;
+  void enableMask(TStencilControl::MaskType maskType =
+                      TStencilControl::SHOW_INSIDE) override;
   void disableMask() override;
 
   double getMinZ() const { return m_minZ; }
+
+  void enableSingleColumn(bool on) { m_singleColumnEnabled = on; }
+  bool isSingleColumnEnabled() const { return m_singleColumnEnabled; }
 };
 
 }  // namespace Stage

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -78,7 +78,9 @@ protected:
     ePreviewVisible        = 0x2,
     eLocked                = 0x8,
     eMasked                = 0x10,
-    eCamstandTransparent43 = 0x20  // obsoleto, solo per retrocompatibilita'
+    eCamstandTransparent43 = 0x20,  // obsoleto, solo per retrocompatibilita'
+    eInvertedMask          = 0x80,
+    eRenderMask            = 0x100
   };
 
   TRaster32P m_icon;
@@ -192,11 +194,16 @@ Return true if column is a mask.
 \sa setMask()
 */
   bool isMask() const;
+  bool isInvertedMask() const;
+  bool canRenderMask() const;
+
   /*!
 Set column status mask to \b on.
 \sa isMask()
 */
   void setIsMask(bool on);
+  void setInvertedMask(bool on);
+  void setCanRenderMask(bool on);
 
   virtual bool isEmpty() const { return true; }
 

--- a/toonz/sources/include/toonz/txshlevelcolumn.h
+++ b/toonz/sources/include/toonz/txshlevelcolumn.h
@@ -88,6 +88,8 @@ Return \b TFx.
   // Used in TCellData::getNumbers
   bool setNumbers(int row, int rowCount, const TXshCell cells[]);
 
+  std::vector<TXshColumn *> getColumnMasks();
+
 private:
   // not implemented
   TXshLevelColumn(const TXshLevelColumn &);

--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -144,14 +144,16 @@ QPixmap DVAPI convertImageToPixmap(const QImage &image);
 QImage DVAPI
 generateIconImage(const QString &iconSVGName, qreal opacity = qreal(1.0),
                   QSize newSize                       = QSize(),
-                  Qt::AspectRatioMode aspectRatioMode = Qt::IgnoreAspectRatio);
+                  Qt::AspectRatioMode aspectRatioMode = Qt::IgnoreAspectRatio,
+                  bool useThemeColor                  = true);
 
 //-----------------------------------------------------------------------------
 
 QPixmap DVAPI
 generateIconPixmap(const QString &iconSVGName, qreal opacity = qreal(1.0),
                    QSize newSize                       = QSize(),
-                   Qt::AspectRatioMode aspectRatioMode = Qt::IgnoreAspectRatio);
+                   Qt::AspectRatioMode aspectRatioMode = Qt::IgnoreAspectRatio,
+                   bool useThemeColor                  = true);
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -167,6 +167,9 @@ public:
 
   double m_colorSpaceGamma;
 
+  bool m_applyMask;
+  bool m_useMaskBox;
+
 public:
   TRenderSettings();
   ~TRenderSettings();

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -168,7 +168,9 @@ public:
   double m_colorSpaceGamma;
 
   bool m_applyMask;
+  bool m_invertedMask;
   bool m_useMaskBox;
+  bool m_plasticMask;
 
 public:
   TRenderSettings();

--- a/toonz/sources/include/tregionoutline.h
+++ b/toonz/sources/include/tregionoutline.h
@@ -13,12 +13,31 @@ public:
 
   TRectD m_bbox;
 
-  TRegionOutline() : m_doAntialiasing(false) {}
+  bool m_calculating;
+  int m_inUse;
+
+  TRegionOutline()
+      : m_doAntialiasing(false), m_calculating(false), m_inUse(0) {}
 
   void clear() {
     m_exterior.clear();
     m_interior.clear();
   }
+
+  bool setCalculating() {
+    if (m_calculating) return false;
+    m_calculating = true;
+    return true;
+  }
+  void unsetCalculating() { m_calculating = false; }
+  int isCalculating() { return m_calculating; }
+
+  void setInUse() { m_inUse++; }
+  void unsetInUse() {
+    m_inUse--;
+    if (m_inUse < 0) m_inUse = 0;
+  }
+  int isInUse() { return m_inUse > 0; }
 };
 
 #endif

--- a/toonz/sources/include/tstencilcontrol.h
+++ b/toonz/sources/include/tstencilcontrol.h
@@ -4,6 +4,7 @@
 #define TSTENCILCONTROL_H
 
 #include <memory>
+#include <stack>
 
 #include "tcommon.h"
 
@@ -34,6 +35,8 @@ private:
   class Imp;
   std::unique_ptr<Imp> m_imp;
 
+  std::stack<Imp *> m_impStack;
+
 public:
   static TStencilControl *instance();
 
@@ -45,6 +48,11 @@ public:
 
   void enableMask(MaskType maskType);
   void disableMask();
+
+  bool isMaskEnabled();
+
+  void stashMask();
+  void restoreMask();
 };
 
 //------------------------------------------------------

--- a/toonz/sources/tnzbase/tfxutil.cpp
+++ b/toonz/sources/tnzbase/tfxutil.cpp
@@ -170,3 +170,26 @@ void TFxUtil::setKeyframe(const TFxP &dstFx, int dstFrame, const TFxP &srcFx,
     dstParam->assignKeyframe(dstFrame, srcParam, srcFrame, changedOnly);
   }
 }
+
+//-------------------------------------------------------------------
+
+TFxP TFxUtil::makeMask(const TFxP &source, const TFxP &mask) {
+  if (!source)
+    return 0;
+  else if (!mask)
+    return source;
+
+  assert(source && mask);
+
+  TFxP columnMaskFx = TFx::create("columnMaskFx");
+  if (!columnMaskFx) {
+    assert(columnMaskFx);
+    return 0;
+  }
+
+  if (!columnMaskFx->connect("Source", source.getPointer()) ||
+      !columnMaskFx->connect("Mask", mask.getPointer()))
+    assert(!"Could not connect ports!");
+
+  return columnMaskFx;
+}

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -1174,7 +1174,9 @@ TRenderSettings::TRenderSettings()
     , m_linearColorSpace(false)
     , m_colorSpaceGamma(2.2)
     , m_applyMask(false)
-    , m_useMaskBox(false) {}
+    , m_invertedMask(false)
+    , m_useMaskBox(false)
+    , m_plasticMask(false) {}
 
 //------------------------------------------------------------------------------
 
@@ -1220,7 +1222,8 @@ bool TRenderSettings::operator==(const TRenderSettings &rhs) const {
       m_userCachable != rhs.m_userCachable ||
       m_linearColorSpace != rhs.m_linearColorSpace ||
       m_colorSpaceGamma != rhs.m_colorSpaceGamma ||
-      m_applyMask != rhs.m_applyMask || m_useMaskBox != rhs.m_useMaskBox)
+      m_applyMask != rhs.m_applyMask || m_invertedMask != rhs.m_invertedMask ||
+      m_useMaskBox != rhs.m_useMaskBox || m_plasticMask != rhs.m_plasticMask)
     return false;
 
   return std::equal(m_data.begin(), m_data.end(), rhs.m_data.begin(), areEqual);

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -1172,7 +1172,9 @@ TRenderSettings::TRenderSettings()
     , m_isCanceled(NULL)
     , m_getFullSizeBBox(false)
     , m_linearColorSpace(false)
-    , m_colorSpaceGamma(2.2) {}
+    , m_colorSpaceGamma(2.2)
+    , m_applyMask(false)
+    , m_useMaskBox(false) {}
 
 //------------------------------------------------------------------------------
 
@@ -1217,7 +1219,8 @@ bool TRenderSettings::operator==(const TRenderSettings &rhs) const {
       m_mark != rhs.m_mark || m_isSwatch != rhs.m_isSwatch ||
       m_userCachable != rhs.m_userCachable ||
       m_linearColorSpace != rhs.m_linearColorSpace ||
-      m_colorSpaceGamma != rhs.m_colorSpaceGamma)
+      m_colorSpaceGamma != rhs.m_colorSpaceGamma ||
+      m_applyMask != rhs.m_applyMask || m_useMaskBox != rhs.m_useMaskBox)
     return false;
 
   return std::equal(m_data.begin(), m_data.end(), rhs.m_data.begin(), areEqual);

--- a/toonz/sources/toonz/icons/dark/actions/16/clipping_mask.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/clipping_mask.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg892"
+   sodipodi:docname="clipping_mask.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview894"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:snap-global="false"
+     inkscape:zoom="64"
+     inkscape:cx="7.5234375"
+     inkscape:cy="6.765625"
+     inkscape:window-width="1920"
+     inkscape:window-height="1141"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     units="px"
+     showguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid965" />
+  </sodipodi:namedview>
+  <defs
+     id="defs889" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       id="path1002"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.0237399;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0.26458333,0.26458333 C 0.03981829,0.78329902 0.50884996,1.7192215 1.0583333,1.8520833 1.351223,1.9229023 1.8154174,1.5944483 2.1166667,1.5875 2.4546326,1.5797037 2.8492942,1.9426255 3.175,1.8520833 3.6967679,1.7070394 4.1856711,0.76079233 3.96875,0.26458333 3.5697303,-0.07377827 2.8143091,0.3504186 2.1166667,0.52916667 1.634165,0.39260468 0.58283798,-0.09177923 0.26458333,0.26458333 Z M 1.3229167,0.79375 c 0.2622239,-8e-8 0.5291668,0.10069343 0.5291666,0.2645833 10e-8,0.1638899 -0.2669428,0.2645835 -0.5291666,0.2645834 -0.2622237,0 -0.52916675,-0.1006936 -0.5291667,-0.2645834 -1.9e-7,-0.16388985 0.2669429,-0.26458329 0.5291667,-0.2645833 z m 1.5875,0 c 0.2622231,1.3e-7 0.529166,0.10069388 0.5291666,0.2645833 1e-7,0.1638897 -0.266943,0.2645833 -0.5291666,0.2645834 -0.2622238,0 -0.5291668,-0.1006935 -0.5291667,-0.2645834 6e-7,-0.16388954 0.2669434,-0.26458334 0.5291667,-0.2645833 z"
+       sodipodi:nodetypes="ccccccccccccccccc" />
+  </g>
+</svg>

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -598,6 +598,8 @@
     <file>icons/dark/actions/16/table.svg</file>
     <file>icons/dark/actions/16/motion_path.svg</file>
 
+    <file>icons/dark/actions/16/clipping_mask.svg</file>
+
     <!-- Keyframe -->
 		<file>icons/dark/actions/20/key_off.svg</file>
 		<file>icons/dark/actions/20/key_on.svg</file>

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -31,6 +31,8 @@ class QPushButton;
 class Orientation;
 class TApp;
 class TXsheet;
+class QCheckBox;
+class QGroupBox;
 
 //=============================================================================
 namespace XsheetGUI {
@@ -222,6 +224,10 @@ class ColumnTransparencyPopup final : public QWidget {
   XsheetViewer *m_viewer;
   QPushButton *m_lockBtn;
 
+  QGroupBox *m_maskGroupBox;
+  QCheckBox *m_invertMask;
+  QCheckBox *m_renderMask;
+
   QTimer *m_keepClosedTimer;
   bool m_keepClosed;
 
@@ -246,6 +252,10 @@ protected slots:
 
   void onFilterColorChanged();
   void onLockButtonClicked(bool on);
+
+  void onMaskGroupBoxChanged(bool clicked);
+  void onInvertMaskCBChanged(int checkedState);
+  void onRenderMaskCBChanged(int checkedState);
 
   void resetKeepClosed();
 };
@@ -352,6 +362,7 @@ class ColumnArea final : public QWidget {
     void drawPegbarName() const;
     void drawParentHandleName() const;
     void drawFilterColor() const;
+    void drawClippingMask() const;
 
     void drawSoundIcon(bool isPlaying) const;
     void drawVolumeControl(double volume) const;
@@ -401,7 +412,6 @@ protected slots:
   void onCameraColumnChangedTriggered();
   void onCameraColumnLockToggled(bool);
   void onXsheetCameraChange(int);
-  void onSetMask(int);
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -151,7 +151,7 @@ void XsheetViewer::getColumnColor(QColor &color, QColor &sideColor, int index,
       getCellTypeAndColors(ltype, color, sideColor, cell);
     }
   }
-  if (xsh->getColumn(index)->isMask()) color = QColor(255, 0, 255);
+//  if (xsh->getColumn(index)->isMask()) color = QColor(255, 0, 255);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -500,6 +500,9 @@ TopToBottomOrientation::TopToBottomOrientation() {
             iconRect(cameraIconArea, ICON_WIDTH, ICON_HEIGHT));
 
     addRect(PredefinedRect::FILTER_COLOR, rect(PredefinedRect::CONFIG));
+
+    addRect(PredefinedRect::CLIPPING_MASK_AREA, QRect(0, 0, -1, -1));
+
     addRect(PredefinedRect::SOUND_ICON, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::VOLUME_AREA, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));
@@ -595,6 +598,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
 
     addRect(PredefinedRect::FILTER_COLOR,
             QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
+
+    addRect(PredefinedRect::CLIPPING_MASK_AREA,
+            QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2, ICON_WIDTH,
+                  ICON_HEIGHT));
 
     addRect(PredefinedRect::SOUND_ICON,
             QRect(thumbnailArea.topLeft(), QSize(40, 30))
@@ -708,6 +715,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::FILTER_COLOR,
             QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
 
+    addRect(PredefinedRect::CLIPPING_MASK_AREA,
+            QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2,
+                  ICON_WIDTH, ICON_HEIGHT));
+
     addRect(PredefinedRect::SOUND_ICON,
             QRect(thumbnailArea.topLeft(), QSize(40, 30))
                 .adjusted((thumbnailArea.width() / 2) - (40 / 2),
@@ -815,6 +826,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
 
     addRect(PredefinedRect::FILTER_COLOR,
             QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
+
+    addRect(PredefinedRect::CLIPPING_MASK_AREA,
+            QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2,
+                  ICON_WIDTH, ICON_HEIGHT));
 
     addRect(
         PredefinedRect::SOUND_ICON,
@@ -1306,6 +1321,10 @@ LeftToRightOrientation::LeftToRightOrientation() {
 
   addRect(PredefinedRect::FILTER_COLOR,
           QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
+
+  addRect(PredefinedRect::CLIPPING_MASK_AREA,
+          QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
+
   addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));         // hide
   addRect(PredefinedRect::PARENT_HANDLE_NAME, QRect(0, 0, -1, -1));  // hide
 

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -46,7 +46,10 @@ Stage::Player::Player()
     , m_isPlaying(false)
     , m_opacity(255)
     , m_bingoOrder(0)
-    , m_currentDrawingOnTop(false) {}
+    , m_currentDrawingOnTop(false)
+    , m_isMask(false)
+    , m_isInvertedMask(false)
+    , m_canRenderMask(false) {}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -327,7 +327,7 @@ void Picker::endMask() {}
 
 //-----------------------------------------------------------------------------
 
-void Picker::enableMask() {}
+void Picker::enableMask(TStencilControl::MaskType maskType) {}
 
 //-----------------------------------------------------------------------------
 
@@ -389,8 +389,8 @@ void RasterPainter::endMask() {
   TStencilControl::instance()->endMask();
 }
 //! Utilizzato solo per TAB Pro
-void RasterPainter::enableMask() {
-  TStencilControl::instance()->enableMask(TStencilControl::SHOW_INSIDE);
+void RasterPainter::enableMask(TStencilControl::MaskType maskType) {
+  TStencilControl::instance()->enableMask(maskType);
 }
 //! Utilizzato solo per TAB Pro
 void RasterPainter::disableMask() {
@@ -785,7 +785,8 @@ static void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
    onToonzImage().
 */
 void RasterPainter::onImage(const Stage::Player &player) {
-  if (m_singleColumnEnabled && !player.m_isCurrentColumn) return;
+  if (m_singleColumnEnabled && !player.m_isCurrentColumn && !player.m_isMask)
+    return;
 
   // Attempt Plastic-deformed drawing
   // For now generating icons of plastic-deformed image causes crash as
@@ -1141,11 +1142,15 @@ OpenGlPainter::OpenGlPainter(const TAffine &viewAff, const TRect &rect,
     , m_isViewer(isViewer)
     , m_alphaEnabled(alphaEnabled)
     , m_paletteHasChanged(false)
-    , m_minZ(0) {}
+    , m_minZ(0)
+    , m_singleColumnEnabled(false) {}
 
 //-----------------------------------------------------------------------------
 
 void OpenGlPainter::onImage(const Stage::Player &player) {
+  if (m_singleColumnEnabled && !player.m_isCurrentColumn && !player.m_isMask)
+    return;
+
   if (player.m_z < m_minZ) m_minZ = player.m_z;
 
   glPushAttrib(GL_ALL_ATTRIB_BITS);
@@ -1330,8 +1335,8 @@ void OpenGlPainter::endMask() {
   --m_maskLevel;
   TStencilControl::instance()->endMask();
 }
-void OpenGlPainter::enableMask() {
-  TStencilControl::instance()->enableMask(TStencilControl::SHOW_INSIDE);
+void OpenGlPainter::enableMask(TStencilControl::MaskType maskType) {
+  TStencilControl::instance()->enableMask(maskType);
 }
 void OpenGlPainter::disableMask() {
   TStencilControl::instance()->disableMask();

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1615,7 +1615,21 @@ std::string TLevelColumnFx::getAlias(double frame,
       rdata += "column_0";
   }
 
-  return getFxType() + "[" + ::to_string(fp.getWideString()) + "," + rdata +
+  std::vector<TXshColumn *> masks = m_levelColumn->getColumnMasks();
+  if (masks.size()) {
+    std::string maskAlias = "masked";
+    for (int i = 0; i < masks.size(); i++) {
+      TXshLevelColumn *mask = masks[i]->getLevelColumn();
+      if (!mask) break;
+
+      if (mask->isInvertedMask()) maskAlias += "inv";
+      if (mask->canRenderMask()) maskAlias += "render";
+      break;
+    }
+    rdata += maskAlias;
+  }
+
+   return getFxType() + "[" + ::to_string(fp.getWideString()) + "," + rdata +
          "]";
 }
 

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -992,7 +992,7 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
   if (!m_levelColumn) return;
 
   if (m_levelColumn->isMask() && !info.m_applyMask &&
-      !m_levelColumn->canRenderMask())
+      !m_levelColumn->canRenderMask() && !info.m_plasticMask)
     return;
 
   // Ensure that a corresponding cell and level exists

--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -192,15 +192,18 @@ DrawableTextureDataP texture_utils::getTextureData(const TXsheet *xsh,
       xsh->getPlacement(xsh->getStageObjectTree()->getCurrentCameraId(), frame);
   bbox = (cameraAff.inv() * bbox).enlarge(1.0);
 
-// Render the xsheet on the specified bbox
+  // Render the xsheet on the specified bbox
+  bool masked = TStencilControl::instance()->isMaskEnabled();
 #ifdef MACOSX
+  // Must move masks aside when building texture
+  if (masked) TStencilControl::instance()->stashMask();
   xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());
+  if (masked) TStencilControl::instance()->restoreMask();
 #else
   // The call below will change context (I know, it's a shame :( )
   TGlContext currentContext = tglGetCurrentContext();
   {
     tglDoneCurrent(currentContext);
-    bool masked = TStencilControl::instance()->isMaskEnabled();
     // Must move masks aside when building texture
     if (masked) TStencilControl::instance()->stashMask();
     xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());

--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -14,6 +14,7 @@
 #include "toonz/toonzscene.h"
 #include "toonz/imagemanager.h"
 #include "imagebuilders.h"
+#include "tstencilcontrol.h"
 
 // TnzCore includes
 #include "tpalette.h"
@@ -199,7 +200,11 @@ DrawableTextureDataP texture_utils::getTextureData(const TXsheet *xsh,
   TGlContext currentContext = tglGetCurrentContext();
   {
     tglDoneCurrent(currentContext);
+    bool masked = TStencilControl::instance()->isMaskEnabled();
+    // Must move masks aside when building texture
+    if (masked) TStencilControl::instance()->stashMask();
     xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());
+    if (masked) TStencilControl::instance()->restoreMask();
     tglMakeCurrent(currentContext);
   }
 #endif

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -812,7 +812,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 #ifdef MACOSX
     std::unique_ptr<QOpenGLFramebufferObject> fb(
         new QOpenGLFramebufferObject(ras->getLx(), ras->getLy()));
-
+    fb->setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
     fb->bind();
     assert(glGetError() == GL_NO_ERROR);
 

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -743,8 +743,40 @@ bool TXshColumn::isMask() const { return (m_status & eMasked) != 0; }
 
 //-----------------------------------------------------------------------------
 
+bool TXshColumn::isInvertedMask() const {
+  return (m_status & eInvertedMask) != 0;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::canRenderMask() const {
+  return (m_status & eRenderMask) != 0;
+}
+
+//-----------------------------------------------------------------------------
+
 void TXshColumn::setIsMask(bool on) {
   const int mask = eMasked;
+  if (on)
+    m_status |= mask;
+  else
+    m_status &= ~mask;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshColumn::setInvertedMask(bool on) {
+  const int mask = eInvertedMask;
+  if (on)
+    m_status |= mask;
+  else
+    m_status &= ~mask;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshColumn::setCanRenderMask(bool on) {
+  const int mask = eRenderMask;
   if (on)
     m_status |= mask;
   else

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -6,6 +6,7 @@
 #include "toonz/tcolumnfxset.h"
 #include "toonz/tcolumnfx.h"
 #include "toonz/txshleveltypes.h"
+#include "toonz/txsheet.h"
 
 #include "tstream.h"
 
@@ -305,6 +306,27 @@ bool TXshLevelColumn::setNumbers(int row, int rowCount,
     m_first = 0;
   }
   return true;
+}
+
+//-----------------------------------------------------------------------------
+
+std::vector<TXshColumn *> TXshLevelColumn::getColumnMasks() {
+  std::vector<TXshColumn *> masks;
+
+  if (m_index <= 0) return masks;
+
+  TXsheet *xsh = getXsheet();
+  for (int i = m_index - 1; i >= 0; i--) {
+    TXshColumn *mcol = xsh->getColumn(i);
+
+    if (!mcol || mcol->isEmpty()) break;
+    if (mcol->getColumnType() == TXshColumn::eMeshType)
+      continue;  // ignore mesh levels
+    if (!mcol->isMask() || !mcol->isPreviewVisible()) break;
+    masks.push_back(mcol);
+  }
+
+  return masks;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -436,7 +436,8 @@ QPixmap convertImageToPixmap(const QImage &image) {
 
 // Load, theme colorize and change opacity of an icon image
 QImage generateIconImage(const QString &iconSVGName, qreal opacity,
-                         QSize newSize, Qt::AspectRatioMode aspectRatioMode) {
+                         QSize newSize, Qt::AspectRatioMode aspectRatioMode,
+                         bool useThemeColor) {
   static ThemeManager &themeManager = ThemeManager::getInstance();
 
   if (iconSVGName.isEmpty() || !themeManager.hasIcon(iconSVGName)) {
@@ -453,7 +454,7 @@ QImage generateIconImage(const QString &iconSVGName, qreal opacity,
   QImage image(svgToImage(imgPath, newSize, aspectRatioMode));
 
   // Colorize QImage
-  image = themeManager.recolorBlackPixels(image);
+  if (useThemeColor) image = themeManager.recolorBlackPixels(image);
 
   // Change opacity if required
   if (opacity != qreal(1.0)) image = adjustImageOpacity(image, opacity);
@@ -465,9 +466,10 @@ QImage generateIconImage(const QString &iconSVGName, qreal opacity,
 
 // Load, theme colorize and change opacity of an icon image file
 QPixmap generateIconPixmap(const QString &iconSVGName, qreal opacity,
-                           QSize newSize, Qt::AspectRatioMode aspectRatioMode) {
-  QImage image =
-      generateIconImage(iconSVGName, opacity, newSize, aspectRatioMode);
+                           QSize newSize, Qt::AspectRatioMode aspectRatioMode,
+                           bool useThemeColor) {
+  QImage image = generateIconImage(iconSVGName, opacity, newSize,
+                                   aspectRatioMode, useThemeColor);
   return convertImageToPixmap(image);
 }
 


### PR DESCRIPTION
This PR re-enables the `Mask` column feature found originally in Digital Video's "The TAB Pro" software which converts any `Vector` column into a real time `Clipping Mask` for the column that is immediately above/right of it.  There is no need to enable `Preview` mode to use it.

Clipping masks normally works with `Panels` -> `Export` .  This also provides the initial attempt at rendering clipping masks via the Fx rendering logic (`Render` -> `Preview`/`Render`).

Enable the option by going into the `Additional column settings` dropdown:

<img src="https://user-images.githubusercontent.com/19245851/224623538-8228e265-81b7-4095-88a2-5a54a3c81793.png" width="40%" height="40%" />

- `Clipping Mask` by default will cut out everything outside the masked area (Matte In)
- `Invert Mask` will cut out everything inside the masked area (Matte Out)
- `Render Mask` will render the image in the column as well as act as a clipping mask for the next column (Visible Matte In/Out)

`Clipping Mask` columns are currently indicated by a small icon in the upper right corner of the thumbnail area that will take the color of the Filter color if enabled.

<img src="https://user-images.githubusercontent.com/19245851/224516349-45ce687e-c2c3-4b3c-a973-eb90538b86b0.png" width="75%" height="75%" />

Notes:
- Masking is based on vector fills, not lines.
   - The vector lines, themselves, are not included as part of the clipping logic.
   - The clipping is actually based on the center of the line, if the line has any thickness.
   - Opacity has no impact to how clipped images look
- Clipping masks will work against Vector, Smart Raster, Raster and Sub-scene columns.
- Mesh columns will not block Clipping Masks if between the mask and the clipped column.
- Multiple clipping mask columns against the same column are allowed.
   - They need to be next to each other (see image above)
- Clipping mask columns can be animated as normal.
