### PR TITLE
Fix untranslatable text

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1,4 +1,251 @@
 <stringtable>
+<!------------------------------ FX Menu Groups and Subgroups ------------------------------------------->
+<!-- List should match groups found in profiles\layouts\fxs\fxs.lst                                -->
+
+  <item>"Background"			"Background"			</item>
+  <item>"Blur"			"Blur"			</item>
+  <item>"Distort"			"Distort"			</item>
+  <item>"Gradient"			"Gradient"			</item>
+  <item>"Image_Adjust"			"Image Adjust"			</item>
+  <item>"Layer_Blending"			"Layer Blending"			</item>
+  <item>"Layer_Blending_Ino"			"Layer Blending (Ino)"			</item>
+  <item>"Light"			"Light"			</item>
+  <item>"Matte"			"Matte"			</item>
+  <item>"Noise"			"Noise"			</item>
+  <item>"Render"			"Render"			</item>
+  <item>"Stylize"			"Stylize"			</item>
+  <item>"Toonz_Level"			"Color Indexed"			</item>
+  <item>"Shaders"			"Shaders"			</item>
+  <item>"Utility"			"Utility"			</item>
+
+<!------------------------------ FX Settings tabs/separators ---------------------------------------->
+  <item>"Add Ino"	"Add Ino"</item>
+  <item>"Add"	"Add"</item>
+  <item>"Adjust Exposure Iwa"	"Adjust Exposure Iwa"</item>
+  <item>"Adjust Levels"	"Adjust Levels"</item>
+  <item>"Alpha"	"Alpha"</item>
+  <item>"Angle"	"Angle"</item>
+  <item>"Animation"	"Animation"</item>
+  <item>"Art Contour"	"Art Contour"</item>
+  <item>"Backlit"	"Backlit"</item>
+  <item>"Barrel Distort Iwa"	"Barrel Distort Iwa"</item>
+  <item>"Base"	"Base"</item>
+  <item>"Birth Color"	"Birth Color"</item>
+  <item>"Birth Params"	"Birth Params"</item>
+  <item>"Bloom Iwa"	"Bloom Iwa"</item>
+  <item>"Blue"	"Blue"</item>
+  <item>"Blur Ino"	"Blur Ino"</item>
+  <item>"Blur"	"Blur"</item>
+  <item>"Body Highlight"	"Body Highlight"</item>
+  <item>"Bokeh Iwa"	"Bokeh Iwa"</item>
+  <item>"Bokeh Ref Iwa"	"Bokeh Ref Iwa"</item>
+  <item>"Brush Tip Geometry"	"Brush Tip Geometry"</item>
+  <item>"Bubble Color"	"Bubble Color"</item>
+  <item>"Calligraphic Line"	"Calligraphic Line"</item>
+  <item>"Cast Shadow"	"Cast Shadow"</item>
+  <item>"Caustics"	"Caustics"</item>
+  <item>"Channel Mixer"	"Channel Mixer"</item>
+  <item>"Channel Selector Ino"	"Channel Selector Ino"</item>
+  <item>"Checkerboard"	"Checkerboard"</item>
+  <item>"Clouds"	"Clouds"</item>
+  <item>"Color and Shape"	"Color and Shape"</item>
+  <item>"Color Blending"	"Color Blending"</item>
+  <item>"Color Burn Ino"	"Color Burn Ino"</item>
+  <item>"Color Card"	"Color Card"</item>
+  <item>"Color Dodge Ino"	"Color Dodge Ino"</item>
+  <item>"Color Emboss"	"Color Emboss"</item>
+  <item>"Color Raylit"	"Color Raylit"</item>
+  <item>"Colors"	"Colors"</item>
+  <item>"Conical Transform"	"Conical Transform"</item>
+  <item>"Contour"	"Contour"</item>
+  <item>"Contrast"	"Contrast"</item>
+  <item>"Corridor Gradient Iwa"	"Corridor Gradient Iwa"</item>
+  <item>"Cross Dissolve Ino"	"Cross Dissolve Ino"</item>
+  <item>"Cross Dissolve"	"Cross Dissolve"</item>
+  <item>"Curves"	"Curves"</item>
+  <item>"Darken Ino"	"Darken Ino"</item>
+  <item>"Darken"	"Darken"</item>
+  <item>"Darker Color Ino"	"Darker Color Ino"</item>
+  <item>"Density Ino"	"Density Ino"</item>
+  <item>"Despeckle"	"Despeckle"</item>
+  <item>"Destination"	"Destination"</item>
+  <item>"Diamond Grad"	"Diamond Grad"</item>
+  <item>"Difference mode"	"Difference mode"</item>
+  <item>"Directional Blur Iwa"	"Directional Blur Iwa"</item>
+  <item>"Directional Blur"	"Directional Blur"</item>
+  <item>"Dissolve"	"Dissolve"</item>
+  <item>"Distortion Wave"	"Distortion Wave"</item>
+  <item>"Distortion"	"Distortion"</item>
+  <item>"Divide Ino"	"Divide Ino"</item>
+  <item>"Ellipse"	"Ellipse"</item>
+  <item>"Emboss"	"Emboss"</item>
+  <item>"End"	"End"</item>
+  <item>"Environment"	"Environment"</item>
+  <item>"Erode/Dilate"	"Erode/Dilate"</item>
+  <item>"Evolution Options"	"Evolution Options"</item>
+  <item>"External Palette"	"External Palette"</item>
+  <item>"Fade-in Color"	"Fade-in Color"</item>
+  <item>"Fade-out Color"	"Fade-out Color"</item>
+  <item>"Fireball"	"Fireball"</item>
+  <item>"Flap Behavior"	"Flap Behavior"</item>
+  <item>"Floor Bump Iwa"	"Floor Bump Iwa"</item>
+  <item>"Flow Blur Iwa"	"Flow Blur Iwa"</item>
+  <item>"Flow Paint Brush Iwa"	"Flow Paint Brush Iwa"</item>
+  <item>"Fog Ino"	"Fog Ino"</item>
+  <item>"Four Points"	"Four Points"</item>
+  <item>"Fractal Noise Iwa"	"Fractal Noise Iwa"</item>
+  <item>"Free Distort"	"Free Distort"</item>
+  <item>"Friction"	"Friction"</item>
+  <item>"Gamma"	"Gamma"</item>
+  <item>"Glare Iwa"	"Glare Iwa"</item>
+  <item>"Glitter"	"Glitter"</item>
+  <item>"Glow"	"Glow"</item>
+  <item>"GPU HSL Blend"	"GPU HSL Blend"</item>
+  <item>"Gradient Warp Iwa"	"Gradient Warp Iwa"</item>
+  <item>"Gravity"	"Gravity"</item>
+  <item>"Green"	"Green"</item>
+  <item>"Hard Light Ino"	"Hard Light Ino"</item>
+  <item>"Hard Mix Ino"	"Hard Mix Ino"</item>
+  <item>"HLS Add Ino"	"HLS Add Ino"</item>
+  <item>"HLS Adjust Ino"	"HLS Adjust Ino"</item>
+  <item>"HLS Noise Ino"	"HLS Noise Ino"</item>
+  <item>"HSV Add Ino"	"HSV Add Ino"</item>
+  <item>"HSV Adjust Ino"	"HSV Adjust Ino"</item>
+  <item>"HSV Key"	"HSV Key"</item>
+  <item>"HSV Noise Ino"	"HSV Noise Ino"</item>
+  <item>"HSV Scale"	"HSV Scale"</item>
+  <item>"Inner Shape"	"Inner Shape"</item>
+  <item>"iwa Bokeh Advanced"	"iwa Bokeh Advanced"</item>
+  <item>"Kaleido"	"Kaleido"</item>
+  <item>"Level Auto Ino"	"Level Auto Ino"</item>
+  <item>"Level Master Ino"	"Level Master Ino"</item>
+  <item>"Level RGBA Ino"	"Level RGBA Ino"</item>
+  <item>"Lifetime"	"Lifetime"</item>
+  <item>"Light Direction"	"Light Direction"</item>
+  <item>"Light Spot"	"Light Spot"</item>
+  <item>"Lighten Ino"	"Lighten Ino"</item>
+  <item>"Lighter Color Ino"	"Lighter Color Ino"</item>
+  <item>"Limits"	"Limits"</item>
+  <item>"Line Blur Ino"	"Line Blur Ino"</item>
+  <item>"Linear Burn Ino"	"Linear Burn Ino"</item>
+  <item>"Linear Dodge Ino"	"Linear Dodge Ino"</item>
+  <item>"Linear Gradient (Classic)"	"Linear Gradient (Classic)"</item>
+  <item>"Linear Gradient"	"Linear Gradient"</item>
+  <item>"Linear Light Ino"	"Linear Light Ino"</item>
+  <item>"Linear Wave"	"Linear Wave"</item>
+  <item>"Local Blur"	"Local Blur"</item>
+  <item>"Local Transp"	"Local Transp"</item>
+  <item>"Max Min Ino"	"Max Min Ino"</item>
+  <item>"Median Filter Ino"	"Median Filter Ino"</item>
+  <item>"Median Ino"	"Median Ino"</item>
+  <item>"Mosaic"	"Mosaic"</item>
+  <item>"Motion Blur Ino"	"Motion Blur Ino"</item>
+  <item>"Motion Blur Iwa"	"Motion Blur Iwa"</item>
+  <item>"Motion Blur"	"Motion Blur"</item>
+  <item>"Motion Flow Iwa"	"Motion Flow Iwa"</item>
+  <item>"Motion Wind Ino"	"Motion Wind Ino"</item>
+  <item>"Multi Linear"	"Multi Linear"</item>
+  <item>"Multi Radial"	"Multi Radial"</item>
+  <item>"Multiply Ino"	"Multiply Ino"</item>
+  <item>"Multiply"	"Multiply"</item>
+  <item>"Multitone"	"Multitone"</item>
+  <item>"Negate Ino"	"Negate Ino"</item>
+  <item>"Noise"	"Noise"</item>
+  <item>"Nothing"	"Nothing"</item>
+  <item>"Opacity"	"Opacity"</item>
+  <item>"Outer Shape"	"Outer Shape"</item>
+  <item>"OutLine"	"OutLine"</item>
+  <item>"Over Ino"	"Over Ino"</item>
+  <item>"Overlay Ino"	"Overlay Ino"</item>
+  <item>"Palette Filter"	"Palette Filter"</item>
+  <item>"Particle Generation"	"Particle Generation"</item>
+  <item>"Particle"	"Particle"</item>
+  <item>"Pattern"	"Pattern"</item>
+  <item>"Perlin Noise"	"Perlin Noise"</item>
+  <item>"Perspective Distort Iwa"	"Perspective Distort Iwa"</item>
+  <item>"Pin Light Ino"	"Pin Light Ino"</item>
+  <item>"Pivot"	"Pivot"</item>
+  <item>"PN Clouds Ino"	"PN Clouds Ino"</item>
+  <item>"PN Perspective Iwa"	"PN Perspective Iwa"</item>
+  <item>"Posterize"	"Posterize"</item>
+  <item>"Radial Blur GPU"	"Radial Blur GPU"</item>
+  <item>"Radial Blur Ino"	"Radial Blur Ino"</item>
+  <item>"Radial Blur"	"Radial Blur"</item>
+  <item>"Radial Gradient"	"Radial Gradient"</item>
+  <item>"Rainbow Iwa"	"Rainbow Iwa"</item>
+  <item>"Random Wave"	"Random Wave"</item>
+  <item>"Raylit"	"Raylit"</item>
+  <item>"Red"	"Red"</item>
+  <item>"Reference Frame"	"Reference Frame"</item>
+  <item>"Reflection mode"	"Reflection mode"</item>
+  <item>"Refraction mode"	"Refraction mode"</item>
+  <item>"RGB Fade"	"RGB Fade"</item>
+  <item>"RGB Key"	"RGB Key"</item>
+  <item>"RGB"	"RGB"</item>
+  <item>"RGBA Cut"	"RGBA Cut"</item>
+  <item>"RGBA Scale"	"RGBA Scale"</item>
+  <item>"Ripple"	"Ripple"</item>
+  <item>"Ripples"	"Ripples"</item>
+  <item>"Rotation"	"Rotation"</item>
+  <item>"Salt Pepper Noise"	"Salt Pepper Noise"</item>
+  <item>"Scale"	"Scale"</item>
+  <item>"Scattering"	"Scattering"</item>
+  <item>"Screen Ino"	"Screen Ino"</item>
+  <item>"Shape"	"Shape"</item>
+  <item>"Sharpen"	"Sharpen"</item>
+  <item>"Shift"	"Shift"</item>
+  <item>"Size Increase"	"Size Increase"</item>
+  <item>"Size, Mass and Orientation"	"Size, Mass and Orientation"</item>
+  <item>"Smudge"	"Smudge"</item>
+  <item>"Soft Light Ino"	"Soft Light Ino"</item>
+  <item>"Solarize"	"Solarize"</item>
+  <item>"Source Area"	"Source Area"</item>
+  <item>"Source Image"	"Source Image"</item>
+  <item>"Source"	"Source"</item>
+  <item>"Source1"	"Source1"</item>
+  <item>"Source2"	"Source2"</item>
+  <item>"Source3"	"Source3"</item>
+  <item>"Source4"	"Source4"</item>
+  <item>"Source5"	"Source5"</item>
+  <item>"Spectrum Iwa"	"Spectrum Iwa"</item>
+  <item>"Speed"	"Speed"</item>
+  <item>"Spin Blur GPU"	"Spin Blur GPU"</item>
+  <item>"Spin Blur Ino"	"Spin Blur Ino"</item>
+  <item>"Spin Blur"	"Spin Blur"</item>
+  <item>"Spin Gradient Iwa"	"Spin Gradient Iwa"</item>
+  <item>"Spiral"	"Spiral"</item>
+  <item>"Square Gradient"	"Square Gradient"</item>
+  <item>"Starsky"	"Starsky"</item>
+  <item>"Start"	"Start"</item>
+  <item>"Sub Settings"	"Sub Settings"</item>
+  <item>"Subtract Ino"	"Subtract Ino"</item>
+  <item>"Subtract"	"Subtract"</item>
+  <item>"Sunflare"	"Sunflare"</item>
+  <item>"Tangent Flow Iwa"	"Tangent Flow Iwa"</item>
+  <item>"Target Spot"	"Target Spot"</item>
+  <item>"Text Iwa"	"Text Iwa"</item>
+  <item>"Texture Offset"	"Texture Offset"</item>
+  <item>"Texture"	"Texture"</item>
+  <item>"Thickness variation"	"Thickness variation"</item>
+  <item>"Tile Horizontally"	"Tile Horizontally"</item>
+  <item>"Tile Iwa"	"Tile Iwa"</item>
+  <item>"Tile Vertically"	"Tile Vertically"</item>
+  <item>"Tile"	"Tile"</item>
+  <item>"TimeCode Iwa"	"TimeCode Iwa"</item>
+  <item>"Tip Placement"	"Tip Placement"</item>
+  <item>"Top Layer"	"Top Layer"</item>
+  <item>"Trail"	"Trail"</item>
+  <item>"Transform"	"Transform"</item>
+  <item>"Transparency"	"Transparency"</item>
+  <item>"Transverse Wave"	"Transverse Wave"</item>
+  <item>"Vector Control"	"Vector Control"</item>
+  <item>"Vivid Light Ino"	"Vivid Light Ino"</item>
+  <item>"Warp HV Ino"	"Warp HV Ino"</item>
+  <item>"Warp"	"Warp"</item>
+  <item>"Waves"	"Waves"</item>
+  <item>"Wavy"	"Wavy"</item>
+  <item>"Wind"	"Wind"</item>
+
 <!------------------------------ FX ------------------------------------------->
 
   <item>"addFx"			"Add"			</item>

--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -2,249 +2,249 @@
 <!------------------------------ FX Menu Groups and Subgroups ------------------------------------------->
 <!-- List should match groups found in profiles\layouts\fxs\fxs.lst                                -->
 
-  <item>"Background"			"Background"			</item>
+  <item>"Background"		"Background"			</item>
   <item>"Blur"			"Blur"			</item>
-  <item>"Distort"			"Distort"			</item>
-  <item>"Gradient"			"Gradient"			</item>
-  <item>"Image_Adjust"			"Image Adjust"			</item>
-  <item>"Layer_Blending"			"Layer Blending"			</item>
-  <item>"Layer_Blending_Ino"			"Layer Blending (Ino)"			</item>
+  <item>"Distort"		"Distort"			</item>
+  <item>"Gradient"		"Gradient"			</item>
+  <item>"Image_Adjust"		"Image Adjust"			</item>
+  <item>"Layer_Blending"	"Layer Blending"			</item>
+  <item>"Layer_Blending_Ino"	"Layer Blending (Ino)"			</item>
   <item>"Light"			"Light"			</item>
   <item>"Matte"			"Matte"			</item>
   <item>"Noise"			"Noise"			</item>
-  <item>"Render"			"Render"			</item>
-  <item>"Stylize"			"Stylize"			</item>
-  <item>"Toonz_Level"			"Color Indexed"			</item>
-  <item>"Shaders"			"Shaders"			</item>
-  <item>"Utility"			"Utility"			</item>
+  <item>"Render"		"Render"			</item>
+  <item>"Stylize"		"Stylize"			</item>
+  <item>"Toonz_Level"		"Color Indexed"			</item>
+  <item>"Shaders"		"Shaders"			</item>
+  <item>"Utility"		"Utility"			</item>
 
 <!------------------------------ FX Settings tabs/separators ---------------------------------------->
-  <item>"Add Ino"	"Add Ino"</item>
-  <item>"Add"	"Add"</item>
-  <item>"Adjust Exposure Iwa"	"Adjust Exposure Iwa"</item>
-  <item>"Adjust Levels"	"Adjust Levels"</item>
-  <item>"Alpha"	"Alpha"</item>
-  <item>"Angle"	"Angle"</item>
-  <item>"Animation"	"Animation"</item>
-  <item>"Art Contour"	"Art Contour"</item>
-  <item>"Backlit"	"Backlit"</item>
-  <item>"Barrel Distort Iwa"	"Barrel Distort Iwa"</item>
-  <item>"Base"	"Base"</item>
-  <item>"Birth Color"	"Birth Color"</item>
-  <item>"Birth Params"	"Birth Params"</item>
-  <item>"Bloom Iwa"	"Bloom Iwa"</item>
-  <item>"Blue"	"Blue"</item>
-  <item>"Blur Ino"	"Blur Ino"</item>
-  <item>"Blur"	"Blur"</item>
-  <item>"Body Highlight"	"Body Highlight"</item>
-  <item>"Bokeh Iwa"	"Bokeh Iwa"</item>
-  <item>"Bokeh Ref Iwa"	"Bokeh Ref Iwa"</item>
-  <item>"Brush Tip Geometry"	"Brush Tip Geometry"</item>
-  <item>"Bubble Color"	"Bubble Color"</item>
-  <item>"Calligraphic Line"	"Calligraphic Line"</item>
-  <item>"Cast Shadow"	"Cast Shadow"</item>
-  <item>"Caustics"	"Caustics"</item>
-  <item>"Channel Mixer"	"Channel Mixer"</item>
-  <item>"Channel Selector Ino"	"Channel Selector Ino"</item>
-  <item>"Checkerboard"	"Checkerboard"</item>
-  <item>"Clouds"	"Clouds"</item>
-  <item>"Color and Shape"	"Color and Shape"</item>
-  <item>"Color Blending"	"Color Blending"</item>
-  <item>"Color Burn Ino"	"Color Burn Ino"</item>
-  <item>"Color Card"	"Color Card"</item>
-  <item>"Color Dodge Ino"	"Color Dodge Ino"</item>
-  <item>"Color Emboss"	"Color Emboss"</item>
-  <item>"Color Raylit"	"Color Raylit"</item>
-  <item>"Colors"	"Colors"</item>
-  <item>"Conical Transform"	"Conical Transform"</item>
-  <item>"Contour"	"Contour"</item>
-  <item>"Contrast"	"Contrast"</item>
-  <item>"Corridor Gradient Iwa"	"Corridor Gradient Iwa"</item>
-  <item>"Cross Dissolve Ino"	"Cross Dissolve Ino"</item>
-  <item>"Cross Dissolve"	"Cross Dissolve"</item>
-  <item>"Curves"	"Curves"</item>
-  <item>"Darken Ino"	"Darken Ino"</item>
-  <item>"Darken"	"Darken"</item>
-  <item>"Darker Color Ino"	"Darker Color Ino"</item>
-  <item>"Density Ino"	"Density Ino"</item>
-  <item>"Despeckle"	"Despeckle"</item>
-  <item>"Destination"	"Destination"</item>
-  <item>"Diamond Grad"	"Diamond Grad"</item>
-  <item>"Difference mode"	"Difference mode"</item>
-  <item>"Directional Blur Iwa"	"Directional Blur Iwa"</item>
-  <item>"Directional Blur"	"Directional Blur"</item>
-  <item>"Dissolve"	"Dissolve"</item>
-  <item>"Distortion Wave"	"Distortion Wave"</item>
-  <item>"Distortion"	"Distortion"</item>
-  <item>"Divide Ino"	"Divide Ino"</item>
-  <item>"Ellipse"	"Ellipse"</item>
-  <item>"Emboss"	"Emboss"</item>
-  <item>"End"	"End"</item>
-  <item>"Environment"	"Environment"</item>
-  <item>"Erode/Dilate"	"Erode/Dilate"</item>
-  <item>"Evolution Options"	"Evolution Options"</item>
-  <item>"External Palette"	"External Palette"</item>
-  <item>"Fade-in Color"	"Fade-in Color"</item>
-  <item>"Fade-out Color"	"Fade-out Color"</item>
-  <item>"Fireball"	"Fireball"</item>
-  <item>"Flap Behavior"	"Flap Behavior"</item>
-  <item>"Floor Bump Iwa"	"Floor Bump Iwa"</item>
-  <item>"Flow Blur Iwa"	"Flow Blur Iwa"</item>
-  <item>"Flow Paint Brush Iwa"	"Flow Paint Brush Iwa"</item>
-  <item>"Fog Ino"	"Fog Ino"</item>
-  <item>"Four Points"	"Four Points"</item>
-  <item>"Fractal Noise Iwa"	"Fractal Noise Iwa"</item>
-  <item>"Free Distort"	"Free Distort"</item>
-  <item>"Friction"	"Friction"</item>
-  <item>"Gamma"	"Gamma"</item>
-  <item>"Glare Iwa"	"Glare Iwa"</item>
-  <item>"Glitter"	"Glitter"</item>
-  <item>"Glow"	"Glow"</item>
-  <item>"GPU HSL Blend"	"GPU HSL Blend"</item>
-  <item>"Gradient Warp Iwa"	"Gradient Warp Iwa"</item>
-  <item>"Gravity"	"Gravity"</item>
-  <item>"Green"	"Green"</item>
-  <item>"Hard Light Ino"	"Hard Light Ino"</item>
-  <item>"Hard Mix Ino"	"Hard Mix Ino"</item>
-  <item>"HLS Add Ino"	"HLS Add Ino"</item>
-  <item>"HLS Adjust Ino"	"HLS Adjust Ino"</item>
-  <item>"HLS Noise Ino"	"HLS Noise Ino"</item>
-  <item>"HSV Add Ino"	"HSV Add Ino"</item>
-  <item>"HSV Adjust Ino"	"HSV Adjust Ino"</item>
-  <item>"HSV Key"	"HSV Key"</item>
-  <item>"HSV Noise Ino"	"HSV Noise Ino"</item>
-  <item>"HSV Scale"	"HSV Scale"</item>
-  <item>"Inner Shape"	"Inner Shape"</item>
-  <item>"iwa Bokeh Advanced"	"iwa Bokeh Advanced"</item>
-  <item>"Kaleido"	"Kaleido"</item>
-  <item>"Level Auto Ino"	"Level Auto Ino"</item>
-  <item>"Level Master Ino"	"Level Master Ino"</item>
-  <item>"Level RGBA Ino"	"Level RGBA Ino"</item>
-  <item>"Lifetime"	"Lifetime"</item>
-  <item>"Light Direction"	"Light Direction"</item>
-  <item>"Light Spot"	"Light Spot"</item>
-  <item>"Lighten Ino"	"Lighten Ino"</item>
-  <item>"Lighter Color Ino"	"Lighter Color Ino"</item>
-  <item>"Limits"	"Limits"</item>
-  <item>"Line Blur Ino"	"Line Blur Ino"</item>
-  <item>"Linear Burn Ino"	"Linear Burn Ino"</item>
-  <item>"Linear Dodge Ino"	"Linear Dodge Ino"</item>
-  <item>"Linear Gradient (Classic)"	"Linear Gradient (Classic)"</item>
-  <item>"Linear Gradient"	"Linear Gradient"</item>
-  <item>"Linear Light Ino"	"Linear Light Ino"</item>
-  <item>"Linear Wave"	"Linear Wave"</item>
-  <item>"Local Blur"	"Local Blur"</item>
-  <item>"Local Transp"	"Local Transp"</item>
-  <item>"Max Min Ino"	"Max Min Ino"</item>
-  <item>"Median Filter Ino"	"Median Filter Ino"</item>
-  <item>"Median Ino"	"Median Ino"</item>
-  <item>"Mosaic"	"Mosaic"</item>
-  <item>"Motion Blur Ino"	"Motion Blur Ino"</item>
-  <item>"Motion Blur Iwa"	"Motion Blur Iwa"</item>
-  <item>"Motion Blur"	"Motion Blur"</item>
-  <item>"Motion Flow Iwa"	"Motion Flow Iwa"</item>
-  <item>"Motion Wind Ino"	"Motion Wind Ino"</item>
-  <item>"Multi Linear"	"Multi Linear"</item>
-  <item>"Multi Radial"	"Multi Radial"</item>
-  <item>"Multiply Ino"	"Multiply Ino"</item>
-  <item>"Multiply"	"Multiply"</item>
-  <item>"Multitone"	"Multitone"</item>
-  <item>"Negate Ino"	"Negate Ino"</item>
-  <item>"Noise"	"Noise"</item>
-  <item>"Nothing"	"Nothing"</item>
-  <item>"Opacity"	"Opacity"</item>
-  <item>"Outer Shape"	"Outer Shape"</item>
-  <item>"OutLine"	"OutLine"</item>
-  <item>"Over Ino"	"Over Ino"</item>
-  <item>"Overlay Ino"	"Overlay Ino"</item>
-  <item>"Palette Filter"	"Palette Filter"</item>
-  <item>"Particle Generation"	"Particle Generation"</item>
-  <item>"Particle"	"Particle"</item>
-  <item>"Pattern"	"Pattern"</item>
-  <item>"Perlin Noise"	"Perlin Noise"</item>
-  <item>"Perspective Distort Iwa"	"Perspective Distort Iwa"</item>
-  <item>"Pin Light Ino"	"Pin Light Ino"</item>
-  <item>"Pivot"	"Pivot"</item>
-  <item>"PN Clouds Ino"	"PN Clouds Ino"</item>
-  <item>"PN Perspective Iwa"	"PN Perspective Iwa"</item>
-  <item>"Posterize"	"Posterize"</item>
-  <item>"Radial Blur GPU"	"Radial Blur GPU"</item>
-  <item>"Radial Blur Ino"	"Radial Blur Ino"</item>
-  <item>"Radial Blur"	"Radial Blur"</item>
-  <item>"Radial Gradient"	"Radial Gradient"</item>
-  <item>"Rainbow Iwa"	"Rainbow Iwa"</item>
-  <item>"Random Wave"	"Random Wave"</item>
-  <item>"Raylit"	"Raylit"</item>
-  <item>"Red"	"Red"</item>
-  <item>"Reference Frame"	"Reference Frame"</item>
-  <item>"Reflection mode"	"Reflection mode"</item>
-  <item>"Refraction mode"	"Refraction mode"</item>
-  <item>"RGB Fade"	"RGB Fade"</item>
-  <item>"RGB Key"	"RGB Key"</item>
-  <item>"RGB"	"RGB"</item>
-  <item>"RGBA Cut"	"RGBA Cut"</item>
-  <item>"RGBA Scale"	"RGBA Scale"</item>
-  <item>"Ripple"	"Ripple"</item>
-  <item>"Ripples"	"Ripples"</item>
-  <item>"Rotation"	"Rotation"</item>
-  <item>"Salt Pepper Noise"	"Salt Pepper Noise"</item>
-  <item>"Scale"	"Scale"</item>
-  <item>"Scattering"	"Scattering"</item>
-  <item>"Screen Ino"	"Screen Ino"</item>
-  <item>"Shape"	"Shape"</item>
-  <item>"Sharpen"	"Sharpen"</item>
-  <item>"Shift"	"Shift"</item>
-  <item>"Size Increase"	"Size Increase"</item>
-  <item>"Size, Mass and Orientation"	"Size, Mass and Orientation"</item>
-  <item>"Smudge"	"Smudge"</item>
-  <item>"Soft Light Ino"	"Soft Light Ino"</item>
-  <item>"Solarize"	"Solarize"</item>
-  <item>"Source Area"	"Source Area"</item>
-  <item>"Source Image"	"Source Image"</item>
-  <item>"Source"	"Source"</item>
-  <item>"Source1"	"Source1"</item>
-  <item>"Source2"	"Source2"</item>
-  <item>"Source3"	"Source3"</item>
-  <item>"Source4"	"Source4"</item>
-  <item>"Source5"	"Source5"</item>
-  <item>"Spectrum Iwa"	"Spectrum Iwa"</item>
-  <item>"Speed"	"Speed"</item>
-  <item>"Spin Blur GPU"	"Spin Blur GPU"</item>
-  <item>"Spin Blur Ino"	"Spin Blur Ino"</item>
-  <item>"Spin Blur"	"Spin Blur"</item>
-  <item>"Spin Gradient Iwa"	"Spin Gradient Iwa"</item>
-  <item>"Spiral"	"Spiral"</item>
-  <item>"Square Gradient"	"Square Gradient"</item>
-  <item>"Starsky"	"Starsky"</item>
-  <item>"Start"	"Start"</item>
-  <item>"Sub Settings"	"Sub Settings"</item>
-  <item>"Subtract Ino"	"Subtract Ino"</item>
-  <item>"Subtract"	"Subtract"</item>
-  <item>"Sunflare"	"Sunflare"</item>
-  <item>"Tangent Flow Iwa"	"Tangent Flow Iwa"</item>
-  <item>"Target Spot"	"Target Spot"</item>
-  <item>"Text Iwa"	"Text Iwa"</item>
-  <item>"Texture Offset"	"Texture Offset"</item>
-  <item>"Texture"	"Texture"</item>
-  <item>"Thickness variation"	"Thickness variation"</item>
-  <item>"Tile Horizontally"	"Tile Horizontally"</item>
-  <item>"Tile Iwa"	"Tile Iwa"</item>
-  <item>"Tile Vertically"	"Tile Vertically"</item>
-  <item>"Tile"	"Tile"</item>
-  <item>"TimeCode Iwa"	"TimeCode Iwa"</item>
-  <item>"Tip Placement"	"Tip Placement"</item>
-  <item>"Top Layer"	"Top Layer"</item>
-  <item>"Trail"	"Trail"</item>
-  <item>"Transform"	"Transform"</item>
-  <item>"Transparency"	"Transparency"</item>
-  <item>"Transverse Wave"	"Transverse Wave"</item>
-  <item>"Vector Control"	"Vector Control"</item>
-  <item>"Vivid Light Ino"	"Vivid Light Ino"</item>
-  <item>"Warp HV Ino"	"Warp HV Ino"</item>
-  <item>"Warp"	"Warp"</item>
-  <item>"Waves"	"Waves"</item>
-  <item>"Wavy"	"Wavy"</item>
-  <item>"Wind"	"Wind"</item>
+  <item>"Add Ino"			"Add Ino"			</item>
+  <item>"Add"				"Add"			</item>
+  <item>"Adjust Exposure Iwa"		"Adjust Exposure Iwa"			</item>
+  <item>"Adjust Levels"			"Adjust Levels"			</item>
+  <item>"Alpha"				"Alpha"			</item>
+  <item>"Angle"				"Angle"			</item>
+  <item>"Animation"			"Animation"			</item>
+  <item>"Art Contour"			"Art Contour"			</item>
+  <item>"Backlit"			"Backlit"			</item>
+  <item>"Barrel Distort Iwa"		"Barrel Distort Iwa"			</item>
+  <item>"Base"				"Base"			</item>
+  <item>"Birth Color"			"Birth Color"			</item>
+  <item>"Birth Params"			"Birth Params"			</item>
+  <item>"Bloom Iwa"			"Bloom Iwa"			</item>
+  <item>"Blue"				"Blue"			</item>
+  <item>"Blur Ino"			"Blur Ino"			</item>
+  <item>"Blur"				"Blur"			</item>
+  <item>"Body Highlight"		"Body Highlight"			</item>
+  <item>"Bokeh Iwa"			"Bokeh Iwa"			</item>
+  <item>"Bokeh Ref Iwa"			"Bokeh Ref Iwa"			</item>
+  <item>"Brush Tip Geometry"		"Brush Tip Geometry"			</item>
+  <item>"Bubble Color"			"Bubble Color"			</item>
+  <item>"Calligraphic Line"		"Calligraphic Line"			</item>
+  <item>"Cast Shadow"			"Cast Shadow"			</item>
+  <item>"Caustics"			"Caustics"			</item>
+  <item>"Channel Mixer"			"Channel Mixer"			</item>
+  <item>"Channel Selector Ino"		"Channel Selector Ino"			</item>
+  <item>"Checkerboard"			"Checkerboard"			</item>
+  <item>"Clouds"			"Clouds"			</item>
+  <item>"Color and Shape"		"Color and Shape"			</item>
+  <item>"Color Blending"		"Color Blending"			</item>
+  <item>"Color Burn Ino"		"Color Burn Ino"			</item>
+  <item>"Color Card"			"Color Card"			</item>
+  <item>"Color Dodge Ino"		"Color Dodge Ino"			</item>
+  <item>"Color Emboss"			"Color Emboss"			</item>
+  <item>"Color Raylit"			"Color Raylit"			</item>
+  <item>"Colors"			"Colors"			</item>
+  <item>"Conical Transform"		"Conical Transform"			</item>
+  <item>"Contour"			"Contour"			</item>
+  <item>"Contrast"			"Contrast"			</item>
+  <item>"Corridor Gradient Iwa"		"Corridor Gradient Iwa"			</item>
+  <item>"Cross Dissolve Ino"		"Cross Dissolve Ino"			</item>
+  <item>"Cross Dissolve"		"Cross Dissolve"			</item>
+  <item>"Curves"			"Curves"			</item>
+  <item>"Darken Ino"			"Darken Ino"			</item>
+  <item>"Darken"			"Darken"			</item>
+  <item>"Darker Color Ino"		"Darker Color Ino"			</item>
+  <item>"Density Ino"			"Density Ino"			</item>
+  <item>"Despeckle"			"Despeckle"			</item>
+  <item>"Destination"			"Destination"			</item>
+  <item>"Diamond Grad"			"Diamond Grad"			</item>
+  <item>"Difference mode"		"Difference mode"			</item>
+  <item>"Directional Blur Iwa"		"Directional Blur Iwa"			</item>
+  <item>"Directional Blur"		"Directional Blur"			</item>
+  <item>"Dissolve"			"Dissolve"			</item>
+  <item>"Distortion Wave"		"Distortion Wave"			</item>
+  <item>"Distortion"			"Distortion"			</item>
+  <item>"Divide Ino"			"Divide Ino"			</item>
+  <item>"Ellipse"			"Ellipse"			</item>
+  <item>"Emboss"			"Emboss"			</item>
+  <item>"End"				"End"			</item>
+  <item>"Environment"			"Environment"			</item>
+  <item>"Erode/Dilate"			"Erode/Dilate"			</item>
+  <item>"Evolution Options"		"Evolution Options"			</item>
+  <item>"External Palette"		"External Palette"			</item>
+  <item>"Fade-in Color"			"Fade-in Color"			</item>
+  <item>"Fade-out Color"		"Fade-out Color"			</item>
+  <item>"Fireball"			"Fireball"			</item>
+  <item>"Flap Behavior"			"Flap Behavior"			</item>
+  <item>"Floor Bump Iwa"		"Floor Bump Iwa"			</item>
+  <item>"Flow Blur Iwa"			"Flow Blur Iwa"			</item>
+  <item>"Flow Paint Brush Iwa"		"Flow Paint Brush Iwa"			</item>
+  <item>"Fog Ino"			"Fog Ino"			</item>
+  <item>"Four Points"			"Four Points"			</item>
+  <item>"Fractal Noise Iwa"		"Fractal Noise Iwa"			</item>
+  <item>"Free Distort"			"Free Distort"			</item>
+  <item>"Friction"			"Friction"			</item>
+  <item>"Gamma"				"Gamma"			</item>
+  <item>"Glare Iwa"			"Glare Iwa"			</item>
+  <item>"Glitter"			"Glitter"			</item>
+  <item>"Glow"				"Glow"			</item>
+  <item>"GPU HSL Blend"			"GPU HSL Blend"			</item>
+  <item>"Gradient Warp Iwa"		"Gradient Warp Iwa"			</item>
+  <item>"Gravity"			"Gravity"			</item>
+  <item>"Green"				"Green"			</item>
+  <item>"Hard Light Ino"		"Hard Light Ino"			</item>
+  <item>"Hard Mix Ino"			"Hard Mix Ino"			</item>
+  <item>"HLS Add Ino"			"HLS Add Ino"			</item>
+  <item>"HLS Adjust Ino"		"HLS Adjust Ino"			</item>
+  <item>"HLS Noise Ino"			"HLS Noise Ino"			</item>
+  <item>"HSV Add Ino"			"HSV Add Ino"			</item>
+  <item>"HSV Adjust Ino"		"HSV Adjust Ino"			</item>
+  <item>"HSV Key"			"HSV Key"			</item>
+  <item>"HSV Noise Ino"			"HSV Noise Ino"			</item>
+  <item>"HSV Scale"			"HSV Scale"			</item>
+  <item>"Inner Shape"			"Inner Shape"			</item>
+  <item>"iwa Bokeh Advanced"		"iwa Bokeh Advanced"			</item>
+  <item>"Kaleido"			"Kaleido"			</item>
+  <item>"Level Auto Ino"		"Level Auto Ino"			</item>
+  <item>"Level Master Ino"		"Level Master Ino"			</item>
+  <item>"Level RGBA Ino"		"Level RGBA Ino"			</item>
+  <item>"Lifetime"			"Lifetime"			</item>
+  <item>"Light Direction"		"Light Direction"			</item>
+  <item>"Light Spot"			"Light Spot"			</item>
+  <item>"Lighten Ino"			"Lighten Ino"			</item>
+  <item>"Lighter Color Ino"		"Lighter Color Ino"			</item>
+  <item>"Limits"			"Limits"			</item>
+  <item>"Line Blur Ino"			"Line Blur Ino"			</item>
+  <item>"Linear Burn Ino"		"Linear Burn Ino"			</item>
+  <item>"Linear Dodge Ino"		"Linear Dodge Ino"			</item>
+  <item>"Linear Gradient (Classic)"	"Linear Gradient (Classic)"			</item>
+  <item>"Linear Gradient"		"Linear Gradient"			</item>
+  <item>"Linear Light Ino"		"Linear Light Ino"			</item>
+  <item>"Linear Wave"			"Linear Wave"			</item>
+  <item>"Local Blur"			"Local Blur"			</item>
+  <item>"Local Transp"			"Local Transp"			</item>
+  <item>"Max Min Ino"			"Max Min Ino"			</item>
+  <item>"Median Filter Ino"		"Median Filter Ino"			</item>
+  <item>"Median Ino"			"Median Ino"			</item>
+  <item>"Mosaic"			"Mosaic"			</item>
+  <item>"Motion Blur Ino"		"Motion Blur Ino"			</item>
+  <item>"Motion Blur Iwa"		"Motion Blur Iwa"			</item>
+  <item>"Motion Blur"			"Motion Blur"			</item>
+  <item>"Motion Flow Iwa"		"Motion Flow Iwa"			</item>
+  <item>"Motion Wind Ino"		"Motion Wind Ino"			</item>
+  <item>"Multi Linear"			"Multi Linear"			</item>
+  <item>"Multi Radial"			"Multi Radial"			</item>
+  <item>"Multiply Ino"			"Multiply Ino"			</item>
+  <item>"Multiply"			"Multiply"			</item>
+  <item>"Multitone"			"Multitone"			</item>
+  <item>"Negate Ino"			"Negate Ino"			</item>
+  <item>"Noise"				"Noise"			</item>
+  <item>"Nothing"			"Nothing"			</item>
+  <item>"Opacity"			"Opacity"			</item>
+  <item>"Outer Shape"			"Outer Shape"			</item>
+  <item>"OutLine"			"OutLine"			</item>
+  <item>"Over Ino"			"Over Ino"			</item>
+  <item>"Overlay Ino"			"Overlay Ino"			</item>
+  <item>"Palette Filter"		"Palette Filter"			</item>
+  <item>"Particle Generation"		"Particle Generation"			</item>
+  <item>"Particle"			"Particle"			</item>
+  <item>"Pattern"			"Pattern"			</item>
+  <item>"Perlin Noise"			"Perlin Noise"			</item>
+  <item>"Perspective Distort Iwa"	"Perspective Distort Iwa"			</item>
+  <item>"Pin Light Ino"			"Pin Light Ino"			</item>
+  <item>"Pivot"				"Pivot"			</item>
+  <item>"PN Clouds Ino"			"PN Clouds Ino"			</item>
+  <item>"PN Perspective Iwa"		"PN Perspective Iwa"			</item>
+  <item>"Posterize"			"Posterize"			</item>
+  <item>"Radial Blur GPU"		"Radial Blur GPU"			</item>
+  <item>"Radial Blur Ino"		"Radial Blur Ino"			</item>
+  <item>"Radial Blur"			"Radial Blur"			</item>
+  <item>"Radial Gradient"		"Radial Gradient"			</item>
+  <item>"Rainbow Iwa"			"Rainbow Iwa"			</item>
+  <item>"Random Wave"			"Random Wave"			</item>
+  <item>"Raylit"			"Raylit"			</item>
+  <item>"Red"				"Red"			</item>
+  <item>"Reference Frame"		"Reference Frame"			</item>
+  <item>"Reflection mode"		"Reflection mode"			</item>
+  <item>"Refraction mode"		"Refraction mode"			</item>
+  <item>"RGB Fade"			"RGB Fade"			</item>
+  <item>"RGB Key"			"RGB Key"			</item>
+  <item>"RGB"				"RGB"			</item>
+  <item>"RGBA Cut"			"RGBA Cut"			</item>
+  <item>"RGBA Scale"			"RGBA Scale"			</item>
+  <item>"Ripple"			"Ripple"			</item>
+  <item>"Ripples"			"Ripples"			</item>
+  <item>"Rotation"			"Rotation"			</item>
+  <item>"Salt Pepper Noise"		"Salt Pepper Noise"			</item>
+  <item>"Scale"				"Scale"			</item>
+  <item>"Scattering"			"Scattering"			</item>
+  <item>"Screen Ino"			"Screen Ino"			</item>
+  <item>"Shape"				"Shape"			</item>
+  <item>"Sharpen"			"Sharpen"			</item>
+  <item>"Shift"				"Shift"			</item>
+  <item>"Size Increase"			"Size Increase"			</item>
+  <item>"Size, Mass and Orientation"	"Size, Mass and Orientation"			</item>
+  <item>"Smudge"			"Smudge"			</item>
+  <item>"Soft Light Ino"		"Soft Light Ino"			</item>
+  <item>"Solarize"			"Solarize"			</item>
+  <item>"Source Area"			"Source Area"			</item>
+  <item>"Source Image"			"Source Image"			</item>
+  <item>"Source"			"Source"			</item>
+  <item>"Source1"			"Source1"			</item>
+  <item>"Source2"			"Source2"			</item>
+  <item>"Source3"			"Source3"			</item>
+  <item>"Source4"			"Source4"			</item>
+  <item>"Source5"			"Source5"			</item>
+  <item>"Spectrum Iwa"			"Spectrum Iwa"			</item>
+  <item>"Speed"				"Speed"			</item>
+  <item>"Spin Blur GPU"			"Spin Blur GPU"			</item>
+  <item>"Spin Blur Ino"			"Spin Blur Ino"			</item>
+  <item>"Spin Blur"			"Spin Blur"			</item>
+  <item>"Spin Gradient Iwa"		"Spin Gradient Iwa"			</item>
+  <item>"Spiral"			"Spiral"			</item>
+  <item>"Square Gradient"		"Square Gradient"			</item>
+  <item>"Starsky"			"Starsky"			</item>
+  <item>"Start"				"Start"			</item>
+  <item>"Sub Settings"			"Sub Settings"			</item>
+  <item>"Subtract Ino"			"Subtract Ino"			</item>
+  <item>"Subtract"			"Subtract"			</item>
+  <item>"Sunflare"			"Sunflare"			</item>
+  <item>"Tangent Flow Iwa"		"Tangent Flow Iwa"			</item>
+  <item>"Target Spot"			"Target Spot"			</item>
+  <item>"Text Iwa"			"Text Iwa"			</item>
+  <item>"Texture Offset"		"Texture Offset"			</item>
+  <item>"Texture"			"Texture"			</item>
+  <item>"Thickness variation"		"Thickness variation"			</item>
+  <item>"Tile Horizontally"		"Tile Horizontally"			</item>
+  <item>"Tile Iwa"			"Tile Iwa"			</item>
+  <item>"Tile Vertically"		"Tile Vertically"			</item>
+  <item>"Tile"				"Tile"			</item>
+  <item>"TimeCode Iwa"			"TimeCode Iwa"			</item>
+  <item>"Tip Placement"			"Tip Placement"			</item>
+  <item>"Top Layer"			"Top Layer"			</item>
+  <item>"Trail"				"Trail"			</item>
+  <item>"Transform"			"Transform"			</item>
+  <item>"Transparency"			"Transparency"			</item>
+  <item>"Transverse Wave"		"Transverse Wave"			</item>
+  <item>"Vector Control"		"Vector Control"			</item>
+  <item>"Vivid Light Ino"		"Vivid Light Ino"			</item>
+  <item>"Warp HV Ino"			"Warp HV Ino"			</item>
+  <item>"Warp"				"Warp"			</item>
+  <item>"Waves"				"Waves"			</item>
+  <item>"Wavy"				"Wavy"			</item>
+  <item>"Wind"				"Wind"			</item>
 
 <!------------------------------ FX ------------------------------------------->
 
@@ -1966,5 +1966,64 @@
   <item>"STD_iwa_TiledParticlesFx.fadeout_color_fade"		"Fade-out Intensity"		</item>
   <item>"STD_iwa_TiledParticlesFx.source_gradation"		"Use Control Image Gradation"		</item>
   <item>"STD_iwa_TiledParticlesFx.pick_color_for_every_frame"	"Pick Control Image's Color for Every Frame"	</item>
+  
+<!------------------------------ MyPaint settings ---------------------------------------->
+ <item>"Opacity"				"Opacity"			</item>
+ <item>"Opacity multiply"			"Opacity multiply"			</item>
+ <item>"Opacity linearize"			"Opacity linearize"			</item>
+ <item>"Radius"					"Radius"			</item>
+ <item>"Hardness"				"Hardness"			</item>
+ <item>"Pixel feather"				"Pixel feather"			</item>
+ <item>"Dabs per basic radius"			"Dabs per basic radius"			</item>
+ <item>"Dabs per actual radius"			"Dabs per actual radius"			</item>
+ <item>"Dabs per second"			"Dabs per second"			</item>
+ <item>"GridMap Scale"				"GridMap Scale"			</item>
+ <item>"GridMap Scale X"			"GridMap Scale X"			</item>
+ <item>"GridMap Scale Y"			"GridMap Scale Y"			</item>
+ <item>"Radius by random"			"Radius by random"			</item>
+ <item>"Fine speed filter"			"Fine speed filter"			</item>
+ <item>"Gross speed filter"			"Gross speed filter"			</item>
+ <item>"Fine speed gamma"			"Fine speed gamma"			</item>
+ <item>"Gross speed gamma"			"Gross speed gamma"			</item>
+ <item>"Jitter"					"Jitter"			</item>
+ <item>"Offset Y"				"Offset Y"			</item>
+ <item>"Offset X"				"Offset X"			</item>
+ <item>"Angular Offset: Direction"		"Angular Offset: Direction"			</item>
+ <item>"Angular Offset: Ascension"		"Angular Offset: Ascension"			</item>
+ <item>"Angular Offset Mirrored: Direction"	"Angular Offset Mirrored: Direction"			</item>
+ <item>"Angular Offset Mirrored: Ascension"	"Angular Offset Mirrored: Ascension"			</item>
+ <item>"Angular Offsets Adjustment"		"Angular Offsets Adjustment"			</item>
+ <item>"Offsets Multiplier"			"Offsets Multiplier"			</item>
+ <item>"Offset by speed"			"Offset by speed"			</item>
+ <item>"Offset by speed filter"			"Offset by speed filter"			</item>
+ <item>"Slow position tracking"			"Slow position tracking"			</item>
+ <item>"Slow tracking per dab"			"Slow tracking per dab"			</item>
+ <item>"Tracking noise"				"Tracking noise"			</item>
+ <item>"Color hue"				"Color hue"			</item>
+ <item>"Color saturation"			"Color saturation"			</item>
+ <item>"Color value"				"Color value"			</item>
+ <item>"Save color"				"Save color"			</item>
+ <item>"Change color hue"			"Change color hue"			</item>
+ <item>"Change color lightness (HSL)"		"Change color lightness (HSL)"			</item>
+ <item>"Change color satur. (HSL)"		"Change color satur. (HSL)"			</item>
+ <item>"Change color value (HSV)"		"Change color value (HSV)"			</item>
+ <item>"Change color satur. (HSV)"		"Change color satur. (HSV)"			</item>
+ <item>"Smudge"					"Smudge"			</item>
+ <item>"Smudge length"				"Smudge length"			</item>
+ <item>"Smudge radius"				"Smudge radius"			</item>
+ <item>"Eraser"					"Eraser"			</item>
+ <item>"Stroke threshold"			"Stroke threshold"			</item>
+ <item>"Stroke duration"			"Stroke duration"			</item>
+ <item>"Stroke hold time"			"Stroke hold time"			</item>
+ <item>"Custom input"				"Custom input"			</item>
+ <item>"Custom input filter"			"Custom input filter"			</item>
+ <item>"Elliptical dab: ratio"			"Elliptical dab: ratio"			</item>
+ <item>"Elliptical dab: angle"			"Elliptical dab: angle"			</item>
+ <item>"Direction filter"			"Direction filter"			</item>
+ <item>"Lock alpha"				"Lock alpha"			</item>
+ <item>"Colorize"				"Colorize"			</item>
+ <item>"Snap to pixel"				"Snap to pixel"			</item>
+ <item>"Pressure gain"				"Pressure gain"			</item>
+
 </stringtable> 
 

--- a/stuff/profiles/layouts/fxs/fxs.lst
+++ b/stuff/profiles/layouts/fxs/fxs.lst
@@ -170,7 +170,7 @@
     STD_iwa_TangentFlowFx
     STD_iwa_MotionFlowFx
   </Stylize>
-  <Tahoma2D_Level>
+  <Toonz_Level>
     STD_artContourFx
     STD_calligraphicFx
     STD_blendTzFx
@@ -179,7 +179,7 @@
     STD_paletteFilterFx
     STD_cornerPinFx
     STD_textureFx
-  </Tahoma2D_Level>
+  </Toonz_Level>
 <Shaders>
   SHADER_caustics
   SHADER_fireball

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -649,7 +649,7 @@ endif()
 
 if(WITH_TRANSLATION)
     # generate Qt translations and messages
-    set(LANGUAGES japanese italian french spanish chinese german russian korean czech)
+    set(LANGUAGES japanese italian french spanish chinese german russian korean czech brazilian-portuguese)
 
     function(add_translation module)
         set(translation)

--- a/toonz/sources/include/tw/stringtable.h
+++ b/toonz/sources/include/tw/stringtable.h
@@ -15,12 +15,15 @@
 #define DVVAR DV_IMPORT_VAR
 #endif
 
+class QString;
 class TFilePath;
 
 class DVAPI TStringTable {
 public:
   static const TStringTable *instance();
   static std::wstring translate(std::string);
+  static void updateTranslation(QString);
+
 
   class Item {
   public:

--- a/toonz/sources/tnzbase/stringtable.cpp
+++ b/toonz/sources/tnzbase/stringtable.cpp
@@ -30,7 +30,7 @@ public:
   void load(const TFilePath &);
 
   void loadCoded(const TFilePath &);
-  void saveCoded(const TFilePath &);
+//  void saveCoded(const TFilePath &);
 
   const Item *getItem(std::string name) const override;
   std::pair<std::string, int> getDefaultFontNameAndSize() const override {
@@ -284,6 +284,8 @@ const TStringTable::Item *TStringTableImp::getItem(std::string name) const {
 
 }  // namespace
 
+static TStringTableImp *StringTable = 0;
+
 //-------------------------------------------------------------------
 
 TStringTable::TStringTable() {}
@@ -306,10 +308,19 @@ std::wstring TStringTable::translate(std::string name) {
 
 const TStringTable *TStringTable::instance() {
   // may hurt MacOsX
-  static TStringTableImp *instance = 0;
-  if (!instance) instance          = new TStringTableImp;
+  if (!StringTable) StringTable = new TStringTableImp;
 
-  instance->init();
+  StringTable->init();
 
-  return instance;
+  return StringTable;
+}
+
+void TStringTable::updateTranslation(QString language) { 
+  if (!StringTable) StringTable = new TStringTableImp;
+
+  if (!language.isEmpty() && language != "English") {
+    TFilePath languageFp = TEnv::getConfigDir() + "loc" +
+                           language.toStdString() + TFilePath("current.txt");
+    if (TFileStatus(languageFp).doesExist()) StringTable->load(languageFp);
+  }
 }

--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -252,7 +252,7 @@ InsertFxPopup::InsertFxPopup()
 
   // add 'Plugins' directory
   auto plugins =
-      new QTreeWidgetItem((QTreeWidget *)NULL, QStringList("Plugins"));
+      new QTreeWidgetItem((QTreeWidget *)NULL, QStringList(tr("Plugins")));
   plugins->setIcon(0, createQIcon("folder", true));
   m_fxTree->addTopLevelItem(plugins);
 
@@ -325,7 +325,8 @@ void InsertFxPopup::loadFolder(QTreeWidgetItem *parent) {
     std::string tagName;
     if (m_is->matchTag(tagName)) {
       // Found a sub-folder
-      QString folderName = QString::fromStdString(tagName);
+      QString folderName =
+          QString::fromStdWString(TStringTable::translate(tagName));
 
       std::unique_ptr<QTreeWidgetItem> folder(
           new QTreeWidgetItem((QTreeWidget *)0, QStringList(folderName)));

--- a/toonz/sources/toonz/locatorpopup.cpp
+++ b/toonz/sources/toonz/locatorpopup.cpp
@@ -108,7 +108,7 @@ void LocatorPopup::changeWindowTitle() {
   }
 
   if (showZoomFactor) {
-    name = name + "  Zoom : " +
+    name = name + tr("  Zoom : ") +
            QString::number((int)(100.0 * sqrt(m_viewer->getViewMatrix().det()) *
                                  m_viewer->getDpiFactor())) +
            "%";

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -14,6 +14,7 @@
 #include "expressionreferencemanager.h"
 #include "thirdparty.h"
 #include "startuppopup.h"
+#include "tw/stringtable.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -546,6 +547,10 @@ int main(int argc, char *argv[]) {
   TTool::updateToolsPropertiesTranslation();
   // Apply translation to file writers properties
   Tiio::updateFileWritersPropertiesTranslation();
+
+  // Translate string table
+  TStringTable::instance()->updateTranslation(
+      Preferences::instance()->getCurrentLanguage());
 
   // Force to have left-to-right layout direction in any language environment.
   // This function has to be called after installTranslator().

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -486,7 +486,72 @@ int main(int argc, char *argv[]) {
   if (!isRunScript) splash.show();
   a.processEvents();
 
-  splash.showMessage(offsetStr + "Initializing QGLFormat...",
+  splash.showMessage(offsetStr + "Loading Translator...",
+                     Qt::AlignRight | Qt::AlignBottom, Qt::black);
+  a.processEvents();
+
+  // Carico la traduzione contenuta in toonz.qm (se ï¿½ presente)
+  QString languagePathString =
+      QString::fromStdString(::to_string(TEnv::getConfigDir() + "loc"));
+#ifndef WIN32
+  // the merge of menu on osx can cause problems with different languages with
+  // the Preferences menu
+  // qt_mac_set_menubar_merge(false);
+  languagePathString += "/" + Preferences::instance()->getCurrentLanguage();
+#else
+  languagePathString += "\\" + Preferences::instance()->getCurrentLanguage();
+#endif
+  QTranslator translator;
+  translator.load("toonz", languagePathString);
+
+  // La installo
+  a.installTranslator(&translator);
+
+  // Carico la traduzione contenuta in toonzqt.qm (se e' presente)
+  QTranslator translator2;
+  translator2.load("toonzqt", languagePathString);
+  a.installTranslator(&translator2);
+
+  // Carico la traduzione contenuta in tnzcore.qm (se e' presente)
+  QTranslator tnzcoreTranslator;
+  tnzcoreTranslator.load("tnzcore", languagePathString);
+  qApp->installTranslator(&tnzcoreTranslator);
+
+  // Carico la traduzione contenuta in toonzlib.qm (se e' presente)
+  QTranslator toonzlibTranslator;
+  toonzlibTranslator.load("toonzlib", languagePathString);
+  qApp->installTranslator(&toonzlibTranslator);
+
+  // Carico la traduzione contenuta in colorfx.qm (se e' presente)
+  QTranslator colorfxTranslator;
+  colorfxTranslator.load("colorfx", languagePathString);
+  qApp->installTranslator(&colorfxTranslator);
+
+  // Carico la traduzione contenuta in tools.qm
+  QTranslator toolTranslator;
+  toolTranslator.load("tnztools", languagePathString);
+  qApp->installTranslator(&toolTranslator);
+
+  // load translation for file writers properties
+  QTranslator imageTranslator;
+  imageTranslator.load("image", languagePathString);
+  qApp->installTranslator(&imageTranslator);
+
+  QTranslator qtTranslator;
+  qtTranslator.load("qt_" + QLocale::system().name(),
+                    QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+  a.installTranslator(&qtTranslator);
+
+  // Aggiorno la traduzione delle properties di tutti i tools
+  TTool::updateToolsPropertiesTranslation();
+  // Apply translation to file writers properties
+  Tiio::updateFileWritersPropertiesTranslation();
+
+  // Force to have left-to-right layout direction in any language environment.
+  // This function has to be called after installTranslator().
+  a.setLayoutDirection(Qt::LeftToRight);
+
+  splash.showMessage(offsetStr + QObject::tr("Initializing QGLFormat..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
@@ -498,7 +563,7 @@ int main(int argc, char *argv[]) {
 
   glutInit(&argc, argv);
 
-  splash.showMessage(offsetStr + "Initializing environment...",
+  splash.showMessage(offsetStr + QObject::tr("Initializing environment..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
@@ -584,72 +649,8 @@ int main(int argc, char *argv[]) {
   // DVDirModel must be instantiated after Version Control initialization...
   FolderListenerManager::instance()->addListener(DvDirModel::instance());
 
-  splash.showMessage(offsetStr + "Loading Translator...",
-                     Qt::AlignRight | Qt::AlignBottom, Qt::black);
-  a.processEvents();
 
-  // Carico la traduzione contenuta in toonz.qm (se ï¿½ presente)
-  QString languagePathString =
-      QString::fromStdString(::to_string(TEnv::getConfigDir() + "loc"));
-#ifndef WIN32
-  // the merge of menu on osx can cause problems with different languages with
-  // the Preferences menu
-  // qt_mac_set_menubar_merge(false);
-  languagePathString += "/" + Preferences::instance()->getCurrentLanguage();
-#else
-  languagePathString += "\\" + Preferences::instance()->getCurrentLanguage();
-#endif
-  QTranslator translator;
-  translator.load("toonz", languagePathString);
-
-  // La installo
-  a.installTranslator(&translator);
-
-  // Carico la traduzione contenuta in toonzqt.qm (se e' presente)
-  QTranslator translator2;
-  translator2.load("toonzqt", languagePathString);
-  a.installTranslator(&translator2);
-
-  // Carico la traduzione contenuta in tnzcore.qm (se e' presente)
-  QTranslator tnzcoreTranslator;
-  tnzcoreTranslator.load("tnzcore", languagePathString);
-  qApp->installTranslator(&tnzcoreTranslator);
-
-  // Carico la traduzione contenuta in toonzlib.qm (se e' presente)
-  QTranslator toonzlibTranslator;
-  toonzlibTranslator.load("toonzlib", languagePathString);
-  qApp->installTranslator(&toonzlibTranslator);
-
-  // Carico la traduzione contenuta in colorfx.qm (se e' presente)
-  QTranslator colorfxTranslator;
-  colorfxTranslator.load("colorfx", languagePathString);
-  qApp->installTranslator(&colorfxTranslator);
-
-  // Carico la traduzione contenuta in tools.qm
-  QTranslator toolTranslator;
-  toolTranslator.load("tnztools", languagePathString);
-  qApp->installTranslator(&toolTranslator);
-
-  // load translation for file writers properties
-  QTranslator imageTranslator;
-  imageTranslator.load("image", languagePathString);
-  qApp->installTranslator(&imageTranslator);
-
-  QTranslator qtTranslator;
-  qtTranslator.load("qt_" + QLocale::system().name(),
-                    QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-  a.installTranslator(&qtTranslator);
-
-  // Aggiorno la traduzione delle properties di tutti i tools
-  TTool::updateToolsPropertiesTranslation();
-  // Apply translation to file writers properties
-  Tiio::updateFileWritersPropertiesTranslation();
-
-  // Force to have left-to-right layout direction in any language environment.
-  // This function has to be called after installTranslator().
-  a.setLayoutDirection(Qt::LeftToRight);
-
-  splash.showMessage(offsetStr + "Loading styles...",
+  splash.showMessage(offsetStr + QObject::tr("Loading styles..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
@@ -663,20 +664,20 @@ int main(int argc, char *argv[]) {
 
   IconGenerator::setFilmstripIconSize(Preferences::instance()->getIconSize());
 
-  splash.showMessage(offsetStr + "Loading shaders...",
+  splash.showMessage(offsetStr + QObject::tr("Loading shaders..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
   loadShaderInterfaces(ToonzFolder::getLibraryFolder() + TFilePath("shaders"));
 
-  splash.showMessage(offsetStr + "Initializing Tahoma2D...",
+  splash.showMessage(offsetStr + QObject::tr("Initializing Tahoma2D..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
   TTool::setApplication(TApp::instance());
   TApp::instance()->init();
 
-  splash.showMessage(offsetStr + "Loading Plugins...",
+  splash.showMessage(offsetStr + QObject::tr("Loading Plugins..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
   /* poll the thread ends:
@@ -689,7 +690,7 @@ int main(int argc, char *argv[]) {
     a.processEvents();
   }
 
-  splash.showMessage(offsetStr + "Creating main window...",
+  splash.showMessage(offsetStr + QObject::tr("Creating main window..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
@@ -759,7 +760,7 @@ int main(int argc, char *argv[]) {
   QWindowsWindowFunctions::setWinTabEnabled(!useQtNativeWinInk);
 #endif
 
-  splash.showMessage(offsetStr + "Loading style sheet...",
+  splash.showMessage(offsetStr + QObject::tr("Loading style sheet..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
@@ -768,7 +769,7 @@ int main(int argc, char *argv[]) {
   a.setStyleSheet(currentStyle);
 
   // Perspective grid tool - custom grid
-  splash.showMessage(offsetStr + "Loading Perspective Grid...",
+  splash.showMessage(offsetStr + QObject::tr("Loading Perspective Grid..."),
                      Qt::AlignRight | Qt::AlignBottom, Qt::black);
   a.processEvents();
 
@@ -778,10 +779,10 @@ int main(int argc, char *argv[]) {
 
   w.setWindowTitle(QString::fromStdString(TEnv::getApplicationFullName()));
   if (TEnv::getIsPortable()) {
-    splash.showMessage(offsetStr + "Starting Tahoma2D...",
+    splash.showMessage(offsetStr + QObject::tr("Starting Tahoma2D..."),
                        Qt::AlignRight | Qt::AlignBottom, Qt::black);
   } else {
-    splash.showMessage(offsetStr + "Starting main window...",
+    splash.showMessage(offsetStr + QObject::tr("Starting main window..."),
                        Qt::AlignRight | Qt::AlignBottom, Qt::black);
   }
   a.processEvents();
@@ -824,9 +825,9 @@ int main(int argc, char *argv[]) {
 
   CommandManager::instance()->execute(T_Hand);
   if (!loadFilePath.isEmpty()) {
-    splash.showMessage(
-        QString("Loading file '") + loadFilePath.getQString() + "'...",
-        Qt::AlignRight | Qt::AlignBottom, Qt::black);
+    splash.showMessage(QString(QObject::tr("Loading file '%1'..."))
+                           .arg(loadFilePath.getQString()),
+                       Qt::AlignRight | Qt::AlignBottom, Qt::black);
     loadFilePath = loadFilePath.withType("tnz");
     if (TFileStatus(loadFilePath).doesExist()) IoCmd::loadScene(loadFilePath);
   }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -222,6 +222,27 @@ int get_version_code_from(std::string ver) {
 // Room
 //-----------------------------------------------------------------------------
 
+void Room::setName(QString name) {
+  m_name   = name;
+  m_trName = name;
+
+  // Set translatable name if it matches default room
+  if (m_name == "2D")
+    m_trName = tr("2D");
+  else if (m_name == "StopMotion")
+    m_trName = tr("StopMotion");
+  else if (m_name == "Timing")
+    m_trName = tr("Timing");
+  else if (m_name == "FX")
+    m_trName = tr("FX");
+  else if (m_name == "Browser")
+    m_trName = tr("Browser");
+  else if (m_name == "History")
+    m_trName = tr("History");
+  else if (m_name == "New Room")
+    m_trName = tr("New Room");
+}
+
 void Room::save() {
   DockLayout *layout = dockLayout();
 
@@ -600,7 +621,7 @@ void MainWindow::readSettings(const QString &argumentLayoutFileName) {
       Room *room = new Room(this);
       m_panelStates.push_back(room->load(roomPath));
       m_stackedWidget->addWidget(room);
-      roomTabWidget->addTab(room->getName());
+      roomTabWidget->addTab(room->getTrName());
 
       // room->setDockOptions(QMainWindow::DockOptions(
       //  (QMainWindow::AnimatedDocks | QMainWindow::AllowNestedDocks) &
@@ -721,7 +742,7 @@ Room *MainWindow::create2DRoom() {
   room->setName("2D");
   room->setObjectName("2DRoom");
 
-  m_topBar->getRoomTabWidget()->addTab("2D");
+  m_topBar->getRoomTabWidget()->addTab(room->getTrName());
 
   DockLayout *layout = room->dockLayout();
 
@@ -797,7 +818,7 @@ Room *MainWindow::createStopMotionRoom() {
   room->setName("StopMotion");
   room->setObjectName("StopMotionRoom");
 
-  m_topBar->getRoomTabWidget()->addTab("StopMotion");
+  m_topBar->getRoomTabWidget()->addTab(room->getTrName());
 
   DockLayout *layout = room->dockLayout();
 
@@ -847,7 +868,7 @@ Room *MainWindow::createTimingRoom() {
   room->setName("Timing");
   room->setObjectName("TimingRoom");
 
-  m_topBar->getRoomTabWidget()->addTab("Timing");
+  m_topBar->getRoomTabWidget()->addTab(room->getTrName());
 
   DockLayout *layout = room->dockLayout();
 
@@ -915,7 +936,7 @@ Room *MainWindow::createFXRoom() {
   room->setName("FX");
   room->setObjectName("FXRoom");
 
-  m_topBar->getRoomTabWidget()->addTab("FX");
+  m_topBar->getRoomTabWidget()->addTab(room->getTrName());
 
   DockLayout *layout = room->dockLayout();
 
@@ -965,7 +986,7 @@ Room *MainWindow::createBrowserRoom() {
   browserRoom->setName("Browser");
   browserRoom->setObjectName("BrowserRoom");
 
-  m_topBar->getRoomTabWidget()->addTab("Browser");
+  m_topBar->getRoomTabWidget()->addTab(browserRoom->getTrName());
 
   DockLayout *layout = browserRoom->dockLayout();
 
@@ -1125,7 +1146,7 @@ void MainWindow::resetRoomsLayout() {
           room->hide();
           m_panelStates.push_back(room->load(fp));
           m_stackedWidget->addWidget(room);
-          roomTabWidget->addTab(room->getName());
+          roomTabWidget->addTab(room->getTrName());
           room->show();
         }
       }
@@ -1203,7 +1224,7 @@ void MainWindow::onIndexSwapped(int firstIndex, int secondIndex) {
 
 void MainWindow::insertNewRoom() {
   Room *room = new Room(this);
-  room->setName("room");
+  room->setName("New Room");
   if (m_saveSettingsOnQuit) makePrivate(room);
   m_stackedWidget->insertWidget(0, room);
 
@@ -1222,7 +1243,7 @@ void MainWindow::deleteRoom(int index) {
   } catch (...) {
     DVGui::error(tr("Cannot delete") + toQString(fp));
     // Se non ho rimosso la stanza devo rimettere il tab!!
-    m_topBar->getRoomTabWidget()->insertTab(index, room->getName());
+    m_topBar->getRoomTabWidget()->insertTab(index, room->getTrName());
     return;
   }
 

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -27,6 +27,7 @@ class Room final : public TMainWindow {
 
   TFilePath m_path;
   QString m_name;
+  QString m_trName;
 
 public:
   Room(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags())
@@ -38,7 +39,9 @@ public:
   void setPath(TFilePath path) { m_path = path; }
 
   QString getName() const { return m_name; }
-  void setName(QString name) { m_name = name; }
+  void setName(QString name);
+
+  QString getTrName() const { return m_trName; }
 
   void save();
   std::pair<DockLayout *, DockLayout::State> load(const TFilePath &fp);

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -219,7 +219,7 @@ void RoomTabWidget::updateTabName() {
 //-----------------------------------------------------------------------------
 
 void RoomTabWidget::addNewTab() {
-  insertTab(0, tr("Room"));
+  insertTab(0, tr("New Room"));
   emit insertNewTabRoom();
 }
 

--- a/toonz/sources/toonz/motionpathpanel.cpp
+++ b/toonz/sources/toonz/motionpathpanel.cpp
@@ -403,10 +403,10 @@ void MotionPathPanel::refreshPaths(bool force) {
 
   if (tree->getSplineCount() > 0) {
     m_pathsLayout->addWidget(new QLabel(""), 0, 0, Qt::AlignLeft);
-    m_pathsLayout->addWidget(new QLabel("Path Name"), 0, 1, Qt::AlignLeft);
-    m_pathsLayout->addWidget(new QLabel("Width"), 0, 2, Qt::AlignCenter);
-    m_pathsLayout->addWidget(new QLabel("Color"), 0, 3, Qt::AlignCenter);
-    m_pathsLayout->addWidget(new QLabel("Steps"), 0, 4, Qt::AlignCenter);
+    m_pathsLayout->addWidget(new QLabel(tr("Path Name")), 0, 1, Qt::AlignLeft);
+    m_pathsLayout->addWidget(new QLabel(tr("Width")), 0, 2, Qt::AlignCenter);
+    m_pathsLayout->addWidget(new QLabel(tr("Color")), 0, 3, Qt::AlignCenter);
+    m_pathsLayout->addWidget(new QLabel(tr("Steps")), 0, 4, Qt::AlignCenter);
     int i = 0;
     for (; i < tree->getSplineCount(); i++) {
       createControl(tree->getSpline(i), i + 1);

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -193,7 +193,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
   renderButton->setIcon(createQIcon("render"));
   renderButton->setIconSize(QSize(20, 20));
   if (isPreview)
-    renderButton->setText("Preview");
+    renderButton->setText(tr("Preview"));
 
   // preview settings
   if (isPreview) {
@@ -1780,7 +1780,7 @@ void OutputSettingsPopup::onDominantFieldChanged(int type) {
   TRenderSettings::FieldPrevalence oldFieldPrevalence = rs.m_fieldPrevalence;
   if (type != c_none &&
       m_stretchFromFld->getValue() != m_stretchToFld->getValue()) {
-    DVGui::error("Can't apply field rendering in a time stretched scene");
+    DVGui::error(tr("Can't apply field rendering in a time stretched scene"));
     rs.m_fieldPrevalence = TRenderSettings::NoField;
     m_dominantFieldOm->setCurrentIndex(c_none);
   } else if (type == c_odd)
@@ -1807,7 +1807,7 @@ void OutputSettingsPopup::onStretchFldEditFinished() {
   TOutputProperties *prop = getProperties();
   TRenderSettings rs      = prop->getRenderSettings();
   if (m_dominantFieldOm->currentIndex() != c_none) {
-    DVGui::error("Can't stretch time in a field rendered scene\n");
+    DVGui::error(tr("Can't stretch time in a field rendered scene\n"));
     m_stretchFromFld->setValue(rs.m_timeStretchFrom);
     m_stretchToFld->setValue(rs.m_timeStretchTo);
     return;
@@ -1876,7 +1876,7 @@ void OutputSettingsPopup::onAddPresetButtonPressed() {
   if (TFileStatus(fp).doesExist()) {
     int ret = QMessageBox::question(
         this, tr("Add output settings preset"),
-        QString("The file %1 does already exist.\nDo you want to overwrite it?")
+        QString(tr("The file %1 does already exist.\nDo you want to overwrite it?"))
             .arg(qs),
         QMessageBox::Save | QMessageBox::Cancel, QMessageBox::Save);
     if (ret == QMessageBox::Cancel) return;
@@ -2008,7 +2008,7 @@ void OutputSettingsPopup::onRemovePresetButtonPressed() {
   int index = m_presetCombo->currentIndex();
   if (index <= 0) return;
   int ret = QMessageBox::question(this, tr("Remove preset"),
-                                  QString("Deleting \"%1\".\nAre you sure?")
+                                  QString(tr("Deleting \"%1\".\nAre you sure?"))
                                       .arg(m_presetCombo->currentText()),
                                   QMessageBox::Ok | QMessageBox::Cancel,
                                   QMessageBox::Ok);
@@ -2034,7 +2034,7 @@ void OutputSettingsPopup::onPresetSelected(const QString &str) {
                  QString("%1.txt").arg(str).toStdString();
   if (!TFileStatus(fp).doesExist()) {
     QMessageBox::warning(this, tr("Warning"),
-                         QString("The preset file %1.txt not found").arg(str),
+                         QString(tr("The preset file %1.txt not found")).arg(str),
                          QMessageBox::Ok, QMessageBox::Ok);
     return;
   }
@@ -2042,7 +2042,7 @@ void OutputSettingsPopup::onPresetSelected(const QString &str) {
   if (!is) {
     QMessageBox::warning(
         this, tr("Warning"),
-        QString("Failed to open the preset file %1.txt").arg(str),
+        QString(tr("Failed to open the preset file %1.txt")).arg(str),
         QMessageBox::Ok, QMessageBox::Ok);
     return;
   }
@@ -2050,7 +2050,7 @@ void OutputSettingsPopup::onPresetSelected(const QString &str) {
   std::string tagName = "";
   if (!is.matchTag(tagName) || tagName != "outputsettingspreset") {
     QMessageBox::warning(this, tr("Warning"),
-                         QString("Bad file format: %1.txt").arg(str),
+                         QString(tr("Bad file format: %1.txt")).arg(str),
                          QMessageBox::Ok, QMessageBox::Ok);
     return;
   }

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -97,7 +97,7 @@ ProjectPopup::ProjectPopup(bool isModal)
   m_showSettingsButton->setFocusPolicy(Qt::NoFocus);
 
   m_useSubSceneCbs =
-      new CheckBox("*Separate assets into scene sub-folders");
+      new CheckBox(tr("*Separate assets into scene sub-folders"));
   m_useSubSceneCbs->setMaximumHeight(WidgetHeight);
 
   m_rulePreferenceBG       = new QButtonGroup(this);

--- a/toonz/sources/toonzlib/imagestyles.cpp
+++ b/toonz/sources/toonzlib/imagestyles.cpp
@@ -537,21 +537,21 @@ int TTextureStyle::getParamCount() const { return 8; }
 QString TTextureStyle::getParamNames(int index) const {
   switch (index) {
   case 0:
-    return "Load From File";
+    return QObject::tr("Load From File");
   case 1:
-    return "Use As Pattern";
+    return QObject::tr("Use As Pattern");
   case 2:
-    return "Position";
+    return QObject::tr("Position");
   case 3:
-    return "Scale";
+    return QObject::tr("Scale");
   case 4:
-    return "Rotation(degrees)";
+    return QObject::tr("Rotation(degrees)");
   case 5:
-    return "X displ";
+    return QObject::tr("X displ");
   case 6:
-    return "Y displ";
+    return QObject::tr("Y displ");
   case 7:
-    return "Contrast";
+    return QObject::tr("Contrast");
   default:
     assert(false);
   }

--- a/toonz/sources/toonzlib/mypaintbrushstyle.cpp
+++ b/toonz/sources/toonzlib/mypaintbrushstyle.cpp
@@ -16,6 +16,8 @@
 
 #include "toonz/mypaintbrushstyle.h"
 
+#include "tw/stringtable.h"
+
 #include <QDebug>
 
 #include <sstream>
@@ -381,8 +383,8 @@ int TMyPaintBrushStyle::getParamCount() const {
 //-----------------------------------------------------------------------------
 
 QString TMyPaintBrushStyle::getParamNames(int index) const {
-  return QString::fromUtf8(
-      mypaint::Setting::byId((MyPaintBrushSetting)index).name.c_str());
+  return QString::fromStdWString(TStringTable::translate(
+      mypaint::Setting::byId((MyPaintBrushSetting)index).name.c_str()));
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/addfxcontextmenu.cpp
+++ b/toonz/sources/toonzqt/addfxcontextmenu.cpp
@@ -245,7 +245,7 @@ void AddFxContextMenu::loadFxs() {
 //---------------------------------------------------
 
 void AddFxContextMenu::loadFxPluginGroup() {
-  QString groupName = QString::fromStdString("Plugins");
+  QString groupName = tr("Plugins");
 
   std::unique_ptr<QMenu> insertFxGroup(new QMenu(groupName, m_insertMenu));
   std::unique_ptr<QMenu> addFxGroup(new QMenu(groupName, m_addMenu));
@@ -263,7 +263,8 @@ void AddFxContextMenu::loadFxGroup(TIStream *is) {
   while (!is->eos()) {
     std::string tagName;
     if (is->matchTag(tagName)) {
-      QString groupName = QString::fromStdString(tagName);
+      QString groupName =
+          QString::fromStdWString(TStringTable::translate(tagName));
 
       std::unique_ptr<QMenu> insertFxGroup(new QMenu(groupName, m_insertMenu));
       std::unique_ptr<QMenu> addFxGroup(new QMenu(groupName, m_addMenu));
@@ -401,16 +402,14 @@ bool AddFxContextMenu::loadPreset(const std::string &name, QMenu *insertFxGroup,
   if (TFileStatus(presetsFilepath).isDirectory()) {
     TFilePathSet presets = TSystem::readDirectory(presetsFilepath, false);
     if (!presets.empty()) {
-      QMenu *inserMenu =
-          new QMenu(QString::fromStdWString(TStringTable::translate(name)),
-                    insertFxGroup);
+      QString translatedName =
+          QString::fromStdWString(TStringTable::translate(name));
+
+      QMenu *inserMenu = new QMenu(translatedName, insertFxGroup);
       insertFxGroup->addMenu(inserMenu);
-      QMenu *addMenu = new QMenu(
-          QString::fromStdWString(TStringTable::translate(name)), addFxGroup);
+      QMenu *addMenu = new QMenu(translatedName, addFxGroup);
       addFxGroup->addMenu(addMenu);
-      QMenu *replaceMenu =
-          new QMenu(QString::fromStdWString(TStringTable::translate(name)),
-                    replaceFxGroup);
+      QMenu *replaceMenu = new QMenu(translatedName, replaceFxGroup);
       replaceFxGroup->addMenu(replaceMenu);
 
       // This is a workaround to set the bold style to the first element of this
@@ -422,12 +421,9 @@ bool AddFxContextMenu::loadPreset(const std::string &name, QMenu *insertFxGroup,
       addMenu->setObjectName("fxMenu");
       replaceMenu->setObjectName("fxMenu");
 
-      QAction *insertAction = new QAction(
-          QString::fromStdWString(TStringTable::translate(name)), inserMenu);
-      QAction *addAction = new QAction(
-          QString::fromStdWString(TStringTable::translate(name)), addMenu);
-      QAction *replaceAction = new QAction(
-          QString::fromStdWString(TStringTable::translate(name)), replaceMenu);
+      QAction *insertAction  = new QAction(translatedName, inserMenu);
+      QAction *addAction     = new QAction(translatedName, addMenu);
+      QAction *replaceAction = new QAction(translatedName, replaceMenu);
 
       insertAction->setCheckable(true);
       addAction->setCheckable(true);
@@ -485,9 +481,10 @@ void AddFxContextMenu::loadMacro() {
       TFilePathSet macros = TSystem::readDirectory(macroDir);
       if (macros.empty()) return;
 
-      QMenu *insertMacroMenu  = new QMenu("Macro", m_insertMenu);
-      QMenu *addMacroMenu     = new QMenu("Macro", m_addMenu);
-      QMenu *replaceMacroMenu = new QMenu("Macro", m_replaceMenu);
+      QString macroGroup      = tr("Macro");
+      QMenu *insertMacroMenu  = new QMenu(macroGroup, m_insertMenu);
+      QMenu *addMacroMenu     = new QMenu(macroGroup, m_addMenu);
+      QMenu *replaceMacroMenu = new QMenu(macroGroup, m_replaceMenu);
 
       m_insertMenu->addMenu(insertMacroMenu);
       m_addMenu->addMenu(addMacroMenu);

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -203,20 +203,20 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
       std::string name;
       is >> name;
       is.matchEndTag();
-      QString str;
+      QString str = QString::fromStdWString(TStringTable::translate(name));
       if (isVertical == false) {
         assert(m_horizontalLayout);
-        m_horizontalLayout->addWidget(new QLabel(str.fromStdString(name)));
+        m_horizontalLayout->addWidget(new QLabel(str));
       } else {
         int currentRow = m_mainLayout->rowCount();
-        m_mainLayout->addWidget(new QLabel(str.fromStdString(name)), currentRow,
+        m_mainLayout->addWidget(new QLabel(str), currentRow,
                                 0, 1, 2);
       }
     } else if (tagName == "separator") {
       // <separator/> o <separator label="xxx"/>
       std::string label = is.getTagAttribute("label");
-      QString str;
-      Separator *sep = new Separator(str.fromStdString(label), this);
+      QString str = QString::fromStdWString(TStringTable::translate(label));
+      Separator *sep = new Separator(str, this);
       int currentRow = m_mainLayout->rowCount();
       m_mainLayout->addWidget(sep, currentRow, 0, 1, 2);
       m_mainLayout->setRowStretch(currentRow, 0);
@@ -249,12 +249,13 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
         if (shrinkStr != "") {
           shrink              = QString::fromStdString(shrinkStr).toInt();
           std::string label   = is.getTagAttribute("label");
+          QString str         = QString::fromStdWString(TStringTable::translate(label));
           QCheckBox *checkBox = new QCheckBox(this);
           QHBoxLayout *sepLay = new QHBoxLayout();
           sepLay->setMargin(0);
           sepLay->setSpacing(5);
           sepLay->addWidget(checkBox, 0);
-          sepLay->addWidget(new Separator(QString::fromStdString(label), this),
+          sepLay->addWidget(new Separator(str, this),
                             1);
           int currentRow = m_mainLayout->rowCount();
           m_mainLayout->addLayout(sepLay, currentRow, 0, 1, 2);
@@ -963,8 +964,8 @@ void ParamsPageSet::createPage(TIStream &is, const TFxP &fx, int index) {
   scrollAreaPage->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   scrollAreaPage->setWidget(paramsPage);
 
-  QString str;
-  m_tabBar->addSimpleTab(str.fromStdString(pageName));
+  QString str = QString::fromStdWString(TStringTable::translate(pageName));
+  m_tabBar->addSimpleTab(str);
   m_pagesList->addWidget(scrollAreaPage);
   if (index >= 0) m_pageFxIndexTable[paramsPage] = index;
 }

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -1193,7 +1193,7 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   }
   QAction *openStyleControlAct = cmd->getAction("MI_OpenStyleControl");
   menu.addAction(openStyleControlAct);
-  QAction *openStyleNameEditorAct = menu.addAction(tr("Name Editor"));
+  QAction *openStyleNameEditorAct = menu.addAction(QObject::tr("Name Editor"));
   openStyleNameEditorAct->setIcon(createQIcon("rename", false, true));
   connect(openStyleNameEditorAct, &QAction::triggered, [&]() {
     if (!m_styleNameEditor) {
@@ -1249,10 +1249,10 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   if (m_page) {
     menu.addSeparator();
     QIcon newStyleIco = createQIcon("newstyle", false, true);
-    QAction *newStyle = menu.addAction(newStyleIco, tr("New Style"));
+    QAction *newStyle = menu.addAction(newStyleIco, QObject::tr("New Style"));
     connect(newStyle, SIGNAL(triggered()), SLOT(addNewColor()));
     QIcon newPageIco = createQIcon("newpage", false, true);
-    QAction *newPage = menu.addAction(newPageIco, tr("New Page"));
+    QAction *newPage = menu.addAction(newPageIco, QObject::tr("New Page"));
     connect(newPage, SIGNAL(triggered()), SLOT(addNewPage()));
   }
 

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -1358,8 +1358,9 @@ ColorChannelControl::ColorChannelControl(ColorChannel channel, QWidget *parent)
   setFocusPolicy(Qt::NoFocus);
 
   QStringList channelList;
-  channelList << tr("R") << tr("G") << tr("B") << tr("A") << tr("H") << tr("S")
-              << tr("V");
+  channelList << QObject::tr("R") << QObject::tr("G") << QObject::tr("B")
+              << QObject::tr("A") << QObject::tr("H") << QObject::tr("S")
+              << QObject::tr("V");
   assert(0 <= (int)m_channel && (int)m_channel < 7);
   QString text = channelList.at(m_channel);
   m_label      = new QLabel(text, this);
@@ -1376,9 +1377,9 @@ ColorChannelControl::ColorChannelControl(ColorChannel channel, QWidget *parent)
   m_field = new ChannelLineEdit(this, 0, minValue, maxValue);
   if (text == "A") {
     m_label->setToolTip(
-        tr("Alpha controls the transparency. \nZero is fully transparent."));
+        QObject::tr("Alpha controls the transparency. \nZero is fully transparent."));
     m_field->setToolTip(
-        tr("Alpha controls the transparency. \nZero is fully transparent."));
+        QObject::tr("Alpha controls the transparency. \nZero is fully transparent."));
   }
   m_slider = new ColorSlider(Qt::Horizontal, this);
 
@@ -2247,7 +2248,7 @@ void StyleChooserPage::mousePressEvent(QMouseEvent *event) {
 void StyleChooserPage::enterEvent(QEvent *event) {
   TApplication *app = m_editor->getApplication();
   if (app)
-    app->showMessage(tr("Style Set Manager:              %1+click - Add Style "
+    app->showMessage(QObject::tr("Style Set Manager:              %1+click - Add Style "
                         "to Palette              %2+click - Multi-Style Select")
                          .arg(trModKey("Alt"))
                          .arg(trModKey("Ctrl")),
@@ -2303,18 +2304,18 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
 
   if (m_editor->isSelecting()) {
     action = new QAction(this);
-    action->setText(tr("Add Selected to Palette"));
+    action->setText(QObject::tr("Add Selected to Palette"));
     connect(action, SIGNAL(triggered()), m_editor,
             SLOT(onAddSelectedStylesToPalette()));
     menu->addAction(action);
 
     action = new QAction(this);
     if (m_editor->isSelectingFavoritesOnly()) {
-      action->setText(tr("Remove Selected from Favorites"));
+      action->setText(QObject::tr("Remove Selected from Favorites"));
       connect(action, SIGNAL(triggered()), m_editor,
               SLOT(onRemoveSelectedStylesFromFavorites()));
     } else {
-      action->setText(tr("Add Selected to Favorites"));
+      action->setText(QObject::tr("Add Selected to Favorites"));
       connect(action, SIGNAL(triggered()), m_editor,
               SLOT(onAddSelectedStylesToFavorites()));
       // Disable if selecting favorites also
@@ -2322,7 +2323,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
     }
     menu->addAction(action);
 
-    QMenu *styleSetMenu = new QMenu(tr("Copy Selected to Style Set..."), this);
+    QMenu *styleSetMenu = new QMenu(QObject::tr("Copy Selected to Style Set..."), this);
     for (int i = 1; i < styleSets->size(); i++) {
       StyleChooserPage *page = styleSets->at(i);
       QAction *subAction     = new QAction(page->getStyleSetName());
@@ -2337,7 +2338,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
     if (styleSets->size() < 2) styleSetMenu->setDisabled(true);
     menu->addMenu(styleSetMenu);
 
-    styleSetMenu = new QMenu(tr("Move Selected to Style Set..."), this);
+    styleSetMenu = new QMenu(QObject::tr("Move Selected to Style Set..."), this);
     for (int i = 1; i < styleSets->size(); i++) {
       StyleChooserPage *page = styleSets->at(i);
       QAction *subAction     = new QAction(page->getStyleSetName());
@@ -2354,7 +2355,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
     menu->addMenu(styleSetMenu);
 
     action = new QAction(this);
-    action->setText(tr("Remove Selected from Sets"));
+    action->setText(QObject::tr("Remove Selected from Sets"));
     connect(action, SIGNAL(triggered()), m_editor,
             SLOT(onRemoveSelectedStyleFromSet()));
     for (int i = 1; i < styleSets->size(); i++) {
@@ -2376,7 +2377,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
     m_currentIndex = currentIndex;
 
     action = new QAction(this);
-    action->setText(tr("Add to Palette"));
+    action->setText(QObject::tr("Add to Palette"));
     connect(action, SIGNAL(triggered()), this, SLOT(onAddStyleToPalette()));
     if (m_currentIndex == 0 || (m_pageType == StylePageType::Texture &&
                                 m_currentIndex == getChipCount() - 1))
@@ -2384,7 +2385,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
     menu->addAction(action);
 
     action = new QAction(this);
-    action->setText(tr("Add to Favorites"));
+    action->setText(QObject::tr("Add to Favorites"));
     connect(action, SIGNAL(triggered()), this, SLOT(onAddStyleToFavorite()));
     if (m_currentIndex == 0 || (m_pageType == StylePageType::Texture &&
                                 m_currentIndex == getChipCount() - 1) ||
@@ -2392,7 +2393,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
       action->setDisabled(true);
     menu->addAction(action);
 
-    QMenu *styleSetMenu = new QMenu(tr("Copy to Style Set..."), this);
+    QMenu *styleSetMenu = new QMenu(QObject::tr("Copy to Style Set..."), this);
     for (int i = 1; i < styleSets->size(); i++) {
       StyleChooserPage *page = styleSets->at(i);
       QAction *subAction     = new QAction(page->getStyleSetName());
@@ -2409,7 +2410,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
       styleSetMenu->setDisabled(true);
     menu->addMenu(styleSetMenu);
 
-    styleSetMenu = new QMenu(tr("Move to Style Set..."), this);
+    styleSetMenu = new QMenu(QObject::tr("Move to Style Set..."), this);
     for (int i = 1; i < styleSets->size(); i++) {
       StyleChooserPage *page = styleSets->at(i);
       QAction *subAction     = new QAction(page->getStyleSetName());
@@ -2427,7 +2428,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
     menu->addMenu(styleSetMenu);
 
     action = new QAction(this);
-    action->setText(tr("Remove from Set"));
+    action->setText(QObject::tr("Remove from Set"));
     connect(action, SIGNAL(triggered()), this, SLOT(onRemoveStyleFromSet()));
     if (m_currentIndex == 0 || (m_pageType == StylePageType::Texture &&
                                 m_currentIndex == getChipCount() - 1) ||
@@ -2438,13 +2439,13 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
     menu->addSeparator();
 
     action = new QAction(this);
-    action->setText(tr("Add Set to Palette"));
+    action->setText(QObject::tr("Add Set to Palette"));
     connect(action, SIGNAL(triggered()), this, SLOT(onAddSetToPalette()));
     if (getChipCount() <= 1) action->setDisabled(true);
     menu->addAction(action);
 
     action = new QAction(this);
-    action->setText(tr("Empty Set"));
+    action->setText(QObject::tr("Empty Set"));
     connect(action, SIGNAL(triggered()), this, SLOT(onEmptySet()));
     if (getChipCount() <= 1 ||
         (m_pageType == StylePageType::Texture && getChipCount() <= 2) ||
@@ -2456,19 +2457,19 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
   }
 
   action = new QAction(this);
-  action->setText(tr("New Style Set..."));
+  action->setText(QObject::tr("New Style Set..."));
   connect(action, SIGNAL(triggered()), m_editor, SLOT(onAddNewStyleSet()));
   menu->addAction(action);
 
   action = new QAction(this);
-  action->setText(tr("Rename Style Set..."));
+  action->setText(QObject::tr("Rename Style Set..."));
   connect(action, SIGNAL(triggered()), this, SLOT(onRenameStyleSet()));
   if (isMyFavoriteSet() || isRootFolder() || isExternal())
     action->setDisabled(true);
   menu->addAction(action);
 
   action = new QAction(this);
-  action->setText(tr("Reload Style Set"));
+  action->setText(QObject::tr("Reload Style Set"));
   connect(action, SIGNAL(triggered()), this, SLOT(onReloadStyleSet()));
   if (m_pageType == StylePageType::VectorGenerated ||
       m_styleSetName == "Unknown Style Set")
@@ -2476,7 +2477,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
   menu->addAction(action);
 
   action = new QAction(this);
-  action->setText(tr("Scan for Style Set Changes"));
+  action->setText(QObject::tr("Scan for Style Set Changes"));
   connect(action, SIGNAL(triggered()), m_editor, SLOT(onScanStyleSetChanges()));
   menu->addAction(action);
 
@@ -2484,7 +2485,7 @@ void StyleChooserPage::contextMenuEvent(QContextMenuEvent *event) {
 
   if (m_styleSetName != "Unknown Style Set") {
     action = new QAction(this);
-    action->setText(tr("Remove '%1' Style Set").arg(m_styleSetName));
+    action->setText(QObject::tr("Remove '%1' Style Set").arg(m_styleSetName));
     if (m_stylesFolder == TFilePath() || (isFavorite() && !allowFavorite()) ||
         !canDeletePage())
       action->setDisabled(true);
@@ -3721,7 +3722,7 @@ SettingsPage::SettingsPage(QWidget *parent)
   paramsContainer->setLayout(paramsContainerLayout);
 
   // Add a vertical layout to store the "autofill" checkbox widgets
-  m_autoFillCheckBox = new QCheckBox(tr("Autopaint for Lines"), this);
+  m_autoFillCheckBox = new QCheckBox(QObject::tr("Autopaint for Lines"), this);
   paramsContainerLayout->addWidget(m_autoFillCheckBox, 0,
                                    Qt::AlignLeft | Qt::AlignVCenter);
 
@@ -3879,7 +3880,7 @@ void SettingsPage::setStyle(const TColorStyleP &editedStyle) {
       // "reset to default" button
       if (m_editedStyle->hasParamDefault(p)) {
         QPushButton *pushButton = new QPushButton;
-        pushButton->setToolTip(tr("Reset to default"));
+        pushButton->setToolTip(QObject::tr("Reset to default"));
         pushButton->setIcon(createQIcon("delete"));
         pushButton->setFixedSize(24, 24);
         m_paramsLayout->addWidget(pushButton, p, 2);

--- a/toonz/sources/translations/brazilian-portuguese/toonz.ts
+++ b/toonz/sources/translations/brazilian-portuguese/toonz.ts
@@ -4010,6 +4010,11 @@ Gostaria de Substituí-lo?</translation>
         <translation>Pesquisar:</translation>
     </message>
     <message>
+        <location filename="../../toonz/insertfxpopup.cpp" line="255"/>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../toonz/insertfxpopup.cpp" line="278"/>
         <source>Insert</source>
         <translation>Inserir</translation>
@@ -4025,37 +4030,37 @@ Gostaria de Substituí-lo?</translation>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="413"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="414"/>
         <source>Macro</source>
         <translation>Macro</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="561"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="562"/>
         <source>Remove Macro FX</source>
         <translation>Remover Macro de Efeito</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="569"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="570"/>
         <source>Remove Preset</source>
         <translation>Remover Predefinição</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="620"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Tem certeza que gostaria de excluir %1?</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="622"/>
         <source>Yes</source>
         <translation>Sim</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="622"/>
         <source>No</source>
         <translation>Não</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="627"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="628"/>
         <source>It is not possible to delete %1.</source>
         <translation>Não é possível deletar %1.</translation>
     </message>
@@ -5064,6 +5069,11 @@ Por favor escolha um arquivo de informação de Sincronia Labial válido para co
         <source>Locator</source>
         <translation>Localizador</translation>
     </message>
+    <message>
+        <location filename="../../toonz/locatorpopup.cpp" line="111"/>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MagpieFileImportPopup</name>
@@ -5123,3518 +5133,3518 @@ Por favor escolha um arquivo de informação de Sincronia Labial válido para co
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="516"/>
+        <location filename="../../toonz/mainwindow.cpp" line="537"/>
         <source>Untitled</source>
         <translation>Sem Título</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1050"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1071"/>
         <source>http://tahoma2d.readthedocs.io</source>
         <translation>http://tahoma2d.readthedocs.io</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1063"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1084"/>
         <source>https://tahoma2d.readthedocs.io/en/latest/whats_new.html</source>
         <translation>https://tahoma2d.readthedocs.io/en/latest/whats_new.html</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1069"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1090"/>
         <source>https://groups.google.com/g/tahoma2d</source>
         <translation>https://groups.google.com/g/tahoma2d</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1097"/>
         <source>To report a bug, click on the button below to open a web browser window for Tahoma2D&apos;s Issues page on https://github.com.  Click on the &apos;New issue&apos; button and fill out the form.</source>
         <translation>Para reportar um bug, clique no botão abaixo para abrir uma janela do navegador para a página de problemas do Tahoma2D em https://github.com.  Clique no botão &quot;New issue&quot; e preencha o formulário.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1096"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1117"/>
         <source>Are you sure you want to reload and restore default rooms?
 Custom rooms will not be touched.</source>
         <translation>Tem certeza de que gostaria de recarregar e restaurar os cômodos padrões?
 Cômodos customizados não serão tocados.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1223"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1244"/>
         <source>Cannot delete</source>
         <translation>Impossível excluir</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1747"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1768"/>
         <source>&amp;New Scene</source>
         <translation>&amp;Nova Cena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1748"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1769"/>
         <source>Create a new scene.</source>
         <translation>Cria uma nova cena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1749"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1770"/>
         <source>&amp;Load Scene...</source>
         <translation>&amp;Carregar Cena...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1750"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1771"/>
         <source>Load an existing scene.</source>
         <translation>Carrega uma Cena existente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1751"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1772"/>
         <source>&amp;Save Scene</source>
         <translation>&amp;Salvar Cena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1752"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1773"/>
         <source>Save ONLY the scene.</source>
         <translation>Salva APENAS esta Cena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1753"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1756"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1774"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1777"/>
         <source>This does NOT save levels or images.</source>
         <translation>Isto NÃO salva seus Níveis ou Imagens.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1754"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1775"/>
         <source>&amp;Save Scene As...</source>
         <translation>&amp;Salvar Cena como...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1755"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1776"/>
         <source>Save ONLY the scene with a new name.</source>
         <translation>Salvar APENAS esta Cena com um novo nome.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1757"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1778"/>
         <source>&amp;Save All</source>
         <translation>&amp;Salvar Tudo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1758"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1779"/>
         <source>Save the scene info and the levels and images.</source>
         <translation>Salva as informações da Cena, Níveis e imagens</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1759"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1780"/>
         <source>Saves everything.</source>
         <translation>Salva Tudo.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1760"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1781"/>
         <source>&amp;Revert Scene</source>
         <translation>&amp;Reverter Cena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1762"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1783"/>
         <source>Revert the scene to its previously saved state.</source>
         <translation>Reverte a cena ao seu estado anterior ao salvamento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1765"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1786"/>
         <source>&amp;Load Folder...</source>
         <translation>&amp;Carregar Pasta...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1766"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1787"/>
         <source>Load the contents of a folder into the current scene.</source>
         <translation>Carrega os conteúdos de uma pasta para a Cena atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1768"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1789"/>
         <source>&amp;Load As Sub-Scene...</source>
         <translation>&amp;Carregar como SubCena...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1769"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1790"/>
         <source>Load an existing scene into the current scene as a sub-scene</source>
         <translation>Carrega uma Cena existente para a Cena atual como uma SubCena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1770"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1791"/>
         <source>&amp;Open Recent Scene File</source>
         <translation>&amp;Abrir Cena Recente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1771"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1792"/>
         <source>Load a recently used scene.</source>
         <translation>Carrega uma Cena usada recentemente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1772"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1793"/>
         <source>&amp;Open Recent Level File</source>
         <translation>&amp;Abrir Nível Recente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1773"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1794"/>
         <source>Load a recently used level.</source>
         <translation>Carrega um Nível usado recentemente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1775"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1796"/>
         <source>&amp;Clear Recent Scene File List</source>
         <translation>&amp;Limpar Lista de Cenas Recentes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1776"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1797"/>
         <source>Remove everything from the recent scene list.</source>
         <translation>Remove tudo da Lista de Cenas Recentes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1778"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1799"/>
         <source>&amp;Clear Recent level File List</source>
         <translation>&amp;Limpar Lista de Níveis Recentes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1779"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1800"/>
         <source>Remove everything from the recent level list.</source>
         <translation>Remove tudo da Lista de Níveis Recentes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1780"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1801"/>
         <source>&amp;Convert File...</source>
         <translation>&amp;Converter Arquivo...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1781"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1802"/>
         <source>Convert an existing file or image sequence to another format.</source>
         <translation>Converte um arquivo existente ou sequência de imagens para outro formato.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1783"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1804"/>
         <source>&amp;Convert TZP Files In Folder...</source>
         <translation>&amp;Converter Arquivos TZP na Pasta...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1784"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1805"/>
         <source>&amp;Load Color Model...</source>
         <translation>&amp;Carregar Modelo de Cor...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1785"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1806"/>
         <source>Load an image as a color guide.</source>
         <translation>Carregar uma imagem como um guia de cor.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1787"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1808"/>
         <source>&amp;Import Toonz Lip Sync File...</source>
         <translation>&amp;Importar Arquivo Toonz Lip-Sync...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1788"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1809"/>
         <source>Import a lip sync file to be applied to a level.</source>
         <translation>Importa um arquivo de Sincronia Labial para ser aplicado ao nível.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1789"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1810"/>
         <source>&amp;New Project...</source>
         <translation>&amp;Novo Projeto...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1791"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1812"/>
         <source>Create a new project.</source>
         <translation>Cria um novo projeto.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1792"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1813"/>
         <source>A project is a container for a collection of related scenes and drawings.</source>
         <translation>Um projeto é um conjunto de pastas contendo cenas e desenhos relacionados.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1794"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1815"/>
         <source>&amp;Open Recent Project</source>
         <translation>&amp;Abrir Projeto Recente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1796"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1817"/>
         <source>&amp;Load Project...</source>
         <translation>&amp;Carregar Projeto...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1797"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1818"/>
         <source>Load an existing project.</source>
         <translation>Carrega um projeto existente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1798"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1819"/>
         <source>&amp;Project Settings...</source>
         <translation>&amp;Configurações de Projeto...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1801"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1822"/>
         <source>&amp;Save Default Settings</source>
         <translation>&amp;Salvar Configurações Padrão</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1803"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1824"/>
         <source>Use the current scene&apos;s settings as a template for all new scenes in the current project.</source>
         <translation>Usa configurações da cena atual como um modelo para todas as novas cenas do projeto atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1805"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1826"/>
         <source>&amp;Export Soundtrack</source>
         <translation>&amp;Exportar Trilha Sonora</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1806"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1827"/>
         <source>Exports the soundtrack to the current scene as a wav file.</source>
         <translation>Exporta a trilha sonora da cena atual como um arquivo wav.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1807"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1828"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;Preferências...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1808"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1829"/>
         <source>Change Tahoma2D&apos;s settings.</source>
         <translation>Muda as configurações do Tahoma2D.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1809"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1830"/>
         <source>&amp;Configure Shortcuts...</source>
         <translation>&amp;Configurar Atalhos...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1810"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1831"/>
         <source>Change the shortcuts of Tahoma2D.</source>
         <translation>Muda os atalhos do Tahoma2D.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1811"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1832"/>
         <source>&amp;Print Xsheet</source>
         <translation>&amp;Imprimir XSheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1812"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1833"/>
         <source>Print the scene&apos;s exposure sheet.</source>
         <translation>Imprime a exposure sheet da cena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1814"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1835"/>
         <source>&amp;Export Xsheet to PDF</source>
         <translation>&amp;Exportar XSheet para PDF</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1819"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1840"/>
         <source>Export Exchange Digital Time Sheet (XDTS)</source>
         <translation>Exportar Exchange Digital Time Sheet (XDTS)</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1824"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1845"/>
         <source>Export Open Cel Animation (OCA)</source>
         <translation>Exportar Animação de Células Abertas(OCA)</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1827"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1848"/>
         <source>Export TVPaint JSON File</source>
         <translation>Exportar arquivo JSON TVPaint</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1828"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1849"/>
         <source>Run Script...</source>
         <translation>Executar Script...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1829"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1850"/>
         <source>Run a script to perform a series of actions on a scene.</source>
         <translation>Executa um script para realizar uma série de ações em uma cena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1831"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1852"/>
         <source>Open Script Console...</source>
         <translation>Abrir um Console de Script...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1832"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1853"/>
         <source>Open a console window where you can enter script commands.</source>
         <translation>Abre um console onde podem ser escritos comandos de script.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1833"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1854"/>
         <source>&amp;Print Current Frame...</source>
         <translation>&amp;Imprimir Quadro Atual...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1835"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
         <source>&amp;Quit</source>
         <translation>&amp;Sair</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1835"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
         <source>Bye.</source>
         <translation>Tchau!</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1837"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1858"/>
         <source>Reload qss</source>
         <translation>Recarregar qss</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1839"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1860"/>
         <source>&amp;Load Recent Image Files</source>
         <translation>&amp;Carregar Imagens Recentes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1842"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1863"/>
         <source>&amp;Clear Recent Flipbook Image List</source>
         <translation>&amp;Limpar Lista de Imagem Recente no Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1843"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1864"/>
         <source>&amp;Clear Cache Folder</source>
         <translation>&amp;Limpar Pasta de Cache</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1846"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1867"/>
         <source>&amp;Export Current Scene</source>
         <translation>&amp;Exportar Cena atual</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1847"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1868"/>
         <source>Export the current scene to another project.</source>
         <translation>Exporta a cena atual para outro projeto.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1851"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1872"/>
         <source>&amp;Select All</source>
         <translation>&amp;Selecionar Tudo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1853"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1874"/>
         <source>&amp;Invert Selection</source>
         <translation>&amp;Inverter Seleção</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1855"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1876"/>
         <source>&amp;Undo</source>
         <translation>&amp;Desfazer</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1877"/>
         <source>&amp;Redo</source>
         <translation>&amp;Refazer</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1857"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1878"/>
         <source>&amp;Cut</source>
         <translation>&amp;Recortar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1858"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1879"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1859"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1880"/>
         <source>&amp;Paste Insert</source>
         <translation>&amp;Colar Inserção</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1861"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1882"/>
         <source>&amp;Paste Insert Below/Before</source>
         <translation>&amp;Colar Inserção Abaixo/Antes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1863"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1884"/>
         <source>&amp;Paste as a Copy</source>
         <translation>&amp;Colar como uma Cópia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1865"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1886"/>
         <source>&amp;Paste Into</source>
         <translation>&amp;Colar em</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1872"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1893"/>
         <source>&amp;Delete</source>
         <translation>&amp;Ecluir</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1873"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1894"/>
         <source>&amp;Insert</source>
         <translation>&amp;Inserir</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1874"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1895"/>
         <source>&amp;Insert Below/Before</source>
         <translation>&amp;Inserir Abaixo/Antes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1876"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1897"/>
         <source>&amp;Group</source>
         <translation>&amp;Agrupar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1877"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1898"/>
         <source>&amp;Ungroup</source>
         <translation>&amp;Desagrupar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1879"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1900"/>
         <source>&amp;Enter Group</source>
         <translation>&amp;Entrar no Grupo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1881"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1902"/>
         <source>&amp;Exit Group</source>
         <translation>&amp;Sair do Grupo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1883"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1904"/>
         <source>&amp;Move to Back</source>
         <translation>&amp;Mover para Trás</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1885"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1906"/>
         <source>&amp;Move Back One</source>
         <translation>&amp;Mover Um para Trás</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1887"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1908"/>
         <source>&amp;Move Forward One</source>
         <translation>&amp;Mover Um para Frente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1889"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1910"/>
         <source>&amp;Move to Front</source>
         <translation>&amp;Mover para Frente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1892"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1913"/>
         <source>&amp;Clear Recent Project List</source>
         <translation>&amp;Limpar Lista de Projetos Recentes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1893"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1914"/>
         <source>Remove everything from the recent project list.</source>
         <translation>Remove tudo da lista de projetos recentes.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1895"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1916"/>
         <source>&amp;Clear Frames</source>
         <translation>&amp;Limpar Quadros</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1900"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1921"/>
         <source>&amp;Cleanup Settings...</source>
         <translation>&amp;Configurações de Limpeza de Linha...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1902"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1923"/>
         <source>&amp;Preview Cleanup</source>
         <translation>&amp;Pré-visualizar Limpeza de Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1905"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1926"/>
         <source>&amp;Camera Test</source>
         <translation>&amp;Teste de Câmera</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1908"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1929"/>
         <source>&amp;Opacity Check</source>
         <translation>&amp;Checagem de Opacidade</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1910"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1931"/>
         <source>&amp;Cleanup</source>
         <translation>&amp;Limpeza de Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1915"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1936"/>
         <source>&amp;New Level...</source>
         <translation>&amp;Novo Nível...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1916"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1937"/>
         <source>Create a new drawing layer.</source>
         <translation>Cria uma nova camada de desenho.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1917"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1938"/>
         <source>&amp;New Vector Level</source>
         <translation>&amp;Novo Nível Vetor</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1918"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1939"/>
         <source>Create a new vector level.</source>
         <translation>Cria um novo nível vetorial.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1919"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1940"/>
         <source>Vectors can be manipulated easily and have some extra tools and features.</source>
         <translation>Vetores podem ser manipulados facilmente e possuem ferramentas e funções extras.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1922"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1943"/>
         <source>&amp;New Smart Raster Level</source>
         <translation>&amp;Novo Nível Raster Inteligente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1923"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1944"/>
         <source>Create a new Smart Raster level.</source>
         <translation>&amp;Cria um novo nível raster inteligente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1924"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1945"/>
         <source>Smart Raster levels are color mapped making the colors easier to adjust at any time.</source>
         <translation>Níveis Raster Inteligente mapeam as cores tornando mais fácil ajustá-las a qualquer momento.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1926"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1947"/>
         <source>&amp;New Raster Level</source>
         <translation>&amp;Novo Nível Raster</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1927"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1948"/>
         <source>Create a new raster level</source>
         <translation>Cria um novo nível raster.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1928"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1949"/>
         <source>Raster levels are traditional drawing levels</source>
         <translation>Níveis Raster são camadas de desenho tradicionais</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1929"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1950"/>
         <source>Imported images will be imported as raster levels.</source>
         <translation>Imagens importadas serão colocadas como nível raster.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1930"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1951"/>
         <source>&amp;Load Level...</source>
         <translation>&amp;Carregar Nível...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1931"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1952"/>
         <source>Load an existing level.</source>
         <translation>Carrega um nível existente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1932"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1953"/>
         <source>&amp;Save Level</source>
         <translation>&amp;Salvar Nível</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1933"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1954"/>
         <source>Save the current level.</source>
         <translation>&amp;Salva o Nível atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1934"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1937"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1940"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1955"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1958"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1961"/>
         <source>This does not save the scene info.</source>
         <translation>Isto não salva a informação da cena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1935"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1956"/>
         <source>&amp;Save All Levels</source>
         <translation>&amp;Salvar Todos os Níveis</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1936"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1957"/>
         <source>Save all levels loaded into the scene.</source>
         <translation>Salva todos os níveis carregados na cena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1938"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1959"/>
         <source>&amp;Save Level As...</source>
         <translation>&amp;Salvar Nível como...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1939"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1960"/>
         <source>Save the current level as a different name.</source>
         <translation>Salva o nível atual com um nome diferente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1941"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1962"/>
         <source>&amp;Export Level...</source>
         <translation>&amp;Exportar Nível...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1942"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1963"/>
         <source>Export the current level as an image sequence.</source>
         <translation>Exporta o nível atual como uma sequência de imagem.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1944"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1965"/>
         <source>&amp;Remove Vector Overflow</source>
         <translation>&amp;Remover Transbordamento de Vetor</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1946"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1967"/>
         <source>&amp;Add Frames...</source>
         <translation>&amp;Adicionar Quadros...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1948"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1969"/>
         <source>&amp;Renumber...</source>
         <translation>&amp;Renumerar...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1950"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1971"/>
         <source>&amp;Replace Level...</source>
         <translation>&amp;Substituir Nível...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1953"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1974"/>
         <source>&amp;Revert to Cleaned Up</source>
         <translation>&amp;Reverter para Limpeza de Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1955"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1976"/>
         <source>&amp;Reload</source>
         <translation>&amp;Recarregar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1957"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1978"/>
         <source>&amp;Expose in Scene</source>
         <translation>&amp;Expor na Cena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1958"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1979"/>
         <source>&amp;Display in Level Strip</source>
         <translation>&amp;Mostrar na Fita de Nível</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1960"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1981"/>
         <source>&amp;Level Settings...</source>
         <translation>&amp;Configurações de Nível...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1962"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1983"/>
         <source>Adjust Levels...</source>
         <translation>Ajustar Níveis...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1964"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1985"/>
         <source>Adjust Thickness...</source>
         <translation>Ajustar Espessura...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1966"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1987"/>
         <source>&amp;Antialias...</source>
         <translation>&amp;Antiserrilhamento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1968"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1989"/>
         <source>&amp;Binarize...</source>
         <translation>&amp;Binarizar...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1971"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1992"/>
         <source>&amp;Brightness and Contrast...</source>
         <translation>&amp;Brilho e Contraste...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1973"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1994"/>
         <source>&amp;Color Fade...</source>
         <translation>&amp;Desvanecimento de Cor...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1975"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1996"/>
         <source>&amp;Canvas Size...</source>
         <translation>&amp;Tamanho da Tela...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1978"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1999"/>
         <source>&amp;Info...</source>
         <translation>&amp;Informações...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1980"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2001"/>
         <source>&amp;Remove All Unused Levels</source>
         <translation>&amp;Remover todos os Níveis não utilizados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1983"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2004"/>
         <source>&amp;Replace Parent Directory...</source>
         <translation>&amp;Substituir Diretório Parente...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1985"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2006"/>
         <source>New Note Level</source>
         <translation>Novo Nível de Anotação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1988"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2009"/>
         <source>Convert to Vectors...</source>
         <translation>Converter para Vetores...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1990"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2011"/>
         <source>Vectors to Smart Raster</source>
         <translation>Vetores para Raster Inteligente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1993"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2014"/>
         <source>Replace Vectors with Simplified Vectors</source>
         <translation>Substituir Vetores com Vetores Simplificados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1996"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2017"/>
         <source>Tracking...</source>
         <translation>Rastreamento...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1997"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2018"/>
         <source>&amp;New Motion Path</source>
         <translation>&amp;Nova Linha de Movimento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1998"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2019"/>
         <source>Create a new motion path.</source>
         <translation>Cria uma nova linha de movimento.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1999"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2020"/>
         <source>Motion paths can be used as animation guides, or you can animate objects along a motion path.</source>
         <translation>Linhas de movimento podem ser usados como guias de animação, ou para animar objetos seguindo uma linha.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2004"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2025"/>
         <source>&amp;Scene Settings...</source>
         <translation>&amp;Configurações da Cena...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2006"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3112"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2027"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3133"/>
         <source>&amp;Camera Settings...</source>
         <translation>&amp;Configurações da Câmera...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2008"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2029"/>
         <source>&amp;Open Sub-Scene</source>
         <translation>&amp;Abrir SubCena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2010"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2031"/>
         <source>&amp;Close Sub-Scene</source>
         <translation>&amp;Fechar SubCena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2012"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2033"/>
         <source>Explode Sub-Scene</source>
         <translation>Explodir SubCena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2014"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2035"/>
         <source>Collapse</source>
         <translation>Colapsar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2016"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2037"/>
         <source>&amp;Toggle Edit In Place</source>
         <translation>&amp;Alterar Edição no Lugar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2020"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2041"/>
         <source>&amp;Save Sub-Scene As...</source>
         <translation>&amp;Salvar SubCena como...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2022"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2043"/>
         <source>Clone Sub-Scene</source>
         <translation>Clonar SubCena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2025"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2046"/>
         <source>&amp;Apply Match Lines...</source>
         <translation>&amp;Aplicar Combinar Linhas...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2027"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2048"/>
         <source>&amp;Merge Tlv Levels...</source>
         <translation>&amp;Unir Níveis Tlv...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2029"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2050"/>
         <source>&amp;Delete Match Lines</source>
         <translation>&amp;Excluir Combinar Linhas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2031"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2052"/>
         <source>&amp;Delete Lines...</source>
         <translation>&amp;Excluir Linhas...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2033"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2054"/>
         <source>&amp;Merge Levels</source>
         <translation>&amp;Unir Níveis</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2035"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2056"/>
         <source>&amp;New FX...</source>
         <translation>&amp;Novo Efeito...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2037"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2058"/>
         <source>&amp;New Output</source>
         <translation>&amp;Nova Saída</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2039"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2060"/>
         <source>Insert Frame</source>
         <translation>Inserir Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2041"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2062"/>
         <source>Remove Frame</source>
         <translation>Remover Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2044"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2065"/>
         <source>Insert Multiple Keys</source>
         <translation>Inserir Múltiplos Chaves</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2047"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2068"/>
         <source>Remove Multiple Keys</source>
         <translation>Remover Múltiplos Chaves</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2050"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2071"/>
         <source>Set Multiple Stop Frames</source>
         <translation>Colocar Múltiplos Quadros de Parada</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2052"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2073"/>
         <source>Remove Multiple Stop Frames</source>
         <translation>Remover Múltiplos Quadros de Parada</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2054"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2075"/>
         <source>Remove Empty Columns</source>
         <translation>Remover Colunas Vazias</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2057"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2078"/>
         <source>Convert to use Implicit Holds</source>
         <translation>Converter para Holds Implícitos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2059"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2080"/>
         <source>Convert to use Explicit Holds</source>
         <translation>Converter para Holds Explícitos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2061"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2082"/>
         <source>&amp;Apply Lip Sync to Column</source>
         <translation>&amp;Aplicar Sincronia Labial para Coluna</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2063"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2084"/>
         <source>Resequence</source>
         <translation>Resequenciar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2065"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2086"/>
         <source>Set Start Marker</source>
         <translation>Colocar Marcador de Início</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2066"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2087"/>
         <source>Set Stop Marker</source>
         <translation>Colocar Marcador de Final</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2067"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2088"/>
         <source>Remove Markers</source>
         <translation>Remover Marcadores</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2068"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2089"/>
         <source>Set Auto Markers</source>
         <translation>Colocar Marcadores Automáticos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2070"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2091"/>
         <source>Set Markers to Current Frame</source>
         <translation>Posicionar Marcadores para o Quadro Atual</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2072"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2093"/>
         <source>Set Markers to Selected Range</source>
         <translation>Posicionar Marcadores no Escopo Selecionado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2074"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2095"/>
         <source>Toggle Navigation Tag</source>
         <translation>Alterar Etiqueta de Navegação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2097"/>
         <source>Next Tag</source>
         <translation>Etiqueta Seguinte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2078"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2099"/>
         <source>Previous Tag</source>
         <translation>Etiqueta Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2080"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2101"/>
         <source>Edit Tag</source>
         <translation>Editar Etiqueta</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2081"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2102"/>
         <source>Remove Tags</source>
         <translation>Remover Etiquetas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2089"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2110"/>
         <source>&amp;Merge</source>
         <translation>&amp;Unir</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2090"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2111"/>
         <source>&amp;Reverse</source>
         <translation>&amp;Reverter</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2091"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2112"/>
         <source>&amp;Swing</source>
         <translation>&amp;Balançar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2092"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2113"/>
         <source>&amp;Random</source>
         <translation>&amp;Aleatório</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2093"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2114"/>
         <source>&amp;Autoexpose</source>
         <translation>&amp;Autoexposição</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2095"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2116"/>
         <source>&amp;Repeat...</source>
         <translation>&amp;Repetir...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2096"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2117"/>
         <source>&amp;Reset Step</source>
         <translation>&amp;Restaurar Intervalos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2098"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2119"/>
         <source>&amp;Increase Step</source>
         <translation>&amp;Aumentar Intervalo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2100"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2121"/>
         <source>&amp;Decrease Step</source>
         <translation>&amp;Diminuir Intervalo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2102"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2123"/>
         <source>&amp;Step 2</source>
         <translation>&amp;2 Intervalos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2103"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2124"/>
         <source>&amp;Step 3</source>
         <translation>&amp;3 Intervalos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2104"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2125"/>
         <source>&amp;Step 4</source>
         <translation>&amp;4 Intervalos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2105"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2126"/>
         <source>&amp;Each 2</source>
         <translation>&amp;Cada 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2106"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2127"/>
         <source>&amp;Each 3</source>
         <translation>&amp;Cada 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2107"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2128"/>
         <source>&amp;Each 4</source>
         <translation>&amp;Cada 4</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2108"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2129"/>
         <source>&amp;Roll Up</source>
         <translation>&amp;Rolar para Cima</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2109"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2130"/>
         <source>&amp;Roll Down</source>
         <translation>&amp;Rolar para Baixo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2110"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2131"/>
         <source>&amp;Time Stretch...</source>
         <translation>&amp;Ajuste Temporal...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2113"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2134"/>
         <source>&amp;Create Blank Drawing</source>
         <translation>&amp;Criar Desenho em Branco</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2115"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2136"/>
         <source>&amp;Stop Frame Hold</source>
         <translation>&amp;Parar Quadro de Hold</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2117"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2138"/>
         <source>&amp;Duplicate Drawing  </source>
         <translation>&amp;Duplicar Desenho  </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2119"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2140"/>
         <source>&amp;Autorenumber</source>
         <translation>&amp;Autorenumerar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2121"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2142"/>
         <source>&amp;Clone Cells</source>
         <translation>&amp;Clonar Células</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2124"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2145"/>
         <source>Drawing Substitution Forward</source>
         <translation>Substituição do Desenho Seguinte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2126"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2147"/>
         <source>Drawing Substitution Backward</source>
         <translation>Substituição do Desenho Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2128"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2149"/>
         <source>Similar Drawing Substitution Forward</source>
         <translation>Substituição do Desenho Parecido Seguinte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2131"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2152"/>
         <source>Similar Drawing Substitution Backward</source>
         <translation>Substituição do Desenho Parecido Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2133"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2154"/>
         <source>Reframe on 1&apos;s</source>
         <translation>Reenquadrar em 1&apos;s</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2134"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2155"/>
         <source>Reframe on 2&apos;s</source>
         <translation>Reenquadrar em 2&apos;s</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2135"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2156"/>
         <source>Reframe on 3&apos;s</source>
         <translation>Reenquadrar em 3&apos;s</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2136"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2157"/>
         <source>Reframe on 4&apos;s</source>
         <translation>Reenquadrar em 4&apos;s</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2138"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2159"/>
         <source>Reframe with Empty Inbetweens...</source>
         <translation>Reenquadrar com Entremeios vazios...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2141"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2162"/>
         <source>Auto Input Cell Number...</source>
         <translation>Automaticamente colocar Números de Células...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2143"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2164"/>
         <source>&amp;Fill In Empty Cells</source>
         <translation>&amp;Preencher Células Vazias</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2148"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2169"/>
         <source>Link Flipbooks</source>
         <translation>Conectar Flipbooks</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2150"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2171"/>
         <source>Play</source>
         <translation>Reproduzir</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2151"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2172"/>
         <source>Short Play</source>
         <translation>Reprodução Curta</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2152"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2173"/>
         <source>Loop</source>
         <translation>Loop</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2153"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2174"/>
         <source>Pause</source>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2154"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2175"/>
         <source>First Frame</source>
         <translation>Primeiro Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2156"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2177"/>
         <source>Last Frame</source>
         <translation>Último Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2158"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2179"/>
         <source>Previous Frame</source>
         <translation>Quadro Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2160"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2181"/>
         <source>Next Frame</source>
         <translation>Quadro Seguinte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2162"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2183"/>
         <source>Next Drawing</source>
         <translation>Desenho Seguinte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2164"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2185"/>
         <source>Previous Drawing</source>
         <translation>Desenho Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2166"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2187"/>
         <source>Next Step</source>
         <translation>Intervalo Seguinte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2167"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2188"/>
         <source>Previous Step</source>
         <translation>Intervalo Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2169"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2190"/>
         <source>Next Key</source>
         <translation>Chave Seguinte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2171"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2192"/>
         <source>Previous Key</source>
         <translation>Chave Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2173"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2194"/>
         <source>Toggle Blank Frames</source>
         <translation>Habilitar Quadros Vazios</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2178"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2199"/>
         <source>&amp;Output Settings...</source>
         <translation>&amp;Configurações de Saída...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2180"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2201"/>
         <source>Control the output settings for the current scene.</source>
         <translation>Controla as configurações de saída da Cena atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2181"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2202"/>
         <source>You can render from the output settings window also.</source>
         <translation>Você também pode renderizar através das configurações de saída.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2182"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2203"/>
         <source>&amp;Preview Settings...</source>
         <translation>&amp;Configurações da Previsualização...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2184"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2205"/>
         <source>Control the settings that will be used to preview the scene.</source>
         <translation>Controla as configurações que serão usadas para pré-visualizar a Cena.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2185"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2206"/>
         <source>&amp;Render</source>
         <translation>&amp;Renderizar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2186"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2207"/>
         <source>Renders according to the settings and location set in Output Settings.</source>
         <translation>Renderiza de acordo com as configurações e localização das Configurações de Saída.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2188"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2209"/>
         <source>&amp;Fast Render to MP4</source>
         <translation>&amp;Render Rápido para MP4</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2189"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2210"/>
         <source>Exports an MP4 file to the location specified in the preferences.</source>
         <translation>Exporta um arquivo MP4 para a localização especificada em Preferências.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2190"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2211"/>
         <source>This is quicker than going into the Output Settings and setting up an MP4 render.</source>
         <translation>Isto é mais rápido do que ir até Configurações de Saída e configurar para um render em MP4.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2193"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2214"/>
         <source>&amp;Preview</source>
         <translation>&amp;Pré-visualizar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2194"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2215"/>
         <source>Previews the current scene with all effects applied.</source>
         <translation>Previsualiza a Cena atual com efeitos aplicados.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2196"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2217"/>
         <source>&amp;Save Previewed Frames</source>
         <translation>&amp;Salvar Quadros Pré-visualizados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2197"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2218"/>
         <source>Save the images created during preview to a specified location.</source>
         <translation>Salva as imagens criadas durante o processo de previsualização para um local especificado.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2198"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2219"/>
         <source>Toggle Viewer Preview</source>
         <translation>Habilitar Pré-visualização do Visualizador</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2201"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2222"/>
         <source>Toggle Viewer Sub-camera Preview</source>
         <translation>Habilitar Pré-visualização do Visualizador da SubCâmera</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2204"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2225"/>
         <source>&amp;Save and Render</source>
         <translation>&amp;Salvar e Renderizar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2205"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2226"/>
         <source>Saves the current scene and renders according to the settings and location set in Output Settings.</source>
         <translation>Salva a Cena atual e renderiza de acordo com as configurações e localização das Configurações de Saída.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2210"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2231"/>
         <source>&amp;Camera Box</source>
         <translation>&amp;Caixa da Câmera</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2212"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2233"/>
         <source>&amp;Table</source>
         <translation>&amp;Mesa</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2214"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2235"/>
         <source>&amp;Grids and Overlays</source>
         <translation>&amp;Grades e Sobreposições</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2216"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2237"/>
         <source>&amp;Raster Bounding Box</source>
         <translation>&amp;Caixa de Contorno Raster</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2218"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2239"/>
         <source>&amp;Safe Area</source>
         <translation>&amp;Área Segura</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2220"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2241"/>
         <source>&amp;Camera BG Color</source>
         <translation>&amp;Cor de Fundo da Câmera</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2222"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2243"/>
         <source>&amp;Guide</source>
         <translation>&amp;Guia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2224"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2245"/>
         <source>&amp;Ruler</source>
         <translation>&amp;Régua</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2226"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2247"/>
         <source>&amp;Transparency Check  </source>
         <translation>&amp;Checagem de Transparência  </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2229"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2250"/>
         <source>&amp;Ink Check</source>
         <translation>&amp;Checagem de Tinta</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2235"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2256"/>
         <source>&amp;Ink#1 Check</source>
         <translation>&amp;Checagem de Tinta#1</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2241"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2262"/>
         <source>&amp;Paint Check</source>
         <translation>&amp;Checagem de Pintura</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2243"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2264"/>
         <source>Inks &amp;Only</source>
         <translation>Apenas &amp;Pinturas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2245"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2266"/>
         <source>&amp;Fill Check</source>
         <translation>&amp;Checagem de Preenchimento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2247"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2268"/>
         <source>&amp;Black BG Check</source>
         <translation>&amp;Checagem de Fundo Preto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2250"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2271"/>
         <source>&amp;Gap Check</source>
         <translation>&amp;Checagem de Buracos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2252"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2273"/>
         <source>Shift and Trace</source>
         <translation>Arrastar &amp; Traçar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2254"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2275"/>
         <source>Edit Shift</source>
         <translation>Editar Posição</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2256"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2277"/>
         <source>No Shift</source>
         <translation>Sem Posicionar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2260"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2281"/>
         <source>Reset Shift</source>
         <translation>Restaurar Posição</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2262"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2283"/>
         <source>Vector Guided Tweening</source>
         <translation>Interpolação Guiada por Vetor</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2266"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2287"/>
         <source>&amp;Visualize Vector As Raster</source>
         <translation>&amp;Visualizar Vetor como Raster</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2274"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2295"/>
         <source>&amp;File Browser</source>
         <translation>&amp;Navegador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2276"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2297"/>
         <source>&amp;Preproduction Board</source>
         <translation>&amp;Quadro de Pré-Produção</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2278"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2299"/>
         <source>&amp;Flipbook</source>
         <translation>&amp;Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2280"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2301"/>
         <source>&amp;Function Editor</source>
         <translation>&amp;Editor Gráfico</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2282"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2303"/>
         <source>&amp;Level Strip</source>
         <translation>&amp;Fita de Nível</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2284"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2305"/>
         <source>&amp;Palette</source>
         <translation>&amp;Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2286"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2307"/>
         <source>&amp;Tasks</source>
         <translation>&amp;Tarefas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2287"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2308"/>
         <source>&amp;Batch Servers</source>
         <translation>&amp;Servidores em Série</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2289"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2310"/>
         <source>&amp;Message Center</source>
         <translation>&amp;Centro de Mensagens</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2291"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2312"/>
         <source>&amp;Color Model</source>
         <translation>&amp;Modelo de Cor</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2293"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2314"/>
         <source>&amp;Studio Palette</source>
         <translation>&amp;Paleta Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2295"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2316"/>
         <source>&amp;Schematic</source>
         <translation>&amp;Esquemática</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2297"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2318"/>
         <source>&amp;FX Editor</source>
         <translation>&amp;Editor de Efeitos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2300"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2321"/>
         <source>&amp;Cleanup Settings</source>
         <translation>&amp;Configurações de Limpeza de Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2302"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2323"/>
         <source>&amp;Scene Cast</source>
         <translation>&amp;Elenco da Cena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2304"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2325"/>
         <source>&amp;Style Editor</source>
         <translation>&amp;Editor de Estilos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2306"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2327"/>
         <source>&amp;Toolbar</source>
         <translation>&amp;Barra de Ferramentas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2307"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2328"/>
         <source>&amp;Tool Option Bar</source>
         <translation>&amp;Barra de Opções de Ferramenta</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2309"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2330"/>
         <source>&amp;Command Bar</source>
         <translation>&amp;Barra de Comandos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2312"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2333"/>
         <source>&amp;Stop Motion Controls</source>
         <translation>&amp;Controles de Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2314"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2335"/>
         <source>&amp;Viewer</source>
         <translation>&amp;Visualizador</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2316"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2337"/>
         <source>&amp;Xsheet</source>
         <translation>&amp;XSheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2317"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
         <source>&amp;Timeline</source>
         <translation>&amp;Timeline</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2319"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2340"/>
         <source>&amp;ComboViewer</source>
         <translation>&amp;Visualizador Combo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2321"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2342"/>
         <source>&amp;History</source>
         <translation>&amp;Histórico</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2323"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2344"/>
         <source>Record Audio</source>
         <translation>Gravação de Áudio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2326"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2347"/>
         <source>&amp;Reset All Default Rooms</source>
         <translation>&amp;Restaurar todos os Cômodos Padrões</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2327"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2348"/>
         <source>Toggle Maximize Panel</source>
         <translation>Maximizar Painel</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2330"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2351"/>
         <source>Toggle Main Window&apos;s Full Screen Mode</source>
         <translation>Deixar a Tela Principal em Modo Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2332"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2353"/>
         <source>&amp;Startup Popup...</source>
         <translation>&amp;Pop-up Inicial</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2335"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2356"/>
         <source>Guided Tweening Controls</source>
         <translation>Controle de Interpolação Guiada</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2359"/>
         <source>&amp;Custom Panels</source>
         <translation>&amp;Painéis Personalizados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2341"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2362"/>
         <source>&amp;Custom Panel Editor...</source>
         <translation>&amp;Editor de Painel Personalizado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2346"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2367"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2347"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2368"/>
         <source>&amp;Motion Paths</source>
         <translation>&amp;Linhas de Movimento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2351"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2372"/>
         <source>&amp;Online Manual...</source>
         <translation>&amp;Manual Online</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2353"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2374"/>
         <source>&amp;What&apos;s New...</source>
         <translation>&amp;Novidades...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2355"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2376"/>
         <source>&amp;Community Forum...</source>
         <translation>&amp;Fórum da Comunidade...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2357"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2378"/>
         <source>&amp;Report a Bug...</source>
         <translation>&amp;Reportar um Bug...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2359"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2380"/>
         <source>&amp;About Tahoma2D...</source>
         <translation>&amp;Sobre o Tahoma2D...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2368"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2389"/>
         <source>Toggle Autofill on Current Palette Color</source>
         <translation>Habilitar Autopreenchimento na Cor de Paleta Atual</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2375"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2396"/>
         <source>&amp;Save Palette As...</source>
         <translation>&amp;Salvar Paleta como...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2376"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2397"/>
         <source>Save the current style palette as a separate file with a new name.</source>
         <translation>Salva a paleta de estilos atual como um arquivo separado com um novo nome.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2377"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2398"/>
         <source>&amp;Save Palette</source>
         <translation>&amp;Salvar Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2378"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2399"/>
         <source>Save the current style palette as a separate file.</source>
         <translation>Salva a paleta de estilos atual como um arquivo separado.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2380"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2401"/>
         <source>&amp;Regenerate Preview</source>
         <translation>&amp;Regenerar Pré-visualização</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2381"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2402"/>
         <source>Recreates a set of preview images.</source>
         <translation>Recria um grupo de imagens de previsualização.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2383"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2404"/>
         <source>&amp;Regenerate Frame Preview</source>
         <translation>&amp;Regenerar Pré-visualização de Quadros</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2384"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2405"/>
         <source>Regenerate the frame preview.</source>
         <translation>Restaura a pré-visualização de quadros.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2385"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2406"/>
         <source>&amp;Clone Preview</source>
         <translation>&amp;Clonar Pré-visualização</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2386"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2407"/>
         <source>Creates a clone of the previewed images.</source>
         <translation>Cria um clone das imagens previsualizadas.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2388"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2409"/>
         <source>&amp;Freeze//Unfreeze Preview</source>
         <translation>&amp;Congelar/Descongelar Previsualização</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2389"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2410"/>
         <source>Prevent the preview from being updated.</source>
         <translation>Impedir a previsualização de atualizar.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2391"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2412"/>
         <source>Freeze Preview</source>
         <translation>Congelar Pré-visualização</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2391"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2412"/>
         <source>Unfreeze Preview</source>
         <translation>Descongelar Pré-visualização</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2392"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2413"/>
         <source>&amp;Save As Preset</source>
         <translation>&amp;Salvar como uma Predefinição</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2393"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2414"/>
         <source>Preview Fx</source>
         <translation>Pré-visualizar Efeitos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2394"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2415"/>
         <source>&amp;Paste Color &amp;&amp; Name</source>
         <translation>&amp;Colar Cor &amp;&amp; Nome</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2396"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2417"/>
         <source>Paste Color</source>
         <translation>Colar Cor</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2398"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2419"/>
         <source>Paste Name</source>
         <translation>Colar Nome</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2401"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2422"/>
         <source>Get Color from Studio Palette</source>
         <translation>Retirar Cor da Paleta Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2403"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2424"/>
         <source>Toggle Link to Studio Palette</source>
         <translation>Habilitar Conexão com a Paleta Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2405"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2426"/>
         <source>Remove Reference to Studio Palette</source>
         <translation>Remover Referência à Paleta Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2407"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2428"/>
         <source>&amp;View...</source>
         <translation>&amp;Visualizar...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2410"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2431"/>
         <source>Toggle Quick Toolbar</source>
         <translation>Habilitar Barra Rápida de Ferramentas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2412"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2433"/>
         <source>Show/Hide Camera Column</source>
         <translation>Mostrar/Esconder Coluna da Câmera</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2413"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2434"/>
         <source>&amp;Set Key</source>
         <translation>&amp;Colocar Chave</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2416"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2437"/>
         <source>&amp;Shift Keys Down</source>
         <translation>&amp;Arrastar Chaves para Baixo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2417"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2438"/>
         <source>&amp;Shift Keys Up</source>
         <translation>&amp;Arrastar Chaves para Cima</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2419"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2440"/>
         <source>&amp;Paste Numbers</source>
         <translation>&amp;Colar Números</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2421"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2442"/>
         <source>&amp;Histogram</source>
         <translation>&amp;Histograma</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2424"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2445"/>
         <source>&amp;Viewer Histogram</source>
         <translation>&amp;Visualizador do Histograma</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2427"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2448"/>
         <source>&amp;Blend colors</source>
         <translation>&amp;Mesclar cores</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2428"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2449"/>
         <source>Onion Skin Toggle</source>
         <translation>Habilitar Onion Skin</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2430"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2451"/>
         <source>Zero Thick Lines</source>
         <translation>Zerar Linhas Espessas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2432"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2453"/>
         <source>Toggle Cursor Size Outline</source>
         <translation>Habilitar Traço de Tamanho do Cursor</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2435"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2456"/>
         <source>Toggle Current Time Indicator</source>
         <translation>Habilitar Indicador de Tempo Atual</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2436"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2457"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2439"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2460"/>
         <source>Show Folder Contents</source>
         <translation>Mostrar Conteúdos da Pasta</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2441"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2462"/>
         <source>Convert...</source>
         <translation>Converter...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2443"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2464"/>
         <source>Collect Assets</source>
         <translation>Adquirir Conteúdos Externos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2445"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2466"/>
         <source>Import Scene</source>
         <translation>Importar Cena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2447"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2468"/>
         <source>Export Scene...</source>
         <translation>Exportar Cena...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2449"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2470"/>
         <source>Remove Level</source>
         <translation>Remover Nível</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2452"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2473"/>
         <source>Add As Render Task</source>
         <translation>Adicionar como Tarefa de Render</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2454"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2475"/>
         <source>Add As Cleanup Task</source>
         <translation>Adicionar como Tarefa de Limpeza de Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2457"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2478"/>
         <source>Select All Keys in this Frame</source>
         <translation>Selecionar Todos os Chaves neste Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2459"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2480"/>
         <source>Select All Keys in this Column</source>
         <translation>Selecionar Todos os Chaves nesta Coluna</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2461"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2482"/>
         <source>Select All Keys</source>
         <translation>Selecionar Todos os Chaves</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2463"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2484"/>
         <source>Select All Following Keys</source>
         <translation>Selecionar Todos os Chaves Seguintes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2465"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2486"/>
         <source>Select All Previous Keys</source>
         <translation>Selecionar Todos os Chaves Anteriores</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2467"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2488"/>
         <source>Select Previous Keys in this Column</source>
         <translation>Selecionar Chaves Anteriores nesta Coluna</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2470"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2491"/>
         <source>Select Following Keys in this Column</source>
         <translation>Selecionar Chaves Seguintes nesta Coluna</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2473"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2494"/>
         <source>Select Previous Keys in this Frame</source>
         <translation>Selecionar Chaves Anteriores neste Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2476"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2497"/>
         <source>Select Following Keys in this Frame</source>
         <translation>Selecionar Chaves Seguintes neste Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2479"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2500"/>
         <source>Invert Key Selection</source>
         <translation>Inverter Seleção de Chaves</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2480"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2501"/>
         <source>Set Acceleration</source>
         <translation>Definir Aceleração</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2482"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2503"/>
         <source>Set Deceleration</source>
         <translation>Definir Desaceleração</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2485"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2506"/>
         <source>Set Constant Speed</source>
         <translation>Definir Velocidade Constante</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2487"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2508"/>
         <source>Reset Interpolation</source>
         <translation>Restaurar Interpolação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2489"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2510"/>
         <source>Linear Interpolation</source>
         <translation>Interpolação Linear</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2491"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2512"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation>Interpolação Velocidade In / Velocidade Out</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2494"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2515"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation>Interpolação Ease In / Ease Out</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2497"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2518"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation>Interpolação Ease In / Ease Out (%)</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2500"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2521"/>
         <source>Exponential Interpolation</source>
         <translation>Interpolação Exponencial</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2502"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2523"/>
         <source>Expression Interpolation</source>
         <translation>Interpolação de Expressão</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2504"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2525"/>
         <source>File Interpolation</source>
         <translation>Interpolação de Arquivo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2506"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2527"/>
         <source>Constant Interpolation</source>
         <translation>Interpolação Constante</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2507"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2528"/>
         <source>Fold Column</source>
         <translation>Dobrar Coluna</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2510"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2531"/>
         <source>Show This Only</source>
         <translation>Mostrar Apenas Isto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2512"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2533"/>
         <source>Show Selected</source>
         <translation>Mostrar Selecionados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2513"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2534"/>
         <source>Show All</source>
         <translation>Mostrar Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2515"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2536"/>
         <source>Hide Selected</source>
         <translation>Esconder Selecionados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2516"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2537"/>
         <source>Hide All</source>
         <translation>Esconder Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2519"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2540"/>
         <source>Toggle Show/Hide</source>
         <translation>Mostrar/Esconder</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2521"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2542"/>
         <source>ON This Only</source>
         <translation>Ligar Apenas Isso</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2523"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2544"/>
         <source>ON Selected</source>
         <translation>Ligar Selecionado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2524"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2545"/>
         <source>ON All</source>
         <translation>Ligar Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2525"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2546"/>
         <source>OFF All</source>
         <translation>Desligar Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2527"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2548"/>
         <source>OFF Selected</source>
         <translation>Desligar Selecionados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2528"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2549"/>
         <source>Swap ON/OFF</source>
         <translation>Trocar Ligado/Desligado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2531"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2552"/>
         <source>Lock This Only</source>
         <translation>Travar Apenas Este</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2533"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2554"/>
         <source>Lock Selected</source>
         <translation>Travar Selecionados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2534"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2555"/>
         <source>Lock All</source>
         <translation>Travar Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2537"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2558"/>
         <source>Unlock Selected</source>
         <translation>Destravar Selecionados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2538"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2559"/>
         <source>Unlock All</source>
         <translation>Destravar Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2541"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2562"/>
         <source>Swap Lock/Unlock</source>
         <translation>Trocar Travado/Destravado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2543"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2564"/>
         <source>Hide Upper Columns</source>
         <translation>Esconder Colunas Superiores</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2545"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2566"/>
         <source>Separate Colors...</source>
         <translation>Separar Cores...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2547"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2568"/>
         <source>&amp;Palette Gizmo</source>
         <translation>&amp;Paleta Gizmo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2550"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2571"/>
         <source>&amp;Delete Unused Styles</source>
         <translation>&amp;Excluir Estilos Inutilizados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2556"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2577"/>
         <source>&amp;Save Studio Palette</source>
         <translation>&amp;Salvar Paleta Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2557"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2578"/>
         <source>Save the current Studio Palette.</source>
         <translation>Salvar Paleta Studio atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2559"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2580"/>
         <source>&amp;Save As Default Palette</source>
         <translation>&amp;Salvar como Paleta Padrão</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2560"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2581"/>
         <source>Save the current style palette as the default for new levels of the current level type.</source>
         <translation>Salva a atual paleta de estilos como padrão para novos níveis do tipo atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2562"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2583"/>
         <source>Toggle Auto-Creation</source>
         <translation>Habilitar Autocriação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2565"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2586"/>
         <source>Toggles the auto-creation of frames when drawing in blank cells on the timeline/xsheet.</source>
         <translation>Habilita a auto-criação de quadros quando desenhar em células vázias na Timeline/XSheet.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2568"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2589"/>
         <source>Toggle Creation In Hold Cells</source>
         <translation>Habilitar Criação em Células Hold</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2571"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2592"/>
         <source>Toggles the auto-creation of frames when drawing in held cells on the timeline/xsheet.</source>
         <translation>Habilita a auto-criação de quadros quando desenhar em células de Hold na Timeline/XSheet.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2573"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2594"/>
         <source>Toggle Auto-Stretch</source>
         <translation>Habilitar Auto-Esticar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2576"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2597"/>
         <source>Toggles the auto-stretch of a frame to the next frame</source>
         <translation>Habilita o Auto-Esticar de um quadro até o próximo quadro.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2577"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2598"/>
         <source>Toggle Viewer Indicators</source>
         <translation>Habilitar Indicadores de Visualizador</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2580"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2601"/>
         <source>Toggle Implicit Hold</source>
         <translation>Habilitar Holds Implícitos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2583"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2604"/>
         <source>Toggles the implicit hold of a frame to the next frame</source>
         <translation>Habilita Holds Implícitos de um quadro até o próximo quadro.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2587"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2608"/>
         <source>Animate Tool</source>
         <translation>Ferramenta de Animação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2588"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2609"/>
         <source>Animate Tool: Modifies the position, rotation and size of the current column</source>
         <translation>Ferramenta de Animação: Modifica a posição, rotação e tamanho da Coluna atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2590"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2611"/>
         <source>Selection Tool</source>
         <translation>Ferramenta de Seleção</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2591"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2612"/>
         <source>Selection Tool: Select parts of your image to transform it.</source>
         <translation>Ferramenta de Seleção: Seleciona partes da sua imagem para transformá-la.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2592"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2613"/>
         <source>Brush Tool</source>
         <translation>Ferramenta de Pincel</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2593"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2614"/>
         <source>Brush Tool: Draws in the work area freehand</source>
         <translation>Ferramenta de Pincel: Desenha na área útil livremente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2594"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2615"/>
         <source>Geometry Tool</source>
         <translation>Ferramenta Geométrica</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2595"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2616"/>
         <source>Geometry Tool: Draws geometric shapes</source>
         <translation>Ferramenta Geométrica: Desenha formas geométricas.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2596"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2617"/>
         <source>Type Tool</source>
         <translation>Ferramenta Tipográfica</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2597"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2618"/>
         <source>Type Tool: Adds text</source>
         <translation>Ferramenta Tipográfica: Adiciona Texto.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2598"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2619"/>
         <source>Fill Tool</source>
         <translation>Ferramente de Preenchimento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2599"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2620"/>
         <source>Fill Tool: Fills drawing areas with the current style</source>
         <translation>Ferramenta de Preenchimento: Preenche áreas com o Estilo atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2600"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2621"/>
         <source>Smart Raster Paint Tool</source>
         <translation>Ferramenta de Pintura Raster Inteligente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2601"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2622"/>
         <source>Smart Raster Paint: Paints areas in Smart Raster levels</source>
         <translation>Ferramenta de Pintura Raster Inteligente: Preenche áreas em Níveis de Raster Inteligente.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2602"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2623"/>
         <source>Eraser Tool</source>
         <translation>Ferramenta de Borracha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2603"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2624"/>
         <source>Eraser Tool: Erases lines and areas</source>
         <translation>Ferramenta de Borracha: Apaga Linhas e Preenchimentos.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2604"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2625"/>
         <source>Tape Tool</source>
         <translation>Ferramenta de Fita</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2605"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2626"/>
         <source>Tape Tool: Closes gaps in raster, joins edges in vector</source>
         <translation>Ferramenta de Fita: Fecha buracos em Raster, une arestas em Vetor.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2607"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2628"/>
         <source>Style Picker Tool</source>
         <translation>Ferramenta de Seleção de Estilo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2608"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2629"/>
         <source>Style Picker: Selects style on current drawing</source>
         <translation>Seletor de Estilo: Seleciona o Estilo no Desenho atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2609"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2630"/>
         <source>RGB Picker Tool</source>
         <translation>Ferramenta de Seleção RGB</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2610"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2631"/>
         <source>RGB Picker: Picks color on screen and applies to current style</source>
         <translation>Seletor RGB: Seleciona a cor na tela e aplica ao Estilo atual.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2612"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2633"/>
         <source>Control Point Editor Tool</source>
         <translation>Ferramenta de Edição de Pontos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2613"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2634"/>
         <source>Control Point Editor: Modifies vector lines by editing its control points</source>
         <translation>Editor de Pontos: Modifica linhas de vetor editando seus pontos de controle.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2615"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2636"/>
         <source>Pinch Tool</source>
         <translation>Ferramenta Apertar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2616"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2637"/>
         <source>Pinch Tool: Pulls vector drawings</source>
         <translation>Ferramenta Apertar: Puxa desenhos Vetoriais.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2617"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2638"/>
         <source>Pump Tool</source>
         <translation>Ferramenta de Bomba</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2618"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2639"/>
         <source>Pump Tool: Changes vector thickness</source>
         <translation>Ferramenta de Bomba: Muda a espessura de Vetores.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2619"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2640"/>
         <source>Magnet Tool</source>
         <translation>Ferramenta de Imã</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2620"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2641"/>
         <source>Magnet Tool: Deforms vector lines</source>
         <translation>Ferramenta de Imã: Deforma linhas de Vetores.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2621"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2642"/>
         <source>Bender Tool</source>
         <translation>Ferramenta de Entortar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2622"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2643"/>
         <source>Bender Tool: Bends vector shapes around the first click</source>
         <translation>Ferramenta de Entortar: Entorta formas Vetoriais em volta do primeiro clique.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2623"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2644"/>
         <source>Iron Tool</source>
         <translation>Ferramenta de Ferro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2624"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2645"/>
         <source>Iron Tool: Smooths out vector lines</source>
         <translation>Ferramenta de Ferro: Suaviza linhas de Vetores.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2626"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2647"/>
         <source>Cutter Tool</source>
         <translation>Ferramenta de Corte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2627"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2648"/>
         <source>Cutter Tool: Splits vector lines</source>
         <translation>Ferramenta de Corte: Separa linhas de Vetor.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2628"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2649"/>
         <source>Skeleton Tool</source>
         <translation>Ferramenta de Esqueleto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2629"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2650"/>
         <source>Skeleton Tool: Allows to build a skeleton and animate in a cut-out workflow</source>
         <translation>Ferramenta de Esqueleto: Permite a construção de um esqueleto para animação de workflow cut-out.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2631"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2652"/>
         <source>Tracker Tool</source>
         <translation>Ferramenta de Rastreio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2632"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2653"/>
         <source>Tracker Tool: Tracks specific regions in a sequence of images</source>
         <translation>Rastreador: Rastreia regiões específicas em uma sequência de imagens.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2633"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2654"/>
         <source>Hook Tool</source>
         <translation>Ferramenta de Gancho</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2634"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2655"/>
         <source>Zoom Tool</source>
         <translation>Ferramenta de Zoom</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2635"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2656"/>
         <source>Zoom Tool: Zooms viewer</source>
         <translation>Ferramenta de Zoom: Dá Zoom no Visualizador.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2636"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2657"/>
         <source>Rotate Tool</source>
         <translation>Ferramenta de Rotação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2637"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2658"/>
         <source>Rotate Tool: Rotate the viewer</source>
         <translation>Ferramenta de Rotação: Rotaciona a Área de Trabalho.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2638"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2659"/>
         <source>Hand Tool</source>
         <translation>Ferramenta de Mão</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2639"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2660"/>
         <source>Hand Tool: Pans the workspace</source>
         <translation>Ferramenta de Mão: Move a área de trabalho.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2640"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2661"/>
         <source>Plastic Tool</source>
         <translation>Ferramenta de Plástico</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2641"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2662"/>
         <source>Plastic Tool: Builds a mesh that allows to deform and animate a level</source>
         <translation>Ferramenta de Plástico: Constrói uma malha que permite a deformação e animação do Nível.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2643"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2664"/>
         <source>Ruler Tool</source>
         <translation>Ferramenta de Régua</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2644"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2665"/>
         <source>Ruler Tool: Measure distances on the canvas</source>
         <translation>Ferramenta de Régua: Mede a distância na tela.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2646"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2667"/>
         <source>Perspective Grid Tool</source>
         <translation>Ferramenta de Guia de Perspectiva</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2647"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2668"/>
         <source>Perspective Grid Tool: Set up perspective grids</source>
         <translation>Ferramenta de Guia de Perspectiva: Posiciona grades de perspectiva.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2648"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2669"/>
         <source>Symmetry Tool</source>
         <translation>Ferramenta de Simetria</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2649"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2670"/>
         <source>Symmetry Tool: Set up symmetrical guide</source>
         <translation>Ferramenta de Simetria: Posiciona Guia Simétrico</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2650"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2671"/>
         <source>Finger Tool</source>
         <translation>Ferramenta de Dedo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2651"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2672"/>
         <source>Finger Tool: Smudges small areas to cover with line</source>
         <translation>Ferramenta de Dedo: Borra pequenas áreas para cobrir com linha.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2654"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2675"/>
         <source>Animate Tool - Next Mode</source>
         <translation>Ferramenta de Animação - Próximo Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2656"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2677"/>
         <source>Animate Tool - Position</source>
         <translation>Ferramenta de Animação - Posicionamento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2658"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2679"/>
         <source>Animate Tool - Rotation</source>
         <translation>Ferramenta de Animação - Rotação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2660"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2681"/>
         <source>Animate Tool - Scale</source>
         <translation>Ferramenta de Animação - Escala</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2662"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2683"/>
         <source>Animate Tool - Shear</source>
         <translation>Ferramenta de Animação - Inclinação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2664"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2685"/>
         <source>Animate Tool - Center</source>
         <translation>Ferramenta de Animação - Centro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2666"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2687"/>
         <source>Animate Tool - All</source>
         <translation>Ferramenta de Animação - Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2670"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2691"/>
         <source>Selection Tool - Next Type</source>
         <translation>Ferramenta de Seleção - Próximo Tipo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2673"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2694"/>
         <source>Selection Tool - Rectangular</source>
         <translation>Ferramenta de Seleção - Retangular</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2675"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2696"/>
         <source>Selection Tool - Freehand</source>
         <translation>Ferramenta de Seleção - Livre</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2677"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2698"/>
         <source>Selection Tool - Polyline</source>
         <translation>Ferramenta de Seleção - Polilinha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2681"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2702"/>
         <source>Brush Tool - Auto Fill On</source>
         <translation>Ferramenta de Pincel - Auto-Preenchimento Ligado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2683"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2704"/>
         <source>Brush Tool - Auto Fill Off</source>
         <translation>Ferramenta de Pincel - Auto-Preenchimento Desligado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2687"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2708"/>
         <source>Geometric Tool - Next Shape</source>
         <translation>Ferramenta Geométrica - Próxima Forma</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2689"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2710"/>
         <source>Geometric Tool - Rectangle</source>
         <translation>Ferramenta Geométrica - Retângulo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2691"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2712"/>
         <source>Geometric Tool - Circle</source>
         <translation>Ferramenta Geométrica - Círculo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2693"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2714"/>
         <source>Geometric Tool - Ellipse</source>
         <translation>Ferramenta Geométrica - Elipse</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2695"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2716"/>
         <source>Geometric Tool - Line</source>
         <translation>Ferramenta Geométrica - Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2697"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2718"/>
         <source>Geometric Tool - Polyline</source>
         <translation>Ferramenta Geométrica - Polilinha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2699"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2720"/>
         <source>Geometric Tool - Arc</source>
         <translation>Ferramenta Geométrica - Arco</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2701"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2722"/>
         <source>Geometric Tool - MultiArc</source>
         <translation>Ferramenta Geométrica - MultiArco</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2703"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2724"/>
         <source>Geometric Tool - Polygon</source>
         <translation>Ferramenta Geométrica - Polígono</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2707"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2728"/>
         <source>Type Tool - Next Style</source>
         <translation>Ferramenta Tipográfica - Próximo Estilo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2709"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2730"/>
         <source>Type Tool - Oblique</source>
         <translation>Ferramenta Tipográfica - Oblíquo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2711"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2732"/>
         <source>Type Tool - Regular</source>
         <translation>Ferramenta Tipográfica - Regular</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2713"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2734"/>
         <source>Type Tool - Bold Oblique</source>
         <translation>Ferramenta Tipográfica - Oblíquo em Negrito</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2715"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2736"/>
         <source>Type Tool - Bold</source>
         <translation>Ferramenta Tipográfica - Negrito</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2719"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2740"/>
         <source>Paint Brush - Next Mode</source>
         <translation>Pincel - Próximo Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2721"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2742"/>
         <source>Paint Brush - Areas</source>
         <translation>Pincel - Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2723"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2744"/>
         <source>Paint Brush - Lines</source>
         <translation>Pincel - Linhas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2726"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2747"/>
         <source>Paint Brush - Lines &amp; Areas</source>
         <translation>Pincel - Linhas e Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2730"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2751"/>
         <source>Fill Tool - Next Type</source>
         <translation>Ferramenta de Preenchimento - Próximo Tipo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2732"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2753"/>
         <source>Fill Tool - Normal</source>
         <translation>Ferramenta de Preenchimento - Normal</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2734"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2755"/>
         <source>Fill Tool - Rectangular</source>
         <translation>Ferramenta de Preenchimento - Retangular</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2736"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2757"/>
         <source>Fill Tool - Freehand</source>
         <translation>Ferramenta de Preenchimento - Livre</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2738"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2759"/>
         <source>Fill Tool - Polyline</source>
         <translation>Ferramenta de Preenchimento - Polilinha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2740"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2761"/>
         <source>Fill Tool - Pick+Freehand</source>
         <translation>Ferramenta de Preenchimento - Escolher+Mão Livre</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2742"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2763"/>
         <source>Fill Tool - Next Mode</source>
         <translation>Ferramenta de Preenchimento - Próximo Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2744"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2765"/>
         <source>Fill Tool - Areas</source>
         <translation>Ferramenta de Preenchimento - Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2746"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2767"/>
         <source>Fill Tool - Lines</source>
         <translation>Ferramenta de Preenchimento - Linhas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2748"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2769"/>
         <source>Fill Tool - Lines &amp; Areas</source>
         <translation>Ferramenta de Preenchimento - Linhas e Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2752"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2773"/>
         <source>Eraser Tool - Next Type</source>
         <translation>Ferramenta de Borracha - Próximo Tipo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2754"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2775"/>
         <source>Eraser Tool - Normal</source>
         <translation>Ferramenta de Borracha - Normal</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2756"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2777"/>
         <source>Eraser Tool - Rectangular</source>
         <translation>Ferramenta de Borracha - Retangular</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2758"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2779"/>
         <source>Eraser Tool - Freehand</source>
         <translation>Ferramenta de Borracha - Livre</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2760"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2781"/>
         <source>Eraser Tool - Polyline</source>
         <translation>Ferramenta de Borracha - Polilinha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2762"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2783"/>
         <source>Eraser Tool - Segment</source>
         <translation>Ferramenta de Borracha - Segmento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2766"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2787"/>
         <source>Tape Tool - Next Type</source>
         <translation>Ferramenta de Fita - Próximo Tipo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2768"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2789"/>
         <source>Tape Tool - Normal</source>
         <translation>Ferramenta de Fita - Normal</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2770"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2791"/>
         <source>Tape Tool - Rectangular</source>
         <translation>Ferramenta de Fita - Retangular</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2772"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2793"/>
         <source>Tape Tool - Next Mode</source>
         <translation>Ferramenta de Fita - Próximo Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2775"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2796"/>
         <source>Tape Tool - Endpoint to Endpoint</source>
         <translation>Ferramenta de Fita - Ponto-final até Ponto-final</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2778"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2799"/>
         <source>Tape Tool - Endpoint to Line</source>
         <translation>Ferramenta de Fita - Ponto-final até Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2780"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2801"/>
         <source>Tape Tool - Line to Line</source>
         <translation>Ferramenta de Fita - Linha até Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2785"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2806"/>
         <source>Style Picker Tool - Next Mode</source>
         <translation>Ferramenta de Seleção de Estilo - Próximo Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2787"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2808"/>
         <source>Style Picker Tool - Areas</source>
         <translation>Ferramenta de Seleção de Estilo - Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2789"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2810"/>
         <source>Style Picker Tool - Lines</source>
         <translation>Ferramenta de Seleção de Estilo - Linhas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2792"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2813"/>
         <source>Style Picker Tool - Lines &amp; Areas</source>
         <translation>Ferramenta de Seleção de Estilo - Linhas e Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2796"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2817"/>
         <source>RGB Picker Tool - Next Type</source>
         <translation>Ferramenta de Seleção RGB - Próximo Tipo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2798"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2819"/>
         <source>RGB Picker Tool - Normal</source>
         <translation>Ferramenta de Seleção RGB - Normal</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2801"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2822"/>
         <source>RGB Picker Tool - Rectangular</source>
         <translation>Ferramenta de Seleção RGB - Retangular</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2803"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2824"/>
         <source>RGB Picker Tool - Freehand</source>
         <translation>Ferramenta de Seleção RGB - Livre</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2805"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2826"/>
         <source>RGB Picker Tool - Polyline</source>
         <translation>Ferramenta de Seleção RGB - Polilinha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2809"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2830"/>
         <source>Skeleton Tool - Next Mode</source>
         <translation>Ferramenta de Esqueleto - Próximo Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2812"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2833"/>
         <source>Skeleton Tool - Build Skeleton</source>
         <translation>Ferramenta de Esqueleto - Construir Esqueleto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2814"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2835"/>
         <source>Skeleton Tool - Animate</source>
         <translation>Ferramenta de Esqueleto - Animação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2817"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2838"/>
         <source>Skeleton Tool - Inverse Kinematics</source>
         <translation>Ferramenta de Esqueleto - Cinemática Inversa</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2821"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2842"/>
         <source>Plastic Tool - Next Mode</source>
         <translation>Ferramenta de Plástico - Próximo Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2823"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2844"/>
         <source>Plastic Tool - Edit Mesh</source>
         <translation>Ferramenta de Plástico - Editação de Malha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2825"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2846"/>
         <source>Plastic Tool - Paint Rigid</source>
         <translation>Ferramenta de Plástico - Pintar Rígido</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2828"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2849"/>
         <source>Plastic Tool - Build Skeleton</source>
         <translation>Ferramenta de Plástico - Construção de Esqueleto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2830"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2851"/>
         <source>Plastic Tool - Animate</source>
         <translation>Ferramenta de Plástico - Animação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2836"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2857"/>
         <source>Select Next Frame Guide Stroke</source>
         <translation>Selecionar Traço Guia do Próximo Quadro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2838"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2859"/>
         <source>Select Previous Frame Guide Stroke</source>
         <translation>Selecionar Traço Guia do Quadro Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2841"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2862"/>
         <source>Select Prev &amp;&amp; Next Frame Guide Strokes</source>
         <translation>Selecionar Traço Guia do Quadro Anterior e do Próximo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2845"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2866"/>
         <source>Reset Guide Stroke Selections</source>
         <translation>Restaurar Seleção do Traço Guia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2847"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2868"/>
         <source>Tween Selected Guide Strokes</source>
         <translation>Interpolar Traços Guia Selecionados</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2849"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2870"/>
         <source>Tween Guide Strokes to Selected</source>
         <translation>Interpolar Traços Guia até o Selecionado</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2851"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2872"/>
         <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
         <translation>Selecionar Traços Guia &amp;&amp; Modo de Interpolação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2853"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2874"/>
         <source>Flip Next Guide Stroke Direction</source>
         <translation>Inverter Direção do Próximo Traço Guia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2855"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2876"/>
         <source>Flip Previous Guide Stroke Direction</source>
         <translation>Inverter Direção do Traço Guia Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2857"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2878"/>
         <source>Global Key</source>
         <translation>Chave Global</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2861"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2882"/>
         <source>Brush size - Increase max</source>
         <translation>Tamanho do Pincel - Aumentar máx.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2863"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2884"/>
         <source>Brush size - Decrease max</source>
         <translation>Tamanho do Pincel - Diminuir máx.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2865"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2886"/>
         <source>Brush size - Increase min</source>
         <translation>Tamanho do Pincel - Aumentar min.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2867"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2888"/>
         <source>Brush size - Decrease min</source>
         <translation>Tamanho do Pincel - Diminuir min.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2869"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2890"/>
         <source>Brush hardness - Increase</source>
         <translation>Dureza do Pincel - Aumentar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2871"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2892"/>
         <source>Brush hardness - Decrease</source>
         <translation>Dureza do Pincel - Diminuir</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2873"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2894"/>
         <source>Snap Sensitivity</source>
         <translation>Sensibilidade de Encaixe</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2874"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2895"/>
         <source>Auto Group</source>
         <translation>Agrupamento Automático</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2877"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2898"/>
         <source>Break sharp angles</source>
         <translation>Quebrar ângulos agudos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2878"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2899"/>
         <source>Frame range</source>
         <translation>Escopo de Quadros</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2880"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2901"/>
         <source>Inverse Kinematics</source>
         <translation>Cinemática Inversa</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2882"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2903"/>
         <source>Invert</source>
         <translation>Inverter</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2883"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2904"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2884"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2905"/>
         <source>Onion skin</source>
         <translation>Onion Skin</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2886"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2907"/>
         <source>Orientation</source>
         <translation>Orientação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2888"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2909"/>
         <source>Pencil Mode</source>
         <translation>Modo Lápis</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2891"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2912"/>
         <source>Preserve Thickness</source>
         <translation>Preservar Espessura</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2893"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2914"/>
         <source>Pressure Sensitivity</source>
         <translation>Preservar Sensibilidade</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2894"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2915"/>
         <source>Segment Ink</source>
         <translation>Tinta de Segmento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2896"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2917"/>
         <source>Selective</source>
         <translation>Seletivo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2899"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2920"/>
         <source>Brush Tool - Draw Order</source>
         <translation>Ferramenta de Pincel - Ordem de Desenho</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2900"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2921"/>
         <source>Smooth</source>
         <translation>Suavizar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2901"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2922"/>
         <source>Snap</source>
         <translation>Encaixar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2903"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2924"/>
         <source>Auto Select Drawing</source>
         <translation>Selecionar Desenho Automaticamente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2904"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2925"/>
         <source>Auto Fill</source>
         <translation>Preenchimento Automático</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2906"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2927"/>
         <source>Join Vectors</source>
         <translation>Unir Vetores</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2908"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2929"/>
         <source>Show Only Active Skeleton</source>
         <translation>Mostrar Apenas Esqueleto Ativo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2910"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2931"/>
         <source>Brush Tool - Eraser (Raster option)</source>
         <translation>Ferramenta de Pincel - Borracha (Opção Raster)</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2913"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2934"/>
         <source>Brush Tool - Lock Alpha</source>
         <translation>Ferramenta de Pincel - Travar Alpha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2916"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2937"/>
         <source>Brush Preset</source>
         <translation>Predefinição de Pincel</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2918"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2939"/>
         <source>Geometric Shape</source>
         <translation>Forma Geométrica</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2920"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2941"/>
         <source>Geometric Shape Rectangle</source>
         <translation>Forma Geométrica Retângulo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2922"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2943"/>
         <source>Geometric Shape Circle</source>
         <translation>Forma Geométrica Círculo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2924"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2945"/>
         <source>Geometric Shape Ellipse</source>
         <translation>Forma Geométrica Elipse</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2926"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2947"/>
         <source>Geometric Shape Line</source>
         <translation>Forma Geométrica Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2928"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2949"/>
         <source>Geometric Shape Polyline</source>
         <translation>Forma Geométrica Polilinha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2930"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2951"/>
         <source>Geometric Shape Arc</source>
         <translation>Forma Geométrica Arco</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2932"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2953"/>
         <source>Geometric Shape MultiArc</source>
         <translation>Forma Geométrica MultiArco</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2934"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2955"/>
         <source>Geometric Shape Polygon</source>
         <translation>Forma Geométrica Polígono</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2936"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2957"/>
         <source>Geometric Edge</source>
         <translation>Contorno Geométrico</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2937"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2958"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2939"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2960"/>
         <source>Mode - Areas</source>
         <translation>Modo - Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2942"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2963"/>
         <source>Mode - Lines</source>
         <translation>Modo - Linhas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2945"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2966"/>
         <source>Mode - Lines &amp;&amp; Areas</source>
         <translation>Modo - Linhas &amp;&amp; Áreas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2948"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2969"/>
         <source>Mode - Endpoint to Endpoint</source>
         <translation>Modo - Ponto-final até Ponto-final</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2950"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2971"/>
         <source>Mode - Endpoint to Line</source>
         <translation>Modo - Ponto-final até Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2952"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2973"/>
         <source>Mode - Line to Line</source>
         <translation>Modo - Linha até Linha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2953"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2974"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2956"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2977"/>
         <source>Type - Normal</source>
         <translation>Tipo - Normal</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2960"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2981"/>
         <source>Type - Rectangular</source>
         <translation>Tipo - Retângulo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2964"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2985"/>
         <source>Type - Freehand</source>
         <translation>Tipo - Livre</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2968"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2989"/>
         <source>Type - Polyline</source>
         <translation>Tipo - Polilinha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2972"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2993"/>
         <source>Type - Pick+Freehand</source>
         <translation>Tipo - Escolher+Mão Livre</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2976"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2997"/>
         <source>Type - Segment</source>
         <translation>Tipo - Segmento</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2979"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3000"/>
         <source>TypeTool Font</source>
         <translation>Ferramenta Tipográfica Fonte</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2981"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3002"/>
         <source>TypeTool Size</source>
         <translation>Ferramenta Tipográfica Tamanho</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2984"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3005"/>
         <source>TypeTool Style</source>
         <translation>Ferramenta Tipográfica Estilo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2986"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3007"/>
         <source>TypeTool Style - Oblique</source>
         <translation>Ferramenta Tipográfica - Oblíquo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2988"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3009"/>
         <source>TypeTool Style - Regular</source>
         <translation>Ferramenta Tipográfica - Regular</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2990"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3011"/>
         <source>TypeTool Style - Bold Oblique</source>
         <translation>Ferramenta Tipográfica - Oblíquo em Negrito</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2992"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3013"/>
         <source>TypeTool Style - Bold</source>
         <translation>Ferramenta Tipográfica - Negrito</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2995"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3016"/>
         <source>Active Axis</source>
         <translation>Eixo Ativo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2997"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3018"/>
         <source>Active Axis - Position</source>
         <translation>Eixo Ativo - Posição</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2999"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3020"/>
         <source>Active Axis - Rotation</source>
         <translation>Eixo Ativo - Rotação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3001"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3022"/>
         <source>Active Axis - Scale</source>
         <translation>Eixo Ativo - Escala</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3003"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3024"/>
         <source>Active Axis - Shear</source>
         <translation>Eixo Ativo - Inclinação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3005"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3026"/>
         <source>Active Axis - Center</source>
         <translation>Eixo Ativo - Centro</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3007"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3028"/>
         <source>Active Axis - All</source>
         <translation>Eixo Ativo - Todos</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3010"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3031"/>
         <source>Skeleton Mode</source>
         <translation>Modo Esqueleto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3012"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3033"/>
         <source>Edit Mesh Mode</source>
         <translation>Editar Modo de Malha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3014"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3035"/>
         <source>Paint Rigid Mode</source>
         <translation>Modo de Pintura Rígida</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3016"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3037"/>
         <source>Build Skeleton Mode</source>
         <translation>Modo de Construção de Esqueleto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3018"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3039"/>
         <source>Animate Mode</source>
         <translation>Modo de Animação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3020"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3041"/>
         <source>Inverse Kinematics Mode</source>
         <translation>Modo de Cinemática Inversa</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3022"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3043"/>
         <source>None Pick Mode</source>
         <translation>Modo de Escolha Vazio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3024"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3045"/>
         <source>Column Pick Mode</source>
         <translation>Modo de Escolha Coluna</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3026"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3047"/>
         <source>Pegbar Pick Mode</source>
         <translation>Modo de Escolha Pegbar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3028"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3049"/>
         <source>Pick Screen</source>
         <translation>Escolhar Tela</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3030"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3051"/>
         <source>Create Mesh</source>
         <translation>Criar Malha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3035"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3056"/>
         <source>Fill Tool - Autopaint Lines</source>
         <translation>Ferramenta de Preenchimento - Autopintar Linhas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3039"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3060"/>
         <source>Auto Close</source>
         <translation>Fechar Automaticamente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3040"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3061"/>
         <source>Draw Under</source>
         <translation>Desenhar Abaixo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3043"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3064"/>
         <source>Flip Selection/Object Horizontally</source>
         <translation>Inverter Seleção/Objeto Horizontalmente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3045"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3066"/>
         <source>Flip Selection/Object Vertically</source>
         <translation>Inverter Seleção/Objeto Verticalmente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3047"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3068"/>
         <source>Rotate Selection/Object Left</source>
         <translation>Rotacionar Seleção/Objeto para Esquerda</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3049"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3070"/>
         <source>Rotate Selection/Object Right</source>
         <translation>Rotacionar Seleção/Objeto para Direita</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3052"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3073"/>
         <source>Zoom In</source>
         <translation>Zoom In</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3053"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3074"/>
         <source>Zoom Out</source>
         <translation>Zoom Out</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3054"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3089"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3075"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3110"/>
         <source>Reset View</source>
         <translation>Restaurar Visão</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3055"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3091"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3112"/>
         <source>Fit to Window</source>
         <translation>Preencher Tela</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3056"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3093"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3077"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3114"/>
         <source>Reset Zoom</source>
         <translation>Restaurar Zoom</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3057"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3095"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3078"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3116"/>
         <source>Reset Rotation</source>
         <translation>Restaurar Rotação</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3058"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3098"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3079"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3119"/>
         <source>Reset Position</source>
         <translation>Restaurar Posição</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3060"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3100"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3081"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3121"/>
         <source>Actual Pixel Size</source>
         <translation>Tamanho Real do Píxel</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3061"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3102"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3082"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3123"/>
         <source>Flip Viewer Horizontally</source>
         <translation>Inverter Visualizador Horizontalmente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3062"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3104"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3083"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3125"/>
         <source>Flip Viewer Vertically</source>
         <translation>Inverter Visualizador Verticalmente</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3063"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3084"/>
         <source>Show//Hide Full Screen</source>
         <translation>Mostrar/Esconder Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3066"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3087"/>
         <source>Full Screen Mode</source>
         <translation>Modo de Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3067"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3088"/>
         <source>Exit Full Screen Mode</source>
         <translation>Sair do Modo Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3068"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3089"/>
         <source>Compare to Snapshot</source>
         <translation>Comparar com Snapshot</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3070"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3091"/>
         <source>&amp;Show Status Bar</source>
         <translation>&amp;Mostrar Barra de Status</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3074"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3095"/>
         <source>&amp;Toggle Transparency</source>
         <translation>&amp;Habilitar Transparência</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3109"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3130"/>
         <source>&amp;Touch Gesture Control</source>
         <translation>&amp;Controle de Toque e Gesto</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3114"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3135"/>
         <source>Refresh Folder Tree</source>
         <translation>Atualizar Árvore de Pastas</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3115"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3136"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3118"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3139"/>
         <source>Toggle FX/Stage schematic</source>
         <translation>Habilitar esquemática de FX/Palco</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3125"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3146"/>
         <source>Red Channel</source>
         <translation>Canal Vermelho</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3126"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3147"/>
         <source>Green Channel</source>
         <translation>Canal Verde</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3127"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3148"/>
         <source>Blue Channel</source>
         <translation>Canal Azul</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3128"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3149"/>
         <source>Alpha Channel</source>
         <translation>Canal Alpha</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3129"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3150"/>
         <source>Red Channel Greyscale</source>
         <translation>Canal Vermelho em Escala de Cinza</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3132"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3153"/>
         <source>Green Channel Greyscale</source>
         <translation>Canal Verde em Escala de Cinza</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3134"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3155"/>
         <source>Blue Channel Greyscale</source>
         <translation>Canal Azul em Escala de Cinza</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3139"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3160"/>
         <source>&amp;Export Stop Motion Image Sequence</source>
         <translation>&amp;Exportar Sequência de Imagem Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3140"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3161"/>
         <source>Exports the full resolution stop motion image sequence.</source>
         <translation>Exporta toda a resolução da sequência de imagem Stop-Motion.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3141"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3162"/>
         <source>This is especially useful if using a DSLR camera.</source>
         <translation>Isto é especialmente útil caso esteja usando uma câmera DSLR.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3143"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3164"/>
         <source>Capture Stop Motion Frame</source>
         <translation>Capturar Quadro Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3145"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3166"/>
         <source>Raise Stop Motion Opacity</source>
         <translation>Aumentar Opacidade Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3147"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3168"/>
         <source>Lower Stop Motion Opacity</source>
         <translation>Abaixar Opacidade Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3149"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3170"/>
         <source>Toggle Stop Motion Live View</source>
         <translation>Habilitar Visão em Tempo Real Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3151"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3172"/>
         <source>Toggle Stop Motion Zoom</source>
         <translation>Habilitar Zoom Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3153"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3174"/>
         <source>Pick Focus Check Location</source>
         <translation>Escolher Localização do Cheque de Foco</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3155"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3176"/>
         <source>Lower Stop Motion Level Subsampling</source>
         <translation>Abaixar Nível de Subsampling Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3157"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3178"/>
         <source>Raise Stop Motion Level Subsampling</source>
         <translation>Aumentar Nível de Subsampling Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3159"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3180"/>
         <source>Go to Stop Motion Insert Frame</source>
         <translation>Ir para Inserção de Quadro Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3161"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3182"/>
         <source>Remove frame before Stop Motion Camera</source>
         <translation>Remover Quadro antes da Câmera Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3164"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3185"/>
         <source>Next Frame including Stop Motion Camera</source>
         <translation>Próximo Quadro incluindo Câmera Stop-Motion</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3167"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3188"/>
         <source>Show original live view images.</source>
         <translation>Mostrar Imagens originais em Tempo Real</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3173"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3194"/>
         <source>Set Cell Mark </source>
         <translation>Estabelecer Marcação de Célula</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3266"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3290"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3303"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3308"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3287"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3311"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3324"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3329"/>
         <source>Clear Cache Folder</source>
         <translation>Limpar Pasta de Cache</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3267"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3288"/>
         <source>There are no unused items in the cache folder.</source>
         <translation>Não há itens inutilizados na Pasta de Cache.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3271"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3292"/>
         <source>Deleting the following items:
 </source>
         <translation>Excluindo os seguintes itens:
 </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3275"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3296"/>
         <source>&lt;DIR&gt; </source>
         <translation>&lt;DIR&gt;.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3283"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3304"/>
         <source>   ... and %1 more items
 </source>
         <translation>   ... e %1 itens
 </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3286"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3307"/>
         <source>
 Are you sure?
 
@@ -8647,23 +8657,23 @@ N.B Tenha certeza de que você não está rodando outro processo do Tahoma2D,
 ou você poderá excluir arquivos necessários.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3304"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3309"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3325"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3330"/>
         <source>Can&apos;t delete %1 : </source>
         <translation>Impossível excluir %1 : </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3346"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3367"/>
         <source>Tahoma2D Transparency</source>
         <translation>Transparência Tahoma2D</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3348"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3369"/>
         <source>Close to turn off Transparency.</source>
         <translation>Feche para desligar Transparência.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3362"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3383"/>
         <source>Amount: </source>
         <translation>Quantia: </translation>
     </message>
@@ -8894,6 +8904,26 @@ O que deseja fazer?</translation>
         <location filename="../../toonz/motionpathpanel.cpp" line="111"/>
         <source>Polygon</source>
         <translation>Polígono</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="406"/>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="407"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="408"/>
+        <source>Color</source>
+        <translation type="unfinished">Cor</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="409"/>
+        <source>Steps</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -9208,6 +9238,11 @@ Os parâmetros a serem salvos são:
         <translation>Comprimento do Canal:</translation>
     </message>
     <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="196"/>
+        <source>Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../toonz/outputsettingspopup.cpp" line="220"/>
         <source>Save current output settings.
 The parameters to be saved are:
@@ -9365,6 +9400,17 @@ Atribua menos que 1.0 para sincronizar o valor com as configurações de saída.
         <translation>Translação da Câmera:</translation>
     </message>
     <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1783"/>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1810"/>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../toonz/outputsettingspopup.cpp" line="1866"/>
         <source>Add preset</source>
         <translation>Adicionar Predefinição</translation>
@@ -9378,6 +9424,12 @@ Atribua menos que 1.0 para sincronizar o valor com as configurações de saída.
         <location filename="../../toonz/outputsettingspopup.cpp" line="1878"/>
         <source>Add output settings preset</source>
         <translation>Adicionar predefinição de configurações de saída</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1879"/>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/outputsettingspopup.cpp" line="1967"/>
@@ -9475,11 +9527,33 @@ Atribua menos que 1.0 para sincronizar o valor com as configurações de saída.
         <translation>Remover Predefinição</translation>
     </message>
     <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2011"/>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished">Excluindo &quot;%1&quot;.
+Tem certeza?</translation>
+    </message>
+    <message>
         <location filename="../../toonz/outputsettingspopup.cpp" line="2036"/>
         <location filename="../../toonz/outputsettingspopup.cpp" line="2044"/>
         <location filename="../../toonz/outputsettingspopup.cpp" line="2052"/>
         <source>Warning</source>
         <translation>Aviso</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2037"/>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2045"/>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2053"/>
+        <source>Bad file format: %1.txt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11132,6 +11206,11 @@ display 30bit está disponível na configuração atual.</translation>
         <translation>Criar Projeto em:</translation>
     </message>
     <message>
+        <location filename="../../toonz/projectpopup.cpp" line="100"/>
+        <source>*Separate assets into scene sub-folders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../toonz/projectpopup.cpp" line="104"/>
         <source>Standard</source>
         <translation>Padrão</translation>
@@ -11364,7 +11443,7 @@ O que gostaria de fazer?</translation>
         <translation>Carregar Cena</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1394"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1415"/>
         <source>Quit</source>
         <translation>Sair</translation>
     </message>
@@ -11630,7 +11709,7 @@ O que gostaria de fazer?</translation>
         <location filename="../../toonz/iocommand.cpp" line="3192"/>
         <location filename="../../toonz/loadfoldercommand.cpp" line="556"/>
         <location filename="../../toonz/loadfolderpopup.cpp" line="30"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1338"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1359"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="145"/>
         <location filename="../../toonz/previewer.cpp" line="797"/>
         <location filename="../../toonz/previewer.cpp" line="914"/>
@@ -12545,7 +12624,7 @@ Alguns arquivos podem estar perdidos.</translation>
         <location filename="../../toonz/filebrowser.cpp" line="1824"/>
         <location filename="../../toonz/levelcreatepopup.cpp" line="588"/>
         <location filename="../../toonz/levelsettingspopup.cpp" line="1146"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1098"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1119"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="144"/>
         <location filename="../../toonz/menubar.cpp" line="233"/>
         <location filename="../../toonz/menubar.cpp" line="249"/>
@@ -12565,7 +12644,7 @@ Alguns arquivos podem estar perdidos.</translation>
         <location filename="../../toonz/iocommand.cpp" line="2503"/>
         <location filename="../../toonz/levelcreatepopup.cpp" line="588"/>
         <location filename="../../toonz/levelsettingspopup.cpp" line="1146"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1098"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1119"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="144"/>
         <location filename="../../toonz/menubar.cpp" line="233"/>
         <location filename="../../toonz/menubar.cpp" line="249"/>
@@ -13100,7 +13179,7 @@ Gostaria de continuar carregando o último salvamento bom ou parar e tentar recu
     </message>
     <message>
         <location filename="../../toonz/iocommand.cpp" line="1943"/>
-        <location filename="../../toonz/main.cpp" line="711"/>
+        <location filename="../../toonz/main.cpp" line="717"/>
         <source>It is not possible to load the scene %1 because it does not belong to any project.</source>
         <translation>Não é possível carregar Cena %1 porque ela não pertence a nenhum projeto.</translation>
     </message>
@@ -13357,59 +13436,119 @@ Do you want to import them or load from their original location?</source>
 Gostaria de importá-las ou carregá-las na localização original?</translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="121"/>
+        <location filename="../../toonz/main.cpp" line="122"/>
         <source>Installing %1 again could fix the problem.</source>
         <translation>Instalando %1 novamente poderia consertar o problema.</translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="166"/>
+        <location filename="../../toonz/main.cpp" line="167"/>
         <source>The qualifier %1 is not a valid key name. Skipping.</source>
         <translation>O qualificador %1 não é um nome de chave válido. Pulando.</translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="735"/>
+        <location filename="../../toonz/main.cpp" line="559"/>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="571"/>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="658"/>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="672"/>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="678"/>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="685"/>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="698"/>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="741"/>
         <source>Script file %1 does not exists.</source>
         <translation>Arquivo de Script %1 não existe.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1011"/>
+        <location filename="../../toonz/main.cpp" line="768"/>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="777"/>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="787"/>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="790"/>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="833"/>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1032"/>
         <source>No more Undo operations available.</source>
         <translation>Não há mais operações Desfazer disponíveis.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1018"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1039"/>
         <source>No more Redo operations available.</source>
         <translation>Não há mais operações Refazer disponíveis.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1080"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1101"/>
         <source>Report a Bug</source>
         <translation>Reportar um Bug</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1081"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1102"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1337"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1358"/>
         <source>Visit Web Site</source>
         <translation>Visitar Website</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1341"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1362"/>
         <source>An update is available for this software.
 Visit the Web site for more information.</source>
         <translation>Uma atualização está disponível para este software.
 Visite o Site para mais informações.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1343"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1364"/>
         <source>Check for the latest version on launch.</source>
         <translation>Checar por atualizações de versão ao iniciar.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1351"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1372"/>
         <source>https://github.com/tahoma2d/tahoma2d/releases/latest</source>
         <translation>https://github.com/tahoma2d/tahoma2d/releases/latest</translation>
     </message>
@@ -14674,6 +14813,44 @@ Estes Níveis não podem ser exportados com essa ferramenta.</translation>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="231"/>
+        <source>2D</source>
+        <translation type="unfinished">2D</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="233"/>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="235"/>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="237"/>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="239"/>
+        <source>Browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="241"/>
+        <source>History</source>
+        <translation type="unfinished">Histórico</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="243"/>
+        <source>New Room</source>
+        <translation type="unfinished">Novo Cômodo</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <location filename="../../toonz/menubar.cpp" line="167"/>
@@ -14687,6 +14864,7 @@ Estes Níveis não podem ser exportados com essa ferramenta.</translation>
     </message>
     <message>
         <location filename="../../toonz/menubar.cpp" line="191"/>
+        <location filename="../../toonz/menubar.cpp" line="222"/>
         <source>New Room</source>
         <translation>Novo Cômodo</translation>
     </message>
@@ -14696,9 +14874,8 @@ Estes Níveis não podem ser exportados com essa ferramenta.</translation>
         <translation>Excluir Cômodo &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="222"/>
         <source>Room</source>
-        <translation>Cômodo</translation>
+        <translation type="vanished">Cômodo</translation>
     </message>
     <message>
         <location filename="../../toonz/menubar.cpp" line="231"/>

--- a/toonz/sources/translations/brazilian-portuguese/toonzlib.ts
+++ b/toonz/sources/translations/brazilian-portuguese/toonzlib.ts
@@ -269,6 +269,7 @@ Provavelmente o codec não está funcionando corretamente.</translation>
     </message>
     <message>
         <location filename="../../toonzlib/cleanupcolorstyles.cpp" line="95"/>
+        <location filename="../../toonzlib/imagestyles.cpp" line="554"/>
         <source>Contrast</source>
         <translation>Contraste</translation>
     </message>
@@ -805,6 +806,41 @@ Provavelmente o codec não está funcionando corretamente.</translation>
         <location filename="../../toonzlib/txshcolumn.cpp" line="772"/>
         <source>DarkMagenta</source>
         <translation>Magenta Escuro</translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="540"/>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="542"/>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="544"/>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="546"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="548"/>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="550"/>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="552"/>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/brazilian-portuguese/toonzqt.ts
+++ b/toonz/sources/translations/brazilian-portuguese/toonzqt.ts
@@ -19,17 +19,27 @@
         <translation>Substituir FX</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="248"/>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="484"/>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="620"/>
         <source>Insert </source>
         <translation>Inserir </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
         <source>Add </source>
         <translation>Adicionar </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="629"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
         <source>Replace </source>
         <translation>Substituir </translation>
     </message>
@@ -259,46 +269,37 @@ Possivelmente o arquivo da pré-definição foi corrompido.</translation>
 <context>
     <name>ColorChannelControl</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>R</source>
-        <translation>R</translation>
+        <translation type="vanished">R</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>G</source>
-        <translation>G</translation>
+        <translation type="vanished">G</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>B</source>
-        <translation>B</translation>
+        <translation type="vanished">B</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>A</source>
-        <translation>A</translation>
+        <translation type="vanished">A</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>H</source>
-        <translation>M</translation>
+        <translation type="vanished">M</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>S</source>
-        <translation>S</translation>
+        <translation type="vanished">S</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
         <source>V</source>
-        <translation>V</translation>
+        <translation type="vanished">V</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1379"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1381"/>
         <source>Alpha controls the transparency. 
 Zero is fully transparent.</source>
-        <translation>Alpha controla a transparência. 
+        <translation type="vanished">Alpha controla a transparência. 
 Zero é completamente transparente.</translation>
     </message>
 </context>
@@ -1605,37 +1606,37 @@ Selecione Nós de Efeitos e conexões relacionadas antes de copiar ou recortar a
 <context>
     <name>FxSettings</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1350"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1351"/>
         <source>&amp;Camera Preview</source>
         <translation>&amp;Pré-Visualização da Câmera</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1356"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1357"/>
         <source>&amp;Preview</source>
         <translation>&amp;Pré-Visualização</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1369"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1370"/>
         <source>&amp;White Background</source>
         <translation>&amp;Fundo Branco</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1377"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1378"/>
         <source>&amp;Black Background</source>
         <translation>&amp;Fundo Preto</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1384"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1385"/>
         <source>&amp;Checkered Background</source>
         <translation>&amp;Fundo Quadriculado</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1469"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1470"/>
         <source>Fx Settings</source>
         <translation>Configurações de Efeitos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1471"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1472"/>
         <source> : </source>
         <translation> : </translation>
     </message>
@@ -1846,32 +1847,32 @@ Selecione Nós de Efeitos e conexões relacionadas antes de copiar ou recortar a
 <context>
     <name>NewStyleSetPopup</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7189"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7190"/>
         <source>New Style Set</source>
         <translation>Novo Conjunto de Estilos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7192"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7193"/>
         <source>Style Set Name:</source>
         <translation>Nome do Conjunto de Estilos:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7194"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7195"/>
         <source>Create as Favorite</source>
         <translation>Criar como Favorito</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7197"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7198"/>
         <source>Style Set Type:</source>
         <translation>Tipo do Conjunto de Estilos:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7223"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7224"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7224"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7225"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1908,20 +1909,17 @@ Selecione Nós de Efeitos e conexões relacionadas antes de copiar ou recortar a
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1196"/>
         <source>Name Editor</source>
-        <translation>Editor de Nome</translation>
+        <translation type="vanished">Editor de Nome</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1252"/>
         <location filename="../../toonzqt/paletteviewergui.cpp" line="1436"/>
         <source>New Style</source>
         <translation>Novo Estilo</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1255"/>
         <source>New Page</source>
-        <translation>Nova Página</translation>
+        <translation type="vanished">Nova Página</translation>
     </message>
     <message>
         <location filename="../../toonzqt/paletteviewergui.cpp" line="1422"/>
@@ -2179,7 +2177,7 @@ Isto não pode ser mudado. Jamais.</translation>
 <context>
     <name>ParamViewer</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1081"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1082"/>
         <source>Swatch Viewer</source>
         <translation>Visualizador de Godê</translation>
     </message>
@@ -2187,12 +2185,12 @@ Isto não pode ser mudado. Jamais.</translation>
 <context>
     <name>ParamsPageSet</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="722"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="723"/>
         <source>View help page</source>
         <translation>Ver Página de Ajuda</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1061"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1062"/>
         <source>This Fx does not support rendering in floating point channel width (32bit).
 The output pixel values from this fx will be clamped to 0.0 - 1.0
 and tone may be slightly discretized.</source>
@@ -2263,10 +2261,10 @@ Tem certeza?</translation>
         <location filename="../../toonzqt/dvdialog.cpp" line="1350"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1436"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2034"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2053"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2165"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6641"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
         <location filename="../../toonzqt/styleselection.cpp" line="775"/>
         <location filename="../../toonzqt/styleselection.cpp" line="1078"/>
         <source>Cancel</source>
@@ -2326,10 +2324,10 @@ Tem certeza?</translation>
     </message>
     <message>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2034"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2053"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2165"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6641"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -2687,6 +2685,21 @@ A segunda linha deveria ser &quot;Mesh [Input bit depth] [Output bit depth]&quot
         <translation>Não Substituir</translation>
     </message>
     <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1196"/>
+        <source>Name Editor</source>
+        <translation type="unfinished">Editor de Nome</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1252"/>
+        <source>New Style</source>
+        <translation type="unfinished">Novo Estilo</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1255"/>
+        <source>New Page</source>
+        <translation type="unfinished">Nova Página</translation>
+    </message>
+    <message>
         <location filename="../../toonzqt/paletteviewergui.cpp" line="1720"/>
         <source>Click &amp; Drag Palette into Studio Palette</source>
         <translation>Clique e Arraste Paleta para a Paleta Studio</translation>
@@ -2799,64 +2812,212 @@ A segunda linha deveria ser &quot;Mesh [Input bit depth] [Output bit depth]&quot
         <translation>Mudar Estilo   Paleta: %1  Estilo#%2  [R%3 G%4 B%5] -&gt; [R%6 G%7 B%8]</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2031"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>R</source>
+        <translation type="unfinished">R</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>B</source>
+        <translation type="unfinished">B</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>H</source>
+        <translation type="unfinished">M</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>S</source>
+        <translation type="unfinished">S</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1363"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1380"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1382"/>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished">Alpha controla a transparência. 
+Zero é completamente transparente.</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2032"/>
         <source>Removing a Style will permanently delete the style file. This cannot be undone!
 Are you sure?</source>
         <translation>Remover um Estilo irá excluir permanentemente o arquivo de Estilo. Esta ação não pode ser desfeita!
 Tem certeza?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2049"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2050"/>
         <source>Emptying Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation>Esvaziando Conjunto &quot;%1&quot; irá permanentemente excluir todos os arquivos de Estilo deste Conjunto. Esta ação não pode ser desfeita!
 Tem certeza?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2161"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2162"/>
         <source>Removing Style Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation>Remover o Conjunto de Estilos &quot;%1&quot; irá excluir permanentemente todos os arquivos de Estilo para este Conjunto. Esta ação não pode ser desfeita!
 Tem certeza?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2638"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2251"/>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished">Gerenciador de Conjuntos de Estilos:              %1+Clique - Adicionar Estilo na Paleta              %2+Clique - Seleção de Múltiplos Estilos</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2307"/>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished">Adicionar Selecionados para Paleta</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2314"/>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished">Remover Selecionados dos Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2318"/>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished">Adicionar Selecionados para Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2326"/>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished">Copiar Selecionados para Conjunto de Estilos...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2341"/>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished">Mover Selecionados para Conjunto de Estilos...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2358"/>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished">Remover Selecionados de Conjuntos</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2380"/>
+        <source>Add to Palette</source>
+        <translation type="unfinished">Adicionar para Paleta</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2388"/>
+        <source>Add to Favorites</source>
+        <translation type="unfinished">Adicionar para Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2396"/>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished">Copiar para Conjunto de Estilos...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2413"/>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished">Mover para Conjunto de Estilos...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2431"/>
+        <source>Remove from Set</source>
+        <translation type="unfinished">Remover do Conjunto</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2442"/>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished">Adicionar Conjunto para Paleta</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2448"/>
+        <source>Empty Set</source>
+        <translation type="unfinished">Esvaziar Conjunto</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2460"/>
+        <source>New Style Set...</source>
+        <translation type="unfinished">Novo Conjunto de Estilos...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2465"/>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished">Renomear Conjunto de Estilos...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2472"/>
+        <source>Reload Style Set</source>
+        <translation type="unfinished">Recarrecar Conjunto de Estilos</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2480"/>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished">Escanear para Mudanças no Conjunto de Estilo</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2488"/>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished">Remover Conjunto de Estilos &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2639"/>
         <source>Plain color</source>
         <comment>CustomStyleChooserPage</comment>
         <translation>Cor Plana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2855"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2856"/>
         <source>Plain color</source>
         <comment>VectorBrushStyleChooserPage</comment>
         <translation>Cor Plana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3114"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3115"/>
         <source>Plain color</source>
         <comment>TextureStyleChooserPage</comment>
         <translation>Cor Plana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3126"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3127"/>
         <source>Custom Texture</source>
         <comment>TextureStyleChooserPage</comment>
         <translation>Textura Personalizada</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3299"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3300"/>
         <source>Plain color</source>
         <comment>MyPaintBrushStyleChooserPage</comment>
         <translation>Cor Plana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3550"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3551"/>
         <source>Plain color</source>
         <comment>SpecialStyleChooserPage</comment>
         <translation>Cor Plana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6638"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3725"/>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">Autopintar para Linhas</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3883"/>
+        <source>Reset to default</source>
+        <translation type="unfinished">Restaurar para o Padrão</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6639"/>
         <source>Removing the selected Styles will permanently delete style files from their sets. This cannot be undone!
 Are you sure?</source>
         <translation>Remover os Estilos selecionados irá excluir permanentemente os arquivos de Estilo de seus Conjuntos. Esta ação não pode ser desfeita!
@@ -2997,9 +3158,9 @@ Tem certeza?</translation>
 <context>
     <name>RenameStyleSet</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7384"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7399"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7411"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7385"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7400"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7412"/>
         <source> (Favorites)</source>
         <translation> (Favoritos)</translation>
     </message>
@@ -3133,14 +3294,12 @@ Tem certeza?</translation>
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3724"/>
         <source>Autopaint for Lines</source>
-        <translation>Autopintar para Linhas</translation>
+        <translation type="vanished">Autopintar para Linhas</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3882"/>
         <source>Reset to default</source>
-        <translation>Restaurar para o Padrão</translation>
+        <translation type="vanished">Restaurar para o Padrão</translation>
     </message>
 </context>
 <context>
@@ -3402,318 +3561,299 @@ Tem certeza?</translation>
 <context>
     <name>StyleChooserPage</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2250"/>
         <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation>Gerenciador de Conjuntos de Estilos:              %1+Clique - Adicionar Estilo na Paleta              %2+Clique - Seleção de Múltiplos Estilos</translation>
+        <translation type="vanished">Gerenciador de Conjuntos de Estilos:              %1+Clique - Adicionar Estilo na Paleta              %2+Clique - Seleção de Múltiplos Estilos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2306"/>
         <source>Add Selected to Palette</source>
-        <translation>Adicionar Selecionados para Paleta</translation>
+        <translation type="vanished">Adicionar Selecionados para Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2313"/>
         <source>Remove Selected from Favorites</source>
-        <translation>Remover Selecionados dos Favoritos</translation>
+        <translation type="vanished">Remover Selecionados dos Favoritos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2317"/>
         <source>Add Selected to Favorites</source>
-        <translation>Adicionar Selecionados para Favoritos</translation>
+        <translation type="vanished">Adicionar Selecionados para Favoritos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2325"/>
         <source>Copy Selected to Style Set...</source>
-        <translation>Copiar Selecionados para Conjunto de Estilos...</translation>
+        <translation type="vanished">Copiar Selecionados para Conjunto de Estilos...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2340"/>
         <source>Move Selected to Style Set...</source>
-        <translation>Mover Selecionados para Conjunto de Estilos...</translation>
+        <translation type="vanished">Mover Selecionados para Conjunto de Estilos...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2357"/>
         <source>Remove Selected from Sets</source>
-        <translation>Remover Selecionados de Conjuntos</translation>
+        <translation type="vanished">Remover Selecionados de Conjuntos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2379"/>
         <source>Add to Palette</source>
-        <translation>Adicionar para Paleta</translation>
+        <translation type="vanished">Adicionar para Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2387"/>
         <source>Add to Favorites</source>
-        <translation>Adicionar para Favoritos</translation>
+        <translation type="vanished">Adicionar para Favoritos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2395"/>
         <source>Copy to Style Set...</source>
-        <translation>Copiar para Conjunto de Estilos...</translation>
+        <translation type="vanished">Copiar para Conjunto de Estilos...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2412"/>
         <source>Move to Style Set...</source>
-        <translation>Mover para Conjunto de Estilos...</translation>
+        <translation type="vanished">Mover para Conjunto de Estilos...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2430"/>
         <source>Remove from Set</source>
-        <translation>Remover do Conjunto</translation>
+        <translation type="vanished">Remover do Conjunto</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2441"/>
         <source>Add Set to Palette</source>
-        <translation>Adicionar Conjunto para Paleta</translation>
+        <translation type="vanished">Adicionar Conjunto para Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2447"/>
         <source>Empty Set</source>
-        <translation>Esvaziar Conjunto</translation>
+        <translation type="vanished">Esvaziar Conjunto</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2459"/>
         <source>New Style Set...</source>
-        <translation>Novo Conjunto de Estilos...</translation>
+        <translation type="vanished">Novo Conjunto de Estilos...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2464"/>
         <source>Rename Style Set...</source>
-        <translation>Renomear Conjunto de Estilos...</translation>
+        <translation type="vanished">Renomear Conjunto de Estilos...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2471"/>
         <source>Reload Style Set</source>
-        <translation>Recarrecar Conjunto de Estilos</translation>
+        <translation type="vanished">Recarrecar Conjunto de Estilos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2479"/>
         <source>Scan for Style Set Changes</source>
-        <translation>Escanear para Mudanças no Conjunto de Estilo</translation>
+        <translation type="vanished">Escanear para Mudanças no Conjunto de Estilo</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2487"/>
         <source>Remove &apos;%1&apos; Style Set</source>
-        <translation>Remover Conjunto de Estilos &apos;%1&apos;</translation>
+        <translation type="vanished">Remover Conjunto de Estilos &apos;%1&apos;</translation>
     </message>
 </context>
 <context>
     <name>StyleEditor</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4285"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4286"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4288"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4289"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4294"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4295"/>
         <source>Apply changes to current style</source>
         <translation>Aplicar mudanas para Estilo atual</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4299"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4300"/>
         <source>Automatically update style changes</source>
         <translation>Automaticamente atualizar mudanças de Estilo</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4303"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4304"/>
         <source>Return To Previous Style</source>
         <translation>Retornar para Estilo Anterior</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4308"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4309"/>
         <source>Current Style</source>
         <translation>Estilo atual</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4323"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4324"/>
         <source>Wheel</source>
         <translation>Roda</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4324"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4325"/>
         <source>HSV</source>
         <translation>MSV</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4325"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4326"/>
         <source>Alpha</source>
         <translation>Alpha</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4326"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4327"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4327"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4328"/>
         <source>Hex</source>
         <translation>Hex</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4328"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4329"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4356"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4357"/>
         <source>Toggle Orientation</source>
         <translation>Habilitar Orientação</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4360"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5561"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4361"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5562"/>
         <source>Hide Auto/Apply</source>
         <translation>Esconder Automático/Aplicar</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4364"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4365"/>
         <source>Hex Color Names...</source>
         <translation>Nomes para Cores Hex</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4372"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4373"/>
         <source>Show or hide parts of the Color Page.</source>
         <translation>Mostrar ou Esconder partes da Página de Cor.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4378"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4379"/>
         <source>Show or hide style sets.</source>
         <translation>Mostrar ou Esconder Conjuntos de Estilos.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4487"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4559"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4632"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4488"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4560"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4633"/>
         <source>Clear Search</source>
         <translation>Limpar Pesquisa</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4753"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4759"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4761"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4754"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4760"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4762"/>
         <source>Color</source>
         <translation>Cor</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4754"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4755"/>
         <source>Raster</source>
         <translation>Raster</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4755"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4756"/>
         <source>Texture</source>
         <translation>Textura</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4756"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4757"/>
         <source>Vector</source>
         <translation>Vetor</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4757"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4762"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4758"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4763"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5032"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5033"/>
         <source>No Style Selected</source>
         <translation>Nenhum Estilo Selecionado</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5049"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5050"/>
         <source>Cleanup </source>
         <translation>Limpeza de Linha</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5051"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5052"/>
         <source>Studio </source>
         <translation>Studio</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5053"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5054"/>
         <source>Level </source>
         <translation>Nível</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5056"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5057"/>
         <source>Palette</source>
         <translation>Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5070"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5071"/>
         <source>Style Editor - No Valid Style Selected</source>
         <translation>Editor de Estilos - Nenhum Estilo Válido Selecionado</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5562"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5563"/>
         <source>Show Auto/Apply</source>
         <translation>Mostrar Automático/Aplicar</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5791"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7172"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7173"/>
         <source>Generated</source>
         <translation>Gerado</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5793"/>
         <source>My Favorites</source>
         <translation>Meus Favoritos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5795"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7089"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5796"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7090"/>
         <source> (Favorites)</source>
         <translation> (Favoritos)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5798"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5799"/>
         <source> (External)</source>
         <translation> (Externo)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6073"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6096"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6119"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6074"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6097"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6120"/>
         <source>Show All</source>
         <translation>Mostrar Todos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6078"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6101"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6124"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6079"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6102"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6125"/>
         <source>Hide All</source>
         <translation>Esconder Todos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6083"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6106"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6129"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6084"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6107"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6130"/>
         <source>Collapse All</source>
         <translation>Colapsar Todos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6088"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6111"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6134"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6089"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6112"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6135"/>
         <source>Expand All</source>
         <translation>Expandir Todos</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7127"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7128"/>
         <source>Style Set Name cannot be empty or contain any of the following characters:
  \ / : * ? &quot; &lt; &gt; |</source>
         <translation>Um nome de Conjunto de Estilos não pode estar vazio ou conter os seguintes caracteres:
  \ / : * ? &quot; &lt; &gt; |</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7174"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7175"/>
         <source>Style Set Name already exists. Please try another name.</source>
         <translation>Nome do Conjunto de Estilos já existe. Por favor tente outro nome.</translation>
     </message>

--- a/toonz/sources/translations/chinese/colorfx.ts
+++ b/toonz/sources/translations/chinese/colorfx.ts
@@ -21,6 +21,29 @@
     </message>
 </context>
 <context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation type="unfinished">密度</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MovingSolidColor</name>
     <message>
         <source>Offset</source>

--- a/toonz/sources/translations/chinese/image.ts
+++ b/toonz/sources/translations/chinese/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished">缩放</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished">循环</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -12,6 +30,97 @@
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
         <translation>未压缩</translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished">压缩方式</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished">质量</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
+        <translation type="unfinished">缩放</translation>
     </message>
 </context>
 <context>
@@ -110,14 +219,12 @@
 <context>
     <name>MovWriterProperties</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
         <source>Quality</source>
-        <translation type="unfinished">质量</translation>
+        <translation type="obsolete">质量</translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
         <source>Scale</source>
-        <translation type="unfinished">缩放</translation>
+        <translation type="obsolete">缩放</translation>
     </message>
 </context>
 <context>
@@ -144,12 +251,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/chinese/tnztools.ts
+++ b/toonz/sources/translations/chinese/tnztools.ts
@@ -667,6 +667,10 @@
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FingerTool</name>
@@ -781,6 +785,30 @@
     </message>
     <message>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation type="unfinished">距离:</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation type="unfinished">样式索引:</translation>
+    </message>
+    <message>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1835,6 +1863,96 @@ Do you want to proceed?</source>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
         <translation>打开这个选项，选中的样式将被移到色板第一页的最后。</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryTool</name>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished">不透明度</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">预设:</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished">&lt;定制&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <source>Rotation:</source>
+        <translation type="unfinished">旋转:</translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation type="unfinished">重置位置</translation>
+    </message>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished">不透明度:</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">预设:</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/chinese/toonz.ts
+++ b/toonz/sources/translations/chinese/toonz.ts
@@ -181,7 +181,7 @@ Please select a different device or check the microphone.</source>
     <message>
         <source>The microphone is not available: 
 Please select a different device or check the microphone.</source>
-        <translation>麦克风不可用: 
+        <translation type="vanished">麦克风不可用: 
 请选择其他设备或者检查该麦克风。</translation>
     </message>
     <message>
@@ -279,6 +279,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -372,6 +392,90 @@ pick up all frames in the selected level.</source>
     <message>
         <source>Field Guide:</source>
         <translation type="vanished">规格板:</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished">显示/隐藏界面</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished">安全区域(右键单击可选择)</translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">摄影机位视图</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">3D 视图</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">摄影机视图</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">冻结</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">预览</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">子摄影机预览</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished">未命名</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished">场景: </translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished">    ::    缩放: </translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"> (已翻转)</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished">层级: </translation>
     </message>
 </context>
 <context>
@@ -679,6 +783,21 @@ Stop it or wait for its completion before removing it.</source>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -702,7 +821,7 @@ Stop it or wait for its completion before removing it.</source>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">单位:</translation>
+        <translation>单位:</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -732,23 +851,23 @@ Do you want to crop the canvas?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">像素</translation>
+        <translation>像素</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">毫米</translation>
+        <translation>毫米</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">厘米</translation>
+        <translation>厘米</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">field</translation>
+        <translation>field</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">英寸</translation>
+        <translation>英寸</translation>
     </message>
 </context>
 <context>
@@ -1315,7 +1434,7 @@ What do you want to do? </source>
     <name>ComboViewerPanel</name>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>安全区域(右键单击可选择)</translation>
+        <translation type="vanished">安全区域(右键单击可选择)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -1323,19 +1442,19 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>摄影机位视图</translation>
+        <translation type="vanished">摄影机位视图</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>3D 视图</translation>
+        <translation type="vanished">3D 视图</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>摄影机视图</translation>
+        <translation type="vanished">摄影机视图</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>冻结</translation>
+        <translation type="vanished">冻结</translation>
     </message>
     <message>
         <source>GUI Show / Hide</source>
@@ -1355,35 +1474,35 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Preview</source>
-        <translation>预览</translation>
+        <translation type="vanished">预览</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>子摄影机预览</translation>
+        <translation type="vanished">子摄影机预览</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>未命名</translation>
+        <translation type="vanished">未命名</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>场景: </translation>
+        <translation type="vanished">场景: </translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>   ::   帧: </translation>
+        <translation type="vanished">   ::   帧: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>   ::   层级: </translation>
+        <translation type="vanished">   ::   层级: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>层级: </translation>
+        <translation type="vanished">层级: </translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (已翻转)</translation>
+        <translation type="vanished"> (已翻转)</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -1399,19 +1518,6 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1475,6 +1581,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished">搜索:</translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1499,6 +1609,131 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>他们的</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished">%1 / %2 正在转换层级: %3</translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">层级 %1 没有帧，跳过。</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished">转换</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">跳过现有的文件</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1791,6 +2026,99 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished">覆盖</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DVGui::ProgressDialog</name>
     <message>
         <source>Loading &quot;%1&quot;...</source>
@@ -2068,6 +2396,13 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2197,6 +2532,47 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
         <source>Export</source>
@@ -2288,26 +2664,6 @@ contain the dpi information, then the current camera dpi will be used.
     <message>
         <source>None</source>
         <translation type="unfinished">无</translation>
-    </message>
-    <message>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Target column</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2429,14 +2785,6 @@ contain the dpi information, then the current camera dpi will be used.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2503,6 +2851,18 @@ Do you want to create it?</source>
     </message>
     <message>
         <source>Failed to create folder %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2951,6 +3311,10 @@ Do you want to overwrite it?</source>
         <translation>文件 %1 已经存在。
 要覆盖它吗？</translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -3022,6 +3386,13 @@ Do you want to overwrite it?</source>
     <message>
         <source>Fx Settings</source>
         <translation>特效设置</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3198,6 +3569,10 @@ Do you want to overwrite it?</source>
     <message>
         <source>Search:</source>
         <translation type="unfinished">搜索:</translation>
+    </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3596,6 +3971,10 @@ Do you want to create it?</source>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -3901,6 +4280,13 @@ Please choose a valid lip sync data file to continue.</source>
     </message>
 </context>
 <context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadColorModelPopup</name>
     <message>
         <source>Load Color Model</source>
@@ -4201,6 +4587,10 @@ Please choose a valid lip sync data file to continue.</source>
     <message>
         <source>Locator</source>
         <translation>定位器</translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7449,6 +7839,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7720,6 +8182,22 @@ What do you want to do?</source>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8177,7 +8655,7 @@ The parameters to be saved are:
 - File options
 - Resample Balance
 - Channel width</source>
-        <translation>保存当前输出设定.
+        <translation type="vanished">保存当前输出设定.
 被保存的参数有:
 --摄影机设定
 --用来保存的项目文件夹
@@ -8224,6 +8702,92 @@ The parameters to be saved are:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">预览</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished">删除 &quot;%1。您确定吗？</translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9043,7 +9607,7 @@ Set the output folder path to the subfolder as well.</source>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">使用 TLV 保存框来限制填充操作</translation>
+        <translation>使用 TLV 保存框来限制填充操作</translation>
     </message>
     <message>
         <source>Paper Thickness:</source>
@@ -9171,7 +9735,7 @@ Set the output folder path to the subfolder as well.</source>
     </message>
     <message>
         <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation>在摄影表帧格的帧编号后面显示“ABC”之类的附加字母</translation>
+        <translation type="vanished">在摄影表帧格的帧编号后面显示“ABC”之类的附加字母</translation>
     </message>
     <message>
         <source>Automatically Remove Scene Number from Loaded Level Name</source>
@@ -9387,7 +9951,7 @@ Set the output folder path to the subfolder as well.</source>
     </message>
     <message>
         <source>Pixels Only:</source>
-        <translation type="vanished">仅像素:</translation>
+        <translation>仅像素:</translation>
     </message>
     <message>
         <source>Rooms*:</source>
@@ -9484,7 +10048,7 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Show Column Numbers in Column Headers</source>
-        <translation>在列头部显示列编号</translation>
+        <translation type="vanished">在列头部显示列编号</translation>
     </message>
     <message>
         <source>Always ask before loading or importing</source>
@@ -10147,6 +10711,58 @@ but a random crash might occur, use at your own risk:</source>
         <source>Edit Additional Style Sheet..</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -10383,6 +10999,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13034,6 +13654,107 @@ Do you want to continue?</source>
         <source>Explicit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -13213,6 +13934,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">浏览器</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished">历史记录</translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">新建工作区</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -13224,7 +13976,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>工作区</translation>
+        <translation type="vanished">工作区</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -14111,6 +14863,13 @@ Please commit or revert changes first.</source>
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -14252,6 +15011,172 @@ Please commit or revert changes first.</source>
     <message>
         <source>Threshold: </source>
         <translation type="vanished">阈值: </translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished">路径: </translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished">打开文件夹失败</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished">输入文件夹的路径是无效的。</translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">无法改变文件扩展名</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">无法设置绘图编号</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">无法重命名。文件已经存在: </translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">无法重命名</translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">加载为子摄影表</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">加载</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">重命名</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">转换为已上色的 TLV</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">转换为未上色的 TLV</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">版本控制</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">编辑帧范围...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished">放置...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">复原</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished">获取</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">获取修订...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished">解锁</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">编辑信息</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">修订历史...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">解锁帧范围</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished">保存场景</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">场景名:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished">拷贝 %1 到 %2 时发生了错误</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">转换为未上色的 TLV</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished">警告: 层级 %1 已经存在，要覆盖它吗？</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">完成: 所有层级已转换为 TLV 格式</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">转换为已上色的 TLV</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">完成: 2 个层级已转换为 TLV 格式</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">新建文件夹</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">无法创建 %1 文件夹。</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">有些您要编辑的文件当前被打开了。请先关闭它们。</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">有些您要解锁的文件当前被打开了。请先关闭它们。</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14523,55 +15448,55 @@ Please commit or revert changes first.</source>
     <name>SceneViewerPanel</name>
     <message>
         <source>Preview</source>
-        <translation>预览</translation>
+        <translation type="vanished">预览</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>子摄影机预览</translation>
+        <translation type="vanished">子摄影机预览</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>未命名</translation>
+        <translation type="vanished">未命名</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>场景: </translation>
+        <translation type="vanished">场景: </translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>    ::    帧: </translation>
+        <translation type="vanished">    ::    帧: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>    ::   层级: </translation>
+        <translation type="vanished">    ::   层级: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>层级: </translation>
+        <translation type="vanished">层级: </translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>冻结</translation>
+        <translation type="vanished">冻结</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>摄影机位视图</translation>
+        <translation type="vanished">摄影机位视图</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>3D 视图</translation>
+        <translation type="vanished">3D 视图</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>摄影机视图</translation>
+        <translation type="vanished">摄影机视图</translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation>    ::    缩放: </translation>
+        <translation type="vanished">    ::    缩放: </translation>
     </message>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>安全区域(右键单击可选择)</translation>
+        <translation type="vanished">安全区域(右键单击可选择)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -14579,7 +15504,7 @@ Please commit or revert changes first.</source>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (已翻转)</translation>
+        <translation type="vanished"> (已翻转)</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -14591,28 +15516,7 @@ Please commit or revert changes first.</source>
     </message>
     <message>
         <source>GUI Show / Hide</source>
-        <translation type="unfinished">显示/隐藏界面</translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">显示/隐藏界面</translation>
     </message>
 </context>
 <context>
@@ -14940,7 +15844,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">摄影表</translation>
+        <translation>摄影表</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -14952,7 +15856,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">窗口</translation>
+        <translation>窗口</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -15253,7 +16157,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>DPI:</source>
-        <translation type="vanished">DPI:</translation>
+        <translation>DPI:</translation>
     </message>
     <message>
         <source>X</source>
@@ -15293,23 +16197,23 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">像素</translation>
+        <translation>像素</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">厘米</translation>
+        <translation>厘米</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">毫米</translation>
+        <translation>毫米</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">英寸</translation>
+        <translation>英寸</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">field</translation>
+        <translation>field</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -15321,7 +16225,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>Units:</source>
-        <translation type="vanished">单位:</translation>
+        <translation>单位:</translation>
     </message>
     <message>
         <source>No Recent Scenes</source>
@@ -15688,235 +16592,300 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="vanished">否</translation>
+        <translation>否</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="vanished">未指定层级名称: 请选择一个有效的层级名称</translation>
+        <translation>未指定层级名称: 请选择一个有效的层级名称</translation>
     </message>
     <message>
         <source>The level name specified is already used: please choose a different level name.</source>
-        <translation type="vanished">所指定的层级名称已经被使用: 请选择一个不同的层级名称。</translation>
+        <translation>所指定的层级名称已经被使用: 请选择一个不同的层级名称。</translation>
     </message>
     <message>
         <source>The save in path specified does not match with the existing level.</source>
-        <translation type="vanished">指定的保存路径和已有层级补匹配。</translation>
+        <translation>指定的保存路径和已有层级补匹配。</translation>
     </message>
     <message>
         <source>The captured image size does not match with the existing level.</source>
-        <translation type="vanished">所拍摄的图像大小和已有层级不匹配。</translation>
+        <translation>所拍摄的图像大小和已有层级不匹配。</translation>
     </message>
     <message>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
-        <translation type="vanished">文件 %1 已经存在。
+        <translation>文件 %1 已经存在。
 要覆盖它吗？</translation>
     </message>
     <message>
         <source>Failed to load %1.</source>
-        <translation type="vanished">加载 %1 失败。</translation>
+        <translation>加载 %1 失败。</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="vanished">文件夹 %1不存在。
+        <translation>文件夹 %1不存在。
 要创建它吗？</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="vanished">无法创建</translation>
+        <translation>无法创建</translation>
     </message>
     <message>
         <source>UNDEFINED WARNING</source>
-        <translation type="vanished">为定义警告</translation>
+        <translation>为定义警告</translation>
     </message>
     <message>
         <source>The level is not registered in the scene, but exists in the file system.</source>
-        <translation type="vanished">该层级没在场景中注册，但存在于文件系统中。</translation>
+        <translation>该层级没在场景中注册，但存在于文件系统中。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告: 图像大小不匹配。保存的图像大小是 %1 x %2。</translation>
     </message>
     <message>
         <source>WARNING </source>
-        <translation type="vanished">警告 </translation>
+        <translation>警告 </translation>
     </message>
     <message>
         <source>
 Frame %1 exists.</source>
-        <translation type="vanished">
+        <translation>
 帧 %1 已存在。</translation>
     </message>
     <message>
         <source>
 Frames %1 exist.</source>
-        <translation type="vanished">
+        <translation>
 帧  %1 已存在。</translation>
     </message>
     <message>
         <source>OVERWRITE 1 of</source>
-        <translation type="vanished">覆盖 1</translation>
+        <translation>覆盖 1</translation>
     </message>
     <message>
         <source>ADD to</source>
-        <translation type="vanished">添加到</translation>
+        <translation>添加到</translation>
     </message>
     <message>
         <source> %1 frame</source>
-        <translation type="vanished"> %1 帧</translation>
+        <translation> %1 帧</translation>
     </message>
     <message>
         <source> %1 frames</source>
-        <translation type="vanished"> %1 帧</translation>
+        <translation> %1 帧</translation>
     </message>
     <message>
         <source>The level will be newly created.</source>
-        <translation type="vanished">层级将被创建。</translation>
+        <translation>层级将被创建。</translation>
     </message>
     <message>
         <source>NEW</source>
-        <translation type="vanished">新建</translation>
+        <translation>新建</translation>
     </message>
     <message>
         <source>The level is already registered in the scene.</source>
-        <translation type="vanished">层级已在场景中注册。</translation>
+        <translation>层级已在场景中注册。</translation>
     </message>
     <message>
         <source>
 NOTE : The level is not saved.</source>
-        <translation type="vanished">
+        <translation>
 注: 层级未保存。</translation>
     </message>
     <message>
         <source>
 WARNING : Failed to get image size of the existing level %1.</source>
-        <translation type="vanished">
+        <translation>
 警告: 获取已有层级 %1 的图像大小失败。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告: 图像大小不匹配。已有层级大小是 %1 x %2。</translation>
     </message>
     <message>
         <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
           %2.</source>
-        <translation type="vanished">警告: 层级名字冲突。在下面路径的场景中已经有名为 %1 的层级
+        <translation>警告: 层级名字冲突。在下面路径的场景中已经有名为 %1 的层级
          %2。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告: 图像大小不匹配。同名层级的大小是 %1 x %2。</translation>
     </message>
     <message>
         <source>WARNING : Level path conflicts. There already is a level with the path %1                        
           in the scene with the name %2.</source>
-        <translation type="vanished">警告: 层级路径冲突。在名为 %2 的场景中，已经有个层级位于路径 %1 上。</translation>
+        <translation>警告: 层级路径冲突。在名为 %2 的场景中，已经有个层级位于路径 %1 上。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告: 图像大小不匹配。同位置的层级大小是 %1 x %2。</translation>
     </message>
     <message>
         <source>WARNING</source>
-        <translation type="vanished">警告</translation>
+        <translation>警告</translation>
     </message>
     <message>
         <source>No camera selected.</source>
-        <translation type="vanished">无摄影机被选上。</translation>
+        <translation>无摄影机被选上。</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please start live view before capturing an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Controls</source>
-        <translation type="vanished">控制</translation>
+        <translation>控制</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">设置</translation>
+        <translation>设置</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">选项</translation>
+        <translation>选项</translation>
     </message>
     <message>
         <source>Resolution: </source>
-        <translation type="vanished">分辨率: </translation>
+        <translation>分辨率: </translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="vanished">刷新</translation>
+        <translation>刷新</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="vanished">文件</translation>
+        <translation>文件</translation>
     </message>
     <message>
         <source>Webcam Settings...</source>
-        <translation type="obsolete">摄像头设置...</translation>
+        <translation type="unfinished">摄像头设置...</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="obsolete">拍摄</translation>
+        <translation type="unfinished">拍摄</translation>
     </message>
     <message>
         <source>Next Level</source>
-        <translation type="obsolete">后一层级</translation>
+        <translation type="unfinished">后一层级</translation>
     </message>
     <message>
         <source>Next New</source>
-        <translation type="obsolete">新建</translation>
+        <translation type="unfinished">新建</translation>
     </message>
     <message>
         <source>Previous Level</source>
-        <translation type="obsolete">前一个层级</translation>
+        <translation type="unfinished">前一个层级</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="obsolete">后一帧</translation>
+        <translation type="unfinished">后一帧</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="obsolete">最后一帧</translation>
+        <translation type="unfinished">最后一帧</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="obsolete">前一帧</translation>
+        <translation type="unfinished">前一帧</translation>
     </message>
     <message>
         <source>Next XSheet Frame</source>
-        <translation type="obsolete">后一摄影表帧</translation>
+        <translation type="unfinished">后一摄影表帧</translation>
     </message>
     <message>
         <source>Previous XSheet Frame</source>
-        <translation type="obsolete">前一摄影表帧</translation>
+        <translation type="unfinished">前一摄影表帧</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="obsolete">当前帧</translation>
+        <translation type="unfinished">当前帧</translation>
     </message>
     <message>
         <source>Set to the Current Playhead Location</source>
-        <translation type="obsolete">设置当前播放位置</translation>
+        <translation type="unfinished">设置当前播放位置</translation>
     </message>
     <message>
         <source>Start Live View</source>
-        <translation type="obsolete">开始实况视图</translation>
+        <translation type="unfinished">开始实况视图</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -15928,15 +16897,15 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Camera:</source>
-        <translation type="vanished">摄影机:</translation>
+        <translation>摄影机:</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="vanished">名称:</translation>
+        <translation>名称:</translation>
     </message>
     <message>
         <source>Frame:</source>
-        <translation type="vanished">帧:</translation>
+        <translation>帧:</translation>
     </message>
     <message>
         <source>File Type:</source>
@@ -15952,47 +16921,47 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Camera Model</source>
-        <translation type="obsolete">摄影机模块</translation>
+        <translation type="unfinished">摄影机模块</translation>
     </message>
     <message>
         <source>Camera Mode</source>
-        <translation type="obsolete">摄影机模式</translation>
+        <translation type="unfinished">摄影机模式</translation>
     </message>
     <message>
         <source>Temperature: </source>
-        <translation type="obsolete">温度: </translation>
+        <translation type="unfinished">温度: </translation>
     </message>
     <message>
         <source>Shutter Speed: </source>
-        <translation type="obsolete">快门速度: </translation>
+        <translation type="unfinished">快门速度: </translation>
     </message>
     <message>
         <source>Aperture: </source>
-        <translation type="obsolete">光圈: </translation>
+        <translation type="unfinished">光圈: </translation>
     </message>
     <message>
         <source>Exposure: </source>
-        <translation type="obsolete">曝光: </translation>
+        <translation type="unfinished">曝光: </translation>
     </message>
     <message>
         <source>Image Quality: </source>
-        <translation type="obsolete">图像质量: </translation>
+        <translation type="unfinished">图像质量: </translation>
     </message>
     <message>
         <source>Picture Style: </source>
-        <translation type="obsolete">图片类型: </translation>
+        <translation type="unfinished">图片类型: </translation>
     </message>
     <message>
         <source>White Balance: </source>
-        <translation type="obsolete">白平衡: </translation>
+        <translation type="unfinished">白平衡: </translation>
     </message>
     <message>
         <source>Webcam Options</source>
-        <translation type="obsolete">摄像头选项</translation>
+        <translation type="unfinished">摄像头选项</translation>
     </message>
     <message>
         <source>DSLR Options</source>
-        <translation type="obsolete">DSLR 选项</translation>
+        <translation type="unfinished">DSLR 选项</translation>
     </message>
     <message>
         <source>Place the frame in the XSheet</source>
@@ -16000,7 +16969,7 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Use Direct Show Webcam Drivers</source>
-        <translation type="obsolete">使用直接显示摄像头驱动程序</translation>
+        <translation type="unfinished">使用直接显示摄像头驱动程序</translation>
     </message>
     <message>
         <source>Black Screen for Capture</source>
@@ -16012,23 +16981,23 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Use MJPG with Webcam</source>
-        <translation type="obsolete">摄像头使用 MJPG</translation>
+        <translation type="unfinished">摄像头使用 MJPG</translation>
     </message>
     <message>
         <source>Place on XSheet</source>
-        <translation type="obsolete">放至摄影表</translation>
+        <translation type="unfinished">放至摄影表</translation>
     </message>
     <message>
         <source>Use Numpad Shortcuts When Active</source>
-        <translation type="obsolete">当打开时使用数字小键盘快捷键</translation>
+        <translation type="unfinished">当打开时使用数字小键盘快捷键</translation>
     </message>
     <message>
         <source>Show Live View on All Frames</source>
-        <translation type="obsolete">所以帧都显示实况视图</translation>
+        <translation type="unfinished">所以帧都显示实况视图</translation>
     </message>
     <message>
         <source>Capture Review Time: </source>
-        <translation type="obsolete">拍摄检查时间:</translation>
+        <translation type="unfinished">拍摄检查时间:</translation>
     </message>
     <message>
         <source>Level Subsampling: </source>
@@ -16036,188 +17005,444 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Opacity:</source>
-        <translation type="obsolete">不透明度:</translation>
+        <translation type="unfinished">不透明度:</translation>
     </message>
     <message>
         <source>No camera detected.</source>
-        <translation type="obsolete">没有检测到摄影机。</translation>
+        <translation type="unfinished">没有检测到摄影机。</translation>
     </message>
     <message>
         <source>No camera detected</source>
-        <translation type="obsolete">没有检测到摄影机</translation>
+        <translation type="unfinished">没有检测到摄影机</translation>
     </message>
     <message>
         <source>- Select camera -</source>
-        <translation type="obsolete">- 选择摄影机 -</translation>
+        <translation type="unfinished">- 选择摄影机 -</translation>
     </message>
     <message>
         <source>Mode: </source>
-        <translation type="obsolete">模式: </translation>
+        <translation type="unfinished">模式: </translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="obsolete">自动</translation>
+        <translation type="unfinished">自动</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="obsolete">禁用</translation>
+        <translation type="unfinished">禁用</translation>
     </message>
     <message>
         <source>Stop Live View</source>
-        <translation type="vanished">停止实况视图</translation>
+        <translation>停止实况视图</translation>
     </message>
     <message>
         <source>Image adjust</source>
-        <translation type="obsolete">图像调整</translation>
+        <translation type="unfinished">图像调整</translation>
     </message>
     <message>
         <source>Grayscale</source>
-        <translation type="obsolete">灰度</translation>
+        <translation type="unfinished">灰度</translation>
     </message>
     <message>
         <source>Black &amp; White</source>
-        <translation type="obsolete">黑白</translation>
+        <translation type="unfinished">黑白</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">亮度: </translation>
+        <translation type="unfinished">亮度: </translation>
     </message>
     <message>
         <source>Color type:</source>
-        <translation type="obsolete">颜色类型:</translation>
+        <translation type="unfinished">颜色类型:</translation>
     </message>
     <message>
         <source>Interval(sec):</source>
-        <translation type="obsolete">间隔(秒):</translation>
+        <translation type="unfinished">间隔(秒):</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">取消</translation>
+        <translation type="unfinished">取消</translation>
     </message>
     <message>
         <source>Load</source>
-        <translation type="obsolete">加载</translation>
+        <translation type="unfinished">加载</translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="obsolete">导出</translation>
+        <translation type="unfinished">导出</translation>
     </message>
     <message>
         <source>Couldn&apos;t load %1</source>
-        <translation type="obsolete">不能加载%1</translation>
+        <translation type="unfinished">不能加载%1</translation>
     </message>
     <message>
         <source>Couldn&apos;t save %1</source>
-        <translation type="obsolete">无法保存 %1</translation>
+        <translation type="unfinished">无法保存 %1</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Iso: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>Create the Destination Subfolder to Save</source>
-        <translation type="obsolete">创建保存目的地子文件夹</translation>
+        <translation type="unfinished">创建保存目的地子文件夹</translation>
     </message>
     <message>
         <source>Set As Default</source>
-        <translation type="obsolete">保存未默认</translation>
+        <translation type="unfinished">保存未默认</translation>
     </message>
     <message>
         <source>Set the current &quot;Save In&quot; path as the default.</source>
-        <translation type="obsolete">设置当前“保存位置”为默认。</translation>
+        <translation type="unfinished">设置当前“保存位置”为默认。</translation>
     </message>
     <message>
         <source>Create Subfolder</source>
-        <translation type="obsolete">创建子文件夹</translation>
+        <translation type="unfinished">创建子文件夹</translation>
     </message>
     <message>
         <source>Infomation</source>
-        <translation type="obsolete">信息</translation>
+        <translation type="unfinished">信息</translation>
     </message>
     <message>
         <source>Subfolder Name</source>
-        <translation type="obsolete">子文件夹名</translation>
+        <translation type="unfinished">子文件夹名</translation>
     </message>
     <message>
         <source>Auto Format:</source>
-        <translation type="obsolete">自动格式:</translation>
+        <translation type="unfinished">自动格式:</translation>
     </message>
     <message>
         <source>Show This on Launch of the Camera Capture</source>
-        <translation type="obsolete">显示到摄影机拍摄启动窗口</translation>
+        <translation type="unfinished">显示到摄影机拍摄启动窗口</translation>
     </message>
     <message>
         <source>Save Scene in Subfolder</source>
-        <translation type="obsolete">保存场景到子文件夹</translation>
+        <translation type="unfinished">保存场景到子文件夹</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">确定</translation>
+        <translation type="unfinished">确定</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">取消</translation>
+        <translation type="unfinished">取消</translation>
     </message>
     <message>
         <source>C- + Sequence + Scene</source>
-        <translation type="obsolete">C- + 序列 + 场景</translation>
+        <translation type="unfinished">C- + 序列 + 场景</translation>
     </message>
     <message>
         <source>Sequence + Scene</source>
-        <translation type="obsolete">序列 + 场景</translation>
+        <translation type="unfinished">序列 + 场景</translation>
     </message>
     <message>
         <source>Episode + Sequence + Scene</source>
-        <translation type="obsolete">片段 + 序列 + 场景</translation>
+        <translation type="unfinished">片段 + 序列 + 场景</translation>
     </message>
     <message>
         <source>Project + Episode + Sequence + Scene</source>
-        <translation type="obsolete">项目 + 片段 + 序列 + 场景</translation>
+        <translation type="unfinished">项目 + 片段 + 序列 + 场景</translation>
     </message>
     <message>
         <source>Save the current scene in the subfolder.
 Set the output folder path to the subfolder as well.</source>
-        <translation type="obsolete">保存当前场景在子文件夹中。
+        <translation type="unfinished">保存当前场景在子文件夹中。
 同时设定输出文件夹路径到子文件夹。</translation>
     </message>
     <message>
         <source>Save In:</source>
-        <translation type="obsolete">保存位置:</translation>
+        <translation type="unfinished">保存位置:</translation>
     </message>
     <message>
         <source>Project:</source>
-        <translation type="obsolete">项目:</translation>
+        <translation type="unfinished">项目:</translation>
     </message>
     <message>
         <source>Episode:</source>
-        <translation type="obsolete">判断:</translation>
+        <translation type="unfinished">判断:</translation>
     </message>
     <message>
         <source>Sequence:</source>
-        <translation type="obsolete">序列:</translation>
+        <translation type="unfinished">序列:</translation>
     </message>
     <message>
         <source>Scene:</source>
-        <translation type="obsolete">场景:</translation>
+        <translation type="unfinished">场景:</translation>
     </message>
     <message>
         <source>Subfolder Name:</source>
-        <translation type="obsolete">子文件夹名:</translation>
+        <translation type="unfinished">子文件夹名:</translation>
     </message>
     <message>
         <source>Subfolder name should not be empty.</source>
-        <translation type="obsolete">子文件名不能空。</translation>
+        <translation type="unfinished">子文件名不能空。</translation>
     </message>
     <message>
         <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
-        <translation type="obsolete">子文件夹名不能包含如下字符:  * . &quot; / \ [ ] : ; | = , </translation>
+        <translation type="unfinished">子文件夹名不能包含如下字符:  * . &quot; / \ [ ] : ; | = , </translation>
     </message>
     <message>
         <source>Folder %1 already exists.</source>
-        <translation type="obsolete">文件夹 %1 已经存在。</translation>
+        <translation type="unfinished">文件夹 %1 已经存在。</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">无法创建 %1 文件夹。</translation>
+        <translation type="unfinished">无法创建 %1 文件夹。</translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -16408,6 +17633,25 @@ Click the arrow button to create a new sub-xsheet</source>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16777,6 +18021,10 @@ Click the arrow button to create a new sub-xsheet</source>
     <message>
         <source>Expand toolbar</source>
         <translation>展开工具条</translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -17209,11 +18457,11 @@ Please refer to the user guide for details.</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <source>Inbetween symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reverse sheet symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17522,6 +18770,21 @@ Please refer to the user guide for details.</source>
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished">添加新备忘</translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished">前一个备忘</translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished">下一个备忘</translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Frame</source>
@@ -17541,7 +18804,7 @@ Please refer to the user guide for details.</source>
     </message>
     <message>
         <source>Toggle Xsheet/Timeline</source>
-        <translation type="vanished">开关摄影表/时间轴</translation>
+        <translation>开关摄影表/时间轴</translation>
     </message>
     <message>
         <source>Add New Memo</source>
@@ -17672,6 +18935,12 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/chinese/toonzlib.ts
+++ b/toonz/sources/translations/chinese/toonzlib.ts
@@ -664,6 +664,34 @@
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Rasterizer</name>

--- a/toonz/sources/translations/chinese/toonzqt.ts
+++ b/toonz/sources/translations/chinese/toonzqt.ts
@@ -27,6 +27,14 @@
         <source>Replace </source>
         <translation>替换 </translation>
     </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddWordButton</name>
@@ -173,7 +181,7 @@ Possibly the preset file has been corrupted</source>
     </message>
     <message>
         <source>A/R</source>
-        <translation type="vanished">A/R</translation>
+        <translation>A/R</translation>
     </message>
     <message>
         <source>&lt;custom&gt;</source>
@@ -181,6 +189,26 @@ Possibly the preset file has been corrupted</source>
     </message>
     <message>
         <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -271,42 +299,6 @@ Possibly the preset file has been corrupted</source>
     </message>
 </context>
 <context>
-    <name>ColorChannelControl</name>
-    <message>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>ColorField</name>
     <message>
         <source>R:</source>
@@ -353,6 +345,14 @@ Zero is fully transparent.</source>
     <message>
         <source>R:%1 G:%2 B:%3</source>
         <translation>R:%1 G:%2 B:%3</translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A:%1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -854,6 +854,27 @@ Control click to reset.</source>
     </message>
     <message>
         <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1805,7 +1826,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
     </message>
     <message>
         <source>New Page</source>
-        <translation>新建页</translation>
+        <translation type="vanished">新建页</translation>
     </message>
     <message>
         <source>- No Styles -</source>
@@ -1813,7 +1834,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
     </message>
     <message>
         <source>Name Editor</source>
-        <translation>名字编辑器</translation>
+        <translation type="vanished">名字编辑器</translation>
     </message>
     <message>
         <source> + </source>
@@ -1991,6 +2012,22 @@ It can&apos;t be changed.  Ever.</source>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">名字编辑器</translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PaletteViewerGUI::PageViewer</name>
@@ -2053,6 +2090,12 @@ It can&apos;t be changed.  Ever.</source>
     </message>
     <message>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2746,6 +2789,139 @@ Are you sure?</source>
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">名字编辑器</translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation type="unfinished">新建样式</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation type="unfinished">新建页</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">线自动上色</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished">重新初始化</translation>
+    </message>
 </context>
 <context>
     <name>QPushButton</name>
@@ -2888,11 +3064,11 @@ Are you sure?</source>
     <name>SettingsPage</name>
     <message>
         <source>Reset to default</source>
-        <translation>重新初始化</translation>
+        <translation type="vanished">重新初始化</translation>
     </message>
     <message>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">线自动上色</translation>
+        <translation type="obsolete">线自动上色</translation>
     </message>
 </context>
 <context>
@@ -3136,85 +3312,6 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
         <source>Apply</source>
@@ -3419,6 +3516,22 @@ Apply</source>
     </message>
     <message>
         <source>Style Set Name already exists. Please try another name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Auto/Apply</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/czech/colorfx.ts
+++ b/toonz/sources/translations/czech/colorfx.ts
@@ -19,9 +19,37 @@
         <translation>Šum</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="460"/>
+        <location filename="../../colorfx/regionstyles.h" line="467"/>
         <source>Irregular</source>
         <translation>Nepravidelnost</translation>
+    </message>
+</context>
+<context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="129"/>
+        <source>Density</source>
+        <translation type="unfinished">Hustota</translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="131"/>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="133"/>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="135"/>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.h" line="58"/>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -70,7 +98,7 @@
         <translation>Odstup</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1240"/>
+        <location filename="../../colorfx/strokestyles.h" line="1275"/>
         <source>OutlineViewer(OnlyDebug)</source>
         <translation>Prohlížeč obrysu (jen ladění)</translation>
     </message>
@@ -93,7 +121,7 @@
         <translation>Délka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="120"/>
+        <location filename="../../colorfx/regionstyles.h" line="121"/>
         <source>Hatched Shading</source>
         <translation>Šrafování</translation>
     </message>
@@ -111,7 +139,7 @@
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="169"/>
+        <location filename="../../colorfx/regionstyles.h" line="171"/>
         <source>Plain Shadow</source>
         <translation>Jednoduchý stín</translation>
     </message>
@@ -124,7 +152,7 @@
         <translation>Stříkací pistole</translation>
     </message>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="69"/>
+        <location filename="../../colorfx/rasterstyles.h" line="70"/>
         <source>Blur value</source>
         <translation>Stupeň měkkosti</translation>
     </message>
@@ -132,7 +160,7 @@
 <context>
     <name>TBiColorStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="577"/>
+        <location filename="../../colorfx/strokestyles.h" line="594"/>
         <source>Shade</source>
         <translation>Stínování</translation>
     </message>
@@ -140,7 +168,7 @@
 <context>
     <name>TBlendRasterStyle</name>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="122"/>
+        <location filename="../../colorfx/rasterstyles.h" line="123"/>
         <source>Blend</source>
         <translation>Výplň</translation>
     </message>
@@ -163,7 +191,7 @@
         <translation>Postupně zeslabit</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="725"/>
+        <location filename="../../colorfx/strokestyles.h" line="745"/>
         <source>Fade</source>
         <translation>Vyblednutí</translation>
     </message>
@@ -176,7 +204,7 @@
         <translation>Vír</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="385"/>
+        <location filename="../../colorfx/strokestyles.h" line="398"/>
         <source>Plait</source>
         <translation>Spleteno</translation>
     </message>
@@ -184,7 +212,7 @@
 <context>
     <name>TBubbleStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="475"/>
+        <location filename="../../colorfx/strokestyles.h" line="490"/>
         <source>Bubbles</source>
         <translation>Fouknout</translation>
     </message>
@@ -192,7 +220,7 @@
 <context>
     <name>TChainStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="133"/>
+        <location filename="../../colorfx/strokestyles.h" line="134"/>
         <source>Chain</source>
         <translation>Řetězec</translation>
     </message>
@@ -210,7 +238,7 @@
         <translation>Velikost tečky</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="508"/>
+        <location filename="../../colorfx/regionstyles.h" line="516"/>
         <source>Chalk</source>
         <translation>Křída</translation>
     </message>
@@ -243,7 +271,7 @@
         <translation>Šum</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="672"/>
+        <location filename="../../colorfx/strokestyles.h" line="691"/>
         <source>Chalk</source>
         <translation>Křída</translation>
     </message>
@@ -276,7 +304,7 @@
         <translation>Tloušťka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="399"/>
+        <location filename="../../colorfx/regionstyles.h" line="405"/>
         <source>Square</source>
         <translation>Čtvercový</translation>
     </message>
@@ -299,7 +327,7 @@
         <translation>Úhel</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="559"/>
+        <location filename="../../colorfx/regionstyles.h" line="569"/>
         <source>Chessboard</source>
         <translation>Šachovnice</translation>
     </message>
@@ -327,7 +355,7 @@
         <translation>Tloušťka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="766"/>
+        <location filename="../../colorfx/regionstyles.h" line="780"/>
         <source>Concentric</source>
         <translation>Soustředný</translation>
     </message>
@@ -345,7 +373,7 @@
         <translation>Neprůhlednost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="342"/>
+        <location filename="../../colorfx/strokestyles.h" line="352"/>
         <source>Tulle</source>
         <translation>Tyl</translation>
     </message>
@@ -363,7 +391,7 @@
         <translation>Vzdálenost tečky</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="346"/>
+        <location filename="../../colorfx/regionstyles.h" line="351"/>
         <source>Polka Dots</source>
         <translation>Puntíkovaný</translation>
     </message>
@@ -391,7 +419,7 @@
         <translation>Mezera</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="254"/>
+        <location filename="../../colorfx/strokestyles.h" line="260"/>
         <source>Vanishing</source>
         <translation>Zředění</translation>
     </message>
@@ -404,7 +432,7 @@
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1090"/>
+        <location filename="../../colorfx/strokestyles.h" line="1119"/>
         <source>Striped</source>
         <translation>Pruhovaný</translation>
     </message>
@@ -422,7 +450,7 @@
         <translation>Tloušťka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1029"/>
+        <location filename="../../colorfx/strokestyles.h" line="1057"/>
         <source>Curl</source>
         <translation>Kudrna</translation>
     </message>
@@ -453,7 +481,7 @@
         <translation>Hustota</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="206"/>
+        <location filename="../../colorfx/strokestyles.h" line="209"/>
         <source>Dashes</source>
         <translation>Čárky</translation>
     </message>
@@ -481,7 +509,7 @@
         <translation>Hladkost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="665"/>
+        <location filename="../../colorfx/regionstyles.h" line="677"/>
         <source>Linear Gradient</source>
         <translation>Lineární přechod</translation>
     </message>
@@ -494,7 +522,7 @@
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1152"/>
+        <location filename="../../colorfx/strokestyles.h" line="1184"/>
         <source>Watercolor</source>
         <translation>Vodová barva</translation>
     </message>
@@ -507,7 +535,7 @@
         <translation>Pruhy</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1304"/>
+        <location filename="../../colorfx/strokestyles.h" line="1340"/>
         <source>Toothpaste</source>
         <translation>Zubní pasta</translation>
     </message>
@@ -535,7 +563,7 @@
         <translation>Největší tloušťka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="822"/>
+        <location filename="../../colorfx/regionstyles.h" line="839"/>
         <source>Stained Glass</source>
         <translation>Vitrážové sklo</translation>
     </message>
@@ -563,7 +591,7 @@
         <translation>Šum</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="872"/>
+        <location filename="../../colorfx/strokestyles.h" line="895"/>
         <source>Gouache</source>
         <translation>Kvaš</translation>
     </message>
@@ -571,7 +599,7 @@
 <context>
     <name>TNoColorRasterStyle</name>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="151"/>
+        <location filename="../../colorfx/rasterstyles.h" line="153"/>
         <source>Markup</source>
         <translation>Značení</translation>
     </message>
@@ -600,7 +628,7 @@
     </message>
     <message>
         <location filename="../../colorfx/strokestyles.cpp" line="2022"/>
-        <location filename="../../colorfx/strokestyles.h" line="629"/>
+        <location filename="../../colorfx/strokestyles.h" line="647"/>
         <source>Bump</source>
         <translation>Boule</translation>
     </message>
@@ -623,7 +651,7 @@
         <translation>Tloušťka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="872"/>
+        <location filename="../../colorfx/regionstyles.h" line="890"/>
         <source>Beehive</source>
         <translation>Voštiny</translation>
     </message>
@@ -651,7 +679,7 @@
         <translation>Velikost tečky</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="283"/>
+        <location filename="../../colorfx/regionstyles.h" line="287"/>
         <source>Sponge Shading</source>
         <translation>Houbovité stínování</translation>
     </message>
@@ -679,7 +707,7 @@
         <translation>Hladkost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="718"/>
+        <location filename="../../colorfx/regionstyles.h" line="731"/>
         <source>Radial Gradient</source>
         <translation>Paprskovitý přechod</translation>
     </message>
@@ -692,7 +720,7 @@
         <translation>Naklonění</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="299"/>
+        <location filename="../../colorfx/strokestyles.h" line="308"/>
         <source>Rope</source>
         <translation>Lano</translation>
     </message>
@@ -705,7 +733,7 @@
         <translation>Síla</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="230"/>
+        <location filename="../../colorfx/regionstyles.h" line="233"/>
         <source>Blob</source>
         <translation>Skvrna</translation>
     </message>
@@ -718,7 +746,7 @@
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="827"/>
+        <location filename="../../colorfx/strokestyles.h" line="849"/>
         <source>Jagged</source>
         <translation>Zoubkovaný</translation>
     </message>
@@ -731,7 +759,7 @@
         <translation>Četnost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="990"/>
+        <location filename="../../colorfx/strokestyles.h" line="1017"/>
         <source>Wave</source>
         <translation>Vlna</translation>
     </message>
@@ -744,7 +772,7 @@
         <translation>Hustota</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="433"/>
+        <location filename="../../colorfx/strokestyles.h" line="447"/>
         <source>Fuzz</source>
         <translation>Chmýří</translation>
     </message>
@@ -767,7 +795,7 @@
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="164"/>
+        <location filename="../../colorfx/strokestyles.h" line="166"/>
         <source>Circlets</source>
         <translation>Kroužky</translation>
     </message>
@@ -790,7 +818,7 @@
         <translation>Tloušťka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="610"/>
+        <location filename="../../colorfx/regionstyles.h" line="621"/>
         <source>Banded</source>
         <translation>Pruhovaný</translation>
     </message>
@@ -808,7 +836,7 @@
         <translation>Velikost okraje</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="530"/>
+        <location filename="../../colorfx/strokestyles.h" line="546"/>
         <source>Gauze</source>
         <translation>Gáza</translation>
     </message>
@@ -826,7 +854,7 @@
         <translation>Stínování</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="775"/>
+        <location filename="../../colorfx/strokestyles.h" line="796"/>
         <source>Ribbon</source>
         <translation>Stuha</translation>
     </message>
@@ -867,7 +895,7 @@
         <translation>Tloušťka</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="942"/>
+        <location filename="../../colorfx/strokestyles.h" line="968"/>
         <source>Zigzag</source>
         <translation>Klikatá čára</translation>
     </message>

--- a/toonz/sources/translations/czech/image.ts
+++ b/toonz/sources/translations/czech/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="cs_CZ">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished">Měřítko</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished">Smyčka</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -12,6 +30,97 @@
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
         <translation>Nezkomprimovaný (nezabalený)</translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished">Bitů na obrazový bod (pixel)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished">Typ komprese</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished">Jakost</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
+        <translation type="unfinished">Měřítko</translation>
     </message>
 </context>
 <context>
@@ -110,14 +219,12 @@
 <context>
     <name>MovWriterProperties</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
         <source>Quality</source>
-        <translation type="unfinished">Jakost</translation>
+        <translation type="obsolete">Jakost</translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
         <source>Scale</source>
-        <translation type="unfinished">Měřítko</translation>
+        <translation type="obsolete">Měřítko</translation>
     </message>
 </context>
 <context>
@@ -144,12 +251,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/czech/tnzcore.ts
+++ b/toonz/sources/translations/czech/tnzcore.ts
@@ -30,7 +30,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../common/tvrender/tpalette.cpp" line="256"/>
+        <location filename="../../common/tvrender/tpalette.cpp" line="265"/>
         <source>colors</source>
         <translation>barvy</translation>
     </message>
@@ -51,12 +51,12 @@
 <context>
     <name>TCenterLineStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="886"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="899"/>
         <source>Constant</source>
         <translation>Stálý</translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="919"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="938"/>
         <source>Thickness</source>
         <translation>Tloušťka</translation>
     </message>
@@ -64,12 +64,12 @@
 <context>
     <name>TRasterImagePatternStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1046"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1088"/>
         <source>Distance</source>
         <translation>Odstup</translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1048"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1090"/>
         <source>Rotation</source>
         <translation>Otočení</translation>
     </message>
@@ -77,12 +77,12 @@
 <context>
     <name>TVectorImagePatternStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1478"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1551"/>
         <source>Distance</source>
         <translation>Odstup</translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1480"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1553"/>
         <source>Rotation</source>
         <translation>Otočení</translation>
     </message>

--- a/toonz/sources/translations/czech/tnztools.ts
+++ b/toonz/sources/translations/czech/tnztools.ts
@@ -4,12 +4,12 @@
 <context>
     <name>ArrowToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="443"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="446"/>
         <source>Z:</source>
         <translation>Z:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="444"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="447"/>
         <source>Position:</source>
         <translation>Poloha:</translation>
     </message>
@@ -22,111 +22,111 @@
         <translation type="vanished">S/J:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="445"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="528"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="448"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="531"/>
         <source>X:</source>
         <translation type="unfinished">X:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="446"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="529"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="449"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="532"/>
         <source>Y:</source>
         <translation type="unfinished">Y:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="461"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="464"/>
         <source>SO:</source>
         <translation>SO:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="466"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="469"/>
         <source>Rotation:</source>
         <translation>Otočení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="482"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="485"/>
         <source>Global:</source>
         <translation>Celkové:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="483"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="509"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="486"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="512"/>
         <source>H:</source>
         <translation>V:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="484"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="510"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="487"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="513"/>
         <source>V:</source>
         <translation>S:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="589"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="592"/>
         <source>Flip Object Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="590"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="593"/>
         <source>Flip Object Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="591"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="594"/>
         <source>Rotate Object Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="592"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="595"/>
         <source>Rotate Object Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="612"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="615"/>
         <source>Pick:</source>
         <translation>Vybrat předmět:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="629"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="632"/>
         <source>Position</source>
         <translation>Poloha</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="652"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="655"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="654"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="657"/>
         <source>)</source>
         <translation>)</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="677"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="680"/>
         <source>Rotation</source>
         <translation>Otočení</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="701"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="704"/>
         <source>Scale</source>
         <translation>Měřítko</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="726"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="729"/>
         <source>Maintain:</source>
         <translation>Zachovat:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="746"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="749"/>
         <source>Shear</source>
         <translation>Stříhat</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="778"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="781"/>
         <source>Center Position</source>
         <translation>Střední poloha</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="991"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="994"/>
         <source>Table</source>
         <translation>Tabulka</translation>
     </message>
@@ -496,117 +496,117 @@
 <context>
     <name>EraserTool</name>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="775"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="428"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="863"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="435"/>
         <source>Size:</source>
         <translation>Velikost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="790"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="429"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="878"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="436"/>
         <source>Selective</source>
         <translation>Výběrový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="791"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="430"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="879"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="437"/>
         <source>Invert</source>
         <translation>Obrátit</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="792"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="431"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="880"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="438"/>
         <source>Frame Range</source>
         <translation>Rozsah snímku</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="778"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="432"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="866"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="439"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="779"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="433"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="867"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="440"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="780"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="434"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="868"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="441"/>
         <source>Rectangular</source>
         <translation>Obdélníkový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="781"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="435"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="869"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="442"/>
         <source>Freehand</source>
         <translation>Kreslení od ruky</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="782"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="436"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="870"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="443"/>
         <source>Polyline</source>
         <translation>Lomená čára</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="776"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="864"/>
         <source>Hardness:</source>
         <translation>Tvrdost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="783"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="437"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="871"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="444"/>
         <source>Segment</source>
         <translation type="unfinished">Část</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="785"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="873"/>
         <source>Mode:</source>
         <translation>Režim:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="786"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="874"/>
         <source>Lines</source>
         <translation>Čáry</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="787"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="875"/>
         <source>Areas</source>
         <translation>Plochy</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="788"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="876"/>
         <source>Lines &amp; Areas</source>
         <translation>Čáry a plochy</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="793"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="881"/>
         <source>Pencil Mode</source>
         <translation>Režim tužky</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="794"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="882"/>
         <source>Savebox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="440"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="447"/>
         <source>Linear</source>
         <translation type="unfinished">Lineární</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="441"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="448"/>
         <source>Ease In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="442"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="449"/>
         <source>Ease Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="443"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="450"/>
         <source>Ease In/Out</source>
         <translation type="unfinished"></translation>
     </message>
@@ -614,122 +614,127 @@
 <context>
     <name>FillTool</name>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2128"/>
+        <location filename="../../tnztools/filltool.cpp" line="2399"/>
         <source>Frame Range</source>
         <translation>Rozsah snímku</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2130"/>
+        <location filename="../../tnztools/filltool.cpp" line="2401"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2131"/>
+        <location filename="../../tnztools/filltool.cpp" line="2402"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2132"/>
+        <location filename="../../tnztools/filltool.cpp" line="2403"/>
         <source>Rectangular</source>
         <translation>Obdélníkový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2133"/>
+        <location filename="../../tnztools/filltool.cpp" line="2404"/>
         <source>Freehand</source>
         <translation>Kreslení od ruky</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2134"/>
+        <location filename="../../tnztools/filltool.cpp" line="2405"/>
         <source>Polyline</source>
         <translation>Lomená čára</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2136"/>
+        <location filename="../../tnztools/filltool.cpp" line="2406"/>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/filltool.cpp" line="2408"/>
         <source>Selective</source>
         <translation>Výběrový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2138"/>
+        <location filename="../../tnztools/filltool.cpp" line="2410"/>
         <source>Mode:</source>
         <translation>Režim:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2139"/>
+        <location filename="../../tnztools/filltool.cpp" line="2411"/>
         <source>Lines</source>
         <translation>Čáry</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2140"/>
+        <location filename="../../tnztools/filltool.cpp" line="2412"/>
         <source>Areas</source>
         <translation>Plochy</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2141"/>
+        <location filename="../../tnztools/filltool.cpp" line="2413"/>
         <source>Lines &amp; Areas</source>
         <translation>Čáry a plochy</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2143"/>
+        <location filename="../../tnztools/filltool.cpp" line="2415"/>
         <source>Onion Skin</source>
         <translation> Cibulový vzhled </translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2144"/>
+        <location filename="../../tnztools/filltool.cpp" line="2416"/>
         <source>Refer Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2145"/>
+        <location filename="../../tnztools/filltool.cpp" line="2417"/>
         <source>Fill Depth</source>
         <translation>Hloubka výplně</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2146"/>
+        <location filename="../../tnztools/filltool.cpp" line="2418"/>
         <source>Segment</source>
         <translation>Část</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2147"/>
+        <location filename="../../tnztools/filltool.cpp" line="2419"/>
         <source>Maximum Gap</source>
         <translation>Největší mezera</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2148"/>
+        <location filename="../../tnztools/filltool.cpp" line="2420"/>
         <source>Autopaint Lines</source>
         <translation>Automatické malování čar</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2149"/>
+        <location filename="../../tnztools/filltool.cpp" line="2421"/>
         <source>Savebox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2150"/>
+        <location filename="../../tnztools/filltool.cpp" line="2422"/>
         <source>Distance:</source>
         <translation type="unfinished">Odstup:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2151"/>
+        <location filename="../../tnztools/filltool.cpp" line="2423"/>
         <source>Style Index:</source>
         <translation type="unfinished">Číslo stylu:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2152"/>
+        <location filename="../../tnztools/filltool.cpp" line="2424"/>
         <source>Gaps:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2153"/>
+        <location filename="../../tnztools/filltool.cpp" line="2425"/>
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2154"/>
+        <location filename="../../tnztools/filltool.cpp" line="2426"/>
         <source>Fill Gaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2155"/>
+        <location filename="../../tnztools/filltool.cpp" line="2427"/>
         <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
@@ -737,12 +742,12 @@
 <context>
     <name>FingerTool</name>
     <message>
-        <location filename="../../tnztools/fingertool.cpp" line="333"/>
+        <location filename="../../tnztools/fingertool.cpp" line="352"/>
         <source>Size:</source>
         <translation>Velikost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fingertool.cpp" line="334"/>
+        <location filename="../../tnztools/fingertool.cpp" line="353"/>
         <source>Invert</source>
         <translation>Obrátit</translation>
     </message>
@@ -750,49 +755,49 @@
 <context>
     <name>FullColorBrushTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="192"/>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="197"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="191"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="196"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="193"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="192"/>
         <source>Pressure</source>
         <translation>Tlak</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="194"/>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="198"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="193"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="197"/>
         <source>Opacity</source>
         <translation>Neprůhlednost</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="195"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="194"/>
         <source>Hardness:</source>
         <translation>Tvrdost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="196"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="195"/>
         <source>Preset:</source>
         <translation>Přednastavení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="199"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="198"/>
         <source>Eraser</source>
         <translation>Guma</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="200"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="199"/>
         <source>Lock Alpha</source>
         <translation>Zamknout alfu</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="201"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="200"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="904"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="914"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;vlastní&gt;</translation>
     </message>
@@ -800,52 +805,52 @@
 <context>
     <name>FullColorEraserTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="414"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="435"/>
         <source>Size:</source>
         <translation>Velikost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="415"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="436"/>
         <source>Opacity:</source>
         <translation>Neprůhlednost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="416"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="437"/>
         <source>Hardness:</source>
         <translation>Tvrdost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="418"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="439"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="419"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="440"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="420"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="441"/>
         <source>Rectangular</source>
         <translation>Obdélníkový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="421"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="442"/>
         <source>Freehand</source>
         <translation>Kreslení od ruky</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="422"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="443"/>
         <source>Polyline</source>
         <translation>Lomená čára</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="424"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="445"/>
         <source>Invert</source>
         <translation>Obrátit</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="425"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="446"/>
         <source>Frame Range</source>
         <translation>Rozsah snímku</translation>
     </message>
@@ -853,20 +858,50 @@
 <context>
     <name>FullColorFillTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorfilltool.cpp" line="158"/>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="181"/>
         <source>Fill Depth</source>
         <translation>Hloubka výplně</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorfilltool.cpp" line="159"/>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="182"/>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="183"/>
+        <source>Distance:</source>
+        <translation type="unfinished">Odstup:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="184"/>
+        <source>Style Index:</source>
+        <translation type="unfinished">Číslo stylu:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="185"/>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="186"/>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="187"/>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="188"/>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HandToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3320"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3617"/>
         <source>Reset Position</source>
         <translation>Obnovit výchozí polohu</translation>
     </message>
@@ -890,42 +925,42 @@
 <context>
     <name>PaintBrushTool</name>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="380"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="399"/>
         <source>Size:</source>
         <translation>Velikost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="382"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="401"/>
         <source>Mode:</source>
         <translation>Režim:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="383"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="402"/>
         <source>Lines</source>
         <translation>Čáry</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="384"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="403"/>
         <source>Areas</source>
         <translation>Plochy</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="385"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="404"/>
         <source>Lines &amp; Areas</source>
         <translation>Čáry a plochy</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="387"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="406"/>
         <source>Selective</source>
         <translation>Výběrový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="389"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="408"/>
         <source>Pressure</source>
         <translation type="unfinished">Tlak</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="391"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="410"/>
         <source>Lock Alpha</source>
         <translation type="unfinished">Zamknout alfu</translation>
     </message>
@@ -933,42 +968,42 @@
 <context>
     <name>PerspectiveGridToolOptionBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2969"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3030"/>
         <source>Spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2974"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3035"/>
         <source>Rotation:</source>
         <translation type="unfinished">Otočení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2990"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3051"/>
         <source>Rotate Perspective Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2991"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3052"/>
         <source>Rotate Perspective Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3024"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3085"/>
         <source>Type:</source>
         <translation type="unfinished">Typ:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3029"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3090"/>
         <source>Opacity:</source>
         <translation type="unfinished">Neprůhlednost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3046"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3107"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3063"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3124"/>
         <source>Preset:</source>
         <translation type="unfinished">Přednastavení:</translation>
     </message>
@@ -1529,14 +1564,14 @@ Chcete pokračovat?</translation>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="224"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="236"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="225"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="237"/>
         <source>Min:</source>
         <translation>Nejméně:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="224"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="236"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="225"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="237"/>
         <source>Max:</source>
         <translation>Nejvíce:</translation>
     </message>
@@ -1546,7 +1581,7 @@ Chcete pokračovat?</translation>
         <translation>Nastavit ukládací box: (X%1,Y%2,W%3,H%4)-&gt;(X%5,Y%6,W%7,H%8)</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="307"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="308"/>
         <source>Move Center</source>
         <translation>Posunout středovou polohu</translation>
     </message>
@@ -1621,7 +1656,7 @@ Chcete pokračovat?</translation>
         <translation>Výběr nelze přesunout. Není upravitelný.</translation>
     </message>
     <message>
-        <location filename="../../tnztools/edittoolgadgets.cpp" line="89"/>
+        <location filename="../../tnztools/edittoolgadgets.cpp" line="287"/>
         <source>Modify Fx Gadget  </source>
         <translation>Změnit udělátko efektu</translation>
     </message>
@@ -1677,7 +1712,7 @@ Chcete pokračovat?</translation>
     </message>
     <message>
         <location filename="../../tnztools/tool.cpp" line="1057"/>
-        <location filename="../../tnztools/tool.cpp" line="1124"/>
+        <location filename="../../tnztools/tool.cpp" line="1119"/>
         <source>The current level is not editable.</source>
         <translation>Nynější úroveň není upravitelná.</translation>
     </message>
@@ -1712,12 +1747,12 @@ Chcete pokračovat?</translation>
         <translation>Nynější snímek je uzamknut: jakékoli úpravy jsou zakázány.</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tool.cpp" line="1135"/>
+        <location filename="../../tnztools/tool.cpp" line="1130"/>
         <source>The current tool cannot be used on empty frames of a Single Frame level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tool.cpp" line="1144"/>
+        <location filename="../../tnztools/tool.cpp" line="1139"/>
         <source>The current tool cannot be used on a stop frame.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1785,7 +1820,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>RGBPickerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2651"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2712"/>
         <source>Pick Screen</source>
         <translation>Zvolit obrazovku</translation>
     </message>
@@ -1793,12 +1828,12 @@ Chcete pokračovat?</translation>
 <context>
     <name>RasterSelectionTool</name>
     <message>
-        <location filename="../../tnztools/rasterselectiontool.cpp" line="1038"/>
+        <location filename="../../tnztools/rasterselectiontool.cpp" line="1086"/>
         <source>Modify Savebox</source>
         <translation>Změnit ukládací box</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rasterselectiontool.cpp" line="1040"/>
+        <location filename="../../tnztools/rasterselectiontool.cpp" line="1088"/>
         <source>No Antialiasing</source>
         <translation>Žádné vyhlazování</translation>
     </message>
@@ -1806,57 +1841,57 @@ Chcete pokračovat?</translation>
 <context>
     <name>RasterTapeTool</name>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="180"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="181"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="181"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="182"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="182"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="183"/>
         <source>Rectangular</source>
         <translation>Obdélníkový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="183"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="184"/>
         <source>Freehand</source>
         <translation>Kreslení od ruky</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="184"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="185"/>
         <source>Polyline</source>
         <translation>Lomená čára</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="186"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="187"/>
         <source>Distance:</source>
         <translation>Odstup:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="187"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="188"/>
         <source>Style Index:</source>
         <translation>Číslo stylu:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="188"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="189"/>
         <source>current</source>
         <translation>Nynější</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="189"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="190"/>
         <source>Opacity:</source>
         <translation>Neprůhlednost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="190"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="191"/>
         <source>Frame Range</source>
         <translation>Rozsah snímku</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="191"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="192"/>
         <source>Angle:</source>
         <translation>Úhel:</translation>
     </message>
@@ -1872,7 +1907,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>RotateToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3293"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3590"/>
         <source>Reset Rotation</source>
         <translation>Obnovit výchozí otočení</translation>
     </message>
@@ -1880,37 +1915,37 @@ Chcete pokračovat?</translation>
 <context>
     <name>RulerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2412"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2473"/>
         <source>X:</source>
         <comment>ruler tool option</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2418"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2479"/>
         <source>Y:</source>
         <comment>ruler tool option</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2426"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2487"/>
         <source>W:</source>
         <comment>ruler tool option</comment>
         <translation>Š:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2432"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2493"/>
         <source>H:</source>
         <comment>ruler tool option</comment>
         <translation>V:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2440"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2501"/>
         <source>A:</source>
         <comment>ruler tool option</comment>
         <translation>A:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2445"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2506"/>
         <source>L:</source>
         <comment>ruler tool option</comment>
         <translation>D:</translation>
@@ -1919,22 +1954,22 @@ Chcete pokračovat?</translation>
 <context>
     <name>SelectionTool</name>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="926"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="927"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="927"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="928"/>
         <source>Rectangular</source>
         <translation>Obdélníkový</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="928"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="929"/>
         <source>Freehand</source>
         <translation>Kreslení od ruky</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="929"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="930"/>
         <source>Polyline</source>
         <translation>Lomená čára</translation>
     </message>
@@ -1942,53 +1977,53 @@ Chcete pokračovat?</translation>
 <context>
     <name>SelectionToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1142"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1145"/>
         <source>H:</source>
         <translation>V:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1144"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1147"/>
         <source>V:</source>
         <translation>S:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1146"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1149"/>
         <source>Link</source>
         <translation>Stanovit poměr stran</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1149"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="1150"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1152"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1153"/>
         <source>Rotation</source>
         <translation>Otočení</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1152"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1155"/>
         <source>X:</source>
         <translation type="unfinished">X:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1154"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1157"/>
         <source>Y:</source>
         <translation type="unfinished">Y:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1186"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1189"/>
         <source>Flip Selection Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1187"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1190"/>
         <source>Flip Selection Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1188"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1191"/>
         <source>Rotate Selection Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1189"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1192"/>
         <source>Rotate Selection Right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2001,18 +2036,18 @@ Chcete pokračovat?</translation>
         <translation type="vanished">Y:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1205"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1208"/>
         <source>Scale</source>
         <translation>Měřítko</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1226"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1229"/>
         <source>Position</source>
         <translation>Poloha</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1243"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="1244"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1246"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1247"/>
         <source>Thickness</source>
         <translation>Tloušťka</translation>
     </message>
@@ -2020,22 +2055,22 @@ Chcete pokračovat?</translation>
 <context>
     <name>ShiftTraceToolOptionBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2788"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2849"/>
         <source>Reset Previous</source>
         <translation>Nastavit znovu předchozí</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2789"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2850"/>
         <source>Reset Following</source>
         <translation>Nastavit znovu následující</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2795"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2856"/>
         <source>Previous Drawing</source>
         <translation>Předchozí kresba</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2796"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2857"/>
         <source>Following Drawing</source>
         <translation>Následující kresba</translation>
     </message>
@@ -2073,7 +2108,7 @@ Chcete pokračovat?</translation>
         <translation>Obrácená kinematika</translation>
     </message>
     <message>
-        <location filename="../../tnztools/skeletontool.cpp" line="1615"/>
+        <location filename="../../tnztools/skeletontool.cpp" line="1614"/>
         <source>Reset Pinned Center</source>
         <translation>Obnovit výchozí stanovený střed</translation>
     </message>
@@ -2137,7 +2172,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>StylePickerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2737"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2798"/>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
         <translation>Se zapnutím této volby bude zvolený styl
@@ -2145,71 +2180,182 @@ přesunut na konec první strany palety.</translation>
     </message>
 </context>
 <context>
+    <name>SymmetryTool</name>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="258"/>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="260"/>
+        <source>Opacity</source>
+        <translation type="unfinished">Neprůhlednost</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="262"/>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="263"/>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="264"/>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="265"/>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="266"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="267"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="268"/>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="269"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="271"/>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="273"/>
+        <source>Preset:</source>
+        <translation type="unfinished">Přednastavení:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="372"/>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished">&lt;vlastní&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3357"/>
+        <source>Rotation:</source>
+        <translation type="unfinished">Otočení:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3373"/>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3374"/>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3384"/>
+        <source>Reset Position</source>
+        <translation type="unfinished">Obnovit výchozí polohu</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3403"/>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3408"/>
+        <source>Opacity:</source>
+        <translation type="unfinished">Neprůhlednost:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3420"/>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3429"/>
+        <source>Preset:</source>
+        <translation type="unfinished">Přednastavení:</translation>
+    </message>
+</context>
+<context>
     <name>ToonzRasterBrushTool</name>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1104"/>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1111"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1139"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1146"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1105"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1140"/>
         <source>Hardness:</source>
         <translation>Tvrdost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1106"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1141"/>
         <source>Smooth:</source>
         <translation>Vyhlazení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1107"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1142"/>
         <source>Draw Order:</source>
         <translation>Pořadí kresby:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1108"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1143"/>
         <source>Over All</source>
         <translation>Nad vše</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1109"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1144"/>
         <source>Under All</source>
         <translation>Pod vše</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1110"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1145"/>
         <source>Palette Order</source>
         <translation>Pořadí palety</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1114"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1149"/>
         <source>Preset:</source>
         <translation>Přednastavení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1115"/>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="2404"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1150"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="2531"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;vlastní&gt;</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1116"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1151"/>
         <source>Pencil</source>
         <translation>Tužka</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1117"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1152"/>
         <source>Pressure</source>
         <translation>Tlak</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1118"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1153"/>
         <source>Lock Alpha</source>
         <translation type="unfinished">Zamknout alfu</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1119"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1154"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2217,153 +2363,153 @@ přesunut na konec první strany palety.</translation>
 <context>
     <name>ToonzVectorBrushTool</name>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="620"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="616"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="621"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="617"/>
         <source>Accuracy:</source>
         <translation>Přesnost:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="622"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="618"/>
         <source>Smooth:</source>
         <translation>Vyhlazení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="623"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="619"/>
         <source>Preset:</source>
         <translation>Přednastavení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="624"/>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="2016"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="620"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="2091"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;vlastní&gt;</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="625"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="621"/>
         <source>Break</source>
         <translation>Zlomit ostré úhly</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="626"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="622"/>
         <source>Pressure</source>
         <translation>Tlak</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="627"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="623"/>
         <source>Cap</source>
         <translation>Čepice</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="628"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="624"/>
         <source>Join</source>
         <translation>Spojit</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="629"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="625"/>
         <source>Miter:</source>
         <translation>Zkosení:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="630"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="626"/>
         <source>Range:</source>
         <translation>Rozsah:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="631"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="627"/>
         <source>Snap</source>
         <translation>Přichytávání</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="633"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="629"/>
         <source>Off</source>
         <translation>Vypnuto</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="634"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="630"/>
         <source>Linear</source>
         <translation>Lineární</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="635"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="631"/>
         <source>In</source>
         <translation>Zpomalení na začátku</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="636"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="632"/>
         <source>Out</source>
         <translation>Zpomalení na konci</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="637"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="633"/>
         <source>In&amp;Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="638"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="634"/>
         <source>Low</source>
         <translation>Nízký</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="639"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="635"/>
         <source>Med</source>
         <translation>Střední</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="640"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="636"/>
         <source>High</source>
         <translation>Vysoký</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="641"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="637"/>
         <source>Butt cap</source>
         <translation>Odřezek</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="642"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="638"/>
         <source>Round cap</source>
         <translation>Zakulacený</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="643"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="639"/>
         <source>Projecting cap</source>
         <translation>Rovný klobouček</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="644"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="640"/>
         <source>Miter join</source>
         <translation>Ostrý ohyb</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="645"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="641"/>
         <source>Round join</source>
         <translation>Kulatý ohyb</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="646"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="642"/>
         <source>Bevel join</source>
         <translation>Zkosený ohyb</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="647"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="643"/>
         <source>Draw Under</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="648"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="644"/>
         <source>Auto Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="649"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="645"/>
         <source>Auto Fill</source>
         <translation type="unfinished">Automatické vyplnění</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="650"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="646"/>
         <source>Auto Group</source>
         <translation type="unfinished">Automatické seskupení</translation>
     </message>
@@ -2525,52 +2671,52 @@ přesunut na konec první strany palety.</translation>
 <context>
     <name>VectorTapeTool</name>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="260"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="264"/>
         <source>Smooth</source>
         <translation>Vyhladit</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="261"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="265"/>
         <source>Join Vectors</source>
         <translation>Spojit vektory</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="262"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="266"/>
         <source>Distance</source>
         <translation>Odstup</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="264"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="268"/>
         <source>Mode:</source>
         <translation>Režim:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="265"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="269"/>
         <source>Endpoint to Endpoint</source>
         <translation>Koncový bod ke koncovému bodu</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="266"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="270"/>
         <source>Endpoint to Line</source>
         <translation>Koncový bod k čáře</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="267"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="271"/>
         <source>Line to Line</source>
         <translation>Čára k čáře</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="269"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="273"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="270"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="274"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="271"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="275"/>
         <source>Rectangular</source>
         <translation>Obdélníkový</translation>
     </message>
@@ -2578,7 +2724,7 @@ přesunut na konec první strany palety.</translation>
 <context>
     <name>ZoomToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3266"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3563"/>
         <source>Reset Zoom</source>
         <translation>Obnovit výchozí zvětšení</translation>
     </message>

--- a/toonz/sources/translations/czech/toonz.ts
+++ b/toonz/sources/translations/czech/toonz.ts
@@ -174,7 +174,7 @@ Special thanks to:</source>
     <message>
         <source>The microphone is not available: 
 Please select a different device or check the microphone.</source>
-        <translation>Mikrofon není dostupný:
+        <translation type="vanished">Mikrofon není dostupný:
 Vyberte, prosím, jiné zařízení nebo prověřte mikrofon.</translation>
     </message>
     <message>
@@ -272,6 +272,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -365,6 +385,90 @@ sebere všechny snímky ve vybrané úrovni.</translation>
     <message>
         <source>Field Guide:</source>
         <translation type="vanished">Praktický úvod:</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished">Ukázat/Skrýt rozhraní</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished">Bezpečná oblast (klepnutí pravým tlačítkem myši pro vybrání)</translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">Trojrozměrný pohled</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">Pohled kamery</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">Pozastavit</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Náhled</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">Náhled na podkameru</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished">Bez názvu</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"> (převráceno)</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -669,6 +773,21 @@ Zastavte ji nebo počkejte na její dokončení, předtím než ji odstraníte.<
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -692,7 +811,7 @@ Zastavte ji nebo počkejte na její dokončení, předtím než ji odstraníte.<
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">Jednotka:</translation>
+        <translation>Jednotka:</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -722,23 +841,23 @@ Chcete pracovní plochu oříznout?</translation>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">obrazový bod (pixel)</translation>
+        <translation>obrazový bod (pixel)</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">cm</translation>
+        <translation>cm</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">Pole</translation>
+        <translation>Pole</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">palec</translation>
+        <translation>palec</translation>
     </message>
 </context>
 <context>
@@ -1311,7 +1430,7 @@ Co chcete dělat?</translation>
     <name>ComboViewerPanel</name>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>Bezpečná oblast (klepnutí pravým tlačítkem myši pro vybrání)</translation>
+        <translation type="vanished">Bezpečná oblast (klepnutí pravým tlačítkem myši pro vybrání)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -1319,19 +1438,19 @@ Co chcete dělat?</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>Pohled stanoviště kamery</translation>
+        <translation type="vanished">Pohled stanoviště kamery</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>Trojrozměrný pohled</translation>
+        <translation type="vanished">Trojrozměrný pohled</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>Pohled kamery</translation>
+        <translation type="vanished">Pohled kamery</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>Pozastavit</translation>
+        <translation type="vanished">Pozastavit</translation>
     </message>
     <message>
         <source>GUI Show / Hide</source>
@@ -1351,35 +1470,35 @@ Co chcete dělat?</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>Náhled</translation>
+        <translation type="vanished">Náhled</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Náhled na podkameru</translation>
+        <translation type="vanished">Náhled na podkameru</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Bez názvu</translation>
+        <translation type="vanished">Bez názvu</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Záběr:</translation>
+        <translation type="vanished">Záběr:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>:: Snímek:</translation>
+        <translation type="vanished">:: Snímek:</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>:: Úroveň:</translation>
+        <translation type="vanished">:: Úroveň:</translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Úroveň:</translation>
+        <translation type="vanished">Úroveň:</translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (převráceno)</translation>
+        <translation type="vanished"> (převráceno)</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -1395,19 +1514,6 @@ Co chcete dělat?</translation>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1471,6 +1577,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished">Hledat:</translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1495,6 +1605,131 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>Jejich</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">Úroveň %1 nemá žádný snímek. Byla přeskočena.</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished">Převést</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušit</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">Přeskočit stávající soubory</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1765,6 +2000,99 @@ contain the dpi information, then the current camera dpi will be used.
     <message>
         <source>Level %1 converting to same file format; skipped.</source>
         <translation>Úroveň %1 se převádí do stejného souborového formátu, přeskočeno.</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Zavřít</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished">Přepsat</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušit</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2044,6 +2372,13 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2239,6 +2574,47 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
         <source>Export</source>
@@ -2328,26 +2704,6 @@ contain the dpi information, then the current camera dpi will be used.
     <name>ExportXDTSCommand</name>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Target column</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2470,14 +2826,6 @@ contain the dpi information, then the current camera dpi will be used.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2546,6 +2894,18 @@ Do you want to create it?</source>
     </message>
     <message>
         <source>Failed to create folder %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3042,6 +3402,10 @@ Chcete jej přepsat?</translation>
         <source>  ::  Shrink </source>
         <translation>:: Zmenšit </translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -3113,6 +3477,13 @@ Chcete jej přepsat?</translation>
     <message>
         <source>Fx Settings</source>
         <translation>Nastavení efektu</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3293,6 +3664,10 @@ Chcete jej přepsat?</translation>
     <message>
         <source>Search:</source>
         <translation type="unfinished">Hledat:</translation>
+    </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3695,6 +4070,10 @@ Chcete ji vytvořit?</translation>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -4000,6 +4379,13 @@ Please choose a valid lip sync data file to continue.</source>
     </message>
 </context>
 <context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadColorModelPopup</name>
     <message>
         <source>Load Color Model</source>
@@ -4300,6 +4686,10 @@ Please choose a valid lip sync data file to continue.</source>
     <message>
         <source>Locator</source>
         <translation>Hledač</translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7564,6 +7954,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7827,6 +8289,22 @@ Co chcete dělat?</translation>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Barva</translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8276,17 +8754,6 @@ Co chcete dělat?</translation>
         <translation>Upravit filmovou klapku...</translation>
     </message>
     <message>
-        <source>Save current output settings.
-The parameters to be saved are:
-- Camera settings
-- Project folder to be saved in
-- File format
-- File options
-- Resample Balance
-- Channel width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save and Render</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8324,6 +8791,93 @@ The parameters to be saved are:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Náhled</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Barva</translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished">Maže se &quot;%1&quot;
+Jste si jistý?</translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9131,7 +9685,7 @@ Nastavit cestu k výstupní složce také na podsložku.</translation>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">Použít ukládací okno TLV k omezení vyplňovacích operací</translation>
+        <translation>Použít ukládací okno TLV k omezení vyplňovacích operací</translation>
     </message>
     <message>
         <source>Paper Thickness:</source>
@@ -9399,7 +9953,7 @@ Nastavit cestu k výstupní složce také na podsložku.</translation>
     </message>
     <message>
         <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation>Ukázat dodatek &quot;ABC&quot; u čísla snímku v buňce podzáběru</translation>
+        <translation type="vanished">Ukázat dodatek &quot;ABC&quot; u čísla snímku v buňce podzáběru</translation>
     </message>
     <message>
         <source>Show Keyframes on Cell Area</source>
@@ -9467,7 +10021,7 @@ Nastavit cestu k výstupní složce také na podsložku.</translation>
     </message>
     <message>
         <source>Pixels Only:</source>
-        <translation type="vanished">Jen pixely:</translation>
+        <translation>Jen pixely:</translation>
     </message>
     <message>
         <source>Rooms*:</source>
@@ -9565,7 +10119,7 @@ Je v pořádku tyto klávesové zkratky uvolnit?</translation>
     </message>
     <message>
         <source>Show Column Numbers in Column Headers</source>
-        <translation>Ukázat čísla sloupců v záhlaví sloupců</translation>
+        <translation type="vanished">Ukázat čísla sloupců v záhlaví sloupců</translation>
     </message>
     <message>
         <source>Show Current Time Indicator (Timeline Mode only)</source>
@@ -10168,6 +10722,58 @@ but a random crash might occur, use at your own risk:</source>
         <source>Edit Additional Style Sheet..</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup:: FormatProperties</name>
@@ -10430,6 +11036,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13093,6 +13703,107 @@ Do you want to continue?</source>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -13271,6 +13982,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">Prohlížeč</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished">Historie</translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">Nová pracovní plocha</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -13282,7 +14024,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>Pracovní plocha</translation>
+        <translation type="vanished">Pracovní plocha</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -14181,6 +14923,13 @@ Nejprve, prosím, změny odešlete, nebo je vraťte zpět.</translation>
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -14322,6 +15071,172 @@ Nejprve, prosím, změny odešlete, nebo je vraťte zpět.</translation>
     <message>
         <source>Threshold: </source>
         <translation type="vanished">Prahová hodnota: </translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished">Složka: </translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished">Složku se nepodařilo otevřít</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished">Cesta ke vstupní složce byla neplatná.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">Příponu souboru nelze změnit</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">Nelze nastavit číslo kresby</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">Přejmenování není možné. Již existuje soubor:</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">Nepodařilo se přejmenovat </translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">Nahrát jako podzáběr</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">Nahrát</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">Přejmenovat</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">Převést na nabarvené TLV</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">Převést na nenabarvené TLV</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">Správa verzí</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">Upravit</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">Upravit rozsah snímků...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished">Nahradit...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">Vrátit</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished">Získat</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Smazat</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">Získat revizi...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished">Odemknout</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">Upravit informace</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">Průběh změn...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">Odemknout rozsah snímků</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished">Uložit výjev</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">Název výjevu:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished">Při kopírování z %1 do %2 se vyskytla chyba</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">Převést na nenabarvené TLV</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished">Varování: Úroveň %1 již existuje. Přepsat?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ano</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Ne</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">Hotovo: Všechny úrovně byly převedeny do formátu TLV</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">Převést na nabarvené TLV</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">Hotovo: 2 úrovně byly převedeny do formátu TLV</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">Nová složka</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">Složku %1 nelze vytvořit.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">Některé soubory, jež chcete vytvořit, jsou nyní otevřeny. Nejprve je, prosím, zavřete.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">Některé soubory, jež chcete odemknout, jsou nyní otevřeny. Nejprve je, prosím, zavřete.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14581,55 +15496,55 @@ Nejprve, prosím, změny odešlete, nebo je vraťte zpět.</translation>
     <name>SceneViewerPanel</name>
     <message>
         <source>Preview</source>
-        <translation>Náhled</translation>
+        <translation type="vanished">Náhled</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Náhled na podkameru</translation>
+        <translation type="vanished">Náhled na podkameru</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Bez názvu</translation>
+        <translation type="vanished">Bez názvu</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Záběr: </translation>
+        <translation type="vanished">Záběr: </translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>:: Snímek: </translation>
+        <translation type="vanished">:: Snímek: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation> :: Úroveň: </translation>
+        <translation type="vanished"> :: Úroveň: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Úroveň: </translation>
+        <translation type="vanished">Úroveň: </translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>Pozastavit</translation>
+        <translation type="vanished">Pozastavit</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>Pohled na stav kamery</translation>
+        <translation type="vanished">Pohled na stav kamery</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>Trojrozměrný pohled</translation>
+        <translation type="vanished">Trojrozměrný pohled</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>Pohled kamery</translation>
+        <translation type="vanished">Pohled kamery</translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation> :: Zvětšení: </translation>
+        <translation type="vanished"> :: Zvětšení: </translation>
     </message>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>Bezpečná oblast (klepnutí pravým tlačítkem myši pro vybrání)</translation>
+        <translation type="vanished">Bezpečná oblast (klepnutí pravým tlačítkem myši pro vybrání)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -14637,7 +15552,7 @@ Nejprve, prosím, změny odešlete, nebo je vraťte zpět.</translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (převráceno)</translation>
+        <translation type="vanished"> (převráceno)</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -14649,28 +15564,7 @@ Nejprve, prosím, změny odešlete, nebo je vraťte zpět.</translation>
     </message>
     <message>
         <source>GUI Show / Hide</source>
-        <translation type="unfinished">Ukázat/Skrýt rozhraní</translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Ukázat/Skrýt rozhraní</translation>
     </message>
 </context>
 <context>
@@ -14999,7 +15893,7 @@ Chcete jej nahradit?</translation>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">Záběr</translation>
+        <translation>Záběr</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -15011,7 +15905,7 @@ Chcete jej nahradit?</translation>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">Okno</translation>
+        <translation>Okno</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -15312,7 +16206,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>DPI:</source>
-        <translation type="vanished">DPI:</translation>
+        <translation>DPI:</translation>
     </message>
     <message>
         <source>X</source>
@@ -15352,23 +16246,23 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">obrazový bod (pixel)</translation>
+        <translation>obrazový bod (pixel)</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">cm</translation>
+        <translation>cm</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">palec</translation>
+        <translation>palec</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">pole</translation>
+        <translation>pole</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -15380,7 +16274,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>Units:</source>
-        <translation type="vanished">Jednotky:</translation>
+        <translation>Jednotky:</translation>
     </message>
     <message>
         <source>No Recent Scenes</source>
@@ -15733,236 +16627,301 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="vanished">Ne</translation>
+        <translation>Ne</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="vanished">Pro soubor nestanoven žádný název úrovně: Zvolte, prosím, platný název pro úroveň</translation>
+        <translation>Pro soubor nestanoven žádný název úrovně: Zvolte, prosím, platný název pro úroveň</translation>
     </message>
     <message>
         <source>The level name specified is already used: please choose a different level name.</source>
-        <translation type="vanished">Název úrovně se již používá: Zvolte, prosím, jiný název.</translation>
+        <translation>Název úrovně se již používá: Zvolte, prosím, jiný název.</translation>
     </message>
     <message>
         <source>The save in path specified does not match with the existing level.</source>
-        <translation type="vanished">Zadaná cesta pro Uložit v neodpovídá existující úrovni.</translation>
+        <translation>Zadaná cesta pro Uložit v neodpovídá existující úrovni.</translation>
     </message>
     <message>
         <source>The captured image size does not match with the existing level.</source>
-        <translation type="vanished">Velikost zachyceného obrázku neodpovídá existující úrovni.</translation>
+        <translation>Velikost zachyceného obrázku neodpovídá existující úrovni.</translation>
     </message>
     <message>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
-        <translation type="vanished">Soubor %1 již existuje.
+        <translation>Soubor %1 již existuje.
 Chcete jej přepsat?</translation>
     </message>
     <message>
         <source>Failed to load %1.</source>
-        <translation type="vanished">Nepodařilo se nahrát %1.</translation>
+        <translation>Nepodařilo se nahrát %1.</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="vanished">Složka %1 neexistuje.
+        <translation>Složka %1 neexistuje.
 Chcete ji vytvořit?</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="vanished">Nelze vytvořit</translation>
+        <translation>Nelze vytvořit</translation>
     </message>
     <message>
         <source>UNDEFINED WARNING</source>
-        <translation type="vanished">NEURČENÉ VAROVÁNÍ</translation>
+        <translation>NEURČENÉ VAROVÁNÍ</translation>
     </message>
     <message>
         <source>The level is not registered in the scene, but exists in the file system.</source>
-        <translation type="vanished">Úroveň není zaregistrována ve výjevu, ale existuje v souborovém systému.</translation>
+        <translation>Úroveň není zaregistrována ve výjevu, ale existuje v souborovém systému.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost uloženého obrázku je %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING </source>
-        <translation type="vanished">VAROVÁNÍ </translation>
+        <translation>VAROVÁNÍ </translation>
     </message>
     <message>
         <source>
 Frame %1 exists.</source>
-        <translation type="vanished">
+        <translation>
 Snímek %1 existuje.</translation>
     </message>
     <message>
         <source>
 Frames %1 exist.</source>
-        <translation type="vanished">
+        <translation>
 Snímky%1 existují.</translation>
     </message>
     <message>
         <source>OVERWRITE 1 of</source>
-        <translation type="vanished">PŘEPSÁNÍ 1</translation>
+        <translation>PŘEPSÁNÍ 1</translation>
     </message>
     <message>
         <source>ADD to</source>
-        <translation type="vanished">PŘIDAT do</translation>
+        <translation>PŘIDAT do</translation>
     </message>
     <message>
         <source> %1 frame</source>
-        <translation type="vanished"> %1 snímek</translation>
+        <translation> %1 snímek</translation>
     </message>
     <message>
         <source> %1 frames</source>
-        <translation type="vanished"> %1 snímků</translation>
+        <translation> %1 snímků</translation>
     </message>
     <message>
         <source>The level will be newly created.</source>
-        <translation type="vanished">Úroveň bude nově vytvořena.</translation>
+        <translation>Úroveň bude nově vytvořena.</translation>
     </message>
     <message>
         <source>NEW</source>
-        <translation type="vanished">NOVÝ</translation>
+        <translation>NOVÝ</translation>
     </message>
     <message>
         <source>The level is already registered in the scene.</source>
-        <translation type="vanished">Úroveň je již zaregistrována ve výjevu.</translation>
+        <translation>Úroveň je již zaregistrována ve výjevu.</translation>
     </message>
     <message>
         <source>
 NOTE : The level is not saved.</source>
-        <translation type="vanished">
+        <translation>
 POZNÁMKA: Úroveň není uložena.</translation>
     </message>
     <message>
         <source>
 WARNING : Failed to get image size of the existing level %1.</source>
-        <translation type="vanished">
+        <translation>
 VAROVÁNÍ: Nepodařilo se získat velikost obrázku stávající úrovně %1.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost stávající úrovně je %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
           %2.</source>
-        <translation type="vanished">VAROVÁNÍ: Střety v názvu úrovně. Ve výjevu již je úroveň %1 s cestou                        
+        <translation>VAROVÁNÍ: Střety v názvu úrovně. Ve výjevu již je úroveň %1 s cestou                        
            %2.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost úrovně se stejným názvem je %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING : Level path conflicts. There already is a level with the path %1                        
           in the scene with the name %2.</source>
-        <translation type="vanished">VAROVÁNÍ: Střety v cestě úrovně. Ve výjevu již je úroveň %1 s cestou                        
+        <translation>VAROVÁNÍ: Střety v cestě úrovně. Ve výjevu již je úroveň %1 s cestou                        
            %2.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost úrovně se stejnou cestou je %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING</source>
-        <translation type="vanished">VAROVÁNÍ</translation>
+        <translation>VAROVÁNÍ</translation>
     </message>
     <message>
         <source>No camera selected.</source>
-        <translation type="vanished">Nevybrána žádná kamera.</translation>
+        <translation>Nevybrána žádná kamera.</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please start live view before capturing an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Controls</source>
-        <translation type="vanished">Ovládání</translation>
+        <translation>Ovládání</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Nastavení</translation>
+        <translation>Nastavení</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">Volby</translation>
+        <translation>Volby</translation>
     </message>
     <message>
         <source>Resolution: </source>
-        <translation type="vanished">Rozlišení: </translation>
+        <translation>Rozlišení: </translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="vanished">Obnovit</translation>
+        <translation>Obnovit</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="vanished">Soubor</translation>
+        <translation>Soubor</translation>
     </message>
     <message>
         <source>Webcam Settings...</source>
-        <translation type="vanished">Nastavení webkamery...</translation>
+        <translation>Nastavení webkamery...</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="vanished">Zachytávání</translation>
+        <translation>Zachytávání</translation>
     </message>
     <message>
         <source>Next Level</source>
-        <translation type="vanished">Další úroveň</translation>
+        <translation>Další úroveň</translation>
     </message>
     <message>
         <source>Next New</source>
-        <translation type="vanished">Další nový</translation>
+        <translation>Další nový</translation>
     </message>
     <message>
         <source>Previous Level</source>
-        <translation type="vanished">Předchozí úroveň</translation>
+        <translation>Předchozí úroveň</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="vanished">Další snímek</translation>
+        <translation>Další snímek</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="vanished">Poslední snímek</translation>
+        <translation>Poslední snímek</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="vanished">Předchozí snímek</translation>
+        <translation>Předchozí snímek</translation>
     </message>
     <message>
         <source>Next XSheet Frame</source>
-        <translation type="vanished">Další snímek v záběru</translation>
+        <translation>Další snímek v záběru</translation>
     </message>
     <message>
         <source>Previous XSheet Frame</source>
-        <translation type="vanished">Předchozí snímek v záběru</translation>
+        <translation>Předchozí snímek v záběru</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="vanished">Nynější snímek</translation>
+        <translation>Nynější snímek</translation>
     </message>
     <message>
         <source>Set to the Current Playhead Location</source>
-        <translation type="vanished">Nastavit na nynější polohu ukazatele přehrávání</translation>
+        <translation>Nastavit na nynější polohu ukazatele přehrávání</translation>
     </message>
     <message>
         <source>Start Live View</source>
-        <translation type="vanished">Spustit živý pohled</translation>
+        <translation>Spustit živý pohled</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -15974,39 +16933,39 @@ VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost úrovně se stejnou cestou 
     </message>
     <message>
         <source>&lt;</source>
-        <translation type="vanished">&lt;</translation>
+        <translation>&lt;</translation>
     </message>
     <message>
         <source>&gt;</source>
-        <translation type="vanished">&gt;</translation>
+        <translation>&gt;</translation>
     </message>
     <message>
         <source>&lt;&lt;</source>
-        <translation type="vanished">&lt;&lt;</translation>
+        <translation>&lt;&lt;</translation>
     </message>
     <message>
         <source>&gt;&gt;</source>
-        <translation type="vanished">&gt;&gt;</translation>
+        <translation>&gt;&gt;</translation>
     </message>
     <message>
         <source>&lt;&lt;&lt;</source>
-        <translation type="vanished">&lt;&lt;&lt;</translation>
+        <translation>&lt;&lt;&lt;</translation>
     </message>
     <message>
         <source>&gt;&gt;&gt;</source>
-        <translation type="vanished">&gt;&gt;&gt;</translation>
+        <translation>&gt;&gt;&gt;</translation>
     </message>
     <message>
         <source>Camera:</source>
-        <translation type="vanished">Kamera:</translation>
+        <translation>Kamera:</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="vanished">Název:</translation>
+        <translation>Název:</translation>
     </message>
     <message>
         <source>Frame:</source>
-        <translation type="vanished">Snímek:</translation>
+        <translation>Snímek:</translation>
     </message>
     <message>
         <source>File Type:</source>
@@ -16022,51 +16981,51 @@ VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost úrovně se stejnou cestou 
     </message>
     <message>
         <source>Camera Model</source>
-        <translation type="vanished">Model kamery</translation>
+        <translation>Model kamery</translation>
     </message>
     <message>
         <source>Camera Mode</source>
-        <translation type="vanished">Režim kamery</translation>
+        <translation>Režim kamery</translation>
     </message>
     <message>
         <source>Temperature: </source>
-        <translation type="vanished">Teplota: </translation>
+        <translation>Teplota: </translation>
     </message>
     <message>
         <source>Shutter Speed: </source>
-        <translation type="vanished">Rychlost závěrky: </translation>
+        <translation>Rychlost závěrky: </translation>
     </message>
     <message>
         <source>Iso: </source>
-        <translation type="vanished">ISO: </translation>
+        <translation>ISO: </translation>
     </message>
     <message>
         <source>Aperture: </source>
-        <translation type="vanished">Clona: </translation>
+        <translation>Clona: </translation>
     </message>
     <message>
         <source>Exposure: </source>
-        <translation type="vanished">Osvit: </translation>
+        <translation>Osvit: </translation>
     </message>
     <message>
         <source>Image Quality: </source>
-        <translation type="vanished">Jakost obrázku: </translation>
+        <translation>Jakost obrázku: </translation>
     </message>
     <message>
         <source>Picture Style: </source>
-        <translation type="vanished">Styl obrázku: </translation>
+        <translation>Styl obrázku: </translation>
     </message>
     <message>
         <source>White Balance: </source>
-        <translation type="vanished">Vyvážení bílé: </translation>
+        <translation>Vyvážení bílé: </translation>
     </message>
     <message>
         <source>Webcam Options</source>
-        <translation type="vanished">Volby webkamery</translation>
+        <translation>Volby webkamery</translation>
     </message>
     <message>
         <source>DSLR Options</source>
-        <translation type="vanished">Volby DSLR</translation>
+        <translation>Volby DSLR</translation>
     </message>
     <message>
         <source>Place the frame in the XSheet</source>
@@ -16074,7 +17033,7 @@ VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost úrovně se stejnou cestou 
     </message>
     <message>
         <source>Use Direct Show Webcam Drivers</source>
-        <translation type="vanished">Použít ovladače webkamery Direct Show</translation>
+        <translation>Použít ovladače webkamery Direct Show</translation>
     </message>
     <message>
         <source>Black Screen for Capture</source>
@@ -16086,23 +17045,23 @@ VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost úrovně se stejnou cestou 
     </message>
     <message>
         <source>Use MJPG with Webcam</source>
-        <translation type="vanished">Použít MJPG s webkamerou</translation>
+        <translation>Použít MJPG s webkamerou</translation>
     </message>
     <message>
         <source>Place on XSheet</source>
-        <translation type="vanished">Umístit v záběru</translation>
+        <translation>Umístit v záběru</translation>
     </message>
     <message>
         <source>Use Numpad Shortcuts When Active</source>
-        <translation type="vanished">Použít klávesové zkratky číselné klávesnice, když je činné</translation>
+        <translation>Použít klávesové zkratky číselné klávesnice, když je činné</translation>
     </message>
     <message>
         <source>Show Live View on All Frames</source>
-        <translation type="vanished">Ukázat živý pohled na všechny snímky</translation>
+        <translation>Ukázat živý pohled na všechny snímky</translation>
     </message>
     <message>
         <source>Capture Review Time: </source>
-        <translation type="vanished">Čas změny při zachytávání: </translation>
+        <translation>Čas změny při zachytávání: </translation>
     </message>
     <message>
         <source>Level Subsampling: </source>
@@ -16110,192 +17069,416 @@ VAROVÁNÍ: Nesoulad ve velikosti obrázku. Velikost úrovně se stejnou cestou 
     </message>
     <message>
         <source>Opacity:</source>
-        <translation type="vanished">Neprůhlednost:</translation>
+        <translation>Neprůhlednost:</translation>
     </message>
     <message>
         <source>No camera detected.</source>
-        <translation type="vanished">Nezjištěna žádná kamera.</translation>
+        <translation>Nezjištěna žádná kamera.</translation>
     </message>
     <message>
         <source>No camera detected</source>
-        <translation type="vanished">Nezjištěna žádná kamera</translation>
+        <translation>Nezjištěna žádná kamera</translation>
     </message>
     <message>
         <source>- Select camera -</source>
-        <translation type="vanished">- Vybrat kameru -</translation>
+        <translation>- Vybrat kameru -</translation>
     </message>
     <message>
         <source>Mode: </source>
-        <translation type="vanished">Režim: </translation>
+        <translation>Režim: </translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="vanished">Automaticky</translation>
+        <translation>Automaticky</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="vanished">Zakázáno</translation>
+        <translation>Zakázáno</translation>
     </message>
     <message>
         <source>Stop Live View</source>
-        <translation type="vanished">Zastavit živý pohled</translation>
+        <translation>Zastavit živý pohled</translation>
     </message>
     <message>
         <source>Image adjust</source>
-        <translation type="obsolete">Přizpůsobení obrázku</translation>
+        <translation type="unfinished">Přizpůsobení obrázku</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Barva</translation>
+        <translation type="unfinished">Barva</translation>
     </message>
     <message>
         <source>Grayscale</source>
-        <translation type="obsolete">Odstíny šedi</translation>
+        <translation type="unfinished">Odstíny šedi</translation>
     </message>
     <message>
         <source>Black &amp; White</source>
-        <translation type="obsolete">Černá a bílá</translation>
+        <translation type="unfinished">Černá a bílá</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">Jas: </translation>
+        <translation type="unfinished">Jas: </translation>
     </message>
     <message>
         <source>Color type:</source>
-        <translation type="obsolete">Typ barvy:</translation>
+        <translation type="unfinished">Typ barvy:</translation>
     </message>
     <message>
         <source>Interval(sec):</source>
-        <translation type="obsolete">Interval (s):</translation>
+        <translation type="unfinished">Interval (s):</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Zrušit</translation>
+        <translation type="unfinished">Zrušit</translation>
     </message>
     <message>
         <source>Load</source>
-        <translation type="obsolete">Nahrát</translation>
+        <translation type="unfinished">Nahrát</translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="obsolete">Vyvést</translation>
+        <translation type="unfinished">Vyvést</translation>
     </message>
     <message>
         <source>Couldn&apos;t load %1</source>
-        <translation type="obsolete">Nepodařilo se nahrát %1</translation>
+        <translation type="unfinished">Nepodařilo se nahrát %1</translation>
     </message>
     <message>
         <source>Couldn&apos;t save %1</source>
-        <translation type="obsolete">Nepodařilo se uložit %1</translation>
+        <translation type="unfinished">Nepodařilo se uložit %1</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>Create the Destination Subfolder to Save</source>
-        <translation type="obsolete">Vytvořit cílovou podsložku k uložení</translation>
+        <translation type="unfinished">Vytvořit cílovou podsložku k uložení</translation>
     </message>
     <message>
         <source>Set As Default</source>
-        <translation type="obsolete">Nastavit jako výchozí</translation>
+        <translation type="unfinished">Nastavit jako výchozí</translation>
     </message>
     <message>
         <source>Set the current &quot;Save In&quot; path as the default.</source>
-        <translation type="obsolete">Nastavit nynější cestu &quot;Uložit v&quot; jako výchozí.</translation>
+        <translation type="unfinished">Nastavit nynější cestu &quot;Uložit v&quot; jako výchozí.</translation>
     </message>
     <message>
         <source>Create Subfolder</source>
-        <translation type="obsolete">Vytvořit podsložku</translation>
+        <translation type="unfinished">Vytvořit podsložku</translation>
     </message>
     <message>
         <source>Infomation</source>
-        <translation type="obsolete">Informace</translation>
+        <translation type="unfinished">Informace</translation>
     </message>
     <message>
         <source>Subfolder Name</source>
-        <translation type="obsolete">Název podsložky</translation>
+        <translation type="unfinished">Název podsložky</translation>
     </message>
     <message>
         <source>Auto Format:</source>
-        <translation type="obsolete">Automatický formát:</translation>
+        <translation type="unfinished">Automatický formát:</translation>
     </message>
     <message>
         <source>Show This on Launch of the Camera Capture</source>
-        <translation type="obsolete">Ukázat toto při spuštění zachytávání kamery</translation>
+        <translation type="unfinished">Ukázat toto při spuštění zachytávání kamery</translation>
     </message>
     <message>
         <source>Save Scene in Subfolder</source>
-        <translation type="obsolete">Uložit výjev v podsložce</translation>
+        <translation type="unfinished">Uložit výjev v podsložce</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Zrušit</translation>
+        <translation type="unfinished">Zrušit</translation>
     </message>
     <message>
         <source>C- + Sequence + Scene</source>
-        <translation type="obsolete">C- + úryvek + výjev</translation>
+        <translation type="unfinished">C- + úryvek + výjev</translation>
     </message>
     <message>
         <source>Sequence + Scene</source>
-        <translation type="obsolete">Úryvek + výjev</translation>
+        <translation type="unfinished">Úryvek + výjev</translation>
     </message>
     <message>
         <source>Episode + Sequence + Scene</source>
-        <translation type="obsolete">Díl + úryvek + výjev</translation>
+        <translation type="unfinished">Díl + úryvek + výjev</translation>
     </message>
     <message>
         <source>Project + Episode + Sequence + Scene</source>
-        <translation type="obsolete">Projekt + díl + úryvek + výjev</translation>
+        <translation type="unfinished">Projekt + díl + úryvek + výjev</translation>
     </message>
     <message>
         <source>Save the current scene in the subfolder.
 Set the output folder path to the subfolder as well.</source>
-        <translation type="obsolete">Uložit nynější výjev do podsložky.
+        <translation type="unfinished">Uložit nynější výjev do podsložky.
 Nastavit cestu k výstupní složce také na podsložku.</translation>
     </message>
     <message>
         <source>Save In:</source>
-        <translation type="obsolete">Uložit v:</translation>
+        <translation type="unfinished">Uložit v:</translation>
     </message>
     <message>
         <source>Project:</source>
-        <translation type="obsolete">Projekt:</translation>
+        <translation type="unfinished">Projekt:</translation>
     </message>
     <message>
         <source>Episode:</source>
-        <translation type="obsolete">Díl:</translation>
+        <translation type="unfinished">Díl:</translation>
     </message>
     <message>
         <source>Sequence:</source>
-        <translation type="obsolete">Úryvek:</translation>
+        <translation type="unfinished">Úryvek:</translation>
     </message>
     <message>
         <source>Scene:</source>
-        <translation type="obsolete">Výjev:</translation>
+        <translation type="unfinished">Výjev:</translation>
     </message>
     <message>
         <source>Subfolder Name:</source>
-        <translation type="obsolete">Název podsložky:</translation>
+        <translation type="unfinished">Název podsložky:</translation>
     </message>
     <message>
         <source>Subfolder name should not be empty.</source>
-        <translation type="obsolete">Název podsložky nesmí být prázdný.</translation>
+        <translation type="unfinished">Název podsložky nesmí být prázdný.</translation>
     </message>
     <message>
         <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
-        <translation type="obsolete">Název podsložky nesmí obsahovat následující znaky:  * . &quot; / \ [ ] : ; | = ,</translation>
+        <translation type="unfinished">Název podsložky nesmí obsahovat následující znaky:  * . &quot; / \ [ ] : ; | = ,</translation>
     </message>
     <message>
         <source>Folder %1 already exists.</source>
-        <translation type="obsolete">Soubor %1 již existuje.</translation>
+        <translation type="unfinished">Soubor %1 již existuje.</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">Složku %1 nelze vytvořit.</translation>
+        <translation type="unfinished">Složku %1 nelze vytvořit.</translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -16482,6 +17665,25 @@ Klepněte na tlačítko pro vytvoření nového pod-Xsheet</translation>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16855,6 +18057,10 @@ Klepněte na tlačítko pro vytvoření nového pod-Xsheet</translation>
     <message>
         <source>Expand toolbar</source>
         <translation>Rozbalit nástrojový pruh</translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -17281,11 +18487,11 @@ Please refer to the user guide for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reverse sheet symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17562,6 +18768,21 @@ Please refer to the user guide for details.</source>
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished">Přidat novou poznámku</translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished">Předchozí poznámka</translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished">Další poznámka</translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Frame</source>
@@ -17581,7 +18802,7 @@ Please refer to the user guide for details.</source>
     </message>
     <message>
         <source>Toggle Xsheet/Timeline</source>
-        <translation type="vanished">Přepnout záběr/časovou osu</translation>
+        <translation>Přepnout záběr/časovou osu</translation>
     </message>
     <message>
         <source>Add New Memo</source>
@@ -17712,6 +18933,12 @@ Podržte klávesu F3 v prohlížeči pro ukázání pouze tohoto snímku</transl
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/czech/toonzlib.ts
+++ b/toonz/sources/translations/czech/toonzlib.ts
@@ -157,27 +157,27 @@
         <translation type="unfinished">Výjimka při zápisu %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="268"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="264"/>
         <source>frame index (%1) must be a number</source>
         <translation type="unfinished">Číslo snímku (%1) musí být číslo</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="272"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="268"/>
         <source>frame index (%1) is out of range (0-%2)</source>
         <translation type="unfinished">Číslo snímku (%1) je mimo rozsah (0-%2)</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="295"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="291"/>
         <source>second argument (%1) is not an image</source>
         <translation type="unfinished">druhýý argument (%1) není obrázkem</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="308"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="304"/>
         <source>can not insert a %1 image into a level</source>
         <translation type="unfinished">nelze vložit %1 obrázek do úrovně</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="329"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="325"/>
         <source>can not insert a %1 image to a %2 level</source>
         <translation type="unfinished">nelze vložit %1 obrázek do %2 úrovně</translation>
     </message>
@@ -213,17 +213,17 @@
 <context>
     <name>Preferences</name>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="101"/>
+        <location filename="../../toonzlib/preferences.cpp" line="102"/>
         <source>Retas Level Format</source>
         <translation>Formát úrovně RETAS</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="107"/>
+        <location filename="../../toonzlib/preferences.cpp" line="108"/>
         <source>Adobe Photoshop</source>
         <translation>Adobe Photoshop</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="204"/>
+        <location filename="../../toonzlib/preferences.cpp" line="208"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
@@ -428,98 +428,98 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
         <translation>Obnovit barvy použitím vybraných poloh v paletě %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="908"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="917"/>
         <source>Add Fx  : </source>
         <translation>Přidat efekt: </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="909"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="918"/>
         <source>Insert Fx  : </source>
         <translation>Vložit efekt: </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1073"/>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1076"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1082"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1085"/>
         <source>Create Linked Fx  : %1</source>
         <translation>Vytvořit propojený efekt: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1298"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1307"/>
         <source>Replace Fx  : </source>
         <translation>Nahradit efekt: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1364"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1373"/>
         <source>Unlink Fx  : %1 - - %2</source>
         <translation>Zrušit propojení efektu: %1 - - %2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1405"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1414"/>
         <source>Make Macro Fx  : %1</source>
         <translation>Vytvořit makro efekt: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1548"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1557"/>
         <source>Explode Macro Fx  : %1</source>
         <translation>Rozbalit makro efekt: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1611"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1620"/>
         <source>Create Output Fx</source>
         <translation>Vytvořit výstupní efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1702"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1711"/>
         <source>Connect to Xsheet  : </source>
         <translation>Spojit s Xsheet: </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1762"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1771"/>
         <source>Disconnect from Xsheet  : </source>
         <translation>Odpojit od Xsheet: </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2035"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2044"/>
         <source>Delete Link</source>
         <translation>Smazat spojení</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2322"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2331"/>
         <source>Delete Fx Node : %1</source>
         <translation>Smazat uzel efektu: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2747"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2756"/>
         <source>Paste Fx  :  </source>
         <translation>Vložit efekt:  </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3116"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3125"/>
         <source>Disconnect Fx</source>
         <translation>Odpojit od efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3368"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3377"/>
         <source>Connect Fx : %1 - %2</source>
         <translation>Spojit efekt: %1 - %2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3550"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3559"/>
         <source>Rename Fx : %1 &gt; %2</source>
         <translation>Přejmenovat efekt: %1 - %2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3602"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3611"/>
         <source>Group Fx</source>
         <translation>Seskupit efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3706"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3715"/>
         <source>Ungroup Fx</source>
         <translation>Zrušit seskupení efektu</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3808"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3817"/>
         <source>Rename Group  : %1 &gt; %2</source>
         <translation>Přejmenovat skupinu: %1 &gt; %2</translation>
     </message>
@@ -529,12 +529,12 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
         <translation>Nastavit klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/doubleparamcmd.cpp" line="816"/>
+        <location filename="../../toonzlib/doubleparamcmd.cpp" line="817"/>
         <source>Remove Keyframe</source>
         <translation>Odstranit klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/doubleparamcmd.cpp" line="856"/>
+        <location filename="../../toonzlib/doubleparamcmd.cpp" line="857"/>
         <source>Cycle</source>
         <translation>Koloběh</translation>
     </message>
@@ -544,14 +544,14 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
         <translation>Přepnout volbu pro automatické malování  Paleta: %1  Styl #%2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="742"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="770"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="760"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="788"/>
         <source>None</source>
         <translation>Žádný</translation>
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="28"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="744"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="762"/>
         <source>Red</source>
         <translation>Červená</translation>
     </message>
@@ -572,7 +572,7 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="32"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="746"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="764"/>
         <source>Green</source>
         <translation>Zelená</translation>
     </message>
@@ -583,7 +583,7 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="34"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="748"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="766"/>
         <source>Blue</source>
         <translation>Modrá</translation>
     </message>
@@ -613,17 +613,17 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="750"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="768"/>
         <source>DarkYellow</source>
         <translation>Tmavá žlutá</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="752"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="770"/>
         <source>DarkCyan</source>
         <translation>Tmavá modrozelená</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="754"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="772"/>
         <source>DarkMagenta</source>
         <translation>Tmavá červenorudá</translation>
     </message>
@@ -723,7 +723,7 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
         <translation>Vektorizace selhala</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="235"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="231"/>
         <source>Argument &apos;%1&apos; does not look like a FrameId</source>
         <translation>Argument &apos;%1&apos; nevypadá jako ID snímku</translation>
     </message>
@@ -791,6 +791,7 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
     </message>
     <message>
         <location filename="../../toonzlib/cleanupcolorstyles.cpp" line="95"/>
+        <location filename="../../toonzlib/imagestyles.cpp" line="554"/>
         <source>Contrast</source>
         <translation>Kontrast</translation>
     </message>
@@ -825,6 +826,41 @@ Pravděpodobně kodek nemůže pracovat řádně.</translation>
     <message>
         <source>Move Center   %1  Frame %2</source>
         <translation type="vanished">Přesunout střed   %1 snímek %2</translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="540"/>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="542"/>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="544"/>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="546"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="548"/>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="550"/>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="552"/>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/czech/toonzqt.ts
+++ b/toonz/sources/translations/czech/toonzqt.ts
@@ -19,17 +19,27 @@
         <translation>Nahradit efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="248"/>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="484"/>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="620"/>
         <source>Insert </source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
         <source>Add </source>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="629"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
         <source>Replace </source>
         <translation>Nahradit</translation>
     </message>
@@ -91,12 +101,12 @@
 <context>
     <name>CameraPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="506"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="518"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Obnovit výchozí střed</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="509"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="521"/>
         <source>&amp;Activate</source>
         <translation>&amp;Zapnout</translation>
     </message>
@@ -104,85 +114,113 @@
 <context>
     <name>CameraSettingsWidget</name>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="406"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="210"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="215"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="432"/>
         <source>Pixels</source>
         <translation>Pixely</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="198"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="214"/>
         <source>DPI</source>
         <translation>DPI</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="195"/>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="199"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="210"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="215"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="200"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="216"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="204"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="221"/>
         <source>Use Current Level Settings</source>
         <translation>Použít nastavení nynější úrovně</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="207"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="224"/>
         <source>Add</source>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="208"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="225"/>
         <source>Remove</source>
         <translation>Odstranit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="245"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="262"/>
         <source>Force Squared Pixel</source>
         <translation>Vynutit čtvercové obrazové body</translation>
     </message>
     <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="217"/>
         <source>A/R</source>
-        <translation type="vanished">A/R</translation>
+        <translation>A/R</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="414"/>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="846"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="186"/>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="187"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="188"/>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="189"/>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="190"/>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="441"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="873"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;vlastní&gt;</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="892"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="919"/>
         <source>Bad camera preset</source>
         <translation>Špatné přednastavení kamery</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="893"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="920"/>
         <source>&apos;%1&apos; doesn&apos;t seem a well formed camera preset. 
 Possibly the preset file has been corrupted</source>
         <translation>Zdá se, že &apos;%1&apos; není dobře udělané přednastavení kamery.
 Možná byl soubor s přednastavením poškozen</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="926"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="953"/>
         <source>Preset name</source>
         <translation>Název přednastavení</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="927"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="954"/>
         <source>Enter the name for %1</source>
         <translation>Zadejte název pro %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="932"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="959"/>
         <source>Error : Preset Name is Invalid</source>
         <translation>Chyba: Název přednastavení je neplatný</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="933"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="960"/>
         <source>The preset name must not use &apos;,&apos;(comma).</source>
         <translation>Název přednastavení nesmí používat&apos;,&apos;(čárku).</translation>
     </message>
@@ -190,27 +228,27 @@ Možná byl soubor s přednastavením poškozen</translation>
 <context>
     <name>ChannelHisto</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="262"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="282"/>
         <source>Red</source>
         <translation>Červená</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="266"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="286"/>
         <source>Green</source>
         <translation>Zelená</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="270"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="290"/>
         <source>Blue</source>
         <translation>Modrá</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="274"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="294"/>
         <source>Alpha</source>
         <translation>Alfa</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="278"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="298"/>
         <source>RGB</source>
         <translation type="unfinished">RGB</translation>
     </message>
@@ -243,46 +281,32 @@ Možná byl soubor s přednastavením poškozen</translation>
 <context>
     <name>ColorChannelControl</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>R</source>
-        <translation type="unfinished">Č</translation>
+        <translation type="obsolete">Č</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>G</source>
-        <translation type="unfinished">Z</translation>
+        <translation type="obsolete">Z</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>B</source>
-        <translation type="unfinished">M</translation>
+        <translation type="obsolete">M</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>A</source>
-        <translation type="unfinished">A</translation>
+        <translation type="obsolete">A</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>H</source>
-        <translation type="unfinished">O</translation>
+        <translation type="obsolete">O</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>S</source>
-        <translation type="unfinished">S</translation>
+        <translation type="obsolete">S</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
         <source>V</source>
-        <translation type="unfinished">V</translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1379"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1381"/>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">V</translation>
     </message>
 </context>
 <context>
@@ -326,7 +350,7 @@ Zero is fully transparent.</source>
 <context>
     <name>ColumnPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="208"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="220"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Obnovit výchozí střed</translation>
     </message>
@@ -334,47 +358,59 @@ Zero is fully transparent.</source>
 <context>
     <name>ComboHistoRGBLabel</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="393"/>
-        <location filename="../../toonzqt/combohistogram.cpp" line="401"/>
-        <location filename="../../toonzqt/combohistogram.cpp" line="408"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="418"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="427"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="436"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="442"/>
         <source>R:%1 G:%2 B:%3</source>
         <translation>Č:%1 Z:%2 M:%3</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/combohistogram.cpp" line="422"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="431"/>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/combohistogram.cpp" line="446"/>
+        <source>A:%1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ComboHistogram</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="445"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="496"/>
         <source>8bit (0-255)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="447"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="498"/>
         <source>16bit (0-65535)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="450"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="501"/>
         <source>0.0-1.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="463"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="522"/>
         <source>Picked Color</source>
         <translation>Sebraná barva</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="471"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="530"/>
         <source>Average Color (Ctrl + Drag)</source>
         <translation>Průměrná barva (Ctrl+tažení)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="479"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="538"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="483"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="541"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
@@ -621,171 +657,176 @@ Zero is fully transparent.</source>
 <context>
     <name>FlipConsole</name>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="805"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="924"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1651"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1714"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="816"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="941"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1698"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1763"/>
         <source> FPS </source>
         <translation> FPS </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1197"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1223"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1201"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1227"/>
         <source>Snapshot</source>
         <translation>Snímek obrazovky</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1204"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1230"/>
         <source>Define Sub-camera</source>
         <translation>Určit podkameru</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1206"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1232"/>
         <source>Define Loading Box</source>
         <translation>Určit nahrávací box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1208"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1234"/>
         <source>Use Loading Box</source>
         <translation>Použít nahrávací box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1213"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1239"/>
         <source>Background Colors</source>
         <translation>Barvy pozadí</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1243"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1269"/>
         <source>Framerate</source>
         <translation>Počet snímků</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1215"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1241"/>
         <source>Playback Controls</source>
         <translation>Ovládání přehrávání</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1219"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1245"/>
         <source>Color Channels</source>
         <translation>Barevné kanály</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1230"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1256"/>
         <source>Set Key</source>
         <translation>Nastavit klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1225"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1251"/>
         <source>Histogram</source>
         <translation>Histogram</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="829"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="842"/>
         <source>This value is different than the scene framerate.
 Control click to reset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="908"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="925"/>
         <source>Cannot set the scene fps to a negative value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1222"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1248"/>
         <source>Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1228"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1254"/>
         <source>Locator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1233"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1259"/>
         <source>Display Areas as Filled</source>
         <translation>Zobrazit plochy jako vyplněné</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1240"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1266"/>
         <source>Viewer Controls</source>
         <translation>Ovládání pohledu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1269"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1272"/>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1298"/>
         <source>&amp;Save Images</source>
         <translation>&amp;Uložit obrázky</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1276"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1305"/>
         <source>&amp;Snapshot</source>
         <translation>&amp;Snímek obrazovky</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1280"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1309"/>
         <source>&amp;Compare to Snapshot</source>
         <translation>&amp;Porovnat se snímkem obrazovky</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1289"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1318"/>
         <source>&amp;Define Sub-camera</source>
         <translation>&amp;Určit podkameru</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1294"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1323"/>
         <source>&amp;Define Loading Box</source>
         <translation>&amp;Určit nahrávací box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1298"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1327"/>
         <source>&amp;Use Loading Box</source>
         <translation>&amp;Použít nahrávací box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1307"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1336"/>
         <source>&amp;White Background</source>
         <translation>&amp;Bílé pozadí</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1310"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1339"/>
         <source>&amp;Black Background</source>
         <translation>Č&amp;erné pozadí</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1314"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1343"/>
         <source>&amp;Checkered Background</source>
         <translation>Ša&amp;chovnicové pozadí</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1321"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1350"/>
         <source>&amp;First Frame</source>
         <translation>&amp;První snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1323"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1352"/>
         <source>&amp;Previous Frame</source>
         <translation>&amp;Předchozí snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1325"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1354"/>
         <source>Pause</source>
         <translation>Pozastavit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1328"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1357"/>
         <source>Play</source>
         <translation>Přehrát</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1331"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1360"/>
         <source>Loop</source>
         <translation>Smyčka</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1335"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1364"/>
         <source>&amp;Next Frame</source>
         <translation type="unfinished"></translation>
     </message>
@@ -794,123 +835,145 @@ Control click to reset.</source>
         <translation type="vanished">&amp;Další snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1337"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1366"/>
         <source>&amp;Last Frame</source>
         <translation>&amp;Poslední snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1346"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1349"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1375"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1378"/>
         <source>Red Channel</source>
         <translation>Červený kanál</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1350"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1379"/>
         <source>Red Channel in Grayscale</source>
         <translation>Červený kanál v odstínech šedi</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1353"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1357"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1382"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1386"/>
         <source>Green Channel</source>
         <translation>Zelený kanál</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1358"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1387"/>
         <source>Green Channel in Grayscale</source>
         <translation>Zelený kanál v odstínech šedi</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1361"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1364"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1390"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1393"/>
         <source>Blue Channel</source>
         <translation>Modrý kanál</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1365"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1394"/>
         <source>Blue Channel in Grayscale</source>
         <translation>Modrý kanál v odstínech šedi</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1371"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1400"/>
         <source>Alpha Channel</source>
         <translation>Alfa kanál</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1381"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1410"/>
         <source>&amp;Soundtrack </source>
         <translation>&amp;Zvukový doprovod</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1385"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1414"/>
         <source>&amp;Histogram</source>
         <translation>&amp;Histogram</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1387"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1416"/>
         <source>&amp;Locator</source>
         <translation>&amp;Polohový maják</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1394"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1423"/>
         <source>&amp;Display Areas as Filled</source>
         <translation>&amp;Zobrazit plochy jako vyplněné</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1408"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1437"/>
         <source>&amp;Zoom In</source>
         <translation>&amp;Přiblížit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1410"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1439"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Oddálit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1412"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1441"/>
         <source>&amp;Flip Horizontally</source>
         <translation>Převrátit &amp;vodorovně</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1414"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1443"/>
         <source>&amp;Flip Vertically</source>
         <translation>Převrátit &amp;svisle</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1416"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1445"/>
         <source>&amp;Reset View</source>
         <translation>&amp;Obnovit výchozí pohled</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1657"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1451"/>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1457"/>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1462"/>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1704"/>
         <source> FPS	</source>
         <translation> FPS	</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1842"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1905"/>
         <source>Set the current frame</source>
         <translation>Nastavit nynější snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1846"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1909"/>
         <source>Drag to play the animation</source>
         <translation>Táhnout pro přehrání animace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1906"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1976"/>
         <source>Set the playback frame rate</source>
         <translation>Nastavit snímkování přehrávání</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="2238"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="2254"/>
+        <source> (gain %1)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FontParamField</name>
     <message>
-        <location filename="../../toonzqt/paramfield.cpp" line="1678"/>
+        <location filename="../../toonzqt/paramfield.cpp" line="1681"/>
         <source>Style:</source>
         <translation>Styl:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paramfield.cpp" line="1682"/>
+        <location filename="../../toonzqt/paramfield.cpp" line="1685"/>
         <source>Size:</source>
         <translation>Velikost:</translation>
     </message>
@@ -950,132 +1013,132 @@ Control click to reset.</source>
 <context>
     <name>FunctionPanel</name>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="255"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="256"/>
         <source>Function Curves</source>
         <translation>Křivky funkce</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1548"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1579"/>
         <source>Link Handles</source>
         <translation>Propojit úchopy</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1549"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1580"/>
         <source>Unlink Handles</source>
         <translation>Zrušit propojení úchopů</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1550"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1581"/>
         <source>Reset Handles</source>
         <translation>Obnovit výchozí úchopy</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1551"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1582"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1552"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1583"/>
         <source>Set Key</source>
         <translation>Nastavit klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1553"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1584"/>
         <source>Activate Cycle</source>
         <translation>Zapnout koloběh</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1554"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1585"/>
         <source>Deactivate Cycle</source>
         <translation>Vypnout koloběh</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1555"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1586"/>
         <source>Linear Interpolation</source>
         <translation>Lineární interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1556"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1587"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation>Interpolace zrychlení na začátku/na konci</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1557"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1588"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation>Interpolace zpomalení na začátku/na konci</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1558"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1589"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation>Interpolace zpomalení na začátku/na konci (%)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1559"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1590"/>
         <source>Exponential Interpolation</source>
         <translation>Exponenciální interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1560"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1591"/>
         <source>Expression Interpolation</source>
         <translation>Výrazová interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1561"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1592"/>
         <source>File Interpolation</source>
         <translation>Souborová interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1562"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1593"/>
         <source>Constant Interpolation</source>
         <translation>Stálá interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1563"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1594"/>
         <source>Similar Shape Interpolation</source>
         <translation>Interpolace skrze podobné tvary</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1564"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1595"/>
         <source>Fit Selection</source>
         <translation>Přizpůsobit výběr</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1565"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1596"/>
         <source>Fit</source>
         <translation>Přizpůsobit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1566"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1597"/>
         <source>Step 1</source>
         <translation>Krok 1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1567"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1598"/>
         <source>Step 2</source>
         <translation>Krok 2</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1568"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1599"/>
         <source>Step 3</source>
         <translation>Krok 3</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1569"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1600"/>
         <source>Step 4</source>
         <translation>Krok 4</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1641"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1672"/>
         <source>Smooth</source>
         <translation>Vyhladit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1642"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1673"/>
         <source>Frame Based</source>
         <translation>Založeno na snímku</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1643"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1674"/>
         <source>Curve Shape</source>
         <translation>Tvar křivky</translation>
     </message>
@@ -1224,7 +1287,7 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheet</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1196"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1206"/>
         <source>Function Editor</source>
         <translation>Editor funkce</translation>
     </message>
@@ -1240,57 +1303,57 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheetCellViewer</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1038"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1048"/>
         <source>Delete Key</source>
         <translation>Smazat klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1039"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1049"/>
         <source>Set Key</source>
         <translation>Nastavit klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1042"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
         <source>Linear Interpolation</source>
         <translation>Lineární interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1043"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1053"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation>Interpolace zrychlení na začátku/na konci</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1044"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1054"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation>Interpolace zpomalení na začátku/na konci</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1045"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1055"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation>Interpolace zpomalení na začátku/na konci (%)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1046"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1056"/>
         <source>Exponential Interpolation</source>
         <translation>Exponenciální interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1047"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1057"/>
         <source>Expression Interpolation</source>
         <translation>Výrazová interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1047"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1057"/>
         <source>File Interpolation</source>
         <translation>Souborová interpolace</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1048"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1058"/>
         <source>Similar Shape Interpolation</source>
         <translation>Interpolace skrze podobné tvary</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1042"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
         <source>Constant Interpolation</source>
         <translation>Stálá interpolace</translation>
     </message>
@@ -1311,32 +1374,32 @@ Control click to reset.</source>
         <translation type="vanished">Krok 4</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1049"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1059"/>
         <source>Activate Cycle</source>
         <translation>Zapnout koloběh</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1050"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1060"/>
         <source>Deactivate Cycle</source>
         <translation>Vypnout koloběh</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1051"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1061"/>
         <source>Show Inbetween Values</source>
         <translation>Ukázat hodnoty mezilehlých snímků</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1062"/>
         <source>Hide Inbetween Values</source>
         <translation>Skrýt hodnoty mezilehlých snímků</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1102"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1112"/>
         <source>Change Interpolation</source>
         <translation>Změnit interpolaci</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1117"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1127"/>
         <source>Change Step</source>
         <translation>Změnit krok</translation>
     </message>
@@ -1344,7 +1407,7 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheetColumnHeadViewer</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="456"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="465"/>
         <source>Some key(s) in this parameter loses original reference in expression.
 Manually changing any keyframe will clear the warning.</source>
         <translation type="unfinished"></translation>
@@ -1366,17 +1429,17 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FunctionTreeModel</name>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="895"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="859"/>
         <source>Stage</source>
         <translation>Fáze</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="896"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="860"/>
         <source>FX</source>
         <translation>Efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1060"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1024"/>
         <source>Plastic Skeleton</source>
         <translation>Tvárná kostra</translation>
     </message>
@@ -1384,7 +1447,7 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FunctionTreeModel::Channel</name>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="668"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="632"/>
         <source>Some key(s) in this parameter loses original reference in expression.
 Manually changing any keyframe will clear the warning.</source>
         <translation type="unfinished"></translation>
@@ -1398,34 +1461,34 @@ Manually changing any keyframe will clear the warning.</source>
         <translation>Tabulka</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1649"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1609"/>
         <source>Save Curve</source>
         <translation>Uložit křivku</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1650"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1610"/>
         <source>Load Curve</source>
         <translation>Nahrát křivku (parametr efektu)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1651"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1611"/>
         <source>Export Data</source>
         <translation>Vyvést data</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="581"/>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1677"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="590"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1637"/>
         <source>Show Animated Only</source>
         <translation>Ukázat jen kreslené</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="582"/>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1678"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="591"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1638"/>
         <source>Show All</source>
         <translation>Ukázat vše</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="583"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="592"/>
         <source>Hide Selected</source>
         <translation>Skrýt vybrané</translation>
     </message>
@@ -1441,32 +1504,32 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Spojit s Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="267"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="280"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="271"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="286"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="278"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="294"/>
         <source>&amp;Paste Add</source>
         <translation>&amp;Vložit/Přidat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="281"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="298"/>
         <source>&amp;Preview</source>
         <translation>&amp;Náhled</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="288"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="305"/>
         <source>&amp;Uncache Fx</source>
         <translation>&amp;Smazat efekt z vyrovnávací paměti</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="288"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="305"/>
         <source>&amp;Cache FX</source>
         <translation>&amp;Vytvořit vyrovnávací paměť pro efekt</translation>
     </message>
@@ -1474,17 +1537,17 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxOutputPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1055"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1117"/>
         <source>Output</source>
         <translation>Výstup</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1073"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1136"/>
         <source>&amp;Delete</source>
         <translation>S&amp;mazat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1076"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1139"/>
         <source>&amp;Activate</source>
         <translation>&amp;Zapnout</translation>
     </message>
@@ -1492,22 +1555,22 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="703"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="747"/>
         <source>&amp;Open Group</source>
         <translation>&amp;Otevřít skupinu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="706"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="751"/>
         <source>&amp;Paste Replace</source>
         <translation>&amp;Vložit/Nahradit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="709"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="755"/>
         <source>&amp;Paste Add</source>
         <translation>&amp;Vložit/Přidat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="715"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="762"/>
         <source>&amp;Delete</source>
         <translation>S&amp;mazat</translation>
     </message>
@@ -1520,57 +1583,57 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Spojit s Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="719"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="767"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="723"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="773"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="727"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="778"/>
         <source>&amp;Create Linked FX</source>
         <translation>&amp;Vytvořit propojený efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="730"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="782"/>
         <source>&amp;Unlink</source>
         <translation>&amp;Zrušit propojení</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="733"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="786"/>
         <source>&amp;Make Macro FX</source>
         <translation>&amp;Vytvořit makro efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="736"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="790"/>
         <source>&amp;Explode Macro FX</source>
         <translation>&amp;Rozbalit makro efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="740"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="795"/>
         <source>&amp;Open Macro FX</source>
         <translation>&amp;Otevřít makro efekt</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="743"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="799"/>
         <source>&amp;Save As Preset...</source>
         <translation>&amp;Uložit jako přednastavení</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="746"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="803"/>
         <source>&amp;Preview</source>
         <translation>&amp;Náhled</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="752"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="811"/>
         <source>&amp;Uncache FX</source>
         <translation>&amp;Smazat efekt z vyrovnávací paměti</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="752"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="811"/>
         <source>&amp;Cache FX</source>
         <translation>&amp;Vytvořit vyrovnávací paměť pro efekt</translation>
     </message>
@@ -1586,17 +1649,17 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Spojit s Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="483"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="512"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="487"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="518"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="491"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="523"/>
         <source>&amp;Preview</source>
         <translation>&amp;Náhled</translation>
     </message>
@@ -1604,12 +1667,12 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxPassThroughPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3842"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3913"/>
         <source>&amp;Paste Add</source>
         <translation type="unfinished">&amp;Vložit/Přidat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3845"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3917"/>
         <source>&amp;Preview</source>
         <translation type="unfinished">&amp;Náhled</translation>
     </message>
@@ -1617,12 +1680,12 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicLink</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1121"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1185"/>
         <source>&amp;Delete</source>
         <translation>S&amp;mazat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1124"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1189"/>
         <source>&amp;Paste Insert</source>
         <translation>&amp;Vložit/Přidat</translation>
     </message>
@@ -1630,7 +1693,7 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicOutputNode</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="2248"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="2316"/>
         <source>Output</source>
         <translation>Výstup</translation>
     </message>
@@ -1638,8 +1701,8 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicPassThroughNode</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3896"/>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="4007"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3968"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="4079"/>
         <source> (Pass Through)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1655,12 +1718,12 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Spojit s Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1590"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1656"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1594"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1662"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1668,21 +1731,21 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicScene</name>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1787"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1776"/>
         <source>Cannot Paste Insert a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation>Nelze vložit/přidat výběr nespojených efektových uzlů.
 Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírováním nebo vyjmutím výběru.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1797"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1786"/>
         <source>Cannot Paste Add a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation>Nelze vložit/přidat výběr nespojených efektových uzlů.
 Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírováním nebo vyjmutím výběru.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1807"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1796"/>
         <source>Cannot Paste Replace a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation>Nelze vložit/nahradit výběr nespojených efektových uzlů.
@@ -1696,7 +1759,7 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
         <translation type="vanished">XSheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="2325"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="2393"/>
         <source>Scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1704,37 +1767,37 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
 <context>
     <name>FxSettings</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1318"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1351"/>
         <source>&amp;Camera Preview</source>
         <translation>&amp;Náhled kamery</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1324"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1357"/>
         <source>&amp;Preview</source>
         <translation>&amp;Náhled</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1337"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1370"/>
         <source>&amp;White Background</source>
         <translation>&amp;Bílé pozadí</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1345"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1378"/>
         <source>&amp;Black Background</source>
         <translation>Č&amp;erné pozadí</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1352"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1385"/>
         <source>&amp;Checkered Background</source>
         <translation>Ša&amp;chovnicové pozadí</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1424"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1470"/>
         <source>Fx Settings</source>
         <translation>Nastavení efektu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1426"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1472"/>
         <source> : </source>
         <translation>: </translation>
     </message>
@@ -1746,17 +1809,17 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
         <translation type="vanished">Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="951"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1011"/>
         <source>Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="985"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1046"/>
         <source>&amp;Paste Add</source>
         <translation>&amp;Vložit/Přidat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="988"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1050"/>
         <source>&amp;Preview</source>
         <translation>&amp;Náhled</translation>
     </message>
@@ -1764,7 +1827,7 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
 <context>
     <name>GroupPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="349"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="361"/>
         <source>&amp;Open Group</source>
         <translation>&amp;Otevřít skupinu</translation>
     </message>
@@ -1832,42 +1895,42 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="890"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="894"/>
         <source>Open Color Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="891"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
         <source>Text or XML (*.txt *.xml);;Text files (*.txt);;XML files (*.xml)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="899"/>
         <source>Hex Color Names Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="899"/>
         <source>Do you want to merge with existing entries?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="901"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="905"/>
         <source>Error importing color names XML</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="917"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="921"/>
         <source>Save Color Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="918"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="922"/>
         <source>XML files (*.xml);;Text files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="927"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="931"/>
         <source>Error exporting color names XML</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1913,7 +1976,7 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
 <context>
     <name>InfoViewer</name>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="117"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="118"/>
         <source>File Info</source>
         <translation>Informace o souboru</translation>
     </message>
@@ -1956,32 +2019,32 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
 <context>
     <name>NewStyleSetPopup</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6960"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7190"/>
         <source>New Style Set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6963"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7193"/>
         <source>Style Set Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6965"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7195"/>
         <source>Create as Favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6968"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7198"/>
         <source>Style Set Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6994"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7224"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6995"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7225"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušit</translation>
     </message>
@@ -2007,34 +2070,27 @@ Vyberte uzly efektů a příbuzné odkazy, jež chcete vložit, před kopírová
 <context>
     <name>PageViewer</name>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="609"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="613"/>
         <source>- No Styles -</source>
         <translation type="unfinished">- Žádné styly -</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="686"/>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="942"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="690"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="955"/>
         <source> + </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1179"/>
-        <source>Name Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1233"/>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1417"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1436"/>
         <source>New Style</source>
         <translation type="unfinished">Nový styl</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1235"/>
         <source>New Page</source>
-        <translation type="unfinished">Nová strana</translation>
+        <translation type="obsolete">Nová strana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1403"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1422"/>
         <source>Style 0 is set to full transparent. 
 It can&apos;t be changed.  Ever.</source>
         <translation type="unfinished"></translation>
@@ -2043,53 +2099,55 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>PaletteViewer</name>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="320"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="624"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="666"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="354"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="659"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="754"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="796"/>
         <source>&amp;Save Palette As</source>
         <translation>&amp;Uložit paletu jako</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="321"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="512"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="625"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="667"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="355"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="640"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="653"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="755"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="797"/>
         <source>&amp;Save Palette</source>
         <translation>&amp;Uložit paletu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="376"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="401"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="442"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="478"/>
         <source>Lock Palette</source>
         <translation>Uzamknout paletu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="405"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="482"/>
         <source>&amp;Lock Palette</source>
         <translation>&amp;Uzamknout paletu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="463"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="555"/>
         <source>Options</source>
         <translation>Volby</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="484"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="576"/>
         <source>&amp;Small Thumbnails View</source>
         <translation>&amp;Malé náhledy</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="485"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="577"/>
         <source>&amp;Medium Thumbnails View</source>
         <translation>&amp;Střední náhledy</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="486"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="578"/>
         <source>&amp;Large Thumbnails View</source>
         <translation>&amp;Velké náhledy</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="487"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="579"/>
         <source>&amp;List View</source>
         <translation>&amp;Pohled se seznamem</translation>
     </message>
@@ -2106,142 +2164,163 @@ It can&apos;t be changed.  Ever.</source>
         <translation type="vanished">Oba názvy</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="152"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="154"/>
         <source>&amp;New Page</source>
         <translation>&amp;Nová strana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="592"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="602"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="722"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="732"/>
         <source>&amp;New Style</source>
         <translation>&amp;Nový styl</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="457"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="925"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="549"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1057"/>
         <source>&amp;Move Palette</source>
         <translation>&amp;Posunout paletu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="322"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="628"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="670"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="722"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="356"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="758"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="800"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="852"/>
         <source>&amp;Save As Default Vector Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="323"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="629"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="671"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="725"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="357"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="759"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="801"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="855"/>
         <source>&amp;Save As Default Smart Raster Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="324"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="630"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="672"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="728"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="358"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="760"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="802"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="858"/>
         <source>&amp;Save As Default Raster Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="325"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="631"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="673"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="731"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="359"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="761"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="803"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="861"/>
         <source>&amp;Save As Default Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="389"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="455"/>
         <source>Stay on Current Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="453"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="499"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="618"/>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="545"/>
         <source>Drag this icon to a Studio or Project palette to add it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="490"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="582"/>
         <source>Show Style Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="513"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="604"/>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="606"/>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="614"/>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="641"/>
         <source>Save the palette.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="626"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="668"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="756"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="798"/>
         <source>&amp;Palette Gizmo</source>
         <translation>Upravit &amp;paletu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="743"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="874"/>
         <source>New Page</source>
         <translation>Nová strana</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="755"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="887"/>
         <source>Delete Page</source>
         <translation>Smazat stranu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1137"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1269"/>
         <source>Overwrite</source>
         <translation>Přepsat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1137"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1269"/>
         <source>Don&apos;t Overwrite</source>
         <translation>Nepřepisovat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1146"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1278"/>
         <source>Failed to save palette.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1284"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1416"/>
         <source>Palette</source>
         <translation>Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1288"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1420"/>
         <source>Level Palette: </source>
         <translation>Paleta úrovně: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1295"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1427"/>
         <source>Cleanup Palette</source>
         <translation>Vyčistit paletu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1306"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1438"/>
         <source>Studio Palette</source>
         <translation>Studiová paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1313"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1445"/>
         <source>     (Color Model: </source>
         <translation> (Barevný model: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1315"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1447"/>
         <source>)</source>
         <translation>)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1354"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1486"/>
         <source>Hide New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1355"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1487"/>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2296,7 +2375,7 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>ParamViewer</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1058"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1082"/>
         <source>Swatch Viewer</source>
         <translation>Pohled na vzor</translation>
     </message>
@@ -2308,15 +2387,22 @@ It can&apos;t be changed.  Ever.</source>
         <translation type="vanished">Nápověda</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="746"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="723"/>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1062"/>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PegbarPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="416"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="428"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Obnovit výchozí střed</translation>
     </message>
@@ -2324,12 +2410,12 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>PlaneViewer</name>
     <message>
-        <location filename="../../toonzqt/planeviewer.cpp" line="303"/>
+        <location filename="../../toonzqt/planeviewer.cpp" line="309"/>
         <source>Reset View</source>
         <translation>Obnovit výchozí pohled</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/planeviewer.cpp" line="308"/>
+        <location filename="../../toonzqt/planeviewer.cpp" line="314"/>
         <source>Fit To Window</source>
         <translation>Přizpůsobit oknu</translation>
     </message>
@@ -2422,148 +2508,148 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 Druhý řádek by měl být &quot;Mesh [Input bit depth] [Output bit depth]&quot;</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/lutcalibrator.cpp" line="520"/>
-        <location filename="../../toonzqt/lutcalibrator.cpp" line="537"/>
+        <location filename="../../toonzqt/lutcalibrator.cpp" line="524"/>
+        <location filename="../../toonzqt/lutcalibrator.cpp" line="545"/>
         <source>Failed to Load 3DLUT File.</source>
         <translation>Nepodařilo se nahrát soubor 3DLUT.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="953"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="980"/>
         <source>Deleting &quot;%1&quot;.
 Are you sure?</source>
         <translation>Maže se &quot;%1&quot;
 Jste si jistý?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="955"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="982"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="955"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="982"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="856"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1350"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1436"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2026"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2045"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2153"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6423"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="773"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="1076"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="775"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1078"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="186"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="187"/>
         <source>It is not possible to delete the style #</source>
         <translation>Není možné smazat styl #</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="321"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="323"/>
         <source>Paste Style  in Palette : %1</source>
         <translation>Vložit styl do palety: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="397"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="399"/>
         <source>Delete Style  from Palette : %1</source>
         <translation>Smazat styl z palety: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="466"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="468"/>
         <source>Cut Style  from Palette : %1</source>
         <translation>Vyjmout styl z palety: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="587"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="659"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="589"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="661"/>
         <source>It is not possible to delete styles #0 and #1.</source>
         <translation>Není možné smazat styly #0 a #1.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="638"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="640"/>
         <source>Can&apos;t paste styles there</source>
         <translation>Nelze vložit styl</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="759"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="761"/>
         <source>There are no unused styles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="766"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="768"/>
         <source>and %1 more styles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="769"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="771"/>
         <source>Erasing unused styles with following indices. Are you sure?
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="773"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="775"/>
         <source>Erase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1037"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1039"/>
         <source>  to Palette : %1</source>
         <translation>  do palety: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1040"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1042"/>
         <source>Paste Color &amp;&amp; Name%1</source>
         <translation>Vložit barvu a název %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1042"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1044"/>
         <source>Paste Name%1</source>
         <translation>Vložit název %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1044"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1046"/>
         <source>Paste Color%1</source>
         <translation>Vložit barvu %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1046"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1048"/>
         <source>Paste%1</source>
         <translation>Vložit %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1062"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1064"/>
         <source>Can&apos;t modify color #0</source>
         <translation>Nelze změnit barvu #0</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1072"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1074"/>
         <source>There are more cut/copied styles than selected. Paste anyway (adding styles)?</source>
         <translation>Je tu více vyjmutých/zkopírovaných stylů, než je vybráno. Přesto vložit (přidání stylů)?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1076"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1078"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1317"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1319"/>
         <source>Blend Colors  in Palette : %1</source>
         <translation>Smíchat barvy v paletě: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1447"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1449"/>
         <source>Toggle Link  in Palette : %1</source>
         <translation>Přepnout spojení v paletě: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1637"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1639"/>
         <source>Remove Reference  in Palette : %1</source>
         <translation>Odstranit odkaz v paletě: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1754"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1756"/>
         <source>Get Color from Studio Palette</source>
         <translation>Získat barvu ze studiové palety</translation>
     </message>
@@ -2593,38 +2679,38 @@ Jste si jistý?</translation>
         <translation>Posunout klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1007"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="999"/>
         <source>Save Motion Path</source>
         <translation>Nová cestu pohybu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1009"/>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1059"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1001"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1051"/>
         <source>Motion Path files (*.mpath)</source>
         <translation>Soubory s cestami pohybu (*.mpath)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1047"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1039"/>
         <source>It is not possible to save the motion path.</source>
         <translation>Není možné uložit cestu pohybu.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1057"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1049"/>
         <source>Load Motion Path</source>
         <translation>Nahrát cestu pohybu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1087"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1079"/>
         <source>It is not possible to load the motion path.</source>
         <translation>Není možné nahrát cestu pohybu.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1124"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1219"/>
         <source>Stage Schematic</source>
         <translation>Náčrtek jeviště</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1146"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1241"/>
         <source>FX Schematic</source>
         <translation>Náčrtek efektu</translation>
     </message>
@@ -2634,61 +2720,208 @@ Jste si jistý?</translation>
         <translation>Změnit styl   Paleta: %1  Styl #%2  [R%3 G%4 B%5] -&gt; [R%6 G%7 B%8]</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2023"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>R</source>
+        <translation type="unfinished">Č</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>G</source>
+        <translation type="unfinished">Z</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>B</source>
+        <translation type="unfinished">M</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>H</source>
+        <translation type="unfinished">O</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>S</source>
+        <translation type="unfinished">S</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1363"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1380"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1382"/>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2032"/>
         <source>Removing a Style will permanently delete the style file. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2041"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2050"/>
         <source>Emptying Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2149"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2162"/>
         <source>Removing Style Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2607"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2251"/>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2307"/>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2314"/>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2318"/>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2326"/>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2341"/>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2358"/>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2380"/>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2388"/>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2396"/>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2413"/>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2431"/>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2442"/>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2448"/>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2460"/>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2465"/>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2472"/>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2480"/>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2488"/>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2639"/>
         <source>Plain color</source>
         <comment>CustomStyleChooserPage</comment>
         <translation type="unfinished">Normální barva</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2822"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2856"/>
         <source>Plain color</source>
         <comment>VectorBrushStyleChooserPage</comment>
         <translation>Normální barva</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3075"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3115"/>
         <source>Plain color</source>
         <comment>TextureStyleChooserPage</comment>
         <translation type="unfinished">Normální barva</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3087"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3127"/>
         <source>Custom Texture</source>
         <comment>TextureStyleChooserPage</comment>
         <translation>Vlastní textura (povrch)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3253"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3300"/>
         <source>Plain color</source>
         <comment>MyPaintBrushStyleChooserPage</comment>
         <translation>Normální barva</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3447"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3551"/>
         <source>Plain color</source>
         <comment>SpecialStyleChooserPage</comment>
         <translation>Normální barva</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6420"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3725"/>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">Automatické malování pro čáry</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3883"/>
+        <source>Reset to default</source>
+        <translation type="unfinished">Vrátit na výchozí</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6639"/>
         <source>Removing the selected Styles will permanently delete style files from their sets. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
@@ -2779,197 +3012,202 @@ Are you sure?</source>
         <translation type="vanished">Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1114"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1246"/>
         <source>Overwrite</source>
         <translation>Přepsat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1115"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1247"/>
         <source>Don&apos;t Overwrite</source>
         <translation>Nepřepisovat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/menubarcommand.cpp" line="292"/>
+        <location filename="../../toonzqt/menubarcommand.cpp" line="293"/>
         <source>It is not possible to assign a shortcut with modifiers to the visualization commands.</source>
         <translation>Není možné přiřadit klávesovou zkratku s modifikátory k příkazům pro znázornění.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="174"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="175"/>
         <source>Current Frame: </source>
         <translation>Nynější snímek: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="177"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="178"/>
         <source>File History</source>
         <translation>Historie souboru</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="185"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="186"/>
         <source>Fullpath:     </source>
         <translation>Plná cesta:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="186"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="187"/>
         <source>File Type:    </source>
         <translation>Typ souboru:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="187"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="188"/>
         <source>Frames:       </source>
         <translation> Snímky:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="188"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="189"/>
         <source>Owner:        </source>
         <translation>Vlastník:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="189"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="190"/>
         <source>Size:         </source>
         <translation>Velikost:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="191"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="192"/>
         <source>Created:      </source>
         <translation>Vytvořeno:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="192"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="193"/>
         <source>Modified:     </source>
         <translation>Změněno:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="193"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="194"/>
         <source>Last Access:  </source>
         <translation>Poslední přístup:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="197"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="198"/>
         <source>Image Size:   </source>
         <translation>Velikost obrázku:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="198"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="199"/>
         <source>SaveBox:      </source>
         <translation>Ukládací box:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="199"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="200"/>
         <source>Bits/Sample:  </source>
         <translation>Bity/Vzorek:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="200"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="201"/>
         <source>Sample/Pixel: </source>
         <translation>Vzorek/Pixel:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="201"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="202"/>
         <source>Dpi:          </source>
         <translation>DPI:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="202"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="203"/>
         <source>Orientation:  </source>
         <translation>Natočení:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="203"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="204"/>
         <source>Compression:  </source>
         <translation>Komprese:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="204"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="205"/>
         <source>Quality:      </source>
         <translation>Jakost:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="205"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="206"/>
         <source>Smoothing:    </source>
         <translation>Vyhlazování:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="206"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="207"/>
         <source>Codec:        </source>
         <translation>Kodek:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="207"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="208"/>
         <source>Alpha Channel:</source>
         <translation>Alfa kanál:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="208"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="209"/>
         <source>Byte Ordering:</source>
         <translation>Pořadí bytů:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="209"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="210"/>
         <source>H Pos:</source>
         <translation>Vodorovná poloha:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="210"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="211"/>
         <source>Palette Pages:</source>
         <translation>Strany palety:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="211"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="212"/>
         <source>Palette Styles:</source>
         <translation>Styly palety:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="213"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="214"/>
         <source>Camera Size:      </source>
         <translation>Velikost kamery:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="214"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="215"/>
         <source>Camera Dpi:       </source>
         <translation>DPI kamery:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="215"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="216"/>
         <source>Number of Frames: </source>
         <translation>Počet snímků:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="216"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="217"/>
         <source>Number of Levels: </source>
         <translation>Počet úrovní:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="217"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="218"/>
         <source>Output Path:      </source>
         <translation>Výstupní cesta:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="218"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="219"/>
         <source>Endianess:      </source>
         <translation>Endian:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="221"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="222"/>
         <source>Length:       </source>
         <translation>Délka:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="222"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="223"/>
         <source>Channels: </source>
         <translation>Kanály:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="223"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="224"/>
         <source>Sample Rate: </source>
         <translation>Vzorkovací kmitočet: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="224"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="225"/>
         <source>Sample Size:      </source>
         <translation>Velikost vzorku:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="549"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="226"/>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/infoviewer.cpp" line="579"/>
         <source>The file %1 does not exist.</source>
         <translation>Soubor %1 neexistuje.</translation>
     </message>
@@ -3019,12 +3257,12 @@ Are you sure?</source>
         <translation>Zdá se, že zdrojový obrázek není vhodný pro tento druh převodu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/gutil.cpp" line="608"/>
+        <location filename="../../toonzqt/gutil.cpp" line="676"/>
         <source>The file name cannot be empty or contain any of the following characters: (new line) \ / : * ? &quot; |</source>
         <translation>Název souboru nesmí být prázdný nebo obsahovat následující znaky: (nový řádek)  \ / : * ? &quot;  |</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/gutil.cpp" line="635"/>
+        <location filename="../../toonzqt/gutil.cpp" line="703"/>
         <source>That is a reserved file name and cannot be used.</source>
         <translation>Toto je vyhrazený název souboru a nelze jej použít.</translation>
     </message>
@@ -3086,10 +3324,10 @@ Are you sure?</source>
     </message>
     <message>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2026"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2045"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2153"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6423"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
         <source>Ok</source>
         <translation>OK</translation>
     </message>
@@ -3109,7 +3347,22 @@ Jste si jistý?</translation>
         <translation type="vanished">Nastavit</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1705"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1196"/>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1252"/>
+        <source>New Style</source>
+        <translation type="unfinished">Nový styl</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1255"/>
+        <source>New Page</source>
+        <translation type="unfinished">Nová strana</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1720"/>
         <source>Click &amp; Drag Palette into Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3133,9 +3386,9 @@ Jste si jistý?</translation>
 <context>
     <name>RenameStyleSet</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7152"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7167"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7179"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7385"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7400"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7412"/>
         <source> (Favorites)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3184,71 +3437,71 @@ Jste si jistý?</translation>
 <context>
     <name>SchematicViewer</name>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="971"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1066"/>
         <source>&amp;Fit to Window</source>
         <translation>&amp;Přizpůsobit oknu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="977"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1072"/>
         <source>&amp;Focus on Current</source>
         <translation>&amp;Zaměřit na nynější předmět</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="982"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1077"/>
         <source>&amp;Reorder Nodes</source>
         <translation>&amp;Přeuspořádat uzly</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="988"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1083"/>
         <source>&amp;Reset Size</source>
         <translation>&amp;Obnovit výchozí velikost</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="995"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1171"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1227"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1090"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1266"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1322"/>
         <source>&amp;Minimize Nodes</source>
         <translation>&amp;Zmenšit uzly</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="995"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1172"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1228"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1090"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1267"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1323"/>
         <source>&amp;Maximize Nodes</source>
         <translation>&amp;Zvětšit uzly</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1001"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1096"/>
         <source>&amp;Selection Mode</source>
         <translation>Režim &amp;výběru</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1006"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1101"/>
         <source>&amp;Zoom Mode</source>
         <translation>Režim &amp;zvětšení</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1011"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1106"/>
         <source>&amp;Hand Mode</source>
         <translation>&amp;Ruční režim</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1019"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1114"/>
         <source>&amp;New Pegbar</source>
         <translation>&amp;Nový pruh na kolíky</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1026"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1121"/>
         <source>&amp;New Camera</source>
         <translation>&amp;Nová kamera</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1033"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1128"/>
         <source>&amp;New Motion Path</source>
         <translation>&amp;Nová cesta pohybu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1041"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1136"/>
         <source>&amp;Switch output port display mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3257,7 +3510,7 @@ Jste si jistý?</translation>
         <translation type="vanished">&amp;Přepnout režim zobrazení výstupní přípojky (port)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1056"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1151"/>
         <source>&amp;Toggle node icons</source>
         <translation>&amp;Přepnout ikony uzlů</translation>
     </message>
@@ -3265,7 +3518,7 @@ Jste si jistý?</translation>
 <context>
     <name>SchematicWindowEditor</name>
     <message>
-        <location filename="../../toonzqt/schematicgroupeditor.cpp" line="170"/>
+        <location filename="../../toonzqt/schematicgroupeditor.cpp" line="164"/>
         <source>&amp;Close Editor</source>
         <translation>&amp;Zavřít editor</translation>
     </message>
@@ -3273,14 +3526,12 @@ Jste si jistý?</translation>
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3621"/>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">Automatické malování pro čáry</translation>
+        <translation type="obsolete">Automatické malování pro čáry</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3779"/>
         <source>Reset to default</source>
-        <translation type="unfinished">Vrátit na výchozí</translation>
+        <translation type="obsolete">Vrátit na výchozí</translation>
     </message>
 </context>
 <context>
@@ -3351,17 +3602,17 @@ Jste si jistý?</translation>
 <context>
     <name>SplinePainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="680"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="692"/>
         <source>&amp;Delete</source>
         <translation>S&amp;mazat</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="683"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="695"/>
         <source>&amp;Save Motion Path...</source>
         <translation>&amp;Uložit cestu pohybu...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="685"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="697"/>
         <source>&amp;Load Motion Path...</source>
         <translation>&amp;Nahrát cestu pohybu...</translation>
     </message>
@@ -3382,17 +3633,17 @@ Jste si jistý?</translation>
 <context>
     <name>StageSchematicScene</name>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1179"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1171"/>
         <source>&amp;New Pegbar</source>
         <translation>&amp;Nový pruh na kolíky</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1183"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1175"/>
         <source>&amp;New Motion Path</source>
         <translation>&amp;Nová cesta pohybu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1187"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1179"/>
         <source>&amp;New Camera</source>
         <translation>&amp;Nová kamera</translation>
     </message>
@@ -3555,127 +3806,29 @@ Jste si jistý?</translation>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2238"/>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2283"/>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2290"/>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2294"/>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2302"/>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2317"/>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2334"/>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2356"/>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2364"/>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2372"/>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2389"/>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2407"/>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2418"/>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2424"/>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2436"/>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2441"/>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2448"/>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2456"/>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2464"/>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4215"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4324"/>
         <source>Wheel</source>
         <translation>Barevné kolo</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4216"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4325"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4217"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4326"/>
         <source>Alpha</source>
         <translation>Alfa</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4218"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4327"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4255"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4373"/>
         <source>Show or hide parts of the Color Page.</source>
         <translation>Ukázat nebo skrýt části barevné strany.</translation>
     </message>
@@ -3684,113 +3837,136 @@ Jste si jistý?</translation>
         <translation type="vanished">Přepnout natočeníi barevné strany.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4176"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4286"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4179"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4289"/>
         <source>Apply</source>
         <translation>Použít</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4186"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4295"/>
         <source>Apply changes to current style</source>
         <translation>Použít změny na nynější styl</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4191"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4300"/>
         <source>Automatically update style changes</source>
         <translation>Automaticky aktualizovat změny stylu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4195"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4304"/>
         <source>Return To Previous Style</source>
         <translation>Vrátit se k předchozímu stylu</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4200"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4309"/>
         <source>Current Style</source>
         <translation>Nynější styl</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4219"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4328"/>
         <source>Hex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4244"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4329"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4357"/>
         <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4247"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4361"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5562"/>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4365"/>
         <source>Hex Color Names...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4261"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4379"/>
         <source>Show or hide style sets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5622"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6943"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4488"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4560"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4633"/>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5563"/>
+        <source>Show Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7173"/>
         <source>Generated</source>
         <translation>Vytvořeno</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5623"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5793"/>
         <source>My Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5626"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6862"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5796"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7090"/>
         <source> (Favorites)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5629"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5799"/>
         <source> (External)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5892"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5915"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5938"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6074"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6097"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6120"/>
         <source>Show All</source>
         <translation type="unfinished">Ukázat vše</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5897"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5920"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5943"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6079"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6102"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6125"/>
         <source>Hide All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5902"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5925"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5948"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6084"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6107"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6130"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5907"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5930"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5953"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6089"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6112"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6135"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6900"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7128"/>
         <source>Style Set Name cannot be empty or contain any of the following characters:
  \ / : * ? &quot; &lt; &gt; |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6945"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7175"/>
         <source>Style Set Name already exists. Please try another name.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,50 +3979,50 @@ Jste si jistý?</translation>
         <translation type="vanished">Vektorový štětec</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4499"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4505"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4507"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4754"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4760"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4762"/>
         <source>Color</source>
         <translation>Barva</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4501"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4756"/>
         <source>Texture</source>
         <translation>Textura (povrch)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4502"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4757"/>
         <source>Vector</source>
         <translation>Vektor</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4500"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4755"/>
         <source>Raster</source>
         <translation>Rastr</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4503"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4508"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4758"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4763"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4768"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5033"/>
         <source>No Style Selected</source>
         <translation>Nevybrán žádný styl</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4785"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5050"/>
         <source>Cleanup </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4787"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5052"/>
         <source>Studio </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4789"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5054"/>
         <source>Level </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3863,12 +4039,12 @@ Jste si jistý?</translation>
         <translation type="vanished">[ÚROVEŇ]  </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5057"/>
         <source>Palette</source>
         <translation>Paleta</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4806"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5071"/>
         <source>Style Editor - No Valid Style Selected</source>
         <translation>Editor stylu - Nevybrán žádný platný styl</translation>
     </message>
@@ -3918,8 +4094,9 @@ Jste si jistý?</translation>
 <context>
     <name>StyleIndexLineEdit</name>
     <message>
-        <location filename="../../toonzqt/styleindexlineedit.cpp" line="19"/>
-        <location filename="../../toonzqt/styleindexlineedit.cpp" line="37"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="20"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="23"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="42"/>
         <source>current</source>
         <translation type="unfinished">Nynější</translation>
     </message>
@@ -3965,12 +4142,12 @@ Jste si jistý?</translation>
 <context>
     <name>SwatchViewer</name>
     <message>
-        <location filename="../../toonzqt/swatchviewer.cpp" line="845"/>
+        <location filename="../../toonzqt/swatchviewer.cpp" line="846"/>
         <source>Reset View</source>
         <translation>Obnovit výchozí pohled</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/swatchviewer.cpp" line="850"/>
+        <location filename="../../toonzqt/swatchviewer.cpp" line="851"/>
         <source>Fit To Window</source>
         <translation>Přizpůsobit oknu</translation>
     </message>
@@ -4006,12 +4183,12 @@ Jste si jistý?</translation>
 <context>
     <name>TablePainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="586"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="598"/>
         <source>Table</source>
         <translation>Tabulka</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="596"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="608"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Obnovit výchozí střed</translation>
     </message>
@@ -4019,22 +4196,22 @@ Jste si jistý?</translation>
 <context>
     <name>ToneCurveField</name>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="902"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="906"/>
         <source>Channel:</source>
         <translation type="unfinished">Kanál:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="905"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="909"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="923"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="927"/>
         <source>Output:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="926"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="930"/>
         <source>Input:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/toonz/sources/translations/french/colorfx.ts
+++ b/toonz/sources/translations/french/colorfx.ts
@@ -21,6 +21,29 @@
     </message>
 </context>
 <context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation type="unfinished">Densité</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MovingSolidColor</name>
     <message>
         <source>Offset</source>

--- a/toonz/sources/translations/french/image.ts
+++ b/toonz/sources/translations/french/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -11,6 +29,97 @@
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -108,19 +217,6 @@
     </message>
 </context>
 <context>
-    <name>MovWriterProperties</name>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
-        <source>Quality</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
-        <source>Scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Mp4WriterProperties</name>
     <message>
         <location filename="../../image/ffmpeg/tiio_mp4.cpp" line="241"/>
@@ -144,12 +240,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/french/tnztools.ts
+++ b/toonz/sources/translations/french/tnztools.ts
@@ -548,6 +548,10 @@
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FingerTool</name>
@@ -662,6 +666,30 @@
     </message>
     <message>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation type="unfinished">Distance:</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation type="unfinished">Indice de Style:</translation>
+    </message>
+    <message>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1693,6 +1721,96 @@ Voulez-vous continuer?</translation>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryTool</name>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">Paramètre Prédéfini:</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <source>Rotation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished">Opacité:</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">Paramètre Prédéfini:</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/french/toonz.ts
+++ b/toonz/sources/translations/french/toonz.ts
@@ -168,11 +168,6 @@ Special thanks to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The microphone is not available: 
-Please select a different device or check the microphone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sync with XSheet/Timeline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,6 +262,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -359,6 +374,90 @@ pick up all frames in the selected level.</source>
     <message>
         <source>Field Guide:</source>
         <translation type="vanished">Field Guide:</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">Visualisation Camera Stand</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">Visualisation 3D</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">Visualisation Camera</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">Geler</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Preview</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">Preview Sous-caméra</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished">Plan:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished">   ::   Niveau: </translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -666,6 +765,21 @@ Arrête ou attendre son achèvement avant de le retirer.</translation>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -689,7 +803,7 @@ Arrête ou attendre son achèvement avant de le retirer.</translation>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">Unité de Mesure:</translation>
+        <translation>Unité de Mesure:</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -719,19 +833,23 @@ Voulez-vous recadrer la zone de travail?</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="obsolete">mm</translation>
+        <translation type="unfinished">mm</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="obsolete">cm</translation>
+        <translation type="unfinished">cm</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="obsolete">field</translation>
+        <translation type="unfinished">field</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="obsolete">pouce</translation>
+        <translation type="unfinished">pouce</translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1263,26 +1381,6 @@ Que voulez-vous faire?</translation>
 <context>
     <name>ComboViewerPanel</name>
     <message>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Camera Stand View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>3D View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Camera View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Freeze</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>GUI Show / Hide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1296,31 +1394,19 @@ Que voulez-vous faire?</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation type="unfinished">Preview</translation>
+        <translation type="obsolete">Preview</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation type="unfinished">Preview Sous-caméra</translation>
-    </message>
-    <message>
-        <source>Untitled</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Preview Sous-caméra</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation type="unfinished">Plan:</translation>
-    </message>
-    <message>
-        <source>   ::   Frame: </source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Plan:</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation type="unfinished">   ::   Niveau: </translation>
-    </message>
-    <message>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">   ::   Niveau: </translation>
     </message>
     <message>
         <source>Playback Toolbar</source>
@@ -1328,23 +1414,6 @@ Que voulez-vous faire?</translation>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1400,6 +1469,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1417,6 +1490,131 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>Les Leurs</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished">Conversion du niveau %1 de %2: %3</translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">Niveau % 1 n&apos;a pas d&apos;images; sauté.</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished">Convertir</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">Ignorer les Fichiers Existants</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1682,6 +1880,99 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
     <message>
         <source>Level %1 converting to same file format; skipped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Fermer</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished">Remplacer</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1958,6 +2249,13 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2087,6 +2385,47 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
         <source>Export</source>
@@ -2177,26 +2516,6 @@ contain the dpi information, then the current camera dpi will be used.
     <message>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
-    </message>
-    <message>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Target column</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2318,14 +2637,6 @@ contain the dpi information, then the current camera dpi will be used.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2391,6 +2702,18 @@ Do you want to create it?</source>
     </message>
     <message>
         <source>Failed to create folder %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2828,6 +3151,10 @@ Do you want to overwrite it?</translation>
         <source>It is not possible to take or compare snapshots for Toonz vector levels.</source>
         <translation>Il n&apos;est pas possible de prendre des instantanés ou comparer les niveaux vecteurs de Toonz.</translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -2899,6 +3226,13 @@ Do you want to overwrite it?</translation>
     <message>
         <source>Fx Settings</source>
         <translation>Paramètres de l&apos;Effet Spécial</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3074,6 +3408,10 @@ Do you want to overwrite it?</translation>
     </message>
     <message>
         <source>Search:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plugins</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3449,6 +3787,10 @@ Voulez-vous le créer?</translation>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -3688,6 +4030,13 @@ Please choose a valid lip sync data file to continue.</source>
     <name>LoadBoardPresetFilePopup</name>
     <message>
         <source>Load Clapperboard Settings Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3983,6 +4332,10 @@ Please choose a valid lip sync data file to continue.</source>
     <name>LocatorPopup</name>
     <message>
         <source>Locator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7114,6 +7467,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7343,6 +7768,22 @@ Que voulez-vous faire?</translation>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Couleur</translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7770,17 +8211,6 @@ Que voulez-vous faire?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save current output settings.
-The parameters to be saved are:
-- Camera settings
-- Project folder to be saved in
-- File format
-- File options
-- Resample Balance
-- Channel width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save and Render</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7818,6 +8248,92 @@ The parameters to be saved are:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Preview</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Couleur</translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8280,7 +8796,7 @@ Voulez-vous le créer?</translation>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">Utilisez le TLV Savebox pour limiter les opérations de remplissage</translation>
+        <translation>Utilisez le TLV Savebox pour limiter les opérations de remplissage</translation>
     </message>
     <message>
         <source>Paper Thickness:</source>
@@ -8541,10 +9057,6 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Enable to Input Cells without Double Clicking</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show Column Numbers in Column Headers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9064,10 +9576,6 @@ These come bundled with Tahoma2D, but you can set path to a different version.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Number of Frames to Play 
 for Short Play:</source>
         <translation type="unfinished"></translation>
@@ -9113,6 +9621,62 @@ but a random crash might occur, use at your own risk:</source>
     </message>
     <message>
         <source>Edit Additional Style Sheet..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pixels Only:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9351,6 +9915,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11855,6 +12423,107 @@ Do you want to continue?</source>
         <source>Explicit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -12022,6 +12691,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">Navigateur</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">Nouvel Espace de Travail</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -12033,7 +12733,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>Espace</translation>
+        <translation type="vanished">Espace</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -12912,6 +13612,13 @@ S&apos;il vous plaît commettre ou annuler les modifications avant.</translation
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -13053,6 +13760,172 @@ S&apos;il vous plaît commettre ou annuler les modifications avant.</translation
     <message>
         <source>Threshold: </source>
         <translation type="vanished">Seuil:</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">Il est impossible de changer l&apos;extension de fichier.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">Il est impossible de définir le numero du dessin</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">Il est impossible de renommer. Le fichier existe déjà:</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">Il est impossible de renommer. </translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">Charger comme Sub-xsheet</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">Charger</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">Renommer</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">Convertir en TLV Peint</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">Convertir en TLV Non-peint </translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">Gestion de Version</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">Modifier l&apos;Intervalle d&apos;Images...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished">Mettre...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">Version Précédente</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished">Obtenir</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Supprimer</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">Obtenir la Révision...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished">Déverrouiller</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">Modifier les Information</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">Historique des Révisions</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">Déverrouiller l&apos;Intervalle d&apos;Images</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished">Enregistrer le Plan</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">Nom du Plan:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished">Il y avait une erreur de copie de %1 à %2</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">Convertir en non peintes Tlv</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished">Attention: le niveau 1% existe déjà; voulez-vous le remplacer?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Oui</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Non</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">Fait: Tous les niveaux convertis en format TLV</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">Convertir en peint tlv</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">Fait: Deux niveaux convertis en format TLV</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">Nouveau Dossier</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">Il n&apos;est pas possible de créer le dossier %1.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">Certains fichiers que vous souhaitez modifier sont actuellement ouverts. Fermez-les en premier.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">Certains fichiers que vous souhaitez débloquer sont actuellement ouverts. Fermez-les en premier.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13296,84 +14169,51 @@ S&apos;il vous plaît commettre ou annuler les modifications avant.</translation
     <name>SceneViewerPanel</name>
     <message>
         <source>Freeze</source>
-        <translation>Geler</translation>
+        <translation type="vanished">Geler</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>Visualisation Camera Stand</translation>
+        <translation type="vanished">Visualisation Camera Stand</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>Visualisation 3D</translation>
+        <translation type="vanished">Visualisation 3D</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>Visualisation Camera</translation>
+        <translation type="vanished">Visualisation Camera</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>Preview</translation>
+        <translation type="vanished">Preview</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Preview Sous-caméra</translation>
+        <translation type="vanished">Preview Sous-caméra</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Sans titre</translation>
+        <translation type="vanished">Sans titre</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Plan:</translation>
+        <translation type="vanished">Plan:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>   ::   Image: </translation>
+        <translation type="vanished">   ::   Image: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>   ::   Niveau: </translation>
+        <translation type="vanished">   ::   Niveau: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Niveau: </translation>
+        <translation type="vanished">Niveau: </translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation>  ::  Zoom : </translation>
-    </message>
-    <message>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>GUI Show / Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">  ::  Zoom : </translation>
     </message>
 </context>
 <context>
@@ -13697,7 +14537,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">Xsheet</translation>
+        <translation>Xsheet</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -13709,7 +14549,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">Fenêtres</translation>
+        <translation>Fenêtres</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -13874,7 +14714,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>DPI:</source>
-        <translation type="obsolete">DPI:</translation>
+        <translation type="unfinished">DPI:</translation>
     </message>
     <message>
         <source>X</source>
@@ -13914,19 +14754,19 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>cm</source>
-        <translation type="obsolete">cm</translation>
+        <translation type="unfinished">cm</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="obsolete">mm</translation>
+        <translation type="unfinished">mm</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="obsolete">pouce</translation>
+        <translation type="unfinished">pouce</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="obsolete">field</translation>
+        <translation type="unfinished">field</translation>
     </message>
     <message>
         <source>No Recent Scenes</source>
@@ -14037,6 +14877,14 @@ What would you like to do?</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <source>Units:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14274,93 +15122,810 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="obsolete">Non</translation>
+        <translation type="unfinished">Non</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="obsolete">Aucun nom n&apos;a pas été spécifié pour le niveau: s&apos;il vous plaît spécifiez un nom de niveau valide.</translation>
+        <translation type="unfinished">Aucun nom n&apos;a pas été spécifié pour le niveau: s&apos;il vous plaît spécifiez un nom de niveau valide.</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="obsolete">Le dossier %1 n&apos;existe pas.
+        <translation type="unfinished">Le dossier %1 n&apos;existe pas.
 Voulez-vous le créer?</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="obsolete">Il est impossible de créer</translation>
+        <translation type="unfinished">Il est impossible de créer</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level name specified is already used: please choose a different level name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The save in path specified does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The captured image size does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please start live view before capturing an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNDEFINED WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level is not registered in the scene, but exists in the file system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Frame %1 exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Frames %1 exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OVERWRITE 1 of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ADD to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %1 frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %1 frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level will be newly created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NEW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level is already registered in the scene.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+NOTE : The level is not saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Failed to get image size of the existing level %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
+          %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING : Level path conflicts. There already is a level with the path %1                        
+          in the scene with the name %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Options</source>
-        <translation type="obsolete">Options</translation>
+        <translation type="unfinished">Options</translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="obsolete">Actualiser</translation>
+        <translation type="unfinished">Actualiser</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="obsolete">Fichier</translation>
+        <translation type="unfinished">Fichier</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="obsolete">Capturer</translation>
+        <translation type="unfinished">Capturer</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="obsolete">Image Suivante</translation>
+        <translation type="unfinished">Image Suivante</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="obsolete">Dernière Image</translation>
+        <translation type="unfinished">Dernière Image</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="obsolete">Image Précédente</translation>
+        <translation type="unfinished">Image Précédente</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="obsolete">Image Courante</translation>
+        <translation type="unfinished">Image Courante</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="obsolete">Nom:</translation>
+        <translation type="unfinished">Nom:</translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="obsolete">Auto</translation>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Couleur</translation>
+        <translation type="unfinished">Couleur</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">Luminosité:</translation>
+        <translation type="unfinished">Luminosité:</translation>
+    </message>
+    <message>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resolution: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set to the Current Playhead Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Picture Style: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Quality: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exposure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image adjust</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grayscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black &amp; White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Webcam Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">Charger</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Exporter</translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Webcam Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DSLR Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place on XSheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Direct Show Webcam Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use MJPG with Webcam</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Numpad Shortcuts When Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Live View on All Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interval(sec):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capture Review Time: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera detected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>- Select camera -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mode: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Iso: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished">Il n&apos;est pas possible d&apos;enregistrer %1.</translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Annuler</translation>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">Il n&apos;est pas possible de créer le dossier %1.</translation>
+        <translation type="unfinished">Il n&apos;est pas possible de créer le dossier %1.</translation>
+    </message>
+    <message>
+        <source>Create the Destination Subfolder to Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set As Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set the current &quot;Save In&quot; path as the default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infomation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show This on Launch of the Camera Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Scene in Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C- + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Project + Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save the current scene in the subfolder.
+Set the output folder path to the subfolder as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Episode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sequence:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder name should not be empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder %1 already exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14540,6 +16105,25 @@ Cliquez sur le bouton fléché pour créer un nouveau sub-xsheet</translation>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14908,6 +16492,10 @@ Cliquez sur le bouton fléché pour créer un nouveau sub-xsheet</translation>
     </message>
     <message>
         <source>Expand toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15337,11 +16925,11 @@ S&apos;il vous plaît se référer à la guide de l&apos;utilisateur pour plus d
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <source>Inbetween symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reverse sheet symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15618,6 +17206,21 @@ S&apos;il vous plaît se référer à la guide de l&apos;utilisateur pour plus d
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Frame</source>
@@ -15649,6 +17252,10 @@ S&apos;il vous plaît se référer à la guide de l&apos;utilisateur pour plus d
     </message>
     <message>
         <source>Add New Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Xsheet/Timeline</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15749,6 +17356,12 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/french/toonzlib.ts
+++ b/toonz/sources/translations/french/toonzlib.ts
@@ -643,6 +643,34 @@ Probablement le codec peut ne pas fonctionner correctement.</translation>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Rasterizer</name>

--- a/toonz/sources/translations/french/toonzqt.ts
+++ b/toonz/sources/translations/french/toonzqt.ts
@@ -27,6 +27,14 @@
         <source>Replace </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddWordButton</name>
@@ -173,6 +181,30 @@ Possibly the preset file has been corrupted</source>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A/R</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChannelHisto</name>
@@ -249,42 +281,6 @@ Possibly the preset file has been corrupted</source>
     </message>
 </context>
 <context>
-    <name>ColorChannelControl</name>
-    <message>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>ColorField</name>
     <message>
         <source>R:</source>
@@ -330,6 +326,14 @@ Zero is fully transparent.</source>
     <name>ComboHistoRGBLabel</name>
     <message>
         <source>R:%1 G:%2 B:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A:%1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -798,6 +802,27 @@ Control click to reset.</source>
     </message>
     <message>
         <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1726,7 +1751,7 @@ Sélectionnez les nœuds FX et les liens connexes avant de copier ou couper la s
     </message>
     <message>
         <source>New Page</source>
-        <translation>Nouvelle Page</translation>
+        <translation type="vanished">Nouvelle Page</translation>
     </message>
     <message>
         <source>- No Styles -</source>
@@ -1734,10 +1759,6 @@ Sélectionnez les nœuds FX et les liens connexes avant de copier ou couper la s
     </message>
     <message>
         <source> + </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1892,6 +1913,22 @@ It can&apos;t be changed.  Ever.</source>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PaletteViewerGUI::PageViewer</name>
@@ -1938,6 +1975,12 @@ It can&apos;t be changed.  Ever.</source>
     <name>ParamsPageSet</name>
     <message>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2577,6 +2620,139 @@ Are you sure?</source>
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation type="unfinished">Nouveau Style</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation type="unfinished">Nouvelle Page</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">Couleur Automatique pour les Lignes</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QPushButton</name>
@@ -2711,11 +2887,7 @@ Are you sure?</source>
     <name>SettingsPage</name>
     <message>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">Couleur Automatique pour les Lignes</translation>
-    </message>
-    <message>
-        <source>Reset to default</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Couleur Automatique pour les Lignes</translation>
     </message>
 </context>
 <context>
@@ -2955,85 +3127,6 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
         <source>Apply</source>
@@ -3194,6 +3287,22 @@ Are you sure ?</source>
     </message>
     <message>
         <source>Style Set Name already exists. Please try another name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Auto/Apply</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/german/colorfx.ts
+++ b/toonz/sources/translations/german/colorfx.ts
@@ -21,6 +21,29 @@
     </message>
 </context>
 <context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation type="unfinished">Dichte</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MovingSolidColor</name>
     <message>
         <source>Offset</source>

--- a/toonz/sources/translations/german/image.ts
+++ b/toonz/sources/translations/german/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -11,6 +29,97 @@
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -108,19 +217,6 @@
     </message>
 </context>
 <context>
-    <name>MovWriterProperties</name>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
-        <source>Quality</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
-        <source>Scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Mp4WriterProperties</name>
     <message>
         <location filename="../../image/ffmpeg/tiio_mp4.cpp" line="241"/>
@@ -144,12 +240,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/german/tnztools.ts
+++ b/toonz/sources/translations/german/tnztools.ts
@@ -572,6 +572,10 @@
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FingerTool</name>
@@ -686,6 +690,30 @@
     </message>
     <message>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation type="unfinished">Abstand：</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation type="unfinished">Stil-Index:</translation>
+    </message>
+    <message>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1728,6 +1756,96 @@ Möchten Sie fortfahren?</translation>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryTool</name>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">Vorlage:</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <source>Rotation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished">Opazität:</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">Vorlage:</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/german/toonz.ts
+++ b/toonz/sources/translations/german/toonz.ts
@@ -168,11 +168,6 @@ Special thanks to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The microphone is not available: 
-Please select a different device or check the microphone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sync with XSheet/Timeline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,6 +262,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -359,6 +374,90 @@ pick up all frames in the selected level.</source>
     <message>
         <source>Field Guide:</source>
         <translation type="vanished">Praktische Anleitung</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished">GUI anzeigen/verbergen</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">Kamera-Stand-Ansicht</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">3D-Ansicht</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">Kamera-Ansicht</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">Einfrieren</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Vorschau</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished">Unbenannt</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished">Szene:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished">:: Frame:</translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished">:: Ebene:</translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished">Ebene:</translation>
     </message>
 </context>
 <context>
@@ -663,6 +762,21 @@ Halten Sie sie an oder warten Sie auf ihre Beendung bevor Sie sie entwenden.</tr
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -686,7 +800,7 @@ Halten Sie sie an oder warten Sie auf ihre Beendung bevor Sie sie entwenden.</tr
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">Einheit:</translation>
+        <translation>Einheit:</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -716,23 +830,23 @@ Möchten sie die Arbeitsfläche freistellen?</translation>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="obsolete">pixel</translation>
+        <translation type="unfinished">pixel</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="obsolete">mm</translation>
+        <translation type="unfinished">mm</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="obsolete">cm</translation>
+        <translation type="unfinished">cm</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="obsolete">Feld</translation>
+        <translation type="unfinished">Feld</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="obsolete">inch</translation>
+        <translation type="unfinished">inch</translation>
     </message>
 </context>
 <context>
@@ -1307,26 +1421,6 @@ Was möchten Sie tun?</translation>
 <context>
     <name>ComboViewerPanel</name>
     <message>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Camera Stand View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>3D View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Camera View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Freeze</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>GUI Show / Hide</source>
         <translation>GUI anzeigen/verbergen</translation>
     </message>
@@ -1344,35 +1438,31 @@ Was möchten Sie tun?</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>Vorschau</translation>
+        <translation type="vanished">Vorschau</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Sub-Kamera Vorschau</translation>
+        <translation type="vanished">Sub-Kamera Vorschau</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Unbenannt</translation>
+        <translation type="vanished">Unbenannt</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Szene:</translation>
+        <translation type="vanished">Szene:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>:: Frame:</translation>
+        <translation type="vanished">:: Frame:</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>:: Ebene:</translation>
+        <translation type="vanished">:: Ebene:</translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Ebene:</translation>
-    </message>
-    <message>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Ebene:</translation>
     </message>
     <message>
         <source>Playback Toolbar</source>
@@ -1380,19 +1470,6 @@ Was möchten Sie tun?</translation>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1448,6 +1525,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1465,6 +1546,131 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>Der Ablage</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished">Wandle Ebene %1 von %2 um: %3</translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">Ebene　%1　hat keinen Frame. Sie wurde übersprungen.</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished">Umwandlung</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">Bestehende Dateien überspringen</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1734,6 +1940,99 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
     <message>
         <source>Level %1 converting to same file format; skipped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Schließen</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished">Überschreiben</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2010,6 +2309,13 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2205,6 +2511,47 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
         <source>Export</source>
@@ -2294,26 +2641,6 @@ contain the dpi information, then the current camera dpi will be used.
     <name>ExportXDTSCommand</name>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Target column</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2436,14 +2763,6 @@ contain the dpi information, then the current camera dpi will be used.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2510,6 +2829,18 @@ Do you want to create it?</source>
     </message>
     <message>
         <source>Failed to create folder %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3002,6 +3333,10 @@ Do you want to overwrite it?</source>
         <source>  ::  Shrink </source>
         <translation type="unfinished">::Schrumpfen</translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -3073,6 +3408,13 @@ Do you want to overwrite it?</source>
     <message>
         <source>Fx Settings</source>
         <translation>Effekt-Einstellungen</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3252,6 +3594,10 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Search:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plugins</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3631,6 +3977,10 @@ Möchten Sie einen erstellen?</translation>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -3918,6 +4268,13 @@ Please choose a valid lip sync data file to continue.</source>
     <name>LoadBoardPresetFilePopup</name>
     <message>
         <source>Load Clapperboard Settings Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4217,6 +4574,10 @@ Please choose a valid lip sync data file to continue.</source>
     <name>LocatorPopup</name>
     <message>
         <source>Locator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7404,6 +7765,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7632,6 +8065,22 @@ Was möchten Sie tun?</translation>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Farbe</translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8067,17 +8516,6 @@ Was möchten Sie tun?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save current output settings.
-The parameters to be saved are:
-- Camera settings
-- Project folder to be saved in
-- File format
-- File options
-- Resample Balance
-- Channel width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save and Render</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8115,6 +8553,92 @@ The parameters to be saved are:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Vorschau</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Farbe</translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8576,7 +9100,7 @@ Möchten Sie einen erstellen?</translation>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">Die TLV-Savebox benutzen um Füll-Operationen zu beschränken</translation>
+        <translation>Die TLV-Savebox benutzen um Füll-Operationen zu beschränken</translation>
     </message>
     <message>
         <source>Paper Thickness:</source>
@@ -8941,10 +9465,6 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Enable to Input Cells without Double Clicking</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show Column Numbers in Column Headers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9464,10 +9984,6 @@ These come bundled with Tahoma2D, but you can set path to a different version.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Number of Frames to Play 
 for Short Play:</source>
         <translation type="unfinished"></translation>
@@ -9513,6 +10029,62 @@ but a random crash might occur, use at your own risk:</source>
     </message>
     <message>
         <source>Edit Additional Style Sheet..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pixels Only:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9776,6 +10348,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12349,6 +12925,107 @@ Do you want to continue?</source>
         <source>Explicit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -12521,6 +13198,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">Browser</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished">Verlauf</translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">Neue Arbeitsfläche</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -12532,7 +13240,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>Arbeitsfläche</translation>
+        <translation type="vanished">Arbeitsfläche</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -13423,6 +14131,13 @@ Bitte tragen Sie die Änderungen ein oder setzen sie zurück.</translation>
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -13564,6 +14279,172 @@ Bitte tragen Sie die Änderungen ein oder setzen sie zurück.</translation>
     <message>
         <source>Threshold: </source>
         <translation type="vanished">Schwellenwert:</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished">Ordner konnte nicht geöffnet werden</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished">Der Pfad des Eingabeordners war nicht gültig.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">Die Dateiendung kann nicht geändert werden</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">Es kann keine Bildnummer eingestellt werden.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">Umbenennen ist nicht möglich. Die Datei ist bereits vorhanden:</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">Konnte nicht umbenennen </translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">Als Sub-Xsheet laden</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">Umbenennen</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">Zu bemalter TLV umwandeln</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">Zu unbemalter TLV umwandeln</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">Versionskontrolle</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">Bearbeiten</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">Frame-Bereich bearbeiten...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished">Ersetzen...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">Zurücksetzen</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished">Holen</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Löschen</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">Revisionen holen...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished">Entsperren</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">Informationen bearbeiten</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">Revisionsverlauf...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">Frame-Bereich entsperren</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished">Szene speichern</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">Szenenname:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished">Es gab einen Fehler beim kopieren von %1 bis %2</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">Zur unbemalten TLV umwandeln</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nein</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">Fertig: Alle Ebenen wurden ins TLV Format umgewandelt</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">Zur bemalten TLV umwandeln</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">Fertig: 2 Ebenen wurden ins TLV Format umgewandelt</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">Neuer Ordner</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">Der Ordner %1 kann nicht erstellt werden.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">Einige Dateien, die Sie bearbeiten möchten, sind zur Zeit offen. Bitte schließen Sie sie zuerst.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">Einige Dateien, die Sie entsperren möchten, sind zur Zeit offen. Bitte schließen Sie sie zuerst.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13807,84 +14688,55 @@ Bitte tragen Sie die Änderungen ein oder setzen sie zurück.</translation>
     <name>SceneViewerPanel</name>
     <message>
         <source>Preview</source>
-        <translation>Vorschau</translation>
+        <translation type="vanished">Vorschau</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Sub-Kamera-Vorschau</translation>
+        <translation type="vanished">Sub-Kamera-Vorschau</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Unbenannt</translation>
+        <translation type="vanished">Unbenannt</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Szene:</translation>
+        <translation type="vanished">Szene:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>:: Frame:</translation>
+        <translation type="vanished">:: Frame:</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>:: Ebene:</translation>
+        <translation type="vanished">:: Ebene:</translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Ebene:</translation>
+        <translation type="vanished">Ebene:</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>Einfrieren</translation>
+        <translation type="vanished">Einfrieren</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>Kamera-Stand-Ansicht</translation>
+        <translation type="vanished">Kamera-Stand-Ansicht</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>3D-Ansicht</translation>
+        <translation type="vanished">3D-Ansicht</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>Kamera-Ansicht</translation>
+        <translation type="vanished">Kamera-Ansicht</translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation>:: Vergrößerung :</translation>
-    </message>
-    <message>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">:: Vergrößerung :</translation>
     </message>
     <message>
         <source>GUI Show / Hide</source>
-        <translation type="unfinished">GUI anzeigen/verbergen</translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">GUI anzeigen/verbergen</translation>
     </message>
 </context>
 <context>
@@ -14208,7 +15060,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">Xsheet</translation>
+        <translation>Xsheet</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -14220,7 +15072,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">Fenster</translation>
+        <translation>Fenster</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -14449,7 +15301,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>DPI:</source>
-        <translation type="obsolete">DPI:</translation>
+        <translation type="unfinished">DPI:</translation>
     </message>
     <message>
         <source>X</source>
@@ -14489,23 +15341,23 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="obsolete">pixel</translation>
+        <translation type="unfinished">pixel</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="obsolete">cm</translation>
+        <translation type="unfinished">cm</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="obsolete">mm</translation>
+        <translation type="unfinished">mm</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="obsolete">inch</translation>
+        <translation type="unfinished">inch</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="obsolete">Feld</translation>
+        <translation type="unfinished">Feld</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -14620,6 +15472,10 @@ What would you like to do?</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <source>Units:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14857,66 +15713,250 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="obsolete">Nein</translation>
+        <translation type="unfinished">Nein</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="obsolete">Der Name der Ebene wurde nicht festgelegt: Bitte einen gültigen Namen wählen.</translation>
+        <translation type="unfinished">Der Name der Ebene wurde nicht festgelegt: Bitte einen gültigen Namen wählen.</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="obsolete">Ordner %1 existiert nicht.
+        <translation type="unfinished">Ordner %1 existiert nicht.
 Möchten Sie einen erstellen?</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="obsolete">Es konnte nicht erstellt werden.</translation>
+        <translation type="unfinished">Es konnte nicht erstellt werden.</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level name specified is already used: please choose a different level name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The save in path specified does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The captured image size does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please start live view before capturing an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNDEFINED WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level is not registered in the scene, but exists in the file system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Frame %1 exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Frames %1 exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OVERWRITE 1 of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ADD to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %1 frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %1 frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level will be newly created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NEW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level is already registered in the scene.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+NOTE : The level is not saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Failed to get image size of the existing level %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
+          %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING : Level path conflicts. There already is a level with the path %1                        
+          in the scene with the name %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Settings</source>
-        <translation type="obsolete">Einstellungen</translation>
+        <translation type="unfinished">Einstellungen</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="obsolete">Optionen</translation>
+        <translation type="unfinished">Optionen</translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="obsolete">Aktualisieren</translation>
+        <translation type="unfinished">Aktualisieren</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="obsolete">Datei</translation>
+        <translation type="unfinished">Datei</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="obsolete">Einfangen</translation>
+        <translation type="unfinished">Einfangen</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="obsolete">Nächster Frame</translation>
+        <translation type="unfinished">Nächster Frame</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="obsolete">Letzter Frame</translation>
+        <translation type="unfinished">Letzter Frame</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="obsolete">Vorheriger Frame</translation>
+        <translation type="unfinished">Vorheriger Frame</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="obsolete">Aktueller Frame</translation>
+        <translation type="unfinished">Aktueller Frame</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -14924,38 +15964,563 @@ Möchten Sie einen erstellen?</translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="obsolete">Automatisch</translation>
+        <translation type="unfinished">Automatisch</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="obsolete">Deaktiviert</translation>
+        <translation type="unfinished">Deaktiviert</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Farbe</translation>
+        <translation type="unfinished">Farbe</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">Helligkeit</translation>
+        <translation type="unfinished">Helligkeit</translation>
+    </message>
+    <message>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resolution: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set to the Current Playhead Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Picture Style: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Quality: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exposure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image adjust</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grayscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black &amp; White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Webcam Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Exportieren</translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Webcam Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DSLR Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place on XSheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Direct Show Webcam Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use MJPG with Webcam</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Numpad Shortcuts When Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Live View on All Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interval(sec):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capture Review Time: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera detected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>- Select camera -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mode: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Iso: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished">%1 konnte nicht gespeichert werden</translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Abbrechen</translation>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Save In:</source>
-        <translation type="obsolete">Speichern in:</translation>
+        <translation type="unfinished">Speichern in:</translation>
     </message>
     <message>
         <source>Project:</source>
-        <translation type="obsolete">Projekt:</translation>
+        <translation type="unfinished">Projekt:</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">Der Ordner %1 kann nicht erstellt werden.</translation>
+        <translation type="unfinished">Der Ordner %1 kann nicht erstellt werden.</translation>
+    </message>
+    <message>
+        <source>Create the Destination Subfolder to Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set As Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set the current &quot;Save In&quot; path as the default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infomation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show This on Launch of the Camera Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Scene in Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C- + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Project + Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save the current scene in the subfolder.
+Set the output folder path to the subfolder as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Episode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sequence:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder name should not be empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder %1 already exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -15141,6 +16706,25 @@ Click the arrow button to create a new sub-xsheet</source>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15513,6 +17097,10 @@ Click the arrow button to create a new sub-xsheet</source>
     </message>
     <message>
         <source>Expand toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15942,11 +17530,11 @@ Genaueres können Sie aus der Nutzerhilfe entnehmen.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reverse sheet symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16223,6 +17811,21 @@ Genaueres können Sie aus der Nutzerhilfe entnehmen.</translation>
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Frame</source>
@@ -16254,6 +17857,10 @@ Genaueres können Sie aus der Nutzerhilfe entnehmen.</translation>
     </message>
     <message>
         <source>Add New Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Xsheet/Timeline</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16362,6 +17969,12 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/german/toonzlib.ts
+++ b/toonz/sources/translations/german/toonzlib.ts
@@ -667,6 +667,34 @@ Wahrscheinlich funktioniert der Codec nicht korrekt.</translation>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Rasterizer</name>

--- a/toonz/sources/translations/german/toonzqt.ts
+++ b/toonz/sources/translations/german/toonzqt.ts
@@ -31,6 +31,14 @@
         <source>Insert FX</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddWordButton</name>
@@ -176,6 +184,30 @@ Possibly the preset file has been corrupted</source>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A/R</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChannelHisto</name>
@@ -256,42 +288,6 @@ Possibly the preset file has been corrupted</source>
     </message>
 </context>
 <context>
-    <name>ColorChannelControl</name>
-    <message>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>ColorField</name>
     <message>
         <source>R:</source>
@@ -337,6 +333,14 @@ Zero is fully transparent.</source>
     <name>ComboHistoRGBLabel</name>
     <message>
         <source>R:%1 G:%2 B:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A:%1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -794,6 +798,27 @@ Control click to reset.</source>
     </message>
     <message>
         <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1745,7 +1770,7 @@ Wählen Sie Effekt-Nodes und verwandte Links, die Sie einfügen möchten, bevor 
     </message>
     <message>
         <source>New Page</source>
-        <translation>Neue Seite</translation>
+        <translation type="vanished">Neue Seite</translation>
     </message>
     <message>
         <source>- No Styles -</source>
@@ -1753,7 +1778,7 @@ Wählen Sie Effekt-Nodes und verwandte Links, die Sie einfügen möchten, bevor 
     </message>
     <message>
         <source>Name Editor</source>
-        <translation type="unfinished">Stil-Name-Editor</translation>
+        <translation type="obsolete">Stil-Name-Editor</translation>
     </message>
     <message>
         <source> + </source>
@@ -1931,6 +1956,22 @@ It can&apos;t be changed.  Ever.</source>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">Stil-Name-Editor</translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PaletteViewerGUI::PageViewer</name>
@@ -1993,6 +2034,12 @@ It can&apos;t be changed.  Ever.</source>
     </message>
     <message>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2660,6 +2707,139 @@ Are you sure?</source>
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">Stil-Name-Editor</translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation type="unfinished">Neuer Stil</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation type="unfinished">Neue Seite</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">Automatisches Malen für Linien</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QPushButton</name>
@@ -2798,11 +2978,7 @@ Are you sure?</source>
     <name>SettingsPage</name>
     <message>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">Automatisches Malen für Linien</translation>
-    </message>
-    <message>
-        <source>Reset to default</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Automatisches Malen für Linien</translation>
     </message>
 </context>
 <context>
@@ -3042,85 +3218,6 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
         <source>Apply</source>
@@ -3287,6 +3384,22 @@ anwenden</translation>
     </message>
     <message>
         <source>Style Set Name already exists. Please try another name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Auto/Apply</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/italian/colorfx.ts
+++ b/toonz/sources/translations/italian/colorfx.ts
@@ -21,6 +21,29 @@
     </message>
 </context>
 <context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation type="unfinished">Densità</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MovingSolidColor</name>
     <message>
         <source>Offset</source>

--- a/toonz/sources/translations/italian/image.ts
+++ b/toonz/sources/translations/italian/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -11,6 +29,97 @@
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -108,19 +217,6 @@
     </message>
 </context>
 <context>
-    <name>MovWriterProperties</name>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
-        <source>Quality</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
-        <source>Scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Mp4WriterProperties</name>
     <message>
         <location filename="../../image/ffmpeg/tiio_mp4.cpp" line="241"/>
@@ -144,12 +240,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/italian/tnztools.ts
+++ b/toonz/sources/translations/italian/tnztools.ts
@@ -548,6 +548,10 @@
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FingerTool</name>
@@ -662,6 +666,30 @@
     </message>
     <message>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation type="unfinished">Distanza:</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation type="unfinished">Indice dello Stile:</translation>
+    </message>
+    <message>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1690,6 +1718,96 @@ Procedere?</translation>
     <message>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryTool</name>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <source>Rotation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished">Opacità:</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/italian/toonz.ts
+++ b/toonz/sources/translations/italian/toonz.ts
@@ -168,11 +168,6 @@ Special thanks to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The microphone is not available: 
-Please select a different device or check the microphone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sync with XSheet/Timeline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,6 +262,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -359,6 +374,90 @@ pick up all frames in the selected level.</source>
     <message>
         <source>Field Guide:</source>
         <translation type="vanished">Field Guide:</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">Vista Camera Stand</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">Vista 3D</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">Vista Camera</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">Disattiva l&apos;aggiornamento</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Anteprima</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">Anteprima della Sotto-Camera</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished">Scena:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished">   ::   Fotogramma: </translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished">   ::   Livello: </translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished">Livello:</translation>
     </message>
 </context>
 <context>
@@ -665,6 +764,21 @@ Stop it or wait for its completion before removing it.</source>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -688,7 +802,7 @@ Stop it or wait for its completion before removing it.</source>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">Unità:</translation>
+        <translation>Unità:</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -718,19 +832,23 @@ Vuoi tagliare il canvas?</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="obsolete">mm</translation>
+        <translation type="unfinished">mm</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="obsolete">cm</translation>
+        <translation type="unfinished">cm</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="obsolete">field</translation>
+        <translation type="unfinished">field</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="obsolete">pollici</translation>
+        <translation type="unfinished">pollici</translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1262,26 +1380,6 @@ Cosa vuoi fare?</translation>
 <context>
     <name>ComboViewerPanel</name>
     <message>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Camera Stand View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>3D View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Camera View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Freeze</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>GUI Show / Hide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1295,35 +1393,27 @@ Cosa vuoi fare?</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation type="unfinished">Anteprima</translation>
+        <translation type="obsolete">Anteprima</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation type="unfinished">Anteprima della Sotto-Camera</translation>
-    </message>
-    <message>
-        <source>Untitled</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Anteprima della Sotto-Camera</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation type="unfinished">Scena:</translation>
+        <translation type="obsolete">Scena:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation type="unfinished">   ::   Fotogramma: </translation>
+        <translation type="obsolete">   ::   Fotogramma: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation type="unfinished">   ::   Livello: </translation>
+        <translation type="obsolete">   ::   Livello: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation type="unfinished">Livello:</translation>
-    </message>
-    <message>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Livello:</translation>
     </message>
     <message>
         <source>Playback Toolbar</source>
@@ -1331,19 +1421,6 @@ Cosa vuoi fare?</translation>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1399,6 +1476,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1416,6 +1497,132 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>Loro</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished">Converti %1 livelli di %2: %3</translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">Il livello %1 non ha fotogrammi; saltato.
+</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished">Converti</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annullare</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">Salta File Esistenti</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1682,6 +1889,99 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
     <message>
         <source>Level %1 converting to same file format; skipped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Chiudi</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished">Sovrascrivi</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annullare</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1959,6 +2259,13 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2088,6 +2395,47 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
         <source>Export</source>
@@ -2178,26 +2526,6 @@ contain the dpi information, then the current camera dpi will be used.
     <name>ExportXDTSCommand</name>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Target column</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2320,14 +2648,6 @@ contain the dpi information, then the current camera dpi will be used.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2393,6 +2713,18 @@ Do you want to create it?</source>
     </message>
     <message>
         <source>Failed to create folder %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2823,6 +3155,10 @@ Vuoi sovrascriverlo?</translation>
         <source>It is not possible to take or compare snapshots for Toonz vector levels.</source>
         <translation>Impossibile prendere o confrontare gli snapshot per i Toonz vector levels.</translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -2894,6 +3230,13 @@ Vuoi sovrascriverlo?</translation>
     <message>
         <source>Fx Settings</source>
         <translation>Impostazioni dell&apos;Effetto</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3069,6 +3412,10 @@ Vuoi sovrascriverlo?</translation>
     </message>
     <message>
         <source>Search:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plugins</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3444,6 +3791,10 @@ Vuoi crearla?</translation>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -3683,6 +4034,13 @@ Please choose a valid lip sync data file to continue.</source>
     <name>LoadBoardPresetFilePopup</name>
     <message>
         <source>Load Clapperboard Settings Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3978,6 +4336,10 @@ Please choose a valid lip sync data file to continue.</source>
     <name>LocatorPopup</name>
     <message>
         <source>Locator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7106,6 +7468,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7335,6 +7769,22 @@ Cosa vuoi fare?</translation>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">A Colori</translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7762,17 +8212,6 @@ Cosa vuoi fare?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save current output settings.
-The parameters to be saved are:
-- Camera settings
-- Project folder to be saved in
-- File format
-- File options
-- Resample Balance
-- Channel width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save and Render</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7810,6 +8249,92 @@ The parameters to be saved are:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">Anteprima</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">A Colori</translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8270,7 +8795,7 @@ Vuoi crearla?</translation>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">Usa il TLV Savebox per Limit Filling ...</translation>
+        <translation>Usa il TLV Savebox per Limit Filling ...</translation>
     </message>
     <message>
         <source>Paper Thickness:</source>
@@ -8523,10 +9048,6 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Enable to Input Cells without Double Clicking</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show Column Numbers in Column Headers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9046,10 +9567,6 @@ These come bundled with Tahoma2D, but you can set path to a different version.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Number of Frames to Play 
 for Short Play:</source>
         <translation type="unfinished"></translation>
@@ -9095,6 +9612,62 @@ but a random crash might occur, use at your own risk:</source>
     </message>
     <message>
         <source>Edit Additional Style Sheet..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pixels Only:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9333,6 +9906,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11837,6 +12414,107 @@ Do you want to continue?</source>
         <source>Explicit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -12004,6 +12682,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">Browser</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">Nuova Stanza</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -12015,7 +12724,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>Stanza</translation>
+        <translation type="vanished">Stanza</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -12894,6 +13603,13 @@ Per favore sottometti o ripristina i cambiamenti prima di proseguire.</translati
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -13035,6 +13751,172 @@ Per favore sottometti o ripristina i cambiamenti prima di proseguire.</translati
     <message>
         <source>Threshold: </source>
         <translation type="vanished">Soglia:</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">Non è possibile cambiare l&apos;estensione del file.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">Non è possibile stabilire un numero per il disegno.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">Non è possibile rinominare. Il file già esiste.</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">Non è possibile rinominare.</translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">Carica come Sub-Xsheet</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">Carica</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">Rinomina</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">Canverti in TLV Colorate</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">Converti in TLV non Colorate</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">Controllo di Versione</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">Modifica l&apos;Intervallo di Fotogrammi...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">Ripristina</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Elimina</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">Ottieni Revisione...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">Informazioni sulla Modificabilità del File</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">Cronologia delle Revisioni</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">Sblocca un Intervallo di Fotogrammi</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished">Salva la Scena</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">Nome della Scena:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">Converti in Unpainted Tlv</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished">Attenzione: il livello %1 esiste già; lo vuoi sovrascrivere?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">No</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">Fatto: Tutti i Livelli sono stati convertiti in Formato TLV</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">Converti in Painted Tlv</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">Fatto: 2 Livelli convertiti in Formato TLV</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">Nuova Cartella</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">Impossibile creare la cartella %1.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">Alcuni file che si vuole modificare sono aperti. Chiuderli prima di procedere.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">Alcuni file che si vuole sbloccare sono aperti. Chiuderli prima di procedere.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13274,84 +14156,51 @@ Per favore sottometti o ripristina i cambiamenti prima di proseguire.</translati
     <name>SceneViewerPanel</name>
     <message>
         <source>Freeze</source>
-        <translation>Disattiva l&apos;aggiornamento</translation>
+        <translation type="vanished">Disattiva l&apos;aggiornamento</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>Vista Camera Stand</translation>
+        <translation type="vanished">Vista Camera Stand</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>Vista 3D</translation>
+        <translation type="vanished">Vista 3D</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>Vista Camera</translation>
+        <translation type="vanished">Vista Camera</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>Anteprima</translation>
+        <translation type="vanished">Anteprima</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Anteprima della Sotto-Camera</translation>
+        <translation type="vanished">Anteprima della Sotto-Camera</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Senza Titolo</translation>
+        <translation type="vanished">Senza Titolo</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Scena:</translation>
+        <translation type="vanished">Scena:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>   ::   Fotogramma: </translation>
+        <translation type="vanished">   ::   Fotogramma: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>   ::   Livello: </translation>
+        <translation type="vanished">   ::   Livello: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Livello:</translation>
+        <translation type="vanished">Livello:</translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation>  ::  Zoom : </translation>
-    </message>
-    <message>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>GUI Show / Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">  ::  Zoom : </translation>
     </message>
 </context>
 <context>
@@ -13675,7 +14524,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">Xsheet</translation>
+        <translation>Xsheet</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -13687,7 +14536,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">Finestre</translation>
+        <translation>Finestre</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -13856,7 +14705,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>DPI:</source>
-        <translation type="obsolete">DPI:</translation>
+        <translation type="unfinished">DPI:</translation>
     </message>
     <message>
         <source>X</source>
@@ -13896,19 +14745,19 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>cm</source>
-        <translation type="obsolete">cm</translation>
+        <translation type="unfinished">cm</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="obsolete">mm</translation>
+        <translation type="unfinished">mm</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="obsolete">pollici</translation>
+        <translation type="unfinished">pollici</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="obsolete">field</translation>
+        <translation type="unfinished">field</translation>
     </message>
     <message>
         <source>No Recent Scenes</source>
@@ -14019,6 +14868,14 @@ What would you like to do?</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Annullare</translation>
+    </message>
+    <message>
+        <source>Units:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14256,95 +15113,811 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="obsolete">No</translation>
+        <translation type="unfinished">No</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="obsolete">Il nome del livello non è stato specificato: scegliere un nome di livello valido.</translation>
+        <translation type="unfinished">Il nome del livello non è stato specificato: scegliere un nome di livello valido.</translation>
     </message>
     <message>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
-        <translation type="obsolete">Il file %1 esiste già.
+        <translation type="unfinished">Il file %1 esiste già.
 Vuoi sovrascriverlo?</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="obsolete">La cartella %1 non esiste.
+        <translation type="unfinished">La cartella %1 non esiste.
 Vuoi crearla?</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="obsolete">Impossibile creare</translation>
+        <translation type="unfinished">Impossibile creare</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level name specified is already used: please choose a different level name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The save in path specified does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The captured image size does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please start live view before capturing an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNDEFINED WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level is not registered in the scene, but exists in the file system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Frame %1 exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Frames %1 exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OVERWRITE 1 of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ADD to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %1 frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %1 frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level will be newly created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NEW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The level is already registered in the scene.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+NOTE : The level is not saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Failed to get image size of the existing level %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
+          %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING : Level path conflicts. There already is a level with the path %1                        
+          in the scene with the name %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Refresh</source>
-        <translation type="obsolete">Aggiorna</translation>
+        <translation type="unfinished">Aggiorna</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="obsolete">File</translation>
+        <translation type="unfinished">File</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="obsolete">Acquisizione</translation>
+        <translation type="unfinished">Acquisizione</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="obsolete">Prossimo Fotogramma</translation>
+        <translation type="unfinished">Prossimo Fotogramma</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="obsolete">Ultimo Fotogramma</translation>
+        <translation type="unfinished">Ultimo Fotogramma</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="obsolete">Fotogramma Precedente</translation>
+        <translation type="unfinished">Fotogramma Precedente</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="obsolete">Fotogramma Corrente</translation>
+        <translation type="unfinished">Fotogramma Corrente</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="obsolete">Nome:</translation>
+        <translation type="unfinished">Nome:</translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="obsolete">Auto</translation>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">A Colori</translation>
+        <translation type="unfinished">A Colori</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">Luminosità:</translation>
+        <translation type="unfinished">Luminosità:</translation>
+    </message>
+    <message>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resolution: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set to the Current Playhead Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Picture Style: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Quality: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exposure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image adjust</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grayscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black &amp; White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Webcam Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annullare</translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">Carica</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Esporta</translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Webcam Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DSLR Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place on XSheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Direct Show Webcam Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use MJPG with Webcam</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Numpad Shortcuts When Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Live View on All Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interval(sec):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capture Review Time: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera detected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No camera detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>- Select camera -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mode: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Iso: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished"> Non è possibile salvare %1</translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Annullare</translation>
+        <translation type="unfinished">Annullare</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">Impossibile creare la cartella %1.</translation>
+        <translation type="unfinished">Impossibile creare la cartella %1.</translation>
+    </message>
+    <message>
+        <source>Create the Destination Subfolder to Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set As Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set the current &quot;Save In&quot; path as the default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infomation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show This on Launch of the Camera Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Scene in Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C- + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Project + Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save the current scene in the subfolder.
+Set the output folder path to the subfolder as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Episode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sequence:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder name should not be empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder %1 already exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14524,6 +16097,25 @@ Clicca la freccia per creare un nuovo sub-xsheet</translation>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14892,6 +16484,10 @@ Clicca la freccia per creare un nuovo sub-xsheet</translation>
     </message>
     <message>
         <source>Expand toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15321,11 +16917,11 @@ Per favore fai riferimento alla Guida utente per i dettagli.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reverse sheet symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15602,6 +17198,21 @@ Per favore fai riferimento alla Guida utente per i dettagli.</translation>
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Frame</source>
@@ -15633,6 +17244,10 @@ Per favore fai riferimento alla Guida utente per i dettagli.</translation>
     </message>
     <message>
         <source>Add New Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Xsheet/Timeline</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15733,6 +17348,12 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/italian/toonzlib.ts
+++ b/toonz/sources/translations/italian/toonzlib.ts
@@ -642,6 +642,34 @@
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Rasterizer</name>

--- a/toonz/sources/translations/italian/toonzqt.ts
+++ b/toonz/sources/translations/italian/toonzqt.ts
@@ -27,6 +27,14 @@
         <source>Replace </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddWordButton</name>
@@ -173,6 +181,30 @@ E&apos; possibile che il file sia corrotto.</translation>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A/R</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChannelHisto</name>
@@ -249,42 +281,6 @@ E&apos; possibile che il file sia corrotto.</translation>
     </message>
 </context>
 <context>
-    <name>ColorChannelControl</name>
-    <message>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>ColorField</name>
     <message>
         <source>R:</source>
@@ -330,6 +326,14 @@ Zero is fully transparent.</source>
     <name>ComboHistoRGBLabel</name>
     <message>
         <source>R:%1 G:%2 B:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A:%1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -787,6 +791,27 @@ Control click to reset.</source>
     </message>
     <message>
         <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1722,7 +1747,7 @@ Seleziona i nodi Effetto ed i relativi collegamenti prima di copiare o tagliare 
     </message>
     <message>
         <source>New Page</source>
-        <translation>Nuova Pagina</translation>
+        <translation type="vanished">Nuova Pagina</translation>
     </message>
     <message>
         <source>- No Styles -</source>
@@ -1730,10 +1755,6 @@ Seleziona i nodi Effetto ed i relativi collegamenti prima di copiare o tagliare 
     </message>
     <message>
         <source> + </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1888,6 +1909,22 @@ It can&apos;t be changed.  Ever.</source>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PaletteViewerGUI::PageViewer</name>
@@ -1934,6 +1971,12 @@ It can&apos;t be changed.  Ever.</source>
     <name>ParamsPageSet</name>
     <message>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2572,6 +2615,139 @@ Are you sure?</source>
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation type="unfinished">Nuovo Stile</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation type="unfinished">Nuova Pagina</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">Colorazione Automatica per le Linee</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QPushButton</name>
@@ -2706,11 +2882,7 @@ Are you sure?</source>
     <name>SettingsPage</name>
     <message>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">Colorazione Automatica per le Linee</translation>
-    </message>
-    <message>
-        <source>Reset to default</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Colorazione Automatica per le Linee</translation>
     </message>
 </context>
 <context>
@@ -2950,85 +3122,6 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
         <source>Apply</source>
@@ -3189,6 +3282,22 @@ Are you sure ?</source>
     </message>
     <message>
         <source>Style Set Name already exists. Please try another name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Auto/Apply</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/japanese/colorfx.ts
+++ b/toonz/sources/translations/japanese/colorfx.ts
@@ -21,6 +21,29 @@
     </message>
 </context>
 <context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation type="unfinished">密度</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MovingSolidColor</name>
     <message>
         <source>Offset</source>

--- a/toonz/sources/translations/japanese/image.ts
+++ b/toonz/sources/translations/japanese/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ja_JP">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished">スケール(%)</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished">繰り返し再生</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -12,6 +30,97 @@
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
         <translation>非圧縮</translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished">色深度</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished">圧縮方式</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished">品質</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
+        <translation type="unfinished">スケール(%)</translation>
     </message>
 </context>
 <context>
@@ -110,14 +219,12 @@
 <context>
     <name>MovWriterProperties</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
         <source>Quality</source>
-        <translation type="unfinished">品質</translation>
+        <translation type="obsolete">品質</translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
         <source>Scale</source>
-        <translation type="unfinished">スケール(%)</translation>
+        <translation type="obsolete">スケール(%)</translation>
     </message>
 </context>
 <context>
@@ -144,12 +251,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/japanese/tnztools.ts
+++ b/toonz/sources/translations/japanese/tnztools.ts
@@ -663,6 +663,10 @@
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FingerTool</name>
@@ -777,6 +781,30 @@
     </message>
     <message>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation type="unfinished">距離：</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation type="unfinished">スタイル番号：</translation>
+    </message>
+    <message>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1820,6 +1848,96 @@ Do you want to proceed?</source>
 moved to the end of the first page of the palette.</source>
         <translation>このオプションを有効にしてカラーモデルから色を拾っていくと、サンプルされた
 スタイルがパレットの1ページ目の末尾に順番に移動します。</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryTool</name>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished">不透明度</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">プリセット：</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished">&lt;カスタム&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <source>Rotation:</source>
+        <translation type="unfinished">回転:</translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation type="unfinished">表示位置をリセット</translation>
+    </message>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished">不透明度：</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">プリセット：</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/japanese/toonz.ts
+++ b/toonz/sources/translations/japanese/toonz.ts
@@ -174,7 +174,7 @@ Special thanks to:</source>
     <message>
         <source>The microphone is not available: 
 Please select a different device or check the microphone.</source>
-        <translation>マイクが使用できません：
+        <translation type="vanished">マイクが使用できません：
 別のデバイスを選択するか、マイクを確認して下さい。</translation>
     </message>
     <message>
@@ -272,6 +272,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -365,6 +385,90 @@ pick up all frames in the selected level.</source>
     <message>
         <source>Field Guide:</source>
         <translation type="vanished">フィールドガイド：</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished">GUI 表示/非表示</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished">セーフエリア （右クリックで選択）</translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">カメラスタンド表示</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">３D表示</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">カメラ表示</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">フリーズ</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">プレビュー</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">サブカメラプレビュー</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished">名称未設定</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished">シーン：</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished">：：フレーム：</translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished">：：ズーム：</translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished">：：レベル：</translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished">レベル：</translation>
     </message>
 </context>
 <context>
@@ -672,6 +776,21 @@ Stop it or wait for its completion before removing it.</source>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -695,7 +814,7 @@ Stop it or wait for its completion before removing it.</source>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">単位：</translation>
+        <translation>単位：</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -725,23 +844,23 @@ Do you want to crop the canvas?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">ピクセル</translation>
+        <translation>ピクセル</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">cm</translation>
+        <translation>cm</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">フィールド</translation>
+        <translation>フィールド</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">inch</translation>
+        <translation>inch</translation>
     </message>
 </context>
 <context>
@@ -1306,7 +1425,7 @@ What do you want to do? </source>
     <name>ComboViewerPanel</name>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>セーフエリア （右クリックで選択）</translation>
+        <translation type="vanished">セーフエリア （右クリックで選択）</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -1314,19 +1433,19 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>カメラスタンド表示</translation>
+        <translation type="vanished">カメラスタンド表示</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>３D表示</translation>
+        <translation type="vanished">３D表示</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>カメラ表示</translation>
+        <translation type="vanished">カメラ表示</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>フリーズ</translation>
+        <translation type="vanished">フリーズ</translation>
     </message>
     <message>
         <source>GUI Show / Hide</source>
@@ -1346,35 +1465,35 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Preview</source>
-        <translation>プレビュー</translation>
+        <translation type="vanished">プレビュー</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>サブカメラプレビュー</translation>
+        <translation type="vanished">サブカメラプレビュー</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>名称未設定</translation>
+        <translation type="vanished">名称未設定</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>シーン：</translation>
+        <translation type="vanished">シーン：</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>：：フレーム：</translation>
+        <translation type="vanished">：：フレーム：</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>：：レベル：</translation>
+        <translation type="vanished">：：レベル：</translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>レベル：</translation>
+        <translation type="vanished">レベル：</translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> （反転表示）</translation>
+        <translation type="vanished"> （反転表示）</translation>
     </message>
     <message>
         <source>   ::   Project: </source>
@@ -1394,19 +1513,6 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1470,6 +1576,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished">検索：</translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1494,6 +1604,131 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>リポジトリの</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished">%1 / %2 レベルを変換中： %3</translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">レベル　%1　はフレームがありません。スキップしました。</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished">変換</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">既存ファイルを飛ばす</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1764,6 +1999,99 @@ contain the dpi information, then the current camera dpi will be used.
     <message>
         <source>Level %1 converting to same file format; skipped.</source>
         <translation>レベル %1 は変換前と同じファイル形式が指定されているのでスキップします。</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">閉じる</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2039,6 +2367,13 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2164,6 +2499,47 @@ contain the dpi information, then the current camera dpi will be used.
     <message>
         <source>Height: </source>
         <translation>高さ： </translation>
+    </message>
+</context>
+<context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2453,6 +2829,10 @@ Do you want to create it?</source>
     <message>
         <source>Inbetween mark 2:</source>
         <translation>中割り記号 2：</translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2899,6 +3279,10 @@ Do you want to overwrite it?</source>
         <translation>ファイル %1 は、既に存在します。
 上書きしてもよろしいですか？</translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -2970,6 +3354,13 @@ Do you want to overwrite it?</source>
     <message>
         <source>Fx Settings</source>
         <translation>エフェクト設定</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3146,6 +3537,10 @@ Do you want to overwrite it?</source>
     <message>
         <source>Search:</source>
         <translation type="unfinished">検索：</translation>
+    </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3544,6 +3939,10 @@ Do you want to create it?</source>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -3842,6 +4241,13 @@ Please choose a valid lip sync data file to continue.</source>
     <message>
         <source>Load Clapperboard Settings Preset</source>
         <translation>カットボールド設定のプリセットを読み込む</translation>
+    </message>
+</context>
+<context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4145,6 +4551,10 @@ Please choose a valid lip sync data file to continue.</source>
     <message>
         <source>Locator</source>
         <translation>ロケーター</translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7411,6 +7821,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7682,6 +8164,22 @@ What do you want to do?</source>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8139,7 +8637,7 @@ The parameters to be saved are:
 - File options
 - Resample Balance
 - Channel width</source>
-        <translation>現在の出力設定を保存します。
+        <translation type="vanished">現在の出力設定を保存します。
 プリセットには以下の値が保存されます：
 - カメラ設定
 - 保存先となるプロジェクトフォルダ
@@ -8186,6 +8684,92 @@ The parameters to be saved are:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">プレビュー</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished">%1 を削除します。よろしいですか？</translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9007,7 +9591,7 @@ Set the output folder path to the subfolder as well.</source>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">TLVのセーブボックスを塗りつぶしの境界線として用いる</translation>
+        <translation>TLVのセーブボックスを塗りつぶしの境界線として用いる</translation>
     </message>
     <message>
         <source>Paper Thickness:</source>
@@ -9123,7 +9707,7 @@ Set the output folder path to the subfolder as well.</source>
     </message>
     <message>
         <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation>タイムシートのセル内で、フレーム番号下一ケタを「A,B,C…」の文字に置き換えて表示する</translation>
+        <translation type="vanished">タイムシートのセル内で、フレーム番号下一ケタを「A,B,C…」の文字に置き換えて表示する</translation>
     </message>
     <message>
         <source>Automatically Remove Scene Number from Loaded Level Name</source>
@@ -9343,7 +9927,7 @@ Set the output folder path to the subfolder as well.</source>
     </message>
     <message>
         <source>Pixels Only:</source>
-        <translation type="vanished">ピクセル単位を用いる：</translation>
+        <translation>ピクセル単位を用いる：</translation>
     </message>
     <message>
         <source>Rooms*:</source>
@@ -9441,7 +10025,7 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Show Column Numbers in Column Headers</source>
-        <translation>列のヘッダに列の番号を表示する</translation>
+        <translation type="vanished">列のヘッダに列の番号を表示する</translation>
     </message>
     <message>
         <source>Always ask before loading or importing</source>
@@ -10122,6 +10706,54 @@ but a random crash might occur, use at your own risk:</source>
         <source>Highlight Line Every Second</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -10357,6 +10989,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13027,6 +13663,87 @@ Do you want to continue?</source>
         <source>Target column</source>
         <translation>対象の列</translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -13206,6 +13923,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">ブラウザ</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished">ヒストリー</translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">新規ワークスペース</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -13217,7 +13965,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>ワークスペース</translation>
+        <translation type="vanished">ワークスペース</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -14104,6 +14852,13 @@ Please commit or revert changes first.</source>
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -14245,6 +15000,172 @@ Please commit or revert changes first.</source>
     <message>
         <source>Threshold: </source>
         <translation type="vanished">しきい値：</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished">フォルダ： </translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished">フォルダを開けませんでした</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished">入力されたフォルダパスは無効です。</translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">ファイル拡張子を変更できません</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">動画番号を設定できません</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">リネームできません。ファイルが既に存在します：</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">リネームできませんでした</translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">サブシーンとして読み込み</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">リネーム</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">彩色済TLVファイルに変換</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">線画TLVファイルに変換</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">バージョン管理</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">編集</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">フレーム範囲を編集...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished">置き換え...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">復帰</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">削除</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">改訂版を受け取る...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">編集情報</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">改訂履歴...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">フレーム範囲のロックを解除</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished">シーンを保存</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">シーン名：</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">線画TLVファイルに変換</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished">警告：レベル %1 は既に存在します。上書きしますか？</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">はい</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">完了：すべてのレベルがTLV形式に変換されました</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">彩色済TLVファイルに変換</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">完了：2つのレベルがTLV形式に変換されました</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">新規フォルダ</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">%1 フォルダを作成できません。</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">いくつかのファイルが開いています。編集を行う前にファイルを閉じて下さい。</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">いくつかのファイルが開いています。ロック解除の前にファイルを閉じて下さい。</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14516,55 +15437,55 @@ Please commit or revert changes first.</source>
     <name>SceneViewerPanel</name>
     <message>
         <source>Preview</source>
-        <translation>プレビュー</translation>
+        <translation type="vanished">プレビュー</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>サブカメラプレビュー</translation>
+        <translation type="vanished">サブカメラプレビュー</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>名称未設定</translation>
+        <translation type="vanished">名称未設定</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>シーン：</translation>
+        <translation type="vanished">シーン：</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>：：フレーム：</translation>
+        <translation type="vanished">：：フレーム：</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>：：レベル：</translation>
+        <translation type="vanished">：：レベル：</translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>レベル：</translation>
+        <translation type="vanished">レベル：</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>フリーズ</translation>
+        <translation type="vanished">フリーズ</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>カメラスタンド表示</translation>
+        <translation type="vanished">カメラスタンド表示</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>３D表示</translation>
+        <translation type="vanished">３D表示</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>カメラ表示</translation>
+        <translation type="vanished">カメラ表示</translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation>：：ズーム：</translation>
+        <translation type="vanished">：：ズーム：</translation>
     </message>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>セーフエリア （右クリックで選択）</translation>
+        <translation type="vanished">セーフエリア （右クリックで選択）</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -14572,7 +15493,7 @@ Please commit or revert changes first.</source>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (反転表示)</translation>
+        <translation type="vanished"> (反転表示)</translation>
     </message>
     <message>
         <source>   ::   Project: </source>
@@ -14588,28 +15509,7 @@ Please commit or revert changes first.</source>
     </message>
     <message>
         <source>GUI Show / Hide</source>
-        <translation type="unfinished">GUI 表示/非表示</translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">GUI 表示/非表示</translation>
     </message>
 </context>
 <context>
@@ -14937,7 +15837,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">タイムシート</translation>
+        <translation>タイムシート</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -14949,7 +15849,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">ウィンドウ</translation>
+        <translation>ウィンドウ</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -15250,7 +16150,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>DPI:</source>
-        <translation type="vanished">DPI：</translation>
+        <translation>DPI：</translation>
     </message>
     <message>
         <source>X</source>
@@ -15290,23 +16190,23 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">pixel</translation>
+        <translation>pixel</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">cm</translation>
+        <translation>cm</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">inch</translation>
+        <translation>inch</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">フィールド</translation>
+        <translation>フィールド</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -15318,7 +16218,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>Units:</source>
-        <translation type="vanished">単位：</translation>
+        <translation>単位：</translation>
     </message>
     <message>
         <source>No Recent Scenes</source>
@@ -15683,244 +16583,305 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="vanished">フレームなし</translation>
+        <translation>フレームなし</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="vanished">レベル名は指定されていません。有効なレベル名を指定して下さい</translation>
+        <translation>レベル名は指定されていません。有効なレベル名を指定して下さい</translation>
     </message>
     <message>
         <source>The level name specified is already used: please choose a different level name.</source>
-        <translation type="vanished">指定されたレベル名はすでに使用中です：別の名前を指定してください。</translation>
+        <translation>指定されたレベル名はすでに使用中です：別の名前を指定してください。</translation>
     </message>
     <message>
         <source>The save in path specified does not match with the existing level.</source>
-        <translation type="vanished">指定された保存先パスが既存のレベルと異なります。</translation>
+        <translation>指定された保存先パスが既存のレベルと異なります。</translation>
     </message>
     <message>
         <source>The captured image size does not match with the existing level.</source>
-        <translation type="vanished">取り込まれた画像サイズが既存のレベルと異なります。</translation>
+        <translation>取り込まれた画像サイズが既存のレベルと異なります。</translation>
     </message>
     <message>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
-        <translation type="vanished">ファイル %1 は既に存在します。
+        <translation>ファイル %1 は既に存在します。
 上書きしてもよろしいですか？</translation>
     </message>
     <message>
         <source>Failed to load %1.</source>
-        <translation type="vanished">ファイル %1 の読み込みに失敗しました。</translation>
+        <translation>ファイル %1 の読み込みに失敗しました。</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="vanished">フォルダー %1 は存在しません。
+        <translation>フォルダー %1 は存在しません。
 作成しますか？</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="vanished">作成できません</translation>
+        <translation>作成できません</translation>
     </message>
     <message>
         <source>UNDEFINED WARNING</source>
-        <translation type="vanished">※ 未定義の警告 ※</translation>
+        <translation>※ 未定義の警告 ※</translation>
     </message>
     <message>
         <source>The level is not registered in the scene, but exists in the file system.</source>
-        <translation type="vanished">このレベルは現在のシーンに読み込まれていませんが、ファイルは存在します。</translation>
+        <translation>このレベルは現在のシーンに読み込まれていませんが、ファイルは存在します。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告： 画像サイズの不一致。保存されている画像のサイズは %1 x %2 ピクセルです。</translation>
     </message>
     <message>
         <source>WARNING </source>
-        <translation type="vanished">警告 </translation>
+        <translation>警告 </translation>
     </message>
     <message>
         <source>
 Frame %1 exists.</source>
-        <translation type="vanished">
+        <translation>
 以下のコマが撮り込み済です： %1</translation>
     </message>
     <message>
         <source>
 Frames %1 exist.</source>
-        <translation type="vanished">
+        <translation>
 以下のコマが撮り込み済です： %1</translation>
     </message>
     <message>
         <source>OVERWRITE 1 of</source>
-        <translation type="vanished">上書き ：</translation>
+        <translation>上書き ：</translation>
     </message>
     <message>
         <source>ADD to</source>
-        <translation type="vanished">追加 ：</translation>
+        <translation>追加 ：</translation>
     </message>
     <message>
         <source> %1 frame</source>
-        <translation type="vanished"> %1 コマ撮り込み済</translation>
+        <translation> %1 コマ撮り込み済</translation>
     </message>
     <message>
         <source> %1 frames</source>
-        <translation type="vanished"> %1 コマ撮り込み済</translation>
+        <translation> %1 コマ撮り込み済</translation>
     </message>
     <message>
         <source>The level will be newly created.</source>
-        <translation type="vanished">レベルは新規作成されます。</translation>
+        <translation>レベルは新規作成されます。</translation>
     </message>
     <message>
         <source>NEW</source>
-        <translation type="vanished">新規作成</translation>
+        <translation>新規作成</translation>
     </message>
     <message>
         <source>The level is already registered in the scene.</source>
-        <translation type="vanished">このレベルは既にシーンに読み込まれています。</translation>
+        <translation>このレベルは既にシーンに読み込まれています。</translation>
     </message>
     <message>
         <source>
 NOTE : The level is not saved.</source>
-        <translation type="vanished">
+        <translation>
 注意： このレベルはまだファイルに保存されていません。</translation>
     </message>
     <message>
         <source>
 WARNING : Failed to get image size of the existing level %1.</source>
-        <translation type="vanished">
+        <translation>
 警告： 既存のレベル %1 の画像サイズの取得に失敗しました。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告： 画像サイズの不一致。既存のレベルのサイズは %1 x %2 です。</translation>
     </message>
     <message>
         <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
           %2.</source>
-        <translation type="vanished">警告： レベル名の重複。このシーンには、既に %1 という名前のレベルが存在します。
+        <translation>警告： レベル名の重複。このシーンには、既に %1 という名前のレベルが存在します。
 既存のレベルのファイルパスは %2 です。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告： 画像サイズの不一致。既存の同名のレベルのサイズは %1 x %2 です。</translation>
     </message>
     <message>
         <source>WARNING : Level path conflicts. There already is a level with the path %1                        
           in the scene with the name %2.</source>
-        <translation type="vanished">警告： ファイルパスの重複。既にこのシーンには %1 から読み込まれている
+        <translation>警告： ファイルパスの重複。既にこのシーンには %1 から読み込まれている
 別名のレベル %2 があります。</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 警告： 画像サイズの不一致。 既存の同じファイルパスのレベルのサイズは %1 x %2 です。</translation>
     </message>
     <message>
         <source>WARNING</source>
-        <translation type="vanished">警告</translation>
+        <translation>警告</translation>
     </message>
     <message>
         <source>No camera selected.</source>
-        <translation type="vanished">カメラが選択されていません。</translation>
+        <translation>カメラが選択されていません。</translation>
     </message>
     <message>
         <source>Please start live view before capturing an image.</source>
-        <translation type="vanished">画像取り込みの前にライブビューを開始してください。</translation>
+        <translation>画像取り込みの前にライブビューを開始してください。</translation>
     </message>
     <message>
         <source>Cannot capture webcam image unless live view is active.</source>
         <translation type="vanished">ライブビューが有効でないと、Webカメラの画像を取り込むことはできません。</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Controls</source>
-        <translation type="vanished">コントロール</translation>
+        <translation>コントロール</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">設定</translation>
+        <translation>設定</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">オプション</translation>
+        <translation>オプション</translation>
     </message>
     <message>
         <source>Resolution: </source>
-        <translation type="vanished">ピクセルサイズ： </translation>
+        <translation>ピクセルサイズ： </translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="vanished">更新</translation>
+        <translation>更新</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="vanished">ファイル</translation>
+        <translation>ファイル</translation>
     </message>
     <message>
         <source>Webcam Settings...</source>
-        <translation type="vanished">ウェブカメラ設定...</translation>
+        <translation>ウェブカメラ設定...</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="vanished">取り込み</translation>
+        <translation>取り込み</translation>
     </message>
     <message>
         <source>Next Level</source>
-        <translation type="vanished">次のレベル</translation>
+        <translation>次のレベル</translation>
     </message>
     <message>
         <source>Next New</source>
-        <translation type="vanished">次の新規レベル</translation>
+        <translation>次の新規レベル</translation>
     </message>
     <message>
         <source>Previous Level</source>
-        <translation type="vanished">前のレベル</translation>
+        <translation>前のレベル</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="vanished">次のフレーム</translation>
+        <translation>次のフレーム</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="vanished">最後のフレーム</translation>
+        <translation>最後のフレーム</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="vanished">前のフレーム</translation>
+        <translation>前のフレーム</translation>
     </message>
     <message>
         <source>Next XSheet Frame</source>
-        <translation type="vanished">タイムシートの次のフレーム</translation>
+        <translation>タイムシートの次のフレーム</translation>
     </message>
     <message>
         <source>Previous XSheet Frame</source>
-        <translation type="vanished">タイムシートの前のフレーム</translation>
+        <translation>タイムシートの前のフレーム</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="vanished">現在のフレーム</translation>
+        <translation>現在のフレーム</translation>
     </message>
     <message>
         <source>Set to the Current Playhead Location</source>
-        <translation type="vanished">現在のフレームに設定</translation>
+        <translation>現在のフレームに設定</translation>
     </message>
     <message>
         <source>Start Live View</source>
-        <translation type="vanished">ライブビューを開始</translation>
+        <translation>ライブビューを開始</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -15932,15 +16893,15 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Camera:</source>
-        <translation type="vanished">カメラ：</translation>
+        <translation>カメラ：</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="vanished">レベル名：</translation>
+        <translation>レベル名：</translation>
     </message>
     <message>
         <source>Frame:</source>
-        <translation type="vanished">フレーム：</translation>
+        <translation>フレーム：</translation>
     </message>
     <message>
         <source>File Type:</source>
@@ -15956,51 +16917,51 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Camera Model</source>
-        <translation type="vanished">カメラ型番</translation>
+        <translation>カメラ型番</translation>
     </message>
     <message>
         <source>Camera Mode</source>
-        <translation type="vanished">カメラモード</translation>
+        <translation>カメラモード</translation>
     </message>
     <message>
         <source>Temperature: </source>
-        <translation type="vanished">色温度： </translation>
+        <translation>色温度： </translation>
     </message>
     <message>
         <source>Shutter Speed: </source>
-        <translation type="vanished">シャッタースピード： </translation>
+        <translation>シャッタースピード： </translation>
     </message>
     <message>
         <source>Iso: </source>
-        <translation type="vanished">ISO： </translation>
+        <translation>ISO： </translation>
     </message>
     <message>
         <source>Aperture: </source>
-        <translation type="vanished">絞り： </translation>
+        <translation>絞り： </translation>
     </message>
     <message>
         <source>Exposure: </source>
-        <translation type="vanished">露出： </translation>
+        <translation>露出： </translation>
     </message>
     <message>
         <source>Image Quality: </source>
-        <translation type="vanished">画質： </translation>
+        <translation>画質： </translation>
     </message>
     <message>
         <source>Picture Style: </source>
-        <translation type="vanished">ピクチャスタイル： </translation>
+        <translation>ピクチャスタイル： </translation>
     </message>
     <message>
         <source>White Balance: </source>
-        <translation type="vanished">ホワイトバランス： </translation>
+        <translation>ホワイトバランス： </translation>
     </message>
     <message>
         <source>Webcam Options</source>
-        <translation type="vanished">ウェブカメラ設定</translation>
+        <translation>ウェブカメラ設定</translation>
     </message>
     <message>
         <source>DSLR Options</source>
-        <translation type="vanished">デジタル一眼レフ設定</translation>
+        <translation>デジタル一眼レフ設定</translation>
     </message>
     <message>
         <source>Place the frame in the XSheet</source>
@@ -16008,7 +16969,7 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Use Direct Show Webcam Drivers</source>
-        <translation type="vanished">DirectShowデバイスドライバを使用する</translation>
+        <translation>DirectShowデバイスドライバを使用する</translation>
     </message>
     <message>
         <source>Black Screen for Capture</source>
@@ -16020,23 +16981,23 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Use MJPG with Webcam</source>
-        <translation type="vanished">ウェブカメラの取り込みにMJPGを用いる</translation>
+        <translation>ウェブカメラの取り込みにMJPGを用いる</translation>
     </message>
     <message>
         <source>Place on XSheet</source>
-        <translation type="vanished">タイムシート内に配置</translation>
+        <translation>タイムシート内に配置</translation>
     </message>
     <message>
         <source>Use Numpad Shortcuts When Active</source>
-        <translation type="vanished">テンキーのショートカットを用いる</translation>
+        <translation>テンキーのショートカットを用いる</translation>
     </message>
     <message>
         <source>Show Live View on All Frames</source>
-        <translation type="vanished">全てのフレームでライブビューを表示</translation>
+        <translation>全てのフレームでライブビューを表示</translation>
     </message>
     <message>
         <source>Capture Review Time: </source>
-        <translation type="vanished">画像を確認する時間： </translation>
+        <translation>画像を確認する時間： </translation>
     </message>
     <message>
         <source>Level Subsampling: </source>
@@ -16044,160 +17005,440 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Opacity:</source>
-        <translation type="vanished">不透明度：</translation>
+        <translation>不透明度：</translation>
     </message>
     <message>
         <source>No camera detected.</source>
-        <translation type="vanished">カメラが認識されていません。</translation>
+        <translation>カメラが認識されていません。</translation>
     </message>
     <message>
         <source>No camera detected</source>
-        <translation type="vanished">カメラが認識されていません</translation>
+        <translation>カメラが認識されていません</translation>
     </message>
     <message>
         <source>- Select camera -</source>
-        <translation type="vanished">- カメラを選択してください -</translation>
+        <translation>- カメラを選択してください -</translation>
     </message>
     <message>
         <source>Mode: </source>
-        <translation type="vanished">モード： </translation>
+        <translation>モード： </translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="vanished">自動</translation>
+        <translation>自動</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="vanished">無効</translation>
+        <translation>無効</translation>
     </message>
     <message>
         <source>Stop Live View</source>
-        <translation type="vanished">ライブビューを停止</translation>
+        <translation>ライブビューを停止</translation>
     </message>
     <message>
         <source>Image adjust</source>
-        <translation type="obsolete">画像調整</translation>
+        <translation type="unfinished">画像調整</translation>
     </message>
     <message>
         <source>Grayscale</source>
-        <translation type="obsolete">グレースケール</translation>
+        <translation type="unfinished">グレースケール</translation>
     </message>
     <message>
         <source>Black &amp; White</source>
-        <translation type="obsolete">白黒二値</translation>
+        <translation type="unfinished">白黒二値</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">明るさ：</translation>
+        <translation type="unfinished">明るさ：</translation>
     </message>
     <message>
         <source>Color type:</source>
-        <translation type="obsolete">タイプ：</translation>
+        <translation type="unfinished">タイプ：</translation>
     </message>
     <message>
         <source>Interval(sec):</source>
-        <translation type="obsolete">間隔（秒）：</translation>
+        <translation type="unfinished">間隔（秒）：</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">書き出し</translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished">%1 を読み込めませんでした</translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished">%1 を保存できませんでした</translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>Create the Destination Subfolder to Save</source>
-        <translation type="obsolete">カットフォルダの作成</translation>
+        <translation type="unfinished">カットフォルダの作成</translation>
     </message>
     <message>
         <source>Set As Default</source>
-        <translation type="obsolete">既定値に設定</translation>
+        <translation type="unfinished">既定値に設定</translation>
     </message>
     <message>
         <source>Set the current &quot;Save In&quot; path as the default.</source>
-        <translation type="obsolete">現在の「作成場所」のパスを既定にします。</translation>
+        <translation type="unfinished">現在の「作成場所」のパスを既定にします。</translation>
     </message>
     <message>
         <source>Create Subfolder</source>
-        <translation type="obsolete">カットフォルダを作成する</translation>
+        <translation type="unfinished">カットフォルダを作成する</translation>
     </message>
     <message>
         <source>Infomation</source>
-        <translation type="obsolete">基本情報</translation>
+        <translation type="unfinished">基本情報</translation>
     </message>
     <message>
         <source>Subfolder Name</source>
-        <translation type="obsolete">フォルダ名</translation>
+        <translation type="unfinished">フォルダ名</translation>
     </message>
     <message>
         <source>Auto Format:</source>
-        <translation type="obsolete">自動生成：</translation>
+        <translation type="unfinished">自動生成：</translation>
     </message>
     <message>
         <source>Show This on Launch of the Camera Capture</source>
-        <translation type="obsolete">”カメラから取り込む”起動時にこのポップアップを表示する</translation>
+        <translation type="unfinished">”カメラから取り込む”起動時にこのポップアップを表示する</translation>
     </message>
     <message>
         <source>Save Scene in Subfolder</source>
-        <translation type="obsolete">カットフォルダ内にシーンを保存する</translation>
+        <translation type="unfinished">カットフォルダ内にシーンを保存する</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">キャンセル</translation>
+        <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
         <source>C- + Sequence + Scene</source>
-        <translation type="obsolete">C- + シーン + カット</translation>
+        <translation type="unfinished">C- + シーン + カット</translation>
     </message>
     <message>
         <source>Sequence + Scene</source>
-        <translation type="obsolete">シーン + カット</translation>
+        <translation type="unfinished">シーン + カット</translation>
     </message>
     <message>
         <source>Episode + Sequence + Scene</source>
-        <translation type="obsolete">話数 + シーン + カット</translation>
+        <translation type="unfinished">話数 + シーン + カット</translation>
     </message>
     <message>
         <source>Project + Episode + Sequence + Scene</source>
-        <translation type="obsolete">作品名 + 話数 + シーン + カット</translation>
+        <translation type="unfinished">作品名 + 話数 + シーン + カット</translation>
     </message>
     <message>
         <source>Save the current scene in the subfolder.
 Set the output folder path to the subfolder as well.</source>
-        <translation type="obsolete">カットフォルダ内にシーンファイルを保存します。同時に、
+        <translation type="unfinished">カットフォルダ内にシーンファイルを保存します。同時に、
 出力設定の保存先をカットフォルダのパスに設定します。</translation>
     </message>
     <message>
         <source>Episode:</source>
-        <translation type="obsolete">話数：</translation>
+        <translation type="unfinished">話数：</translation>
     </message>
     <message>
         <source>Sequence:</source>
-        <translation type="obsolete">シーン：</translation>
+        <translation type="unfinished">シーン：</translation>
     </message>
     <message>
         <source>Scene:</source>
-        <translation type="obsolete">カット番号：</translation>
+        <translation type="unfinished">カット番号：</translation>
     </message>
     <message>
         <source>Subfolder Name:</source>
-        <translation type="obsolete">フォルダ名：</translation>
+        <translation type="unfinished">フォルダ名：</translation>
     </message>
     <message>
         <source>Subfolder name should not be empty.</source>
-        <translation type="obsolete">フォルダ名を入力してください。</translation>
+        <translation type="unfinished">フォルダ名を入力してください。</translation>
     </message>
     <message>
         <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
-        <translation type="obsolete">フォルダ名に次のいずれかを含む事はできません：  * . &quot; / \ [ ] : ; | = , </translation>
+        <translation type="unfinished">フォルダ名に次のいずれかを含む事はできません：  * . &quot; / \ [ ] : ; | = , </translation>
     </message>
     <message>
         <source>Folder %1 already exists.</source>
-        <translation type="obsolete">フォルダ %1 は既に存在します。</translation>
+        <translation type="unfinished">フォルダ %1 は既に存在します。</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">%1 フォルダを作成できません。</translation>
+        <translation type="unfinished">%1 フォルダを作成できません。</translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -16387,6 +17628,25 @@ Click the arrow button to create a new sub-xsheet</source>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16756,6 +18016,10 @@ Click the arrow button to create a new sub-xsheet</source>
     <message>
         <source>Expand toolbar</source>
         <translation>ツールバーを展開する</translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -17513,6 +18777,21 @@ Please refer to the user guide for details.</source>
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished">新規メモを追加</translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished">前のメモ</translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished">次のメモ</translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Frame</source>
@@ -17532,7 +18811,7 @@ Please refer to the user guide for details.</source>
     </message>
     <message>
         <source>Toggle Xsheet/Timeline</source>
-        <translation type="vanished">タイムシート/タイムライン切り替え</translation>
+        <translation>タイムシート/タイムライン切り替え</translation>
     </message>
     <message>
         <source>Add New Memo</source>
@@ -17663,6 +18942,12 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/japanese/toonzlib.ts
+++ b/toonz/sources/translations/japanese/toonzlib.ts
@@ -664,6 +664,34 @@
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Rasterizer</name>

--- a/toonz/sources/translations/japanese/toonzqt.ts
+++ b/toonz/sources/translations/japanese/toonzqt.ts
@@ -27,6 +27,14 @@
         <source>Replace </source>
         <translation>置き換え</translation>
     </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddWordButton</name>
@@ -167,7 +175,7 @@ Possibly the preset file has been corrupted</source>
     </message>
     <message>
         <source>A/R</source>
-        <translation type="vanished">縦横比</translation>
+        <translation>縦横比</translation>
     </message>
     <message>
         <source>&lt;custom&gt;</source>
@@ -175,6 +183,26 @@ Possibly the preset file has been corrupted</source>
     </message>
     <message>
         <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -265,42 +293,6 @@ Possibly the preset file has been corrupted</source>
     </message>
 </context>
 <context>
-    <name>ColorChannelControl</name>
-    <message>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>ColorField</name>
     <message>
         <source>R:</source>
@@ -347,6 +339,14 @@ Zero is fully transparent.</source>
     <message>
         <source>R:%1 G:%2 B:%3</source>
         <translation></translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A:%1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -810,6 +810,27 @@ Control click to reset.</source>
     </message>
     <message>
         <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1761,7 +1782,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
     </message>
     <message>
         <source>New Page</source>
-        <translation>新規ページ</translation>
+        <translation type="vanished">新規ページ</translation>
     </message>
     <message>
         <source>- No Styles -</source>
@@ -1769,7 +1790,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
     </message>
     <message>
         <source>Name Editor</source>
-        <translation type="unfinished">スタイル名エディタ</translation>
+        <translation type="obsolete">スタイル名エディタ</translation>
     </message>
     <message>
         <source> + </source>
@@ -1947,6 +1968,22 @@ It can&apos;t be changed.  Ever.</source>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">スタイル名エディタ</translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PaletteViewerGUI::PageViewer</name>
@@ -2009,6 +2046,12 @@ It can&apos;t be changed.  Ever.</source>
     </message>
     <message>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2669,6 +2712,139 @@ Are you sure?</source>
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">スタイル名エディタ</translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation type="unfinished">新規スタイル</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation type="unfinished">新規ページ</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">色トレース線として、含み塗りを行う</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished">リセット</translation>
+    </message>
 </context>
 <context>
     <name>QPushButton</name>
@@ -2807,11 +2983,11 @@ Are you sure?</source>
     <name>SettingsPage</name>
     <message>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">色トレース線として、含み塗りを行う</translation>
+        <translation type="obsolete">色トレース線として、含み塗りを行う</translation>
     </message>
     <message>
         <source>Reset to default</source>
-        <translation type="unfinished">リセット</translation>
+        <translation type="obsolete">リセット</translation>
     </message>
 </context>
 <context>
@@ -3055,85 +3231,6 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
         <source>Apply</source>
@@ -3332,6 +3429,22 @@ Apply</source>
     </message>
     <message>
         <source>Style Set Name already exists. Please try another name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Auto/Apply</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/korean/colorfx.ts
+++ b/toonz/sources/translations/korean/colorfx.ts
@@ -21,6 +21,29 @@
     </message>
 </context>
 <context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation type="unfinished">밀도</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MovingSolidColor</name>
     <message>
         <source>Horiz Offset</source>

--- a/toonz/sources/translations/korean/image.ts
+++ b/toonz/sources/translations/korean/image.ts
@@ -2,6 +2,21 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ko" sourcelanguage="en">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished">비율</translation>
+    </message>
+    <message>
+        <source>Looping</source>
+        <translation type="unfinished">반복</translation>
+    </message>
+    <message>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <source>Codec</source>
@@ -10,6 +25,80 @@
     <message>
         <source>Uncompressed</source>
         <translation>압축해제</translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished">픽셀당 비트 수</translation>
+    </message>
+    <message>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Compression Type</source>
+        <translation type="unfinished">압축</translation>
+    </message>
+    <message>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <source>Quality</source>
+        <translation type="unfinished">품질</translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished">비율</translation>
     </message>
 </context>
 <context>
@@ -91,11 +180,11 @@
     <name>MovWriterProperties</name>
     <message>
         <source>Quality</source>
-        <translation type="unfinished">품질</translation>
+        <translation type="obsolete">품질</translation>
     </message>
     <message>
         <source>Scale</source>
-        <translation type="unfinished">비율</translation>
+        <translation type="obsolete">비율</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/korean/tnztools.ts
+++ b/toonz/sources/translations/korean/tnztools.ts
@@ -603,6 +603,10 @@
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FingerTool</name>
@@ -705,6 +709,30 @@
     </message>
     <message>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation type="unfinished">거리:</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation type="unfinished">스타일 인덱스:</translation>
+    </message>
+    <message>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1731,6 +1759,96 @@ Do you want to proceed?</source>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
         <translation>이 옵션이 활성화되면 선택한 스타일이 팔레트의 첫 페이지 끝으로 이동한다.</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryTool</name>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished">불투명도</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">사전설정:</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished">&lt;사용자 정의&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <source>Rotation:</source>
+        <translation type="unfinished">회전:</translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation type="unfinished">위치 재설정</translation>
+    </message>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished">불투명도:</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">사전설정:</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/korean/toonz.ts
+++ b/toonz/sources/translations/korean/toonz.ts
@@ -174,7 +174,7 @@ Special thanks to:</source>
     <message>
         <source>The microphone is not available: 
 Please select a different device or check the microphone.</source>
-        <translation>마이크를 사용할 수 없음;
+        <translation type="vanished">마이크를 사용할 수 없음;
 다른 장치를 선택하거나 마이크를 확인하세요.</translation>
     </message>
     <message>
@@ -272,6 +272,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -364,6 +384,90 @@ pick up all frames in the selected level.</source>
     <message>
         <source>Pegbar Holes:</source>
         <translation type="vanished">페그바 구멍:</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished">GUI 표시/비표시</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished">안전 영역(선택하려면 오늘쪽 클릭)</translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">카메라 스텐드 보기</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">3D 보기</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">카메라 보기</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">고정</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">미리보기</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">서브 카메라 미리보기</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished">제목없음</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished">장면:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished">  ::  프레임: </translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished">  ::  확대/축소 : </translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"> (플립)</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished">  ::  레벨: </translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished">레벨:</translation>
     </message>
 </context>
 <context>
@@ -671,6 +775,21 @@ Do you want to save your changes?</source>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -694,27 +813,27 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">픽셀</translation>
+        <translation>픽셀</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">미리</translation>
+        <translation>미리</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">센치</translation>
+        <translation>센치</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">필드</translation>
+        <translation>필드</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">인치</translation>
+        <translation>인치</translation>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">단위:</translation>
+        <translation>단위:</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -1313,7 +1432,7 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>안전 영역(선택하려면 오늘쪽 클릭)</translation>
+        <translation type="vanished">안전 영역(선택하려면 오늘쪽 클릭)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -1321,51 +1440,51 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>카메라 스텐드 보기</translation>
+        <translation type="vanished">카메라 스텐드 보기</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>3D 보기</translation>
+        <translation type="vanished">3D 보기</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>카메라 보기</translation>
+        <translation type="vanished">카메라 보기</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>고정</translation>
+        <translation type="vanished">고정</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>미리보기</translation>
+        <translation type="vanished">미리보기</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>서브 카메라 미리보기</translation>
+        <translation type="vanished">서브 카메라 미리보기</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>제목없음</translation>
+        <translation type="vanished">제목없음</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>장면:</translation>
+        <translation type="vanished">장면:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>  ::  프레임: </translation>
+        <translation type="vanished">  ::  프레임: </translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (플립)</translation>
+        <translation type="vanished"> (플립)</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>  ::  레벨: </translation>
+        <translation type="vanished">  ::  레벨: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>레벨:</translation>
+        <translation type="vanished">레벨:</translation>
     </message>
     <message>
         <source>   ::   Project: </source>
@@ -1385,19 +1504,6 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1461,6 +1567,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished">검색:</translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1485,6 +1595,131 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>그들의 것</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished">%2의 변환 레벨 %1 : %3 </translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">레벨 %1에 프레임이 없음. 건너뜁니다.</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished">변환</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">기존파일 건너뛰기</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1745,6 +1980,99 @@ DPI 정보를 포함하면 현재 카메라 DPI가 적용됩니다. </translatio
     </message>
 </context>
 <context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">닫기</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished">덮어쓰기</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DVGui::ProgressDialog</name>
     <message>
         <source>Loading &quot;%1&quot;...</source>
@@ -1962,6 +2290,13 @@ DPI 정보를 포함하면 현재 카메라 DPI가 적용됩니다. </translatio
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2082,6 +2417,47 @@ DPI 정보를 포함하면 현재 카메라 DPI가 적용됩니다. </translatio
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
         <source>Export</source>
@@ -2176,26 +2552,6 @@ DPI 정보를 포함하면 현재 카메라 DPI가 적용됩니다. </translatio
     <message>
         <source>None</source>
         <translation type="unfinished">없음</translation>
-    </message>
-    <message>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Target column</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2317,14 +2673,6 @@ DPI 정보를 포함하면 현재 카메라 DPI가 적용됩니다. </translatio
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2390,6 +2738,18 @@ Do you want to create it?</source>
     </message>
     <message>
         <source>Failed to create folder %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2829,6 +3189,10 @@ Do you want to overwrite it?</source>
         <source>  ::  Shrink </source>
         <translation> :: 축소</translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -2896,6 +3260,13 @@ Do you want to overwrite it?</source>
     <message>
         <source>Fx Settings</source>
         <translation>Fx 설정</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3064,6 +3435,10 @@ Do you want to overwrite it?</source>
     <message>
         <source>Search:</source>
         <translation type="unfinished">검색:</translation>
+    </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3446,6 +3821,10 @@ Do you want to create it?</source>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -3750,6 +4129,13 @@ Please choose a valid lip sync data file to continue.</source>
     </message>
 </context>
 <context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadColorModelPopup</name>
     <message>
         <source>Load Color Model</source>
@@ -4034,6 +4420,10 @@ Please choose a valid lip sync data file to continue.</source>
     <message>
         <source>Locator</source>
         <translation>로케이터</translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7069,6 +7459,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7325,6 +7787,22 @@ What do you want to do?</source>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">색상</translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7611,7 +8089,7 @@ The parameters to be saved are:
 - File options
 - Resample Balance
 - Channel width</source>
-        <translation>현재 출력설정을 저장
+        <translation type="vanished">현재 출력설정을 저장
 저장할 매개 변수는 다음과 같다.
 -카메라 설정
 -저장 할 프로젝트 폴도
@@ -7782,6 +8260,92 @@ The parameters to be saved are:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">미리보기</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">색상</translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished">&quot;%1&quot;을 삭제합니다. 확실합니까?</translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8473,7 +9037,7 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation>표시 &quot;ABC&quot;X 셀의 프레임 번호 부록</translation>
+        <translation type="vanished">표시 &quot;ABC&quot;X 셀의 프레임 번호 부록</translation>
     </message>
     <message>
         <source>Visualization</source>
@@ -8533,7 +9097,7 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">충전 작업을 제한하려면 TLV 저장 상자를 사용하세요</translation>
+        <translation>충전 작업을 제한하려면 TLV 저장 상자를 사용하세요</translation>
     </message>
     <message>
         <source>Minimize Savebox after Editing</source>
@@ -8589,7 +9153,7 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Show Column Numbers in Column Headers</source>
-        <translation>열 머리글에 열 번호 표시</translation>
+        <translation type="vanished">열 머리글에 열 번호 표시</translation>
     </message>
     <message>
         <source>Sync Level Strip Drawing Number Changes with the Xsheet</source>
@@ -8951,7 +9515,7 @@ if both are possible on coding file path.</source>
     </message>
     <message>
         <source>Pixels Only:</source>
-        <translation type="vanished">픽셀 만:</translation>
+        <translation>픽셀 만:</translation>
     </message>
     <message>
         <source>Unit:</source>
@@ -9520,6 +10084,58 @@ but a random crash might occur, use at your own risk:</source>
         <source>Edit Additional Style Sheet..</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -9742,6 +10358,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12292,6 +12912,107 @@ Do you want to continue?</source>
         <source>Explicit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -12466,6 +13187,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished">역사</translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">새로운 공간</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -12481,7 +13233,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>공간/방</translation>
+        <translation type="vanished">공간/방</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -13360,6 +14112,13 @@ Please commit or revert changes first.</source>
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -13501,6 +14260,172 @@ Please commit or revert changes first.</source>
     <message>
         <source>Brightness: </source>
         <translation type="vanished">밝기:</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished">폴더</translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished">폴더 열기 실패</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished">입력 폴더 경로가 잘못됨.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">파일 확장명을 변경할 수 없음</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">동영상 번호를 설정할 수 없음</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">이름 바꿀 수 없음. 파일이 이미 있음:</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">다시 이름 짓지 못함</translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">서브-X시트로 가져오기</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">가져오기</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">이름변경</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">그림 TLV로 변환</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">채색되지 않은 TLV로 변환</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">버전 관리</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">편집</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">프레임 범위 편집...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished">넣기...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">되돌리기</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished">얻기</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">삭제</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">수정 가져오기...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished">잠금 해제</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">정보 편집</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">역사 수정...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">프레임 범위 잠금 해제</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">장면 이름:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished">%1을 %2에 복사하는 중에 오류가 발생함</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">채색되지 않은 TLV로 변환</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished">경고: 레벨 %1 이미 존재함. 덮어쓰겠습니까?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">네</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">아니오</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">완료: TLV 형식으로 변환된 모든 레벨</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">그림 TLV로 변환</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">완료:TLV 형식으로 변환된 레벨 2개</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">새폴더</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">%1 폴더를 만들 수 없음.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">편집 하려는 일부 파일이 열려있음. 먼저 닫으세요.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">편집 하려는 일부 파일이 열려있음. 먼저 닫으세요.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13720,7 +14645,7 @@ Please commit or revert changes first.</source>
     <name>SceneViewerPanel</name>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>안전 영역(선택하려면 오늘쪽 클릭)</translation>
+        <translation type="vanished">안전 영역(선택하려면 오늘쪽 클릭)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -13728,55 +14653,55 @@ Please commit or revert changes first.</source>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>카메라 스텐드 보기</translation>
+        <translation type="vanished">카메라 스텐드 보기</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>3D 보기</translation>
+        <translation type="vanished">3D 보기</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>카메라 보기</translation>
+        <translation type="vanished">카메라 보기</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>고정</translation>
+        <translation type="vanished">고정</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>미리보기</translation>
+        <translation type="vanished">미리보기</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>서브 카메라 미리보기</translation>
+        <translation type="vanished">서브 카메라 미리보기</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>제목없음</translation>
+        <translation type="vanished">제목없음</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>장면:</translation>
+        <translation type="vanished">장면:</translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>  ::  프레임: </translation>
+        <translation type="vanished">  ::  프레임: </translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation>  ::  확대/축소 : </translation>
+        <translation type="vanished">  ::  확대/축소 : </translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (플립)</translation>
+        <translation type="vanished"> (플립)</translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>  ::  레벨: </translation>
+        <translation type="vanished">  ::  레벨: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>레벨:</translation>
+        <translation type="vanished">레벨:</translation>
     </message>
     <message>
         <source>   ::   Project: </source>
@@ -13792,28 +14717,7 @@ Please commit or revert changes first.</source>
     </message>
     <message>
         <source>GUI Show / Hide</source>
-        <translation type="unfinished">GUI 표시/비표시</translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">GUI 표시/비표시</translation>
     </message>
 </context>
 <context>
@@ -14141,7 +15045,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">X-시트</translation>
+        <translation>X-시트</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -14153,7 +15057,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">윈도우</translation>
+        <translation>윈도우</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -14490,23 +15394,23 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">픽셀</translation>
+        <translation>픽셀</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">센치</translation>
+        <translation>센치</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">미리</translation>
+        <translation>미리</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">인치</translation>
+        <translation>인치</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">필드</translation>
+        <translation>필드</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -14518,7 +15422,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>Units:</source>
-        <translation type="vanished">단위:</translation>
+        <translation>단위:</translation>
     </message>
     <message>
         <source>Minutes</source>
@@ -14634,6 +15538,10 @@ What would you like to do?</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14871,234 +15779,295 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="vanished">아니오</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="vanished">레벨 이름지정 되지 않음: 유효한 레벨 이름을 선택하세요</translation>
+        <translation>레벨 이름지정 되지 않음: 유효한 레벨 이름을 선택하세요</translation>
     </message>
     <message>
         <source>The level name specified is already used: please choose a different level name.</source>
-        <translation type="vanished">지정된 레벨 이름은 이미 사용중. 다른 레벨 이름을 선택하세요.</translation>
+        <translation>지정된 레벨 이름은 이미 사용중. 다른 레벨 이름을 선택하세요.</translation>
     </message>
     <message>
         <source>The save in path specified does not match with the existing level.</source>
-        <translation type="vanished">지정한 저장 경로가 기존 레벨과 일치하지 않음.</translation>
+        <translation>지정한 저장 경로가 기존 레벨과 일치하지 않음.</translation>
     </message>
     <message>
         <source>The captured image size does not match with the existing level.</source>
-        <translation type="vanished">캡처된 이미지 크기가 기존 레벨과 일치하지 않음.</translation>
+        <translation>캡처된 이미지 크기가 기존 레벨과 일치하지 않음.</translation>
     </message>
     <message>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
-        <translation type="vanished">%1 파일이 이미존재함.
+        <translation>%1 파일이 이미존재함.
 덮어쓰시겠습니까?</translation>
     </message>
     <message>
         <source>Failed to load %1.</source>
-        <translation type="vanished">%1를 가져오지 못함.</translation>
+        <translation>%1를 가져오지 못함.</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="vanished">폴더 %1 존재하지 않음.
+        <translation>폴더 %1 존재하지 않음.
 생성하겠습니까?</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="vanished">만들 수 없음</translation>
+        <translation>만들 수 없음</translation>
     </message>
     <message>
         <source>UNDEFINED WARNING</source>
-        <translation type="vanished">정의 되지 않은 경고</translation>
+        <translation>정의 되지 않은 경고</translation>
     </message>
     <message>
         <source>The level is not registered in the scene, but exists in the file system.</source>
-        <translation type="vanished">레벨은 장면에 등록되지 않지만 파일 시스템에 존재함.</translation>
+        <translation>레벨은 장면에 등록되지 않지만 파일 시스템에 존재함.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
-        <translation type="vanished">경고: 이미지 크기가 일치하지 않음. 저장된 이미지 크기는 %1 x %2임.</translation>
+        <translation>경고: 이미지 크기가 일치하지 않음. 저장된 이미지 크기는 %1 x %2임.</translation>
     </message>
     <message>
         <source>WARNING </source>
-        <translation type="vanished">경고 </translation>
+        <translation>경고 </translation>
     </message>
     <message>
         <source>
 Frame %1 exists.</source>
-        <translation type="vanished">%1 프레임이 존재함.</translation>
+        <translation>%1 프레임이 존재함.</translation>
     </message>
     <message>
         <source>
 Frames %1 exist.</source>
-        <translation type="vanished">%1 프레임이 존재함.</translation>
+        <translation>%1 프레임이 존재함.</translation>
     </message>
     <message>
         <source>OVERWRITE 1 of</source>
-        <translation type="vanished">1의 덮어쓰기</translation>
+        <translation>1의 덮어쓰기</translation>
     </message>
     <message>
         <source>ADD to</source>
-        <translation type="vanished">추가</translation>
+        <translation>추가</translation>
     </message>
     <message>
         <source> %1 frame</source>
-        <translation type="vanished">프레임 %1</translation>
+        <translation>프레임 %1</translation>
     </message>
     <message>
         <source> %1 frames</source>
-        <translation type="vanished">프레임 %1</translation>
+        <translation>프레임 %1</translation>
     </message>
     <message>
         <source>The level will be newly created.</source>
-        <translation type="vanished">레벨이 새로 생성됨.</translation>
+        <translation>레벨이 새로 생성됨.</translation>
     </message>
     <message>
         <source>NEW</source>
-        <translation type="vanished">새로운</translation>
+        <translation>새로운</translation>
     </message>
     <message>
         <source>The level is already registered in the scene.</source>
-        <translation type="vanished">레벨은 이미 장면에 등록되어 있음.</translation>
+        <translation>레벨은 이미 장면에 등록되어 있음.</translation>
     </message>
     <message>
         <source>
 NOTE : The level is not saved.</source>
-        <translation type="vanished">참고: 레벨이 저장되지 않음.</translation>
+        <translation>참고: 레벨이 저장되지 않음.</translation>
     </message>
     <message>
         <source>
 WARNING : Failed to get image size of the existing level %1.</source>
-        <translation type="vanished">경고: 기존 레벨 %1의 이미지 크기를 가져오지 못함.</translation>
+        <translation>경고: 기존 레벨 %1의 이미지 크기를 가져오지 못함.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
-        <translation type="vanished">경고: 이미지 크기가 일치하지 안음. 기존 레벨 크기는 %1 x %2임.</translation>
+        <translation>경고: 이미지 크기가 일치하지 안음. 기존 레벨 크기는 %1 x %2임.</translation>
     </message>
     <message>
         <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
           %2.</source>
-        <translation type="vanished">경고: 레벨 이름이 충돌함. 경로가 있는 장면에 이미 레벨 %1가 있음 %2.</translation>
+        <translation>경고: 레벨 이름이 충돌함. 경로가 있는 장면에 이미 레벨 %1가 있음 %2.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
-        <translation type="vanished">경고: 이미지 크기가 일치하지 않음. 이름이 같은 레벨의 크기는 %1 x %2임.</translation>
+        <translation>경고: 이미지 크기가 일치하지 않음. 이름이 같은 레벨의 크기는 %1 x %2임.</translation>
     </message>
     <message>
         <source>WARNING : Level path conflicts. There already is a level with the path %1                        
           in the scene with the name %2.</source>
-        <translation type="vanished">경고: 레벨 경로 충돌. 경로가 %1인 레벨이 이미 있음. 이름이 %2인 장면에서</translation>
+        <translation>경고: 레벨 경로 충돌. 경로가 %1인 레벨이 이미 있음. 이름이 %2인 장면에서</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
-        <translation type="vanished">경고: 이미지 크기가 일치하지 않음. 경로가 같은 레벨의 크기는 %1 x %2임.</translation>
+        <translation>경고: 이미지 크기가 일치하지 않음. 경로가 같은 레벨의 크기는 %1 x %2임.</translation>
     </message>
     <message>
         <source>WARNING</source>
-        <translation type="vanished">경고</translation>
+        <translation>경고</translation>
     </message>
     <message>
         <source>No camera selected.</source>
-        <translation type="vanished">카메라가 감지되지 않음.</translation>
+        <translation>카메라가 감지되지 않음.</translation>
     </message>
     <message>
         <source>Please start live view before capturing an image.</source>
-        <translation type="vanished">이미지를 캡처하기 전에 라이브 보기를 시작하십시오.</translation>
+        <translation>이미지를 캡처하기 전에 라이브 보기를 시작하십시오.</translation>
     </message>
     <message>
         <source>Cannot capture webcam image unless live view is active.</source>
         <translation type="vanished">라이브 뷰가 활성화되어 있지 않으면 웹캠 이미지를 캡처할 수 없다.</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Controls</source>
-        <translation type="vanished">컨트롤</translation>
+        <translation>컨트롤</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">설정</translation>
+        <translation>설정</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">옵션</translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <source>Resolution: </source>
-        <translation type="vanished">해상도:</translation>
+        <translation>해상도:</translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="vanished">새로고침</translation>
+        <translation>새로고침</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="vanished">파일</translation>
+        <translation>파일</translation>
     </message>
     <message>
         <source>Webcam Settings...</source>
-        <translation type="vanished">웹캠세팅...</translation>
+        <translation>웹캠세팅...</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="vanished">캡처</translation>
+        <translation>캡처</translation>
     </message>
     <message>
         <source>Next Level</source>
-        <translation type="vanished">새로운 레벨</translation>
+        <translation>새로운 레벨</translation>
     </message>
     <message>
         <source>Next New</source>
-        <translation type="vanished">새로 만들기</translation>
+        <translation>새로 만들기</translation>
     </message>
     <message>
         <source>Previous Level</source>
-        <translation type="vanished">이전 레벨</translation>
+        <translation>이전 레벨</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="vanished">다음 프레임</translation>
+        <translation>다음 프레임</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="vanished">마지막 프레임</translation>
+        <translation>마지막 프레임</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="vanished">이전 프레임</translation>
+        <translation>이전 프레임</translation>
     </message>
     <message>
         <source>Next XSheet Frame</source>
-        <translation type="vanished">다음 X시트 프레임</translation>
+        <translation>다음 X시트 프레임</translation>
     </message>
     <message>
         <source>Previous XSheet Frame</source>
-        <translation type="vanished">이전 X시트프레임</translation>
+        <translation>이전 X시트프레임</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="vanished">현재 프레임</translation>
+        <translation>현재 프레임</translation>
     </message>
     <message>
         <source>Set to the Current Playhead Location</source>
-        <translation type="vanished">현재 플레이헤드 위치로 설정</translation>
+        <translation>현재 플레이헤드 위치로 설정</translation>
     </message>
     <message>
         <source>Start Live View</source>
-        <translation type="vanished">라이브 뷰 시작</translation>
+        <translation>라이브 뷰 시작</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -15110,15 +16079,15 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Camera:</source>
-        <translation type="vanished">카메라:</translation>
+        <translation>카메라:</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="vanished">이름:</translation>
+        <translation>이름:</translation>
     </message>
     <message>
         <source>Frame:</source>
-        <translation type="vanished">프레임:</translation>
+        <translation>프레임:</translation>
     </message>
     <message>
         <source>File Type:</source>
@@ -15134,47 +16103,47 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Camera Model</source>
-        <translation type="vanished">카메라 모델</translation>
+        <translation>카메라 모델</translation>
     </message>
     <message>
         <source>Camera Mode</source>
-        <translation type="vanished">카메라 모드</translation>
+        <translation>카메라 모드</translation>
     </message>
     <message>
         <source>Temperature: </source>
-        <translation type="vanished">온도: </translation>
+        <translation>온도: </translation>
     </message>
     <message>
         <source>Shutter Speed: </source>
-        <translation type="vanished">셔터 속도: </translation>
+        <translation>셔터 속도: </translation>
     </message>
     <message>
         <source>Aperture: </source>
-        <translation type="vanished">구멍: </translation>
+        <translation>구멍: </translation>
     </message>
     <message>
         <source>Exposure: </source>
-        <translation type="vanished">노출: </translation>
+        <translation>노출: </translation>
     </message>
     <message>
         <source>Image Quality: </source>
-        <translation type="vanished">이미지 품질: </translation>
+        <translation>이미지 품질: </translation>
     </message>
     <message>
         <source>Picture Style: </source>
-        <translation type="vanished">사진 스타일: </translation>
+        <translation>사진 스타일: </translation>
     </message>
     <message>
         <source>White Balance: </source>
-        <translation type="vanished">화이트밸런스: </translation>
+        <translation>화이트밸런스: </translation>
     </message>
     <message>
         <source>Webcam Options</source>
-        <translation type="vanished">웹캠옵션</translation>
+        <translation>웹캠옵션</translation>
     </message>
     <message>
         <source>DSLR Options</source>
-        <translation type="vanished">DSLR 옵션</translation>
+        <translation>DSLR 옵션</translation>
     </message>
     <message>
         <source>Place the frame in the XSheet</source>
@@ -15182,7 +16151,7 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Use Direct Show Webcam Drivers</source>
-        <translation type="vanished">직접 웹캠 드라이버 사용</translation>
+        <translation>직접 웹캠 드라이버 사용</translation>
     </message>
     <message>
         <source>Black Screen for Capture</source>
@@ -15194,23 +16163,23 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Use MJPG with Webcam</source>
-        <translation type="vanished">웹캠과 함께 MJPG 사용</translation>
+        <translation>웹캠과 함께 MJPG 사용</translation>
     </message>
     <message>
         <source>Place on XSheet</source>
-        <translation type="vanished">X시트에 배치</translation>
+        <translation>X시트에 배치</translation>
     </message>
     <message>
         <source>Use Numpad Shortcuts When Active</source>
-        <translation type="vanished">활성화 시 Numpad 바로 가기 사용</translation>
+        <translation>활성화 시 Numpad 바로 가기 사용</translation>
     </message>
     <message>
         <source>Show Live View on All Frames</source>
-        <translation type="vanished">모든 프레임에 라이브 뷰 표시</translation>
+        <translation>모든 프레임에 라이브 뷰 표시</translation>
     </message>
     <message>
         <source>Capture Review Time: </source>
-        <translation type="vanished">캡처 검토 시간: </translation>
+        <translation>캡처 검토 시간: </translation>
     </message>
     <message>
         <source>Level Subsampling: </source>
@@ -15218,172 +16187,444 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
     </message>
     <message>
         <source>Opacity:</source>
-        <translation type="vanished">불투명도:</translation>
+        <translation>불투명도:</translation>
     </message>
     <message>
         <source>No camera detected.</source>
-        <translation type="vanished">카메라가 감지되지 않음.</translation>
+        <translation>카메라가 감지되지 않음.</translation>
     </message>
     <message>
         <source>No camera detected</source>
-        <translation type="vanished">카메라가 감지되지 않음</translation>
+        <translation>카메라가 감지되지 않음</translation>
     </message>
     <message>
         <source>- Select camera -</source>
-        <translation type="vanished">- 카메라 선택 -</translation>
+        <translation>- 카메라 선택 -</translation>
     </message>
     <message>
         <source>Mode: </source>
-        <translation type="vanished">모드: </translation>
+        <translation>모드: </translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="vanished">자동</translation>
+        <translation>자동</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="vanished">비활성화</translation>
+        <translation>비활성화</translation>
     </message>
     <message>
         <source>Stop Live View</source>
-        <translation type="vanished">라이브 뷰 중지</translation>
+        <translation>라이브 뷰 중지</translation>
     </message>
     <message>
         <source>Image adjust</source>
-        <translation type="obsolete">이미지 조정</translation>
+        <translation type="unfinished">이미지 조정</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">색상</translation>
+        <translation type="unfinished">색상</translation>
     </message>
     <message>
         <source>Grayscale</source>
-        <translation type="obsolete">그레이 스케일</translation>
+        <translation type="unfinished">그레이 스케일</translation>
     </message>
     <message>
         <source>Black &amp; White</source>
-        <translation type="obsolete">블랙 &amp; 화이트</translation>
+        <translation type="unfinished">블랙 &amp; 화이트</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">밝기:</translation>
+        <translation type="unfinished">밝기:</translation>
     </message>
     <message>
         <source>Color type:</source>
-        <translation type="obsolete">색상 유형:</translation>
+        <translation type="unfinished">색상 유형:</translation>
     </message>
     <message>
         <source>Interval(sec):</source>
-        <translation type="obsolete">간격(초):</translation>
+        <translation type="unfinished">간격(초):</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">가져오기</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">내보내기</translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Iso: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished">%1을 가져오지 못음.</translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished">%1을 저장할 수 없음.</translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>Create the Destination Subfolder to Save</source>
-        <translation type="obsolete">저장할 대상 하위 폴더 생성</translation>
+        <translation type="unfinished">저장할 대상 하위 폴더 생성</translation>
     </message>
     <message>
         <source>Set As Default</source>
-        <translation type="obsolete">기본값으로 설정</translation>
+        <translation type="unfinished">기본값으로 설정</translation>
     </message>
     <message>
         <source>Set the current &quot;Save In&quot; path as the default.</source>
-        <translation type="obsolete">현재 설정 및 저장(&quot;S) 기본값으로 저장.</translation>
+        <translation type="unfinished">현재 설정 및 저장(&quot;S) 기본값으로 저장.</translation>
     </message>
     <message>
         <source>Create Subfolder</source>
-        <translation type="obsolete">하위 폴더 작성</translation>
+        <translation type="unfinished">하위 폴더 작성</translation>
     </message>
     <message>
         <source>Infomation</source>
-        <translation type="obsolete">정보</translation>
+        <translation type="unfinished">정보</translation>
     </message>
     <message>
         <source>Subfolder Name</source>
-        <translation type="obsolete">하위 폴더 이름</translation>
+        <translation type="unfinished">하위 폴더 이름</translation>
     </message>
     <message>
         <source>Auto Format:</source>
-        <translation type="obsolete">자동 형식:</translation>
+        <translation type="unfinished">자동 형식:</translation>
     </message>
     <message>
         <source>Show This on Launch of the Camera Capture</source>
-        <translation type="obsolete">카메라 캡처 시작시 표시</translation>
+        <translation type="unfinished">카메라 캡처 시작시 표시</translation>
     </message>
     <message>
         <source>Save Scene in Subfolder</source>
-        <translation type="obsolete">서브 폴더에 장면 저장</translation>
+        <translation type="unfinished">서브 폴더에 장면 저장</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">네</translation>
+        <translation type="unfinished">네</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">취소</translation>
+        <translation type="unfinished">취소</translation>
     </message>
     <message>
         <source>C- + Sequence + Scene</source>
-        <translation type="obsolete">C + 시퀀스 + 장면</translation>
+        <translation type="unfinished">C + 시퀀스 + 장면</translation>
     </message>
     <message>
         <source>Sequence + Scene</source>
-        <translation type="obsolete">시퀀스 + 장면</translation>
+        <translation type="unfinished">시퀀스 + 장면</translation>
     </message>
     <message>
         <source>Episode + Sequence + Scene</source>
-        <translation type="obsolete">에피소드 + 시퀀스 + 장면</translation>
+        <translation type="unfinished">에피소드 + 시퀀스 + 장면</translation>
     </message>
     <message>
         <source>Project + Episode + Sequence + Scene</source>
-        <translation type="obsolete">프로젝트 + 에피소드 + 시퀀스 + 장면</translation>
+        <translation type="unfinished">프로젝트 + 에피소드 + 시퀀스 + 장면</translation>
     </message>
     <message>
         <source>Save the current scene in the subfolder.
 Set the output folder path to the subfolder as well.</source>
-        <translation type="obsolete">현재 장면을 하위폴더에 저장하세요.
+        <translation type="unfinished">현재 장면을 하위폴더에 저장하세요.
 출력 폴더 경로도 하위 폴더로 설정하세요.</translation>
     </message>
     <message>
         <source>Save In:</source>
-        <translation type="obsolete">저장:</translation>
+        <translation type="unfinished">저장:</translation>
     </message>
     <message>
         <source>Project:</source>
-        <translation type="obsolete">프로젝트:</translation>
+        <translation type="unfinished">프로젝트:</translation>
     </message>
     <message>
         <source>Episode:</source>
-        <translation type="obsolete">에피소드:</translation>
+        <translation type="unfinished">에피소드:</translation>
     </message>
     <message>
         <source>Sequence:</source>
-        <translation type="obsolete">시퀀스:</translation>
+        <translation type="unfinished">시퀀스:</translation>
     </message>
     <message>
         <source>Scene:</source>
-        <translation type="obsolete">장면:</translation>
+        <translation type="unfinished">장면:</translation>
     </message>
     <message>
         <source>Subfolder Name:</source>
-        <translation type="obsolete">하위 폴더 이름:</translation>
+        <translation type="unfinished">하위 폴더 이름:</translation>
     </message>
     <message>
         <source>Subfolder name should not be empty.</source>
-        <translation type="obsolete">하위 폴더 이름은 비워둘수 없음: &quot; / \ [ ] : ; | = ,</translation>
+        <translation type="unfinished">하위 폴더 이름은 비워둘수 없음: &quot; / \ [ ] : ; | = ,</translation>
     </message>
     <message>
         <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
-        <translation type="obsolete">하위 폴더 이름에는 다음문자를 사용할 수 없음. </translation>
+        <translation type="unfinished">하위 폴더 이름에는 다음문자를 사용할 수 없음. </translation>
     </message>
     <message>
         <source>Folder %1 already exists.</source>
-        <translation type="obsolete">%1 폴더가 이미 존재함.</translation>
+        <translation type="unfinished">%1 폴더가 이미 존재함.</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">%1 폴더를 만들 수 없음.</translation>
+        <translation type="unfinished">%1 폴더를 만들 수 없음.</translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -15522,6 +16763,25 @@ Set the output folder path to the subfolder as well.</source>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15879,6 +17139,10 @@ Set the output folder path to the subfolder as well.</source>
     <message>
         <source>Expand toolbar</source>
         <translation>도구 모음 확장</translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -16321,11 +17585,11 @@ Please refer to the user guide for details.</source>
         <translation type="unfinished">없음</translation>
     </message>
     <message>
-        <source>Inbetween symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reverse sheet symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16574,10 +17838,25 @@ Please refer to the user guide for details.</source>
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished">새 메모 추가</translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished">이전 메모</translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished">다음 메모</translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Toggle Xsheet/Timeline</source>
-        <translation type="vanished">타임시트/타임라인 전환</translation>
+        <translation>타임시트/타임라인 전환</translation>
     </message>
     <message>
         <source>Add New Memo</source>
@@ -16716,6 +17995,12 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/korean/toonzlib.ts
+++ b/toonz/sources/translations/korean/toonzlib.ts
@@ -664,6 +664,34 @@
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Rasterizer</name>

--- a/toonz/sources/translations/korean/toonzqt.ts
+++ b/toonz/sources/translations/korean/toonzqt.ts
@@ -27,6 +27,14 @@
         <source>Replace </source>
         <translation>교체</translation>
     </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddWordButton</name>
@@ -145,6 +153,30 @@ Possibly the preset file has been corrupted</source>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A/R</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChannelHisto</name>
@@ -184,36 +216,7 @@ Possibly the preset file has been corrupted</source>
     <name>ColorChannelControl</name>
     <message>
         <source>H</source>
-        <translation>수평</translation>
-    </message>
-    <message>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">수평</translation>
     </message>
 </context>
 <context>
@@ -259,6 +262,14 @@ Zero is fully transparent.</source>
     <message>
         <source>R:%1 G:%2 B:%3</source>
         <translation></translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A:%1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -699,6 +710,27 @@ Control click to reset.</source>
     </message>
     <message>
         <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1618,7 +1650,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
     </message>
     <message>
         <source>Name Editor</source>
-        <translation>이름 편집기</translation>
+        <translation type="vanished">이름 편집기</translation>
     </message>
     <message>
         <source>New Style</source>
@@ -1626,7 +1658,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
     </message>
     <message>
         <source>New Page</source>
-        <translation>새로운 페이지</translation>
+        <translation type="vanished">새로운 페이지</translation>
     </message>
     <message>
         <source> + </source>
@@ -1788,6 +1820,22 @@ It can&apos;t be changed.  Ever.</source>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">이름 편집기</translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PaletteViewerGUI::PageViewer</name>
@@ -1846,6 +1894,12 @@ It can&apos;t be changed.  Ever.</source>
     </message>
     <message>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2484,6 +2538,139 @@ Are you sure?</source>
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">이름 편집기</translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation type="unfinished">새로운 스타일</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation type="unfinished">새로운 페이지</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished">수평</translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">선 자동 페인트</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished">기본값으로 재설정</translation>
+    </message>
 </context>
 <context>
     <name>QPushButton</name>
@@ -2618,11 +2805,11 @@ Are you sure?</source>
     <name>SettingsPage</name>
     <message>
         <source>Reset to default</source>
-        <translation>기본값으로 재설정</translation>
+        <translation type="vanished">기본값으로 재설정</translation>
     </message>
     <message>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">선 자동 페인트</translation>
+        <translation type="obsolete">선 자동 페인트</translation>
     </message>
 </context>
 <context>
@@ -2827,85 +3014,6 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
         <source>Generated</source>
@@ -3074,6 +3182,22 @@ Are you sure ?</source>
     </message>
     <message>
         <source>Style Set Name already exists. Please try another name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Auto/Apply</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/norwegian_bokmal/colorfx.ts
+++ b/toonz/sources/translations/norwegian_bokmal/colorfx.ts
@@ -19,8 +19,36 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="460"/>
+        <location filename="../../colorfx/regionstyles.h" line="467"/>
         <source>Irregular</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="129"/>
+        <source>Density</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="131"/>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="133"/>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="135"/>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.h" line="58"/>
+        <source>Flow Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -70,7 +98,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1240"/>
+        <location filename="../../colorfx/strokestyles.h" line="1275"/>
         <source>OutlineViewer(OnlyDebug)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -93,7 +121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="120"/>
+        <location filename="../../colorfx/regionstyles.h" line="121"/>
         <source>Hatched Shading</source>
         <translation type="unfinished"></translation>
     </message>
@@ -111,7 +139,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="169"/>
+        <location filename="../../colorfx/regionstyles.h" line="171"/>
         <source>Plain Shadow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,7 +152,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="69"/>
+        <location filename="../../colorfx/rasterstyles.h" line="70"/>
         <source>Blur value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -132,7 +160,7 @@
 <context>
     <name>TBiColorStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="577"/>
+        <location filename="../../colorfx/strokestyles.h" line="594"/>
         <source>Shade</source>
         <translation type="unfinished"></translation>
     </message>
@@ -140,7 +168,7 @@
 <context>
     <name>TBlendRasterStyle</name>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="122"/>
+        <location filename="../../colorfx/rasterstyles.h" line="123"/>
         <source>Blend</source>
         <translation type="unfinished"></translation>
     </message>
@@ -163,7 +191,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="725"/>
+        <location filename="../../colorfx/strokestyles.h" line="745"/>
         <source>Fade</source>
         <translation type="unfinished"></translation>
     </message>
@@ -176,7 +204,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="385"/>
+        <location filename="../../colorfx/strokestyles.h" line="398"/>
         <source>Plait</source>
         <translation type="unfinished"></translation>
     </message>
@@ -184,7 +212,7 @@
 <context>
     <name>TBubbleStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="475"/>
+        <location filename="../../colorfx/strokestyles.h" line="490"/>
         <source>Bubbles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -192,7 +220,7 @@
 <context>
     <name>TChainStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="133"/>
+        <location filename="../../colorfx/strokestyles.h" line="134"/>
         <source>Chain</source>
         <translation type="unfinished"></translation>
     </message>
@@ -210,7 +238,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="508"/>
+        <location filename="../../colorfx/regionstyles.h" line="516"/>
         <source>Chalk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -243,7 +271,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="672"/>
+        <location filename="../../colorfx/strokestyles.h" line="691"/>
         <source>Chalk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -276,7 +304,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="399"/>
+        <location filename="../../colorfx/regionstyles.h" line="405"/>
         <source>Square</source>
         <translation type="unfinished"></translation>
     </message>
@@ -299,7 +327,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="559"/>
+        <location filename="../../colorfx/regionstyles.h" line="569"/>
         <source>Chessboard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -327,7 +355,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="766"/>
+        <location filename="../../colorfx/regionstyles.h" line="780"/>
         <source>Concentric</source>
         <translation type="unfinished"></translation>
     </message>
@@ -345,7 +373,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="342"/>
+        <location filename="../../colorfx/strokestyles.h" line="352"/>
         <source>Tulle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -363,7 +391,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="346"/>
+        <location filename="../../colorfx/regionstyles.h" line="351"/>
         <source>Polka Dots</source>
         <translation type="unfinished"></translation>
     </message>
@@ -391,7 +419,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="254"/>
+        <location filename="../../colorfx/strokestyles.h" line="260"/>
         <source>Vanishing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -404,7 +432,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1090"/>
+        <location filename="../../colorfx/strokestyles.h" line="1119"/>
         <source>Striped</source>
         <translation type="unfinished"></translation>
     </message>
@@ -422,7 +450,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1029"/>
+        <location filename="../../colorfx/strokestyles.h" line="1057"/>
         <source>Curl</source>
         <translation type="unfinished"></translation>
     </message>
@@ -453,7 +481,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="206"/>
+        <location filename="../../colorfx/strokestyles.h" line="209"/>
         <source>Dashes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +509,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="665"/>
+        <location filename="../../colorfx/regionstyles.h" line="677"/>
         <source>Linear Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -494,7 +522,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1152"/>
+        <location filename="../../colorfx/strokestyles.h" line="1184"/>
         <source>Watercolor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,7 +535,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1304"/>
+        <location filename="../../colorfx/strokestyles.h" line="1340"/>
         <source>Toothpaste</source>
         <translation type="unfinished"></translation>
     </message>
@@ -535,7 +563,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="822"/>
+        <location filename="../../colorfx/regionstyles.h" line="839"/>
         <source>Stained Glass</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,7 +591,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="872"/>
+        <location filename="../../colorfx/strokestyles.h" line="895"/>
         <source>Gouache</source>
         <translation type="unfinished"></translation>
     </message>
@@ -571,7 +599,7 @@
 <context>
     <name>TNoColorRasterStyle</name>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="151"/>
+        <location filename="../../colorfx/rasterstyles.h" line="153"/>
         <source>Markup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -600,7 +628,7 @@
     </message>
     <message>
         <location filename="../../colorfx/strokestyles.cpp" line="2022"/>
-        <location filename="../../colorfx/strokestyles.h" line="629"/>
+        <location filename="../../colorfx/strokestyles.h" line="647"/>
         <source>Bump</source>
         <translation type="unfinished"></translation>
     </message>
@@ -623,7 +651,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="872"/>
+        <location filename="../../colorfx/regionstyles.h" line="890"/>
         <source>Beehive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -651,7 +679,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="283"/>
+        <location filename="../../colorfx/regionstyles.h" line="287"/>
         <source>Sponge Shading</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,7 +707,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="718"/>
+        <location filename="../../colorfx/regionstyles.h" line="731"/>
         <source>Radial Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -692,7 +720,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="299"/>
+        <location filename="../../colorfx/strokestyles.h" line="308"/>
         <source>Rope</source>
         <translation type="unfinished"></translation>
     </message>
@@ -705,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="230"/>
+        <location filename="../../colorfx/regionstyles.h" line="233"/>
         <source>Blob</source>
         <translation type="unfinished"></translation>
     </message>
@@ -718,7 +746,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="827"/>
+        <location filename="../../colorfx/strokestyles.h" line="849"/>
         <source>Jagged</source>
         <translation type="unfinished"></translation>
     </message>
@@ -731,7 +759,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="990"/>
+        <location filename="../../colorfx/strokestyles.h" line="1017"/>
         <source>Wave</source>
         <translation type="unfinished"></translation>
     </message>
@@ -744,7 +772,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="433"/>
+        <location filename="../../colorfx/strokestyles.h" line="447"/>
         <source>Fuzz</source>
         <translation type="unfinished"></translation>
     </message>
@@ -767,7 +795,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="164"/>
+        <location filename="../../colorfx/strokestyles.h" line="166"/>
         <source>Circlets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -790,7 +818,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="610"/>
+        <location filename="../../colorfx/regionstyles.h" line="621"/>
         <source>Banded</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,7 +836,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="530"/>
+        <location filename="../../colorfx/strokestyles.h" line="546"/>
         <source>Gauze</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,7 +854,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="775"/>
+        <location filename="../../colorfx/strokestyles.h" line="796"/>
         <source>Ribbon</source>
         <translation type="unfinished"></translation>
     </message>
@@ -867,7 +895,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="942"/>
+        <location filename="../../colorfx/strokestyles.h" line="968"/>
         <source>Zigzag</source>
         <translation type="unfinished"></translation>
     </message>

--- a/toonz/sources/translations/norwegian_bokmal/image.ts
+++ b/toonz/sources/translations/norwegian_bokmal/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -11,6 +29,97 @@
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -108,19 +217,6 @@
     </message>
 </context>
 <context>
-    <name>MovWriterProperties</name>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
-        <source>Quality</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
-        <source>Scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Mp4WriterProperties</name>
     <message>
         <location filename="../../image/ffmpeg/tiio_mp4.cpp" line="241"/>
@@ -144,12 +240,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/norwegian_bokmal/tnzcore.ts
+++ b/toonz/sources/translations/norwegian_bokmal/tnzcore.ts
@@ -9,7 +9,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tpalette.cpp" line="256"/>
+        <location filename="../../common/tvrender/tpalette.cpp" line="265"/>
         <source>colors</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,12 +17,12 @@
 <context>
     <name>TCenterLineStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="886"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="899"/>
         <source>Constant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="919"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="938"/>
         <source>Thickness</source>
         <translation type="unfinished"></translation>
     </message>
@@ -30,12 +30,12 @@
 <context>
     <name>TRasterImagePatternStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1046"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1088"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1048"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1090"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,12 +43,12 @@
 <context>
     <name>TVectorImagePatternStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1478"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1551"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1480"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1553"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>

--- a/toonz/sources/translations/norwegian_bokmal/tnztools.ts
+++ b/toonz/sources/translations/norwegian_bokmal/tnztools.ts
@@ -4,121 +4,121 @@
 <context>
     <name>ArrowToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="443"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="446"/>
         <source>Z:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="444"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="447"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="445"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="528"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="448"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="531"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="446"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="529"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="449"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="532"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="461"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="464"/>
         <source>SO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="466"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="469"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="482"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="485"/>
         <source>Global:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="483"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="509"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="486"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="512"/>
         <source>H:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="484"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="510"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="487"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="513"/>
         <source>V:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="589"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="592"/>
         <source>Flip Object Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="590"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="593"/>
         <source>Flip Object Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="591"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="594"/>
         <source>Rotate Object Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="592"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="595"/>
         <source>Rotate Object Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="612"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="615"/>
         <source>Pick:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="629"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="632"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="652"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="655"/>
         <source>(</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="654"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="657"/>
         <source>)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="677"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="680"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="701"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="704"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="726"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="729"/>
         <source>Maintain:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="746"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="749"/>
         <source>Shear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="778"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="781"/>
         <source>Center Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="991"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="994"/>
         <source>Table</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,117 +343,117 @@
 <context>
     <name>EraserTool</name>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="775"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="428"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="863"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="435"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="776"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="864"/>
         <source>Hardness:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="778"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="432"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="866"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="439"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="779"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="433"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="867"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="440"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="780"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="434"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="868"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="441"/>
         <source>Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="781"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="435"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="869"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="442"/>
         <source>Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="782"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="436"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="870"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="443"/>
         <source>Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="783"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="437"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="871"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="444"/>
         <source>Segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="785"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="873"/>
         <source>Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="786"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="874"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="787"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="875"/>
         <source>Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="788"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="876"/>
         <source>Lines &amp; Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="790"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="429"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="878"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="436"/>
         <source>Selective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="791"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="430"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="879"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="437"/>
         <source>Invert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="792"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="431"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="880"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="438"/>
         <source>Frame Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="793"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="881"/>
         <source>Pencil Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="794"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="882"/>
         <source>Savebox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="440"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="447"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="441"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="448"/>
         <source>Ease In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="442"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="449"/>
         <source>Ease Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="443"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="450"/>
         <source>Ease In/Out</source>
         <translation type="unfinished"></translation>
     </message>
@@ -461,122 +461,127 @@
 <context>
     <name>FillTool</name>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2128"/>
+        <location filename="../../tnztools/filltool.cpp" line="2399"/>
         <source>Frame Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2130"/>
+        <location filename="../../tnztools/filltool.cpp" line="2401"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2131"/>
+        <location filename="../../tnztools/filltool.cpp" line="2402"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2132"/>
+        <location filename="../../tnztools/filltool.cpp" line="2403"/>
         <source>Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2133"/>
+        <location filename="../../tnztools/filltool.cpp" line="2404"/>
         <source>Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2134"/>
+        <location filename="../../tnztools/filltool.cpp" line="2405"/>
         <source>Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2136"/>
+        <location filename="../../tnztools/filltool.cpp" line="2406"/>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/filltool.cpp" line="2408"/>
         <source>Selective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2138"/>
+        <location filename="../../tnztools/filltool.cpp" line="2410"/>
         <source>Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2139"/>
+        <location filename="../../tnztools/filltool.cpp" line="2411"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2140"/>
+        <location filename="../../tnztools/filltool.cpp" line="2412"/>
         <source>Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2141"/>
+        <location filename="../../tnztools/filltool.cpp" line="2413"/>
         <source>Lines &amp; Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2143"/>
+        <location filename="../../tnztools/filltool.cpp" line="2415"/>
         <source>Onion Skin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2144"/>
+        <location filename="../../tnztools/filltool.cpp" line="2416"/>
         <source>Refer Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2145"/>
+        <location filename="../../tnztools/filltool.cpp" line="2417"/>
         <source>Fill Depth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2146"/>
+        <location filename="../../tnztools/filltool.cpp" line="2418"/>
         <source>Segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2147"/>
+        <location filename="../../tnztools/filltool.cpp" line="2419"/>
         <source>Maximum Gap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2148"/>
+        <location filename="../../tnztools/filltool.cpp" line="2420"/>
         <source>Autopaint Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2149"/>
+        <location filename="../../tnztools/filltool.cpp" line="2421"/>
         <source>Savebox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2150"/>
+        <location filename="../../tnztools/filltool.cpp" line="2422"/>
         <source>Distance:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2151"/>
+        <location filename="../../tnztools/filltool.cpp" line="2423"/>
         <source>Style Index:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2152"/>
+        <location filename="../../tnztools/filltool.cpp" line="2424"/>
         <source>Gaps:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2153"/>
+        <location filename="../../tnztools/filltool.cpp" line="2425"/>
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2154"/>
+        <location filename="../../tnztools/filltool.cpp" line="2426"/>
         <source>Fill Gaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2155"/>
+        <location filename="../../tnztools/filltool.cpp" line="2427"/>
         <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
@@ -584,12 +589,12 @@
 <context>
     <name>FingerTool</name>
     <message>
-        <location filename="../../tnztools/fingertool.cpp" line="333"/>
+        <location filename="../../tnztools/fingertool.cpp" line="352"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fingertool.cpp" line="334"/>
+        <location filename="../../tnztools/fingertool.cpp" line="353"/>
         <source>Invert</source>
         <translation type="unfinished"></translation>
     </message>
@@ -597,49 +602,49 @@
 <context>
     <name>FullColorBrushTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="192"/>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="197"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="191"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="196"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="193"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="192"/>
         <source>Pressure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="194"/>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="198"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="193"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="197"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="195"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="194"/>
         <source>Hardness:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="196"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="195"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="199"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="198"/>
         <source>Eraser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="200"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="199"/>
         <source>Lock Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="201"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="200"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="904"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="914"/>
         <source>&lt;custom&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -647,52 +652,52 @@
 <context>
     <name>FullColorEraserTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="414"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="435"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="415"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="436"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="416"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="437"/>
         <source>Hardness:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="418"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="439"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="419"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="440"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="420"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="441"/>
         <source>Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="421"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="442"/>
         <source>Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="422"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="443"/>
         <source>Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="424"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="445"/>
         <source>Invert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="425"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="446"/>
         <source>Frame Range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -700,20 +705,50 @@
 <context>
     <name>FullColorFillTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorfilltool.cpp" line="158"/>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="181"/>
         <source>Fill Depth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorfilltool.cpp" line="159"/>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="182"/>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="183"/>
+        <source>Distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="184"/>
+        <source>Style Index:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="185"/>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="186"/>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="187"/>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="188"/>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HandToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3320"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3617"/>
         <source>Reset Position</source>
         <translation type="unfinished"></translation>
     </message>
@@ -737,42 +772,42 @@
 <context>
     <name>PaintBrushTool</name>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="380"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="399"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="382"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="401"/>
         <source>Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="383"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="402"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="384"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="403"/>
         <source>Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="385"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="404"/>
         <source>Lines &amp; Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="387"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="406"/>
         <source>Selective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="389"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="408"/>
         <source>Pressure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="391"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="410"/>
         <source>Lock Alpha</source>
         <translation type="unfinished"></translation>
     </message>
@@ -780,42 +815,42 @@
 <context>
     <name>PerspectiveGridToolOptionBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2969"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3030"/>
         <source>Spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2974"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3035"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2990"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3051"/>
         <source>Rotate Perspective Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2991"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3052"/>
         <source>Rotate Perspective Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3024"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3085"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3029"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3090"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3046"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3107"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3063"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3124"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1374,7 +1409,7 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/edittoolgadgets.cpp" line="89"/>
+        <location filename="../../tnztools/edittoolgadgets.cpp" line="287"/>
         <source>Modify Fx Gadget  </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1484,7 +1519,7 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="307"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="308"/>
         <source>Move Center</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1515,7 +1550,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="../../tnztools/tool.cpp" line="1057"/>
-        <location filename="../../tnztools/tool.cpp" line="1124"/>
+        <location filename="../../tnztools/tool.cpp" line="1119"/>
         <source>The current level is not editable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1550,24 +1585,24 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tool.cpp" line="1135"/>
+        <location filename="../../tnztools/tool.cpp" line="1130"/>
         <source>The current tool cannot be used on empty frames of a Single Frame level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tool.cpp" line="1144"/>
+        <location filename="../../tnztools/tool.cpp" line="1139"/>
         <source>The current tool cannot be used on a stop frame.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="224"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="236"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="225"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="237"/>
         <source>Min:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="224"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="236"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="225"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="237"/>
         <source>Max:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1608,7 +1643,7 @@ Do you want to proceed?</source>
 <context>
     <name>RGBPickerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2651"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2712"/>
         <source>Pick Screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,12 +1651,12 @@ Do you want to proceed?</source>
 <context>
     <name>RasterSelectionTool</name>
     <message>
-        <location filename="../../tnztools/rasterselectiontool.cpp" line="1038"/>
+        <location filename="../../tnztools/rasterselectiontool.cpp" line="1086"/>
         <source>Modify Savebox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rasterselectiontool.cpp" line="1040"/>
+        <location filename="../../tnztools/rasterselectiontool.cpp" line="1088"/>
         <source>No Antialiasing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1629,57 +1664,57 @@ Do you want to proceed?</source>
 <context>
     <name>RasterTapeTool</name>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="180"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="181"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="181"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="182"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="182"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="183"/>
         <source>Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="183"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="184"/>
         <source>Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="184"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="185"/>
         <source>Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="186"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="187"/>
         <source>Distance:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="187"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="188"/>
         <source>Style Index:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="188"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="189"/>
         <source>current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="189"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="190"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="190"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="191"/>
         <source>Frame Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="191"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="192"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1695,7 +1730,7 @@ Do you want to proceed?</source>
 <context>
     <name>RotateToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3293"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3590"/>
         <source>Reset Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1703,37 +1738,37 @@ Do you want to proceed?</source>
 <context>
     <name>RulerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2412"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2473"/>
         <source>X:</source>
         <comment>ruler tool option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2418"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2479"/>
         <source>Y:</source>
         <comment>ruler tool option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2426"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2487"/>
         <source>W:</source>
         <comment>ruler tool option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2432"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2493"/>
         <source>H:</source>
         <comment>ruler tool option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2440"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2501"/>
         <source>A:</source>
         <comment>ruler tool option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2445"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2506"/>
         <source>L:</source>
         <comment>ruler tool option</comment>
         <translation type="unfinished"></translation>
@@ -1742,22 +1777,22 @@ Do you want to proceed?</source>
 <context>
     <name>SelectionTool</name>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="926"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="927"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="927"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="928"/>
         <source>Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="928"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="929"/>
         <source>Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="929"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="930"/>
         <source>Polyline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1765,69 +1800,69 @@ Do you want to proceed?</source>
 <context>
     <name>SelectionToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1142"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1145"/>
         <source>H:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1144"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1147"/>
         <source>V:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1146"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1149"/>
         <source>Link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1149"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="1150"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1152"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1153"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1152"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1155"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1154"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1157"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1186"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1189"/>
         <source>Flip Selection Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1187"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1190"/>
         <source>Flip Selection Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1188"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1191"/>
         <source>Rotate Selection Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1189"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1192"/>
         <source>Rotate Selection Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1205"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1208"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1226"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1229"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1243"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="1244"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1246"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1247"/>
         <source>Thickness</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1835,22 +1870,22 @@ Do you want to proceed?</source>
 <context>
     <name>ShiftTraceToolOptionBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2788"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2849"/>
         <source>Reset Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2789"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2850"/>
         <source>Reset Following</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2795"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2856"/>
         <source>Previous Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2796"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2857"/>
         <source>Following Drawing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1888,7 +1923,7 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/skeletontool.cpp" line="1615"/>
+        <location filename="../../tnztools/skeletontool.cpp" line="1614"/>
         <source>Reset Pinned Center</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1952,78 +1987,189 @@ Do you want to proceed?</source>
 <context>
     <name>StylePickerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2737"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2798"/>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ToonzRasterBrushTool</name>
+    <name>SymmetryTool</name>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1104"/>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1111"/>
-        <source>Size</source>
+        <location filename="../../tnztools/symmetrytool.cpp" line="258"/>
+        <source>Lines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1105"/>
-        <source>Hardness:</source>
+        <location filename="../../tnztools/symmetrytool.cpp" line="260"/>
+        <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1106"/>
-        <source>Smooth:</source>
+        <location filename="../../tnztools/symmetrytool.cpp" line="262"/>
+        <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1107"/>
-        <source>Draw Order:</source>
+        <location filename="../../tnztools/symmetrytool.cpp" line="263"/>
+        <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1108"/>
-        <source>Over All</source>
+        <location filename="../../tnztools/symmetrytool.cpp" line="264"/>
+        <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1109"/>
-        <source>Under All</source>
+        <location filename="../../tnztools/symmetrytool.cpp" line="265"/>
+        <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1110"/>
-        <source>Palette Order</source>
+        <location filename="../../tnztools/symmetrytool.cpp" line="266"/>
+        <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1114"/>
+        <location filename="../../tnztools/symmetrytool.cpp" line="267"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="268"/>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="269"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="271"/>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="273"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1115"/>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="2404"/>
+        <location filename="../../tnztools/symmetrytool.cpp" line="372"/>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3357"/>
+        <source>Rotation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3373"/>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3374"/>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3384"/>
+        <source>Reset Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3403"/>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3408"/>
+        <source>Opacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3420"/>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3429"/>
+        <source>Preset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ToonzRasterBrushTool</name>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1139"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1146"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1140"/>
+        <source>Hardness:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1141"/>
+        <source>Smooth:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1142"/>
+        <source>Draw Order:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1143"/>
+        <source>Over All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1144"/>
+        <source>Under All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1145"/>
+        <source>Palette Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1149"/>
+        <source>Preset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1150"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="2531"/>
         <source>&lt;custom&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1116"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1151"/>
         <source>Pencil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1117"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1152"/>
         <source>Pressure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1118"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1153"/>
         <source>Lock Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1119"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1154"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2031,153 +2177,153 @@ moved to the end of the first page of the palette.</source>
 <context>
     <name>ToonzVectorBrushTool</name>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="620"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="616"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="621"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="617"/>
         <source>Accuracy:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="622"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="618"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="623"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="619"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="624"/>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="2016"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="620"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="2091"/>
         <source>&lt;custom&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="625"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="621"/>
         <source>Break</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="626"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="622"/>
         <source>Pressure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="627"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="623"/>
         <source>Cap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="628"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="624"/>
         <source>Join</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="629"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="625"/>
         <source>Miter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="630"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="626"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="631"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="627"/>
         <source>Snap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="633"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="629"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="634"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="630"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="635"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="631"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="636"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="632"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="637"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="633"/>
         <source>In&amp;Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="638"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="634"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="639"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="635"/>
         <source>Med</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="640"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="636"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="641"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="637"/>
         <source>Butt cap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="642"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="638"/>
         <source>Round cap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="643"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="639"/>
         <source>Projecting cap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="644"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="640"/>
         <source>Miter join</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="645"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="641"/>
         <source>Round join</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="646"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="642"/>
         <source>Bevel join</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="647"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="643"/>
         <source>Draw Under</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="648"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="644"/>
         <source>Auto Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="649"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="645"/>
         <source>Auto Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="650"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="646"/>
         <source>Auto Group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2339,52 +2485,52 @@ moved to the end of the first page of the palette.</source>
 <context>
     <name>VectorTapeTool</name>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="260"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="264"/>
         <source>Smooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="261"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="265"/>
         <source>Join Vectors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="262"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="266"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="264"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="268"/>
         <source>Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="265"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="269"/>
         <source>Endpoint to Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="266"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="270"/>
         <source>Endpoint to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="267"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="271"/>
         <source>Line to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="269"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="273"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="270"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="274"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="271"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="275"/>
         <source>Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2392,7 +2538,7 @@ moved to the end of the first page of the palette.</source>
 <context>
     <name>ZoomToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3266"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3563"/>
         <source>Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>

--- a/toonz/sources/translations/norwegian_bokmal/toonz.ts
+++ b/toonz/sources/translations/norwegian_bokmal/toonz.ts
@@ -176,144 +176,162 @@ Special thanks to:</source>
 <context>
     <name>AudioRecordingPopup</name>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="59"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="65"/>
         <source>Audio Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="66"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="72"/>
         <source>Save and Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="74"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="80"/>
         <source>Sync with XSheet/Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="80"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="86"/>
         <source>Device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="81"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="87"/>
         <source>Sample rate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="82"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="88"/>
         <source>Sample format: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="85"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="91"/>
         <source>8000 Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="86"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="92"/>
         <source>11025 Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="87"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="93"/>
         <source>22050 Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="88"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="94"/>
         <source>44100 Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="89"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="95"/>
         <source>48000 Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="90"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="96"/>
         <source>96000 Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="92"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="97"/>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="99"/>
         <source>Mono 8-Bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="93"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="100"/>
         <source>Stereo 8-Bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="94"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="101"/>
         <source>Mono 16-Bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="95"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="102"/>
         <source>Stereo 16-Bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="149"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="103"/>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="104"/>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="105"/>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="106"/>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="162"/>
         <source>Audio input device to record</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="150"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="164"/>
         <source>Number of samples per second, 44.1KHz = CD Quality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="151"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="166"/>
         <source>Number of channels and bits per sample, 16-bits recommended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="152"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="168"/>
         <source>Play animation from current frame while recording/playback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="153"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="169"/>
         <source>Save recording and insert into new column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="154"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="171"/>
         <source>Refresh list of connected audio input devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="261"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="284"/>
         <source>Record failed: 
 Make sure there&apos;s XSheet or Timeline in the room.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="292"/>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="345"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="308"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="362"/>
         <source>Failed to save WAV file:
 Make sure you have write permissions in folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="695"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="713"/>
         <source>Audio format unsupported:
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="202"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="219"/>
         <source> </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="255"/>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="267"/>
-        <source>The microphone is not available: 
-Please select a different device or check the microphone.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -415,75 +433,181 @@ pick up all frames in the selected level.</source>
     </message>
 </context>
 <context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="210"/>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="213"/>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="214"/>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="399"/>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="413"/>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="428"/>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="437"/>
+        <source>Camera Stand View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="445"/>
+        <source>3D View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="452"/>
+        <source>Camera View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="460"/>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="475"/>
+        <source>Freeze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="485"/>
+        <source>Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="495"/>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="650"/>
+        <source>Untitled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="652"/>
+        <source>Scene: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="655"/>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="672"/>
+        <location filename="../../toonz/viewerpane.cpp" line="702"/>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="675"/>
+        <location filename="../../toonz/viewerpane.cpp" line="705"/>
+        <source> (Flipped)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="685"/>
+        <source>   ::   Level: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="694"/>
+        <source>Level: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BatchServersViewer</name>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="273"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="269"/>
         <source>Process with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="276"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="272"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="276"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="272"/>
         <source>Render Farm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="282"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="278"/>
         <source>Farm Global Root:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="301"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="297"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="302"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="298"/>
         <source>IP Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="303"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="299"/>
         <source>Port Number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="304"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="300"/>
         <source>Tasks:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="305"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="301"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="306"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="302"/>
         <source>Number of CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="307"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="303"/>
         <source>Physical Memory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="339"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="335"/>
         <source>In order to use the render farm you have to define the Farm Global Root first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="345"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="341"/>
         <source>The Farm Global Root folder doesn&apos;t exist
 Please create this folder before using the render farm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="360"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="356"/>
         <source>Unable to connect to the ToonzFarm Controller
    The Controller should run on %1 at port %2
    Please start the Controller before using the ToonzFarm</source>
@@ -493,43 +617,43 @@ Please create this folder before using the render farm.</source>
 <context>
     <name>BatchesController</name>
     <message>
-        <location filename="../../toonz/batches.cpp" line="424"/>
+        <location filename="../../toonz/batches.cpp" line="439"/>
         <source>The %1 task is currently active.
 Stop it or wait for its completion before removing it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="766"/>
-        <location filename="../../toonz/batches.cpp" line="797"/>
+        <location filename="../../toonz/batches.cpp" line="781"/>
+        <location filename="../../toonz/batches.cpp" line="812"/>
         <source>The current task list has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="768"/>
-        <location filename="../../toonz/batches.cpp" line="799"/>
+        <location filename="../../toonz/batches.cpp" line="783"/>
+        <location filename="../../toonz/batches.cpp" line="814"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="768"/>
-        <location filename="../../toonz/batches.cpp" line="799"/>
+        <location filename="../../toonz/batches.cpp" line="783"/>
+        <location filename="../../toonz/batches.cpp" line="814"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="768"/>
-        <location filename="../../toonz/batches.cpp" line="799"/>
+        <location filename="../../toonz/batches.cpp" line="783"/>
+        <location filename="../../toonz/batches.cpp" line="814"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="859"/>
+        <location filename="../../toonz/batches.cpp" line="874"/>
         <source>Tasks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="868"/>
+        <location filename="../../toonz/batches.cpp" line="883"/>
         <source>The Task List is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -793,63 +917,111 @@ Do you want to save your changes?</source>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <location filename="../../stopmotion/canon.cpp" line="567"/>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/canon.cpp" line="569"/>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/canon.cpp" line="1027"/>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="519"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="520"/>
         <source>Canvas Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="524"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="525"/>
         <source>Current Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="532"/>
-        <location filename="../../toonz/canvassizepopup.cpp" line="557"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="533"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="560"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="538"/>
-        <location filename="../../toonz/canvassizepopup.cpp" line="564"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="539"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="567"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="540"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="541"/>
         <source>New Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="569"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="545"/>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="546"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="547"/>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="548"/>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="549"/>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="552"/>
+        <source>Unit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="572"/>
         <source>Relative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="575"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="578"/>
         <source>Anchor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="583"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="586"/>
         <source>Resize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="585"/>
-        <location filename="../../toonz/canvassizepopup.cpp" line="700"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="588"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="703"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="698"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="701"/>
         <source>The new canvas size is smaller than the current one.
 Do you want to crop the canvas?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="700"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="703"/>
         <source>Crop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -857,27 +1029,27 @@ Do you want to crop the canvas?</source>
 <context>
     <name>CastBrowser</name>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="826"/>
+        <location filename="../../toonz/castviewer.cpp" line="822"/>
         <source>It is not possible to edit the selected file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="828"/>
+        <location filename="../../toonz/castviewer.cpp" line="824"/>
         <source>It is not possible to edit more than one file at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="851"/>
+        <location filename="../../toonz/castviewer.cpp" line="847"/>
         <source>It is not possible to show the folder containing the selected file, as the file has not been saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="881"/>
+        <location filename="../../toonz/castviewer.cpp" line="877"/>
         <source>It is not possible to view the selected file, as the file has not been saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="916"/>
+        <location filename="../../toonz/castviewer.cpp" line="913"/>
         <source>It is not possible to show the info of the selected file, as the file has not been saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1439,118 +1611,35 @@ What do you want to do? </source>
 <context>
     <name>ComboViewerPanel</name>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="253"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="109"/>
         <source>GUI Show / Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="255"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="111"/>
         <source>Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="256"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="112"/>
         <source>Tool Options Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="257"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="113"/>
         <source>Playback Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="258"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="114"/>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="461"/>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="475"/>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="490"/>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="499"/>
-        <source>Camera Stand View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="507"/>
-        <source>3D View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="514"/>
-        <source>Camera View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="522"/>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="537"/>
-        <source>Freeze</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="547"/>
-        <source>Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="556"/>
-        <source>Sub-camera Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="659"/>
-        <source>Untitled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="662"/>
-        <source>Scene: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="665"/>
-        <source>   ::   Frame: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="670"/>
-        <location filename="../../toonz/comboviewerpane.cpp" line="680"/>
-        <location filename="../../toonz/comboviewerpane.cpp" line="741"/>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="689"/>
-        <source>   ::   Level: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="728"/>
-        <source>Level: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CommandBar</name>
     <message>
-        <location filename="../../toonz/commandbar.cpp" line="151"/>
+        <location filename="../../toonz/commandbar.cpp" line="201"/>
         <source>Customize Command Bar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,7 +1647,7 @@ Right click to adjust.</source>
 <context>
     <name>CommandBarListTree</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="380"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="383"/>
         <source>----Separator----</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1566,47 +1655,52 @@ Right click to adjust.</source>
 <context>
     <name>CommandBarPopup</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="479"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="483"/>
         <source>Quick Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="480"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="484"/>
         <source>Customize Quick Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="483"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="493"/>
         <source>Command Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="484"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="494"/>
         <source>Customize Command Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="490"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="500"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="491"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="501"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="496"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="503"/>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/commandbarpopup.cpp" line="508"/>
         <source>Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="503"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="515"/>
         <source>Duplicated commands will be ignored. Only the last one will appear in the toolbar.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="531"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="542"/>
         <source>Search:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1614,7 +1708,7 @@ Right click to adjust.</source>
 <context>
     <name>CommandBarTree</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="260"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="263"/>
         <source>Remove &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1629,6 +1723,160 @@ Right click to adjust.</source>
     <message>
         <location filename="../../toonz/versioncontrolwidget.cpp" line="179"/>
         <source>Theirs</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="76"/>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="83"/>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="91"/>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="99"/>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="116"/>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="228"/>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="230"/>
+        <source>Convert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="231"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="235"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="236"/>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="237"/>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="247"/>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="260"/>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="357"/>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="359"/>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="375"/>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="379"/>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="384"/>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="385"/>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="401"/>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="402"/>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="403"/>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="405"/>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="407"/>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="408"/>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="436"/>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="438"/>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="441"/>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="445"/>
+        <source>Ended: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1703,7 +1951,7 @@ Right click to adjust.</source>
     <message>
         <location filename="../../toonz/convertpopup.cpp" line="354"/>
         <location filename="../../toonz/convertpopup.cpp" line="360"/>
-        <location filename="../../toonz/convertpopup.cpp" line="965"/>
+        <location filename="../../toonz/convertpopup.cpp" line="966"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1803,22 +2051,22 @@ Right click to adjust.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="591"/>
+        <location filename="../../toonz/convertpopup.cpp" line="592"/>
         <source>Keep Original Antialiasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="592"/>
+        <location filename="../../toonz/convertpopup.cpp" line="593"/>
         <source>Add Antialiasing with Intensity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="593"/>
+        <location filename="../../toonz/convertpopup.cpp" line="594"/>
         <source>Remove Antialiasing using Threshold:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="603"/>
+        <location filename="../../toonz/convertpopup.cpp" line="604"/>
         <source>When activated, styles of the default palette
 ($TOONZSTUDIOPALETTE\cleanup_default.tpl) will 
 be appended to the palette after conversion in 
@@ -1827,22 +2075,22 @@ before color designing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="614"/>
+        <location filename="../../toonz/convertpopup.cpp" line="615"/>
         <source>Image DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="614"/>
+        <location filename="../../toonz/convertpopup.cpp" line="615"/>
         <source>Current Camera DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="614"/>
+        <location filename="../../toonz/convertpopup.cpp" line="615"/>
         <source>Custom DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="616"/>
+        <location filename="../../toonz/convertpopup.cpp" line="617"/>
         <source>Specify the policy for setting DPI of converted tlv. 
 If you select the &quot;Image DPI&quot; option and the source image does not 
 contain the dpi information, then the current camera dpi will be used.
@@ -1850,104 +2098,221 @@ contain the dpi information, then the current camera dpi will be used.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="626"/>
+        <location filename="../../toonz/convertpopup.cpp" line="627"/>
         <source>Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="638"/>
+        <location filename="../../toonz/convertpopup.cpp" line="639"/>
         <source>Antialias:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="643"/>
+        <location filename="../../toonz/convertpopup.cpp" line="644"/>
         <source>Palette:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="646"/>
+        <location filename="../../toonz/convertpopup.cpp" line="647"/>
         <source>Tolerance:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="654"/>
+        <location filename="../../toonz/convertpopup.cpp" line="655"/>
         <source>Dpi:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="829"/>
+        <location filename="../../toonz/convertpopup.cpp" line="830"/>
         <source>Convert 1 Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="862"/>
+        <location filename="../../toonz/convertpopup.cpp" line="863"/>
         <source>Convert %1 Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="945"/>
-        <location filename="../../toonz/convertpopup.cpp" line="1000"/>
+        <location filename="../../toonz/convertpopup.cpp" line="946"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1001"/>
         <source>Level </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="948"/>
+        <location filename="../../toonz/convertpopup.cpp" line="949"/>
         <source> already exists; skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="980"/>
+        <location filename="../../toonz/convertpopup.cpp" line="981"/>
         <source>Generating level </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1003"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1004"/>
         <source> converted to tlv.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1018"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1019"/>
         <source>Level %1 converted to TLV Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1023"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1024"/>
         <source>Warning: Level %1 NOT converted to TLV Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1028"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1029"/>
         <source>Converted %1 out of %2 Levels to TLV Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1089"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1090"/>
         <source>Warning: Can&apos;t read palette &apos;%1&apos; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1133"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1134"/>
         <source>No output filename specified: please choose a valid level name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1140"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1141"/>
         <source>No unpainted suffix specified: cannot convert.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1225"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1221"/>
         <source>Convert completed with %1 error(s) and %2 level(s) skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1229"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1225"/>
         <source>Convert completed with %1 error(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1231"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1227"/>
         <source>%1 level(s) skipped</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="183"/>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="184"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="194"/>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="401"/>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="408"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="423"/>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="436"/>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="471"/>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="471"/>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="756"/>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="764"/>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="766"/>
+        <source>Overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="766"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="828"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="774"/>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="782"/>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="796"/>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="814"/>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="818"/>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="827"/>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="842"/>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="867"/>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="63"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="86"/>
+        <source>Drag and set command</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2047,79 +2412,79 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>DvDirTreeView</name>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="463"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="449"/>
         <source>There was an error copying %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="510"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="496"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="524"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="510"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="529"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="515"/>
         <source>Put...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="537"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="523"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="545"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="531"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="552"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="538"/>
         <source>Cleanup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="556"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="542"/>
         <source>Purge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="646"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="632"/>
         <source>Delete folder </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="646"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="632"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="647"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="633"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="654"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="640"/>
         <source>It is not possible to delete the folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="693"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="679"/>
         <source>The local path does not exist:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="905"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="891"/>
         <source>Refreshing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="1251"/>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="1386"/>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="1416"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="1237"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="1372"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="1402"/>
         <source>Refresh operation failed:
 </source>
         <translation type="unfinished"></translation>
@@ -2128,57 +2493,57 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>DvItemViewerButtonBar</name>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1833"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1842"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1836"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1845"/>
         <source>Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1841"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1850"/>
         <source>Up One Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1842"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1851"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1847"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1856"/>
         <source>New Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1848"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1857"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1857"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1866"/>
         <source>Icons View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1859"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1868"/>
         <source>Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1868"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1877"/>
         <source>List View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1870"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1879"/>
         <source>List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1886"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1895"/>
         <source>Export File List</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2186,20 +2551,28 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>DvItemViewerPanel</name>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1430"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1439"/>
         <source>Save File List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1430"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1439"/>
         <source>File List (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="5069"/>
+        <source>Export Camera Calibration Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="665"/>
+        <location filename="../../toonz/fileselection.cpp" line="666"/>
         <source>You must save the current scene first.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2331,35 +2704,86 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="418"/>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="419"/>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="422"/>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="426"/>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="429"/>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="431"/>
+        <location filename="../../toonz/ocaio.cpp" line="432"/>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="452"/>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="453"/>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="478"/>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="785"/>
-        <location filename="../../toonz/exportpanel.cpp" line="885"/>
+        <location filename="../../toonz/exportpanel.cpp" line="781"/>
+        <location filename="../../toonz/exportpanel.cpp" line="881"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="828"/>
+        <location filename="../../toonz/exportpanel.cpp" line="824"/>
         <source>Save in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="840"/>
+        <location filename="../../toonz/exportpanel.cpp" line="836"/>
         <source>File Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="860"/>
+        <location filename="../../toonz/exportpanel.cpp" line="856"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="864"/>
+        <location filename="../../toonz/exportpanel.cpp" line="860"/>
         <source>File Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="873"/>
+        <location filename="../../toonz/exportpanel.cpp" line="869"/>
         <source>Use Markers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2436,279 +2860,259 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>ExportXDTSCommand</name>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="667"/>
+        <location filename="../../toonz/xdtsio.cpp" line="671"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/xdtsio.cpp" line="687"/>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/xdtsio.cpp" line="688"/>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/xdtsio.cpp" line="695"/>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/xdtsio.cpp" line="698"/>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/xdtsio.cpp" line="701"/>
-        <source>Target column</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ExportXsheetPdfPopup</name>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1883"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1886"/>
         <source>Export Xsheet PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1896"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1900"/>
         <source>Print Export DateTime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1897"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1901"/>
         <source>Print Scene Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1898"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1902"/>
         <source>Print Soundtrack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1899"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1903"/>
         <source>Print Scene Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1901"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1905"/>
         <source>Put Serial Frame Numbers Over Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1903"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1907"/>
         <source>Print Level Names On The Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1904"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1908"/>
         <source>Print Dialogue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1909"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1913"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1910"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1914"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1917"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1921"/>
         <source>&lt; Prev</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1918"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1922"/>
         <source>Next &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1920"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1924"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1921"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1925"/>
         <source>Export PNG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1922"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1926"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1942"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1946"/>
         <source>ACTIONS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1943"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1947"/>
         <source>CELLS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1952"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1956"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1953"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1957"/>
         <source>More Than 3 Continuous Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1955"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1959"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2005"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2009"/>
         <source>Template Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2012"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2016"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2017"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2021"/>
         <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2021"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2025"/>
         <source>Template font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2026"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2030"/>
         <source>Logo:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2039"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2043"/>
         <source>Export Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2046"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2050"/>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2054"/>
         <source>Output area:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2051"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2059"/>
         <source>Output font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2056"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2064"/>
         <source>Continuous line:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2082"/>
-        <source>Inbetween mark:</source>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2090"/>
+        <source>Inbetween mark 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2087"/>
-        <source>Reverse sheet mark:</source>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2095"/>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2092"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2100"/>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2096"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2104"/>
         <source>Memo:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2115"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2123"/>
         <source>Save in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2119"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2127"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2213"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2223"/>
         <source>B4 size, 3 seconds sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2214"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2249"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2224"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2259"/>
         <source>B4 size, 6 seconds sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2215"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2225"/>
         <source>A3 size, 3 seconds sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2216"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2226"/>
         <source>A3 size, 6 seconds sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2328"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2340"/>
         <source>Col%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2447"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2459"/>
         <source>The preset file %1 is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2558"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2570"/>
         <source>%n page(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2562"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2574"/>
         <source>%1 x %2 pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2574"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2644"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2586"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2656"/>
         <source>Please specify the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2584"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2654"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2596"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2666"/>
         <source>The file %1 already exists.
 Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2594"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2664"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2606"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2676"/>
         <source>A folder %1 does not exist.
 Do you want to create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2604"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2674"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2616"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2686"/>
         <source>Failed to create folder %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2789,197 +3193,197 @@ Do you want to explode anyway ?</source>
 <context>
     <name>FileBrowser</name>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="171"/>
+        <location filename="../../toonz/filebrowser.cpp" line="161"/>
         <source>Folder: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="307"/>
+        <location filename="../../toonz/filebrowser.cpp" line="297"/>
         <source>Open folder failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="308"/>
+        <location filename="../../toonz/filebrowser.cpp" line="298"/>
         <source>The input folder path was invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1060"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1050"/>
         <source>Can&apos;t change file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1066"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1056"/>
         <source>Can&apos;t set a drawing number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1081"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1071"/>
         <source>Can&apos;t rename. File already exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1103"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1093"/>
         <source>Couldn&apos;t rename </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1169"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1159"/>
         <source>Load As Sub-Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1171"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1161"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1224"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1214"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1238"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1228"/>
         <source>Convert to Painted TLV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1244"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1234"/>
         <source>Convert to Unpainted TLV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1271"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1261"/>
         <source>Version Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1277"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1289"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1267"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1279"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1284"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1380"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1274"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1370"/>
         <source>Edit Frame Range...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1296"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1342"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1409"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1286"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1332"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1399"/>
         <source>Put...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1300"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1413"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1290"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1403"/>
         <source>Revert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1307"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1358"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1376"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1390"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1404"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1297"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1348"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1366"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1380"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1394"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1312"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1302"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1320"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1310"/>
         <source>Get Revision...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1336"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1348"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1326"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1338"/>
         <source>Unlock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1352"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1384"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1399"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1342"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1374"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1389"/>
         <source>Edit Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1364"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1354"/>
         <source>Revision History...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1395"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1385"/>
         <source>Unlock Frame Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1552"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1542"/>
         <source>Save Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1552"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1542"/>
         <source>Scene name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1606"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1595"/>
         <source>There was an error copying %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1901"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1886"/>
         <source>Convert To Unpainted Tlv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1915"/>
-        <location filename="../../toonz/filebrowser.cpp" line="2009"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1900"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1994"/>
         <source>Warning: level %1 already exists; overwrite?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1917"/>
-        <location filename="../../toonz/filebrowser.cpp" line="2011"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1902"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1996"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1917"/>
-        <location filename="../../toonz/filebrowser.cpp" line="2011"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1902"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1996"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1977"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1962"/>
         <source>Done: All Levels  converted to TLV Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1997"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1982"/>
         <source>Convert To Painted Tlv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2055"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2040"/>
         <source>Done: 2 Levels  converted to TLV Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2214"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2199"/>
         <source>New Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2225"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2210"/>
         <source>It is not possible to create the %1 folder.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3040,20 +3444,20 @@ Do you want to explode anyway ?</source>
 <context>
     <name>Filmstrip</name>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1592"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1681"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1703"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1721"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1580"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1669"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1691"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1709"/>
         <source>- No Level -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1833"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1821"/>
         <source>Level Strip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1841"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1829"/>
         <source>Level:  </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3102,50 +3506,50 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
 <context>
     <name>FilmstripFrames</name>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="789"/>
-        <location filename="../../toonz/filmstrip.cpp" line="798"/>
-        <location filename="../../toonz/filmstrip.cpp" line="810"/>
+        <location filename="../../toonz/filmstrip.cpp" line="785"/>
+        <location filename="../../toonz/filmstrip.cpp" line="794"/>
+        <location filename="../../toonz/filmstrip.cpp" line="806"/>
         <source>INBETWEEN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="818"/>
+        <location filename="../../toonz/filmstrip.cpp" line="814"/>
         <source>no icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1138"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1144"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1134"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1140"/>
         <source>Auto Inbetween</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1308"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1301"/>
         <source>Panel Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1309"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1302"/>
         <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1310"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1303"/>
         <source>Show/Hide Drop Down Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1312"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1305"/>
         <source>Show/Hide Level Navigator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1345"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1338"/>
         <source>Select Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1496"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1489"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3154,67 +3558,72 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     <name>FlipBook</name>
     <message>
         <location filename="../../toonz/flipbook.cpp" line="252"/>
-        <location filename="../../toonz/flipbook.cpp" line="1912"/>
+        <location filename="../../toonz/flipbook.cpp" line="1940"/>
         <source>Flipbook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="645"/>
+        <location filename="../../toonz/flipbook.cpp" line="647"/>
         <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? &quot;  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="652"/>
+        <location filename="../../toonz/flipbook.cpp" line="654"/>
         <source>It is not possible to save because the selected file format is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="686"/>
+        <location filename="../../toonz/flipbook.cpp" line="688"/>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="734"/>
+        <location filename="../../toonz/flipbook.cpp" line="736"/>
         <source>It is not possible to save Flipbook content.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="751"/>
+        <location filename="../../toonz/flipbook.cpp" line="753"/>
         <source>Saved %1 frames out of %2 in %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="783"/>
+        <location filename="../../toonz/flipbook.cpp" line="785"/>
         <source>There are no rendered images to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="787"/>
-        <location filename="../../toonz/flipbook.cpp" line="810"/>
+        <location filename="../../toonz/flipbook.cpp" line="789"/>
+        <location filename="../../toonz/flipbook.cpp" line="812"/>
         <source>It is not possible to take or compare snapshots for Toonz vector levels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="1229"/>
+        <location filename="../../toonz/flipbook.cpp" line="1232"/>
         <source>Rendered Frames  ::  From %1 To %2  ::  Step %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="1234"/>
+        <location filename="../../toonz/flipbook.cpp" line="1237"/>
         <source>  ::  Shrink </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/flipbook.cpp" line="1571"/>
+        <source>Gamma : %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1133"/>
+        <location filename="../../toonz/tpanels.cpp" line="1134"/>
         <source>Safe Area (Right Click to Select)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1149"/>
+        <location filename="../../toonz/tpanels.cpp" line="1150"/>
         <source>Minimize</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3289,87 +3698,95 @@ Do you want to overwrite it?</source>
     </message>
 </context>
 <context>
+    <name>GPhotoCam</name>
+    <message>
+        <location filename="../../stopmotion/gphotocam.cpp" line="729"/>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="244"/>
-        <location filename="../../toonz/imageviewer.cpp" line="444"/>
-        <location filename="../../toonz/imageviewer.cpp" line="454"/>
+        <location filename="../../toonz/imageviewer.cpp" line="245"/>
+        <location filename="../../toonz/imageviewer.cpp" line="446"/>
+        <location filename="../../toonz/imageviewer.cpp" line="456"/>
         <source>Flipbook Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="270"/>
+        <location filename="../../toonz/imageviewer.cpp" line="271"/>
         <source>Clone Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="277"/>
+        <location filename="../../toonz/imageviewer.cpp" line="278"/>
         <source>Unfreeze Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="283"/>
+        <location filename="../../toonz/imageviewer.cpp" line="284"/>
         <source>Freeze Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="289"/>
+        <location filename="../../toonz/imageviewer.cpp" line="290"/>
         <source>Regenerate Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="294"/>
+        <location filename="../../toonz/imageviewer.cpp" line="295"/>
         <source>Regenerate Frame Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="302"/>
+        <location filename="../../toonz/imageviewer.cpp" line="303"/>
         <source>Load / Append Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="310"/>
+        <location filename="../../toonz/imageviewer.cpp" line="311"/>
         <source>Clear Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="316"/>
+        <location filename="../../toonz/imageviewer.cpp" line="317"/>
         <source>Reset View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="321"/>
+        <location filename="../../toonz/imageviewer.cpp" line="322"/>
         <source>Fit To Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="332"/>
+        <location filename="../../toonz/imageviewer.cpp" line="333"/>
         <source>Exit Full Screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="333"/>
+        <location filename="../../toonz/imageviewer.cpp" line="334"/>
         <source>Full Screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="348"/>
+        <location filename="../../toonz/imageviewer.cpp" line="349"/>
         <source>Show Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="357"/>
+        <location filename="../../toonz/imageviewer.cpp" line="358"/>
         <source>Swap Compared Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="363"/>
+        <location filename="../../toonz/imageviewer.cpp" line="364"/>
         <source>Save Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="531"/>
         <location filename="../../toonz/imageviewer.cpp" line="533"/>
+        <location filename="../../toonz/imageviewer.cpp" line="535"/>
         <source>  ::  Zoom : </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3395,38 +3812,38 @@ Do you want to overwrite it?</source>
 <context>
     <name>InbetweenDialog</name>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1991"/>
-        <location filename="../../toonz/filmstrip.cpp" line="2006"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1979"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1994"/>
         <source>Inbetween</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1993"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1981"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1994"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1982"/>
         <source>Ease In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1995"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1983"/>
         <source>Ease Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1996"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1984"/>
         <source>Ease In / Ease Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="2003"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1991"/>
         <source>Interpolation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="2007"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1995"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3441,6 +3858,11 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../../toonz/insertfxpopup.cpp" line="228"/>
         <source>Search:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/insertfxpopup.cpp" line="255"/>
+        <source>Plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3459,37 +3881,37 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="413"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="414"/>
         <source>Macro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="561"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="562"/>
         <source>Remove Macro FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="569"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="570"/>
         <source>Remove Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="620"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
         <source>Are you sure you want to delete %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="622"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="622"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="627"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="628"/>
         <source>It is not possible to delete %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3613,17 +4035,17 @@ Do you want to overwrite it?</source>
 <context>
     <name>LayerHeaderPanel</name>
     <message>
-        <location filename="../../toonz/layerheaderpanel.cpp" line="182"/>
+        <location filename="../../toonz/layerheaderpanel.cpp" line="177"/>
         <source>Preview Visibility Toggle All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/layerheaderpanel.cpp" line="187"/>
+        <location filename="../../toonz/layerheaderpanel.cpp" line="182"/>
         <source>Camera Stand Visibility Toggle All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/layerheaderpanel.cpp" line="192"/>
+        <location filename="../../toonz/layerheaderpanel.cpp" line="187"/>
         <source>Lock Toggle All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3631,138 +4053,138 @@ Do you want to overwrite it?</source>
 <context>
     <name>LevelCreatePopup</name>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="169"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="174"/>
         <source>New Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="179"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="184"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="181"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="186"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="183"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="188"/>
         <source>DPI:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="190"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="195"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="191"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="196"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="192"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="197"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="201"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="206"/>
         <source>Vector Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="200"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="205"/>
         <source>Smart Raster Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="186"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="191"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="188"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="193"/>
         <source>Frame Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="199"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="204"/>
         <source>Raster Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="232"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="237"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="237"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="242"/>
         <source>From:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="240"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="245"/>
         <source>To:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="245"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="250"/>
         <source>Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="248"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="253"/>
         <source>Increment:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="253"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="258"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="258"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="263"/>
         <source>Save In:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="506"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="511"/>
         <source>No level name specified: please choose a valid level name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="514"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="519"/>
         <source>Invalid frame range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="518"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="523"/>
         <source>Invalid increment value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="522"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="527"/>
         <source>Invalid step value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="534"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="539"/>
         <source>The level name specified is already used: please choose a different level name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="570"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="575"/>
         <source>The level name specified is already used as a file by another level: please choose a different level name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="581"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="586"/>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="589"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="594"/>
         <source>Unable to create</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3773,174 +4195,181 @@ Do you want to create it?</source>
         <location filename="../../toonz/levelsettingspopup.cpp" line="74"/>
         <location filename="../../toonz/levelsettingspopup.cpp" line="95"/>
         <location filename="../../toonz/levelsettingspopup.cpp" line="96"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="913"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="918"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="961"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="966"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="989"/>
         <source>[Various]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="323"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="341"/>
         <source>Level Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="331"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="353"/>
         <source>Scan Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="336"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="358"/>
         <location filename="../../toonz/preferencespopup.cpp" line="170"/>
         <source>DPI:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="338"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="360"/>
         <source>Forced Squared Pixel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="340"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="362"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="342"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="364"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="345"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="367"/>
         <source>Use Camera DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="350"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="372"/>
         <source>Camera DPI:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="351"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="373"/>
         <source>Image DPI:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="352"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="374"/>
         <source>Resolution:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="355"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="377"/>
         <location filename="../../toonz/preferencespopup.cpp" line="199"/>
         <source>Subsampling:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="358"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="380"/>
         <location filename="../../toonz/preferencespopup.cpp" line="180"/>
         <source>Premultiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="360"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="382"/>
         <location filename="../../toonz/preferencespopup.cpp" line="184"/>
         <source>White As Transparent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="362"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="384"/>
         <location filename="../../toonz/preferencespopup.cpp" line="188"/>
         <source>Add Antialiasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="363"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="385"/>
         <location filename="../../toonz/preferencespopup.cpp" line="192"/>
         <source>Antialias Softness:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="371"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="388"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="205"/>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="397"/>
         <source>Image DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="372"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="398"/>
         <source>Custom DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="434"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="464"/>
         <source>Name &amp;&amp; Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="439"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="469"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="442"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="472"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="461"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="491"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="463"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="493"/>
         <source>DPI &amp;&amp; Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="698"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="741"/>
         <source>Smart Raster level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="701"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="745"/>
         <source>Raster level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="704"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="748"/>
         <source>Mesh level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="707"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="751"/>
         <source>Vector level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="710"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="754"/>
         <source>Palette level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="713"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="757"/>
         <source>SubXsheet Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="716"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="760"/>
         <source>Sound Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="719"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="763"/>
         <source>Another Level Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1027"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1086"/>
         <source>The file %1 is not a sound level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1075"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1134"/>
         <source>The file you entered is already used by another level.
 Please choose a different file</source>
         <translation type="unfinished"></translation>
@@ -3972,193 +4401,193 @@ Please choose a different file</source>
 <context>
     <name>LipSyncPopup</name>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="199"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="200"/>
         <source>Lip Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="205"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="206"/>
         <source>From Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="206"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="207"/>
         <source>From Data File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="207"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="208"/>
         <source>Use audio from a column or external file to lip sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="208"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="209"/>
         <source>Use a file generated in Papagayo to lip sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="229"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="230"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="230"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="231"/>
         <source>A I Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="231"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="232"/>
         <source>O Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="232"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="233"/>
         <source>E Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="233"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="234"/>
         <source>U Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="234"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="235"/>
         <source>L Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="235"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="236"/>
         <source>W Q Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="236"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="237"/>
         <source>M B P Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="237"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="238"/>
         <source>F V Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="238"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="239"/>
         <source>Rest Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="239"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="240"/>
         <source>C D G K N R S Th Y Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="241"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="242"/>
         <source>Extend Rest Drawing to End Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="258"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="259"/>
         <source>Audio Source: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="266"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="267"/>
         <source>Audio Script (Optional, Improves accuracy): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="268"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="269"/>
         <source>A script significantly increases the accuracy of the lip sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="298"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="299"/>
         <source>Lip Sync Data File: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="321"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="322"/>
         <source>Previous Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="324"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="325"/>
         <source>Next Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="451"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="452"/>
         <source>Insert at Frame: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="546"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="547"/>
         <source>Thumbnails are not available for sub-Xsheets.
 Please use the frame numbers for reference.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="549"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="550"/>
         <source>Unable to apply lip sync data to this column type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="583"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="584"/>
         <source>Column </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="586"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="587"/>
         <source>Choose File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="674"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="675"/>
         <source>Please choose an audio file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="811"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="772"/>
         <source>Rhubarb Processing Error:
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="844"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="805"/>
         <source>Rhubarb not found, please set the location in Preferences and restart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="877"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="838"/>
         <source>Please choose a lip sync data file to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="886"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="847"/>
         <source>Cannot find the file specified. 
 Please choose a valid lip sync data file to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="892"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="853"/>
         <source>Unable to open the file: 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="913"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="874"/>
         <source>Invalid data file.
  Please choose a valid lip sync data file to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="1010"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="971"/>
         <source>SubXSheet Frame </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="1018"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="979"/>
         <source>Drawing: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4168,6 +4597,14 @@ Please choose a valid lip sync data file to continue.</source>
     <message>
         <location filename="../../toonz/boardsettingspopup.cpp" line="1078"/>
         <source>Load Clapperboard Settings Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="5085"/>
+        <source>Load Camera Calibration Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4210,32 +4647,32 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="397"/>
+        <location filename="../../toonz/flipbook.cpp" line="399"/>
         <source>From:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="402"/>
+        <location filename="../../toonz/flipbook.cpp" line="404"/>
         <source>To:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="407"/>
+        <location filename="../../toonz/flipbook.cpp" line="409"/>
         <source>Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="412"/>
+        <location filename="../../toonz/flipbook.cpp" line="414"/>
         <source>Shrink:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="434"/>
+        <location filename="../../toonz/flipbook.cpp" line="436"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="436"/>
+        <location filename="../../toonz/flipbook.cpp" line="438"/>
         <source>Load / Append Images</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4475,6 +4912,11 @@ Please choose a valid lip sync data file to continue.</source>
         <source>Locator</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../toonz/locatorpopup.cpp" line="111"/>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MagpieFileImportPopup</name>
@@ -4534,3425 +4976,3515 @@ Please choose a valid lip sync data file to continue.</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="517"/>
+        <location filename="../../toonz/mainwindow.cpp" line="537"/>
         <source>Untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1050"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1071"/>
         <source>http://tahoma2d.readthedocs.io</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1069"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1090"/>
         <source>https://groups.google.com/g/tahoma2d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1097"/>
         <source>To report a bug, click on the button below to open a web browser window for Tahoma2D&apos;s Issues page on https://github.com.  Click on the &apos;New issue&apos; button and fill out the form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1096"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1117"/>
         <source>Are you sure you want to reload and restore default rooms?
 Custom rooms will not be touched.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1223"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1244"/>
         <source>Cannot delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1724"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1768"/>
         <source>&amp;New Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1725"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1769"/>
         <source>Create a new scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1726"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1770"/>
         <source>&amp;Load Scene...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1727"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1771"/>
         <source>Load an existing scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1728"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1772"/>
         <source>&amp;Save Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1729"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1773"/>
         <source>Save ONLY the scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1730"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1733"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1774"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1777"/>
         <source>This does NOT save levels or images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1731"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1775"/>
         <source>&amp;Save Scene As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1732"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1776"/>
         <source>Save ONLY the scene with a new name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1734"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1778"/>
         <source>&amp;Save All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1735"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1779"/>
         <source>Save the scene info and the levels and images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1736"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1780"/>
         <source>Saves everything.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1737"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1781"/>
         <source>&amp;Revert Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1739"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1783"/>
         <source>Revert the scene to its previously saved state.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1742"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1786"/>
         <source>&amp;Load Folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1743"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1787"/>
         <source>Load the contents of a folder into the current scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1745"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1789"/>
         <source>&amp;Load As Sub-Scene...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1746"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1790"/>
         <source>Load an existing scene into the current scene as a sub-scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1747"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1791"/>
         <source>&amp;Open Recent Scene File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1748"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1792"/>
         <source>Load a recently used scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1749"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1793"/>
         <source>&amp;Open Recent Level File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1750"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1794"/>
         <source>Load a recently used level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1752"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1796"/>
         <source>&amp;Clear Recent Scene File List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1753"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1797"/>
         <source>Remove everything from the recent scene list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1755"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1799"/>
         <source>&amp;Clear Recent level File List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1756"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1800"/>
         <source>Remove everything from the recent level list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1757"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1801"/>
         <source>&amp;Convert File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1758"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1802"/>
         <source>Convert an existing file or image sequence to another format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1759"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1805"/>
         <source>&amp;Load Color Model...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1760"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1806"/>
         <source>Load an image as a color guide.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1762"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1808"/>
         <source>&amp;Import Toonz Lip Sync File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1763"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1809"/>
         <source>Import a lip sync file to be applied to a level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1764"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1810"/>
         <source>&amp;New Project...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1765"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1812"/>
         <source>Create a new project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1766"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1813"/>
         <source>A project is a container for a collection of related scenes and drawings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1774"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1822"/>
         <source>&amp;Save Default Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1775"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1824"/>
         <source>Use the current scene&apos;s settings as a template for all new scenes in the current project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1777"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1826"/>
         <source>&amp;Export Soundtrack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1778"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1827"/>
         <source>Exports the soundtrack to the current scene as a wav file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1779"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1828"/>
         <source>&amp;Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1780"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1829"/>
         <source>Change Tahoma2D&apos;s settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1781"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1830"/>
         <source>&amp;Configure Shortcuts...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1782"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1831"/>
         <source>Change the shortcuts of Tahoma2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1783"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1832"/>
         <source>&amp;Print Xsheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1784"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1833"/>
         <source>Print the scene&apos;s exposure sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1791"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1840"/>
         <source>Export Exchange Digital Time Sheet (XDTS)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1797"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1849"/>
         <source>Run Script...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1798"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1850"/>
         <source>Run a script to perform a series of actions on a scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1800"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1852"/>
         <source>Open Script Console...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1801"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1853"/>
         <source>Open a console window where you can enter script commands.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1802"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1854"/>
         <source>&amp;Print Current Frame...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1804"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1804"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
         <source>Bye.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1806"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1858"/>
         <source>Reload qss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1808"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1860"/>
         <source>&amp;Load Recent Image Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1811"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1863"/>
         <source>&amp;Clear Recent Flipbook Image List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1812"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1864"/>
         <source>&amp;Clear Cache Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1820"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1872"/>
         <source>&amp;Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1822"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1874"/>
         <source>&amp;Invert Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1824"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1876"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1825"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1877"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1826"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1878"/>
         <source>&amp;Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1827"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1879"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1828"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1880"/>
         <source>&amp;Paste Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1830"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1882"/>
         <source>&amp;Paste Insert Below/Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1832"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1884"/>
         <source>&amp;Paste as a Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1834"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1886"/>
         <source>&amp;Paste Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1836"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1893"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1837"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1894"/>
         <source>&amp;Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1838"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1895"/>
         <source>&amp;Insert Below/Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1840"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1897"/>
         <source>&amp;Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1841"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1898"/>
         <source>&amp;Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1843"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1900"/>
         <source>&amp;Enter Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1845"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1902"/>
         <source>&amp;Exit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1847"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1904"/>
         <source>&amp;Move to Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1849"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1906"/>
         <source>&amp;Move Back One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1851"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1908"/>
         <source>&amp;Move Forward One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1853"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1910"/>
         <source>&amp;Move to Front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1913"/>
         <source>&amp;Clear Recent Project List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1857"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1914"/>
         <source>Remove everything from the recent project list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1859"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1916"/>
         <source>&amp;Clear Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1864"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1921"/>
         <source>&amp;Cleanup Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1866"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1923"/>
         <source>&amp;Preview Cleanup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1869"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1926"/>
         <source>&amp;Camera Test</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1872"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1929"/>
         <source>&amp;Opacity Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1874"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1931"/>
         <source>&amp;Cleanup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1879"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1936"/>
         <source>&amp;New Level...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1880"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1937"/>
         <source>Create a new drawing layer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1881"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1938"/>
         <source>&amp;New Vector Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1882"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1939"/>
         <source>Create a new vector level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1883"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1940"/>
         <source>Vectors can be manipulated easily and have some extra tools and features.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1886"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1943"/>
         <source>&amp;New Smart Raster Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1887"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1944"/>
         <source>Create a new Smart Raster level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1888"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1945"/>
         <source>Smart Raster levels are color mapped making the colors easier to adjust at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1890"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1947"/>
         <source>&amp;New Raster Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1891"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1948"/>
         <source>Create a new raster level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1892"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1949"/>
         <source>Raster levels are traditional drawing levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1893"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1950"/>
         <source>Imported images will be imported as raster levels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1894"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1951"/>
         <source>&amp;Load Level...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1895"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1952"/>
         <source>Load an existing level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1896"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1953"/>
         <source>&amp;Save Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1897"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1954"/>
         <source>Save the current level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1898"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1901"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1904"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1955"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1958"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1961"/>
         <source>This does not save the scene info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1899"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1956"/>
         <source>&amp;Save All Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1900"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1957"/>
         <source>Save all levels loaded into the scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1902"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1959"/>
         <source>&amp;Save Level As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1903"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1960"/>
         <source>Save the current level as a different name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1905"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1962"/>
         <source>&amp;Export Level...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1906"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1963"/>
         <source>Export the current level as an image sequence.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1908"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1965"/>
         <source>&amp;Remove Vector Overflow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1910"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1967"/>
         <source>&amp;Add Frames...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1912"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1969"/>
         <source>&amp;Renumber...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1914"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1971"/>
         <source>&amp;Replace Level...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1917"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1974"/>
         <source>&amp;Revert to Cleaned Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1919"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1976"/>
         <source>&amp;Reload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1921"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1978"/>
         <source>&amp;Expose in Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1922"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1979"/>
         <source>&amp;Display in Level Strip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1924"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1981"/>
         <source>&amp;Level Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1926"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1983"/>
         <source>Adjust Levels...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1928"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1985"/>
         <source>Adjust Thickness...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1930"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1987"/>
         <source>&amp;Antialias...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1932"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1989"/>
         <source>&amp;Binarize...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1935"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1992"/>
         <source>&amp;Brightness and Contrast...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1937"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1994"/>
         <source>&amp;Color Fade...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1939"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1996"/>
         <source>&amp;Canvas Size...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1942"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1999"/>
         <source>&amp;Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1944"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2001"/>
         <source>&amp;Remove All Unused Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1947"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2004"/>
         <source>&amp;Replace Parent Directory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1949"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2006"/>
         <source>New Note Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1952"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2009"/>
         <source>Convert to Vectors...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1954"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2011"/>
         <source>Vectors to Smart Raster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1957"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2014"/>
         <source>Replace Vectors with Simplified Vectors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1960"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2017"/>
         <source>Tracking...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1962"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2018"/>
         <source>&amp;New Motion Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1963"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2019"/>
         <source>Create a new motion path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1964"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2020"/>
         <source>Motion paths can be used as animation guides, or you can animate objects along a motion path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1969"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2025"/>
         <source>&amp;Scene Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1971"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3031"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2027"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3133"/>
         <source>&amp;Camera Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1973"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2029"/>
         <source>&amp;Open Sub-Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1975"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2031"/>
         <source>&amp;Close Sub-Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1977"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2033"/>
         <source>Explode Sub-Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1979"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2035"/>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1981"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2037"/>
         <source>&amp;Toggle Edit In Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1985"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2041"/>
         <source>&amp;Save Sub-Scene As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1987"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2043"/>
         <source>Clone Sub-Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1990"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2046"/>
         <source>&amp;Apply Match Lines...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1992"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2048"/>
         <source>&amp;Merge Tlv Levels...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1994"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2050"/>
         <source>&amp;Delete Match Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1996"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2052"/>
         <source>&amp;Delete Lines...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1998"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2054"/>
         <source>&amp;Merge Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2000"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2056"/>
         <source>&amp;New FX...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2002"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2058"/>
         <source>&amp;New Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2004"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2060"/>
         <source>Insert Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2006"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2062"/>
         <source>Remove Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2009"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2065"/>
         <source>Insert Multiple Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2012"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2068"/>
         <source>Remove Multiple Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2019"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2075"/>
         <source>Remove Empty Columns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2026"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2082"/>
         <source>&amp;Apply Lip Sync to Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2028"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2084"/>
         <source>Resequence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2030"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2086"/>
         <source>Set Start Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2031"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2087"/>
         <source>Set Stop Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2032"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2088"/>
         <source>Remove Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2033"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2089"/>
         <source>Set Auto Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2035"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2091"/>
         <source>Set Markers to Current Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2052"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2110"/>
         <source>&amp;Merge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2053"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2111"/>
         <source>&amp;Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2054"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2112"/>
         <source>&amp;Swing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2055"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2113"/>
         <source>&amp;Random</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2056"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2114"/>
         <source>&amp;Autoexpose</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2058"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2116"/>
         <source>&amp;Repeat...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2059"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2117"/>
         <source>&amp;Reset Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2061"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2119"/>
         <source>&amp;Increase Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2063"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2121"/>
         <source>&amp;Decrease Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2065"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2123"/>
         <source>&amp;Step 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2066"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2124"/>
         <source>&amp;Step 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2067"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2125"/>
         <source>&amp;Step 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2068"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2126"/>
         <source>&amp;Each 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2069"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2127"/>
         <source>&amp;Each 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2070"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2128"/>
         <source>&amp;Each 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2071"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2129"/>
         <source>&amp;Roll Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2072"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2130"/>
         <source>&amp;Roll Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2073"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2131"/>
         <source>&amp;Time Stretch...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2134"/>
         <source>&amp;Create Blank Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2080"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2138"/>
         <source>&amp;Duplicate Drawing  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2082"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2140"/>
         <source>&amp;Autorenumber</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2084"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2142"/>
         <source>&amp;Clone Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2087"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2145"/>
         <source>Drawing Substitution Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2089"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2147"/>
         <source>Drawing Substitution Backward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2091"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2149"/>
         <source>Similar Drawing Substitution Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2094"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2152"/>
         <source>Similar Drawing Substitution Backward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2096"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2154"/>
         <source>Reframe on 1&apos;s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2097"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2155"/>
         <source>Reframe on 2&apos;s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2098"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2156"/>
         <source>Reframe on 3&apos;s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2099"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2157"/>
         <source>Reframe on 4&apos;s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2101"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2159"/>
         <source>Reframe with Empty Inbetweens...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2104"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2162"/>
         <source>Auto Input Cell Number...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2106"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2164"/>
         <source>&amp;Fill In Empty Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2111"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2169"/>
         <source>Link Flipbooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2113"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2171"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2114"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2172"/>
         <source>Short Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2115"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2173"/>
         <source>Loop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2116"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2174"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2117"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2175"/>
         <source>First Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2119"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2177"/>
         <source>Last Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2121"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2179"/>
         <source>Previous Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2123"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2181"/>
         <source>Next Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2125"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2183"/>
         <source>Next Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2127"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2185"/>
         <source>Previous Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2129"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2187"/>
         <source>Next Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2130"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2188"/>
         <source>Previous Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2132"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2190"/>
         <source>Next Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2134"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2192"/>
         <source>Previous Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2139"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2199"/>
         <source>&amp;Output Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2141"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2201"/>
         <source>Control the output settings for the current scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2142"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2202"/>
         <source>You can render from the output settings window also.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2143"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2203"/>
         <source>&amp;Preview Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2145"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2205"/>
         <source>Control the settings that will be used to preview the scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2146"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2206"/>
         <source>&amp;Render</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2147"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2207"/>
         <source>Renders according to the settings and location set in Output Settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2149"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2209"/>
         <source>&amp;Fast Render to MP4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2150"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2210"/>
         <source>Exports an MP4 file to the location specified in the preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2151"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2211"/>
         <source>This is quicker than going into the Output Settings and setting up an MP4 render.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2154"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2214"/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2155"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2215"/>
         <source>Previews the current scene with all effects applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2157"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2217"/>
         <source>&amp;Save Previewed Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2158"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2218"/>
         <source>Save the images created during preview to a specified location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2159"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2225"/>
         <source>&amp;Save and Render</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2160"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2226"/>
         <source>Saves the current scene and renders according to the settings and location set in Output Settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2165"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2231"/>
         <source>&amp;Camera Box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2167"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2233"/>
         <source>&amp;Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2169"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2235"/>
         <source>&amp;Grids and Overlays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2171"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2237"/>
         <source>&amp;Raster Bounding Box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2173"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2239"/>
         <source>&amp;Safe Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2175"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2241"/>
         <source>&amp;Camera BG Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2177"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2243"/>
         <source>&amp;Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2179"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2245"/>
         <source>&amp;Ruler</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2181"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2247"/>
         <source>&amp;Transparency Check  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2184"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2250"/>
         <source>&amp;Ink Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2190"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2256"/>
         <source>&amp;Ink#1 Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2196"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2262"/>
         <source>&amp;Paint Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2198"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2264"/>
         <source>Inks &amp;Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2200"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2266"/>
         <source>&amp;Fill Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2202"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2268"/>
         <source>&amp;Black BG Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2205"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2271"/>
         <source>&amp;Gap Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2207"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2273"/>
         <source>Shift and Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2209"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2275"/>
         <source>Edit Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2211"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2277"/>
         <source>No Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2215"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2281"/>
         <source>Reset Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2221"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2287"/>
         <source>&amp;Visualize Vector As Raster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2229"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2295"/>
         <source>&amp;File Browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2231"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2299"/>
         <source>&amp;Flipbook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2233"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2301"/>
         <source>&amp;Function Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2235"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2303"/>
         <source>&amp;Level Strip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2237"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2305"/>
         <source>&amp;Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2239"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2307"/>
         <source>&amp;Tasks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2240"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2308"/>
         <source>&amp;Batch Servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2242"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2310"/>
         <source>&amp;Message Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2244"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2312"/>
         <source>&amp;Color Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2246"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2314"/>
         <source>&amp;Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2248"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2316"/>
         <source>&amp;Schematic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2250"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2318"/>
         <source>&amp;FX Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2253"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2321"/>
         <source>&amp;Cleanup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2255"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2323"/>
         <source>&amp;Scene Cast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2257"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2325"/>
         <source>&amp;Style Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2259"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2327"/>
         <source>&amp;Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2260"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2328"/>
         <source>&amp;Tool Option Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2262"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2330"/>
         <source>&amp;Command Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2265"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2333"/>
         <source>&amp;Stop Motion Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2267"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2335"/>
         <source>&amp;Viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2269"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2337"/>
         <source>&amp;Xsheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2270"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
         <source>&amp;Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2272"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2340"/>
         <source>&amp;ComboViewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2274"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2342"/>
         <source>&amp;History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2276"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2344"/>
         <source>Record Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2279"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2347"/>
         <source>&amp;Reset All Default Rooms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2280"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2348"/>
         <source>Toggle Maximize Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2283"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2351"/>
         <source>Toggle Main Window&apos;s Full Screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2285"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2353"/>
         <source>&amp;Startup Popup...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2293"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2367"/>
         <source>&amp;Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2294"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2368"/>
         <source>&amp;Motion Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2298"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2372"/>
         <source>&amp;Online Manual...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2300"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2374"/>
         <source>&amp;What&apos;s New...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2302"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2376"/>
         <source>&amp;Community Forum...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2304"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2378"/>
         <source>&amp;Report a Bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2306"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2380"/>
         <source>&amp;About Tahoma2D...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1063"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1084"/>
         <source>https://tahoma2d.readthedocs.io/en/latest/whats_new.html</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1768"/>
-        <source>&amp;Open Recent Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1770"/>
-        <source>&amp;Load Project...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1771"/>
-        <source>Load an existing project.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1772"/>
-        <source>&amp;Project Settings...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1786"/>
-        <source>&amp;Export Xsheet to PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1796"/>
-        <source>Export TVPaint JSON File</source>
+        <location filename="../../toonz/mainwindow.cpp" line="1804"/>
+        <source>&amp;Convert TZP Files In Folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="1815"/>
+        <source>&amp;Open Recent Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1817"/>
+        <source>&amp;Load Project...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1818"/>
+        <source>Load an existing project.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1819"/>
+        <source>&amp;Project Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1835"/>
+        <source>&amp;Export Xsheet to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1845"/>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1848"/>
+        <source>Export TVPaint JSON File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1867"/>
         <source>&amp;Export Current Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1816"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1868"/>
         <source>Export the current scene to another project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2015"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2071"/>
         <source>Set Multiple Stop Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2017"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2073"/>
         <source>Remove Multiple Stop Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2022"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2078"/>
         <source>Convert to use Implicit Holds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2024"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2080"/>
         <source>Convert to use Explicit Holds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2037"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2093"/>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2095"/>
         <source>Toggle Navigation Tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2039"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2097"/>
         <source>Next Tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2041"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2099"/>
         <source>Previous Tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2043"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2101"/>
         <source>Edit Tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2044"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2102"/>
         <source>Remove Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2078"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2136"/>
         <source>&amp;Stop Frame Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2217"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2194"/>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2219"/>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2222"/>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2283"/>
         <source>Vector Guided Tweening</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2288"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2297"/>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2356"/>
         <source>Guided Tweening Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2315"/>
-        <source>Toggle Autofill on Current Palette Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2322"/>
-        <source>&amp;Save Palette As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2323"/>
-        <source>Save the current style palette as a separate file with a new name.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2324"/>
-        <source>&amp;Save Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2325"/>
-        <source>Save the current style palette as a separate file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2327"/>
-        <source>&amp;Regenerate Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2328"/>
-        <source>Recreates a set of preview images.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2330"/>
-        <source>&amp;Regenerate Frame Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2331"/>
-        <source>Regenerate the frame preview.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2332"/>
-        <source>&amp;Clone Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2333"/>
-        <source>Creates a clone of the previewed images.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2335"/>
-        <source>&amp;Freeze//Unfreeze Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2336"/>
-        <source>Prevent the preview from being updated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
-        <source>Freeze Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
-        <source>Unfreeze Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2339"/>
-        <source>&amp;Save As Preset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2340"/>
-        <source>Preview Fx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2341"/>
-        <source>&amp;Paste Color &amp;&amp; Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2343"/>
-        <source>Paste Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2344"/>
-        <source>Paste Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2346"/>
-        <source>Get Color from Studio Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2348"/>
-        <source>Toggle Link to Studio Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2350"/>
-        <source>Remove Reference to Studio Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2352"/>
-        <source>&amp;View...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2355"/>
-        <source>Toggle Quick Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2357"/>
-        <source>Show/Hide Camera Column</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2358"/>
-        <source>&amp;Set Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2361"/>
-        <source>&amp;Shift Keys Down</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2359"/>
+        <source>&amp;Custom Panels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2362"/>
-        <source>&amp;Shift Keys Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2364"/>
-        <source>&amp;Paste Numbers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2366"/>
-        <source>&amp;Histogram</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2367"/>
-        <source>&amp;Blend colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2368"/>
-        <source>Onion Skin Toggle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2370"/>
-        <source>Zero Thick Lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2372"/>
-        <source>Toggle Cursor Size Outline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2375"/>
-        <source>Toggle Current Time Indicator</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2376"/>
-        <source>Duplicate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2379"/>
-        <source>Show Folder Contents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2381"/>
-        <source>Convert...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2383"/>
-        <source>Collect Assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2385"/>
-        <source>Import Scene</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2387"/>
-        <source>Export Scene...</source>
+        <source>&amp;Custom Panel Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2389"/>
-        <source>Remove Level</source>
+        <source>Toggle Autofill on Current Palette Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2392"/>
-        <source>Add As Render Task</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2396"/>
+        <source>&amp;Save Palette As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2395"/>
-        <source>Add As Cleanup Task</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2397"/>
+        <source>Save the current style palette as a separate file with a new name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2398"/>
-        <source>Select All Keys in this Frame</source>
+        <source>&amp;Save Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2400"/>
-        <source>Select All Keys in this Column</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2399"/>
+        <source>Save the current style palette as a separate file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2401"/>
+        <source>&amp;Regenerate Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2402"/>
-        <source>Select All Keys</source>
+        <source>Recreates a set of preview images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2404"/>
-        <source>Select All Following Keys</source>
+        <source>&amp;Regenerate Frame Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2405"/>
+        <source>Regenerate the frame preview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2406"/>
-        <source>Select All Previous Keys</source>
+        <source>&amp;Clone Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2408"/>
-        <source>Select Previous Keys in this Column</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2407"/>
+        <source>Creates a clone of the previewed images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2411"/>
-        <source>Select Following Keys in this Column</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2409"/>
+        <source>&amp;Freeze//Unfreeze Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2410"/>
+        <source>Prevent the preview from being updated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2412"/>
+        <source>Freeze Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2412"/>
+        <source>Unfreeze Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2413"/>
+        <source>&amp;Save As Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2414"/>
-        <source>Select Previous Keys in this Frame</source>
+        <source>Preview Fx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2415"/>
+        <source>&amp;Paste Color &amp;&amp; Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2417"/>
-        <source>Select Following Keys in this Frame</source>
+        <source>Paste Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2420"/>
-        <source>Invert Key Selection</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2419"/>
+        <source>Paste Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2421"/>
-        <source>Set Acceleration</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2422"/>
+        <source>Get Color from Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2423"/>
-        <source>Set Deceleration</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2424"/>
+        <source>Toggle Link to Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2426"/>
-        <source>Set Constant Speed</source>
+        <source>Remove Reference to Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2428"/>
-        <source>Reset Interpolation</source>
+        <source>&amp;View...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2430"/>
-        <source>Linear Interpolation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2431"/>
+        <source>Toggle Quick Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2432"/>
-        <source>Speed In / Speed Out Interpolation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2433"/>
+        <source>Show/Hide Camera Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2435"/>
-        <source>Ease In / Ease Out Interpolation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2434"/>
+        <source>&amp;Set Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2437"/>
+        <source>&amp;Shift Keys Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2438"/>
-        <source>Ease In / Ease Out (%) Interpolation</source>
+        <source>&amp;Shift Keys Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2441"/>
-        <source>Exponential Interpolation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2440"/>
+        <source>&amp;Paste Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2443"/>
-        <source>Expression Interpolation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2442"/>
+        <source>&amp;Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2445"/>
-        <source>File Interpolation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2447"/>
-        <source>Constant Interpolation</source>
+        <source>&amp;Viewer Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2448"/>
-        <source>Fold Column</source>
+        <source>&amp;Blend colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2449"/>
+        <source>Onion Skin Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2451"/>
-        <source>Show This Only</source>
+        <source>Zero Thick Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2453"/>
-        <source>Show Selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2454"/>
-        <source>Show All</source>
+        <source>Toggle Cursor Size Outline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2456"/>
-        <source>Hide Selected</source>
+        <source>Toggle Current Time Indicator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2457"/>
-        <source>Hide All</source>
+        <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2460"/>
-        <source>Toggle Show/Hide</source>
+        <source>Show Folder Contents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2462"/>
-        <source>ON This Only</source>
+        <source>Convert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2464"/>
-        <source>ON Selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2465"/>
-        <source>ON All</source>
+        <source>Collect Assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2466"/>
-        <source>OFF All</source>
+        <source>Import Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2468"/>
-        <source>OFF Selected</source>
+        <source>Export Scene...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2469"/>
-        <source>Swap ON/OFF</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2470"/>
+        <source>Remove Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2472"/>
-        <source>Lock This Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2474"/>
-        <source>Lock Selected</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2473"/>
+        <source>Add As Render Task</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2475"/>
-        <source>Lock All</source>
+        <source>Add As Cleanup Task</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2478"/>
-        <source>Unlock Selected</source>
+        <source>Select All Keys in this Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2479"/>
-        <source>Unlock All</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2480"/>
+        <source>Select All Keys in this Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2482"/>
-        <source>Swap Lock/Unlock</source>
+        <source>Select All Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2484"/>
-        <source>Hide Upper Columns</source>
+        <source>Select All Following Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2486"/>
-        <source>Separate Colors...</source>
+        <source>Select All Previous Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2488"/>
-        <source>&amp;Palette Gizmo</source>
+        <source>Select Previous Keys in this Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2491"/>
-        <source>&amp;Delete Unused Styles</source>
+        <source>Select Following Keys in this Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2496"/>
-        <source>&amp;Save Studio Palette</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2494"/>
+        <source>Select Previous Keys in this Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2497"/>
-        <source>Save the current Studio Palette.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2499"/>
-        <source>&amp;Save As Default Palette</source>
+        <source>Select Following Keys in this Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2500"/>
-        <source>Save the current style palette as the default for new levels of the current level type.</source>
+        <source>Invert Key Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2502"/>
-        <source>Toggle Auto-Creation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2501"/>
+        <source>Set Acceleration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2505"/>
-        <source>Toggles the auto-creation of frames when drawing in blank cells on the timeline/xsheet.</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2503"/>
+        <source>Set Deceleration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2506"/>
+        <source>Set Constant Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2508"/>
-        <source>Toggle Creation In Hold Cells</source>
+        <source>Reset Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2511"/>
-        <source>Toggles the auto-creation of frames when drawing in held cells on the timeline/xsheet.</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2510"/>
+        <source>Linear Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2513"/>
-        <source>Toggle Auto-Stretch</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2512"/>
+        <source>Speed In / Speed Out Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2516"/>
-        <source>Toggles the auto-stretch of a frame to the next frame</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2515"/>
+        <source>Ease In / Ease Out Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2517"/>
-        <source>Toggle Viewer Indicators</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2518"/>
+        <source>Ease In / Ease Out (%) Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2520"/>
-        <source>Toggle Implicit Hold</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2521"/>
+        <source>Exponential Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2523"/>
-        <source>Toggles the implicit hold of a frame to the next frame</source>
+        <source>Expression Interpolation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2525"/>
+        <source>File Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2527"/>
-        <source>Animate Tool</source>
+        <source>Constant Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2528"/>
-        <source>Animate Tool: Modifies the position, rotation and size of the current column</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2530"/>
-        <source>Selection Tool</source>
+        <source>Fold Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2531"/>
-        <source>Selection Tool: Select parts of your image to transform it.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2532"/>
-        <source>Brush Tool</source>
+        <source>Show This Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2533"/>
-        <source>Brush Tool: Draws in the work area freehand</source>
+        <source>Show Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2534"/>
-        <source>Geometry Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2535"/>
-        <source>Geometry Tool: Draws geometric shapes</source>
+        <source>Show All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2536"/>
-        <source>Type Tool</source>
+        <source>Hide Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2537"/>
-        <source>Type Tool: Adds text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2538"/>
-        <source>Fill Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2539"/>
-        <source>Fill Tool: Fills drawing areas with the current style</source>
+        <source>Hide All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2540"/>
-        <source>Smart Raster Paint Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2541"/>
-        <source>Smart Raster Paint: Paints areas in Smart Raster levels</source>
+        <source>Toggle Show/Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2542"/>
-        <source>Eraser Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2543"/>
-        <source>Eraser Tool: Erases lines and areas</source>
+        <source>ON This Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2544"/>
-        <source>Tape Tool</source>
+        <source>ON Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2545"/>
-        <source>Tape Tool: Closes gaps in raster, joins edges in vector</source>
+        <source>ON All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2547"/>
-        <source>Style Picker Tool</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2546"/>
+        <source>OFF All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2548"/>
-        <source>Style Picker: Selects style on current drawing</source>
+        <source>OFF Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2549"/>
-        <source>RGB Picker Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2550"/>
-        <source>RGB Picker: Picks color on screen and applies to current style</source>
+        <source>Swap ON/OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2552"/>
-        <source>Control Point Editor Tool</source>
+        <source>Lock This Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2553"/>
-        <source>Control Point Editor: Modifies vector lines by editing its control points</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2554"/>
+        <source>Lock Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2555"/>
-        <source>Pinch Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2556"/>
-        <source>Pinch Tool: Pulls vector drawings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2557"/>
-        <source>Pump Tool</source>
+        <source>Lock All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2558"/>
-        <source>Pump Tool: Changes vector thickness</source>
+        <source>Unlock Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2559"/>
-        <source>Magnet Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2560"/>
-        <source>Magnet Tool: Deforms vector lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2561"/>
-        <source>Bender Tool</source>
+        <source>Unlock All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2562"/>
-        <source>Bender Tool: Bends vector shapes around the first click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2563"/>
-        <source>Iron Tool</source>
+        <source>Swap Lock/Unlock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2564"/>
-        <source>Iron Tool: Smooths out vector lines</source>
+        <source>Hide Upper Columns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2566"/>
-        <source>Cutter Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2567"/>
-        <source>Cutter Tool: Splits vector lines</source>
+        <source>Separate Colors...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2568"/>
-        <source>Skeleton Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2569"/>
-        <source>Skeleton Tool: Allows to build a skeleton and animate in a cut-out workflow</source>
+        <source>&amp;Palette Gizmo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2571"/>
-        <source>Tracker Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2572"/>
-        <source>Tracker Tool: Tracks specific regions in a sequence of images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2573"/>
-        <source>Hook Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2574"/>
-        <source>Zoom Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2575"/>
-        <source>Zoom Tool: Zooms viewer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2576"/>
-        <source>Rotate Tool</source>
+        <source>&amp;Delete Unused Styles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2577"/>
-        <source>Rotate Tool: Rotate the viewer</source>
+        <source>&amp;Save Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2578"/>
-        <source>Hand Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2579"/>
-        <source>Hand Tool: Pans the workspace</source>
+        <source>Save the current Studio Palette.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2580"/>
-        <source>Plastic Tool</source>
+        <source>&amp;Save As Default Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2581"/>
-        <source>Plastic Tool: Builds a mesh that allows to deform and animate a level</source>
+        <source>Save the current style palette as the default for new levels of the current level type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2583"/>
-        <source>Ruler Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2584"/>
-        <source>Ruler Tool: Measure distances on the canvas</source>
+        <source>Toggle Auto-Creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2586"/>
-        <source>Perspective Grid Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2587"/>
-        <source>Perspective Grid Tool: Set up perspective grids</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2588"/>
-        <source>Finger Tool</source>
+        <source>Toggles the auto-creation of frames when drawing in blank cells on the timeline/xsheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2589"/>
-        <source>Finger Tool: Smudges small areas to cover with line</source>
+        <source>Toggle Creation In Hold Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2592"/>
-        <source>Animate Tool - Next Mode</source>
+        <source>Toggles the auto-creation of frames when drawing in held cells on the timeline/xsheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2594"/>
-        <source>Animate Tool - Position</source>
+        <source>Toggle Auto-Stretch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2596"/>
-        <source>Animate Tool - Rotation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2597"/>
+        <source>Toggles the auto-stretch of a frame to the next frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2598"/>
-        <source>Animate Tool - Scale</source>
+        <source>Toggle Viewer Indicators</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2600"/>
-        <source>Animate Tool - Shear</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2602"/>
-        <source>Animate Tool - Center</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2601"/>
+        <source>Toggle Implicit Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2604"/>
-        <source>Animate Tool - All</source>
+        <source>Toggles the implicit hold of a frame to the next frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2608"/>
-        <source>Selection Tool - Next Type</source>
+        <source>Animate Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2609"/>
+        <source>Animate Tool: Modifies the position, rotation and size of the current column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2611"/>
-        <source>Selection Tool - Rectangular</source>
+        <source>Selection Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2612"/>
+        <source>Selection Tool: Select parts of your image to transform it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2613"/>
-        <source>Selection Tool - Freehand</source>
+        <source>Brush Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2614"/>
+        <source>Brush Tool: Draws in the work area freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2615"/>
-        <source>Selection Tool - Polyline</source>
+        <source>Geometry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2616"/>
+        <source>Geometry Tool: Draws geometric shapes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2617"/>
+        <source>Type Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2618"/>
+        <source>Type Tool: Adds text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2619"/>
-        <source>Brush Tool - Auto Fill On</source>
+        <source>Fill Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2620"/>
+        <source>Fill Tool: Fills drawing areas with the current style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2621"/>
-        <source>Brush Tool - Auto Fill Off</source>
+        <source>Smart Raster Paint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2622"/>
+        <source>Smart Raster Paint: Paints areas in Smart Raster levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2623"/>
+        <source>Eraser Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2624"/>
+        <source>Eraser Tool: Erases lines and areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2625"/>
-        <source>Geometric Tool - Next Shape</source>
+        <source>Tape Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2627"/>
-        <source>Geometric Tool - Rectangle</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2626"/>
+        <source>Tape Tool: Closes gaps in raster, joins edges in vector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2628"/>
+        <source>Style Picker Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2629"/>
-        <source>Geometric Tool - Circle</source>
+        <source>Style Picker: Selects style on current drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2630"/>
+        <source>RGB Picker Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2631"/>
-        <source>Geometric Tool - Ellipse</source>
+        <source>RGB Picker: Picks color on screen and applies to current style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2633"/>
-        <source>Geometric Tool - Line</source>
+        <source>Control Point Editor Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2635"/>
-        <source>Geometric Tool - Polyline</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2634"/>
+        <source>Control Point Editor: Modifies vector lines by editing its control points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2636"/>
+        <source>Pinch Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2637"/>
-        <source>Geometric Tool - Arc</source>
+        <source>Pinch Tool: Pulls vector drawings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2638"/>
+        <source>Pump Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2639"/>
-        <source>Geometric Tool - MultiArc</source>
+        <source>Pump Tool: Changes vector thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2640"/>
+        <source>Magnet Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2641"/>
-        <source>Geometric Tool - Polygon</source>
+        <source>Magnet Tool: Deforms vector lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2642"/>
+        <source>Bender Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2643"/>
+        <source>Bender Tool: Bends vector shapes around the first click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2644"/>
+        <source>Iron Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2645"/>
-        <source>Type Tool - Next Style</source>
+        <source>Iron Tool: Smooths out vector lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2647"/>
-        <source>Type Tool - Oblique</source>
+        <source>Cutter Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2648"/>
+        <source>Cutter Tool: Splits vector lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2649"/>
-        <source>Type Tool - Regular</source>
+        <source>Skeleton Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2651"/>
-        <source>Type Tool - Bold Oblique</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2650"/>
+        <source>Skeleton Tool: Allows to build a skeleton and animate in a cut-out workflow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2652"/>
+        <source>Tracker Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2653"/>
-        <source>Type Tool - Bold</source>
+        <source>Tracker Tool: Tracks specific regions in a sequence of images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2654"/>
+        <source>Hook Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2655"/>
+        <source>Zoom Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2656"/>
+        <source>Zoom Tool: Zooms viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2657"/>
-        <source>Fill Tool - Next Type</source>
+        <source>Rotate Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2658"/>
+        <source>Rotate Tool: Rotate the viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2659"/>
-        <source>Fill Tool - Normal</source>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2660"/>
+        <source>Hand Tool: Pans the workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2661"/>
-        <source>Fill Tool - Rectangular</source>
+        <source>Plastic Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2663"/>
-        <source>Fill Tool - Freehand</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2662"/>
+        <source>Plastic Tool: Builds a mesh that allows to deform and animate a level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2664"/>
+        <source>Ruler Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2665"/>
-        <source>Fill Tool - Polyline</source>
+        <source>Ruler Tool: Measure distances on the canvas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2667"/>
-        <source>Fill Tool - Next Mode</source>
+        <source>Perspective Grid Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2668"/>
+        <source>Perspective Grid Tool: Set up perspective grids</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2669"/>
-        <source>Fill Tool - Areas</source>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2670"/>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2671"/>
-        <source>Fill Tool - Lines</source>
+        <source>Finger Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2673"/>
-        <source>Fill Tool - Lines &amp; Areas</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2672"/>
+        <source>Finger Tool: Smudges small areas to cover with line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2675"/>
+        <source>Animate Tool - Next Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2677"/>
-        <source>Eraser Tool - Next Type</source>
+        <source>Animate Tool - Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2679"/>
-        <source>Eraser Tool - Normal</source>
+        <source>Animate Tool - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2681"/>
-        <source>Eraser Tool - Rectangular</source>
+        <source>Animate Tool - Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2683"/>
-        <source>Eraser Tool - Freehand</source>
+        <source>Animate Tool - Shear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2685"/>
-        <source>Eraser Tool - Polyline</source>
+        <source>Animate Tool - Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2687"/>
-        <source>Eraser Tool - Segment</source>
+        <source>Animate Tool - All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2691"/>
-        <source>Tape Tool - Next Type</source>
+        <source>Selection Tool - Next Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2693"/>
-        <source>Tape Tool - Normal</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2694"/>
+        <source>Selection Tool - Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2695"/>
-        <source>Tape Tool - Rectangular</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2696"/>
+        <source>Selection Tool - Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2697"/>
-        <source>Tape Tool - Next Mode</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2698"/>
+        <source>Selection Tool - Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2700"/>
-        <source>Tape Tool - Endpoint to Endpoint</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2702"/>
+        <source>Brush Tool - Auto Fill On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2703"/>
-        <source>Tape Tool - Endpoint to Line</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2704"/>
+        <source>Brush Tool - Auto Fill Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2705"/>
-        <source>Tape Tool - Line to Line</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2708"/>
+        <source>Geometric Tool - Next Shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2710"/>
-        <source>Style Picker Tool - Next Mode</source>
+        <source>Geometric Tool - Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2712"/>
-        <source>Style Picker Tool - Areas</source>
+        <source>Geometric Tool - Circle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2714"/>
-        <source>Style Picker Tool - Lines</source>
+        <source>Geometric Tool - Ellipse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2717"/>
-        <source>Style Picker Tool - Lines &amp; Areas</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2716"/>
+        <source>Geometric Tool - Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2721"/>
-        <source>RGB Picker Tool - Next Type</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2718"/>
+        <source>Geometric Tool - Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2723"/>
-        <source>RGB Picker Tool - Normal</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2720"/>
+        <source>Geometric Tool - Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2726"/>
-        <source>RGB Picker Tool - Rectangular</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2722"/>
+        <source>Geometric Tool - MultiArc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2724"/>
+        <source>Geometric Tool - Polygon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2728"/>
-        <source>RGB Picker Tool - Freehand</source>
+        <source>Type Tool - Next Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2730"/>
-        <source>RGB Picker Tool - Polyline</source>
+        <source>Type Tool - Oblique</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2732"/>
+        <source>Type Tool - Regular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2734"/>
-        <source>Skeleton Tool - Next Mode</source>
+        <source>Type Tool - Bold Oblique</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2737"/>
-        <source>Skeleton Tool - Build Skeleton</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2736"/>
+        <source>Type Tool - Bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2739"/>
-        <source>Skeleton Tool - Animate</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2740"/>
+        <source>Paint Brush - Next Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2742"/>
-        <source>Skeleton Tool - Inverse Kinematics</source>
+        <source>Paint Brush - Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2746"/>
-        <source>Plastic Tool - Next Mode</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2744"/>
+        <source>Paint Brush - Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2748"/>
-        <source>Plastic Tool - Edit Mesh</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2747"/>
+        <source>Paint Brush - Lines &amp; Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2750"/>
-        <source>Plastic Tool - Paint Rigid</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2751"/>
+        <source>Fill Tool - Next Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2753"/>
-        <source>Plastic Tool - Build Skeleton</source>
+        <source>Fill Tool - Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2755"/>
-        <source>Plastic Tool - Animate</source>
+        <source>Fill Tool - Rectangular</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2757"/>
+        <source>Fill Tool - Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2759"/>
+        <source>Fill Tool - Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2761"/>
-        <source>Select Next Frame Guide Stroke</source>
+        <source>Fill Tool - Pick+Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2763"/>
-        <source>Select Previous Frame Guide Stroke</source>
+        <source>Fill Tool - Next Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2766"/>
-        <source>Select Prev &amp;&amp; Next Frame Guide Strokes</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2765"/>
+        <source>Fill Tool - Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2770"/>
-        <source>Reset Guide Stroke Selections</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2767"/>
+        <source>Fill Tool - Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2772"/>
-        <source>Tween Selected Guide Strokes</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2769"/>
+        <source>Fill Tool - Lines &amp; Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2774"/>
-        <source>Tween Guide Strokes to Selected</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2773"/>
+        <source>Eraser Tool - Next Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2776"/>
-        <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2775"/>
+        <source>Eraser Tool - Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2778"/>
-        <source>Flip Next Guide Stroke Direction</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2777"/>
+        <source>Eraser Tool - Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2780"/>
-        <source>Flip Previous Guide Stroke Direction</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2779"/>
+        <source>Eraser Tool - Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2782"/>
-        <source>Global Key</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2781"/>
+        <source>Eraser Tool - Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2786"/>
-        <source>Brush size - Increase max</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2783"/>
+        <source>Eraser Tool - Segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2788"/>
-        <source>Brush size - Decrease max</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2787"/>
+        <source>Tape Tool - Next Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2790"/>
-        <source>Brush size - Increase min</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2789"/>
+        <source>Tape Tool - Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2792"/>
-        <source>Brush size - Decrease min</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2791"/>
+        <source>Tape Tool - Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2794"/>
-        <source>Brush hardness - Increase</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2793"/>
+        <source>Tape Tool - Next Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2796"/>
-        <source>Brush hardness - Decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2798"/>
-        <source>Snap Sensitivity</source>
+        <source>Tape Tool - Endpoint to Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2799"/>
-        <source>Auto Group</source>
+        <source>Tape Tool - Endpoint to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2802"/>
-        <source>Break sharp angles</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2801"/>
+        <source>Tape Tool - Line to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2803"/>
-        <source>Frame range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2805"/>
-        <source>Inverse Kinematics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2807"/>
-        <source>Invert</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2806"/>
+        <source>Style Picker Tool - Next Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2808"/>
-        <source>Manual</source>
+        <source>Style Picker Tool - Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2809"/>
-        <source>Onion skin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2811"/>
-        <source>Orientation</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2810"/>
+        <source>Style Picker Tool - Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2813"/>
-        <source>Pencil Mode</source>
+        <source>Style Picker Tool - Lines &amp; Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2816"/>
-        <source>Preserve Thickness</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2818"/>
-        <source>Pressure Sensitivity</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2817"/>
+        <source>RGB Picker Tool - Next Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2819"/>
-        <source>Segment Ink</source>
+        <source>RGB Picker Tool - Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2821"/>
-        <source>Selective</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2822"/>
+        <source>RGB Picker Tool - Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2824"/>
-        <source>Brush Tool - Draw Order</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2825"/>
-        <source>Smooth</source>
+        <source>RGB Picker Tool - Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2826"/>
-        <source>Snap</source>
+        <source>RGB Picker Tool - Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2828"/>
-        <source>Auto Select Drawing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2829"/>
-        <source>Auto Fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2831"/>
-        <source>Join Vectors</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2830"/>
+        <source>Skeleton Tool - Next Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2833"/>
-        <source>Show Only Active Skeleton</source>
+        <source>Skeleton Tool - Build Skeleton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2835"/>
-        <source>Brush Tool - Eraser (Raster option)</source>
+        <source>Skeleton Tool - Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2838"/>
-        <source>Brush Tool - Lock Alpha</source>
+        <source>Skeleton Tool - Inverse Kinematics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2841"/>
-        <source>Brush Preset</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2842"/>
+        <source>Plastic Tool - Next Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2843"/>
-        <source>Geometric Shape</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2844"/>
+        <source>Plastic Tool - Edit Mesh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2845"/>
-        <source>Geometric Shape Rectangle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2847"/>
-        <source>Geometric Shape Circle</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2846"/>
+        <source>Plastic Tool - Paint Rigid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2849"/>
-        <source>Geometric Shape Ellipse</source>
+        <source>Plastic Tool - Build Skeleton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2851"/>
-        <source>Geometric Shape Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2853"/>
-        <source>Geometric Shape Polyline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2855"/>
-        <source>Geometric Shape Arc</source>
+        <source>Plastic Tool - Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2857"/>
-        <source>Geometric Shape MultiArc</source>
+        <source>Select Next Frame Guide Stroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2859"/>
-        <source>Geometric Shape Polygon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2861"/>
-        <source>Geometric Edge</source>
+        <source>Select Previous Frame Guide Stroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2862"/>
-        <source>Mode</source>
+        <source>Select Prev &amp;&amp; Next Frame Guide Strokes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2864"/>
-        <source>Mode - Areas</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2866"/>
+        <source>Reset Guide Stroke Selections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2867"/>
-        <source>Mode - Lines</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2868"/>
+        <source>Tween Selected Guide Strokes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2870"/>
-        <source>Mode - Lines &amp;&amp; Areas</source>
+        <source>Tween Guide Strokes to Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2873"/>
-        <source>Mode - Endpoint to Endpoint</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2872"/>
+        <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2875"/>
-        <source>Mode - Endpoint to Line</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2874"/>
+        <source>Flip Next Guide Stroke Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2877"/>
-        <source>Mode - Line to Line</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2876"/>
+        <source>Flip Previous Guide Stroke Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2878"/>
-        <source>Type</source>
+        <source>Global Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2881"/>
-        <source>Type - Normal</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2882"/>
+        <source>Brush size - Increase max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2885"/>
-        <source>Type - Rectangular</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2884"/>
+        <source>Brush size - Decrease max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2889"/>
-        <source>Type - Freehand</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2886"/>
+        <source>Brush size - Increase min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2893"/>
-        <source>Type - Polyline</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2888"/>
+        <source>Brush size - Decrease min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2897"/>
-        <source>Type - Segment</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2890"/>
+        <source>Brush hardness - Increase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2900"/>
-        <source>TypeTool Font</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2892"/>
+        <source>Brush hardness - Decrease</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2902"/>
-        <source>TypeTool Size</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2894"/>
+        <source>Snap Sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2895"/>
+        <source>Auto Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2898"/>
+        <source>Break sharp angles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2899"/>
+        <source>Frame range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2901"/>
+        <source>Inverse Kinematics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2903"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2904"/>
+        <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2905"/>
-        <source>TypeTool Style</source>
+        <source>Onion skin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2907"/>
-        <source>TypeTool Style - Oblique</source>
+        <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2909"/>
-        <source>TypeTool Style - Regular</source>
+        <source>Pencil Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2911"/>
-        <source>TypeTool Style - Bold Oblique</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2912"/>
+        <source>Preserve Thickness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2913"/>
-        <source>TypeTool Style - Bold</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2914"/>
+        <source>Pressure Sensitivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2916"/>
-        <source>Active Axis</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2915"/>
+        <source>Segment Ink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2918"/>
-        <source>Active Axis - Position</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2917"/>
+        <source>Selective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2920"/>
-        <source>Active Axis - Rotation</source>
+        <source>Brush Tool - Draw Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2921"/>
+        <source>Smooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2922"/>
-        <source>Active Axis - Scale</source>
+        <source>Snap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2924"/>
-        <source>Active Axis - Shear</source>
+        <source>Auto Select Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2926"/>
-        <source>Active Axis - Center</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2925"/>
+        <source>Auto Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2928"/>
-        <source>Active Axis - All</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2927"/>
+        <source>Join Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2929"/>
+        <source>Show Only Active Skeleton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2931"/>
-        <source>Skeleton Mode</source>
+        <source>Brush Tool - Eraser (Raster option)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2933"/>
-        <source>Edit Mesh Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2935"/>
-        <source>Paint Rigid Mode</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2934"/>
+        <source>Brush Tool - Lock Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2937"/>
-        <source>Build Skeleton Mode</source>
+        <source>Brush Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2939"/>
-        <source>Animate Mode</source>
+        <source>Geometric Shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2941"/>
-        <source>Inverse Kinematics Mode</source>
+        <source>Geometric Shape Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2943"/>
-        <source>None Pick Mode</source>
+        <source>Geometric Shape Circle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2945"/>
-        <source>Column Pick Mode</source>
+        <source>Geometric Shape Ellipse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2947"/>
-        <source>Pegbar Pick Mode</source>
+        <source>Geometric Shape Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2949"/>
-        <source>Pick Screen</source>
+        <source>Geometric Shape Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2951"/>
-        <source>Create Mesh</source>
+        <source>Geometric Shape Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2956"/>
-        <source>Fill Tool - Autopaint Lines</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2953"/>
+        <source>Geometric Shape MultiArc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2955"/>
+        <source>Geometric Shape Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2957"/>
+        <source>Geometric Edge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2958"/>
+        <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2960"/>
-        <source>Auto Close</source>
+        <source>Mode - Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2961"/>
-        <source>Draw Under</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2964"/>
-        <source>Flip Selection/Object Horizontally</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2963"/>
+        <source>Mode - Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2966"/>
-        <source>Flip Selection/Object Vertically</source>
+        <source>Mode - Lines &amp;&amp; Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2968"/>
-        <source>Rotate Selection/Object Left</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2969"/>
+        <source>Mode - Endpoint to Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2970"/>
-        <source>Rotate Selection/Object Right</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2971"/>
+        <source>Mode - Endpoint to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2973"/>
-        <source>Zoom In</source>
+        <source>Mode - Line to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2974"/>
-        <source>Zoom Out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2975"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3010"/>
-        <source>Reset View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2976"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3012"/>
-        <source>Fit to Window</source>
+        <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2977"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3014"/>
-        <source>Reset Zoom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2978"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3015"/>
-        <source>Reset Rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2979"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3017"/>
-        <source>Reset Position</source>
+        <source>Type - Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2981"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3019"/>
-        <source>Actual Pixel Size</source>
+        <source>Type - Rectangular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2982"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3021"/>
-        <source>Flip Viewer Horizontally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2983"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3023"/>
-        <source>Flip Viewer Vertically</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2984"/>
-        <source>Show//Hide Full Screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2987"/>
-        <source>Full Screen Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2988"/>
-        <source>Exit Full Screen Mode</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2985"/>
+        <source>Type - Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="2989"/>
-        <source>Compare to Snapshot</source>
+        <source>Type - Polyline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2991"/>
-        <source>&amp;Show Status Bar</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2993"/>
+        <source>Type - Pick+Freehand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2995"/>
-        <source>&amp;Toggle Transparency</source>
+        <location filename="../../toonz/mainwindow.cpp" line="2997"/>
+        <source>Type - Segment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3000"/>
+        <source>TypeTool Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3002"/>
+        <source>TypeTool Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3005"/>
+        <source>TypeTool Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3007"/>
+        <source>TypeTool Style - Oblique</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3009"/>
+        <source>TypeTool Style - Regular</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3011"/>
+        <source>TypeTool Style - Bold Oblique</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3013"/>
+        <source>TypeTool Style - Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3016"/>
+        <source>Active Axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3018"/>
+        <source>Active Axis - Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3020"/>
+        <source>Active Axis - Rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3022"/>
+        <source>Active Axis - Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3024"/>
+        <source>Active Axis - Shear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3026"/>
+        <source>Active Axis - Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3028"/>
-        <source>&amp;Touch Gesture Control</source>
+        <source>Active Axis - All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3031"/>
+        <source>Skeleton Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3033"/>
-        <source>Refresh Folder Tree</source>
+        <source>Edit Mesh Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3034"/>
-        <source>Refresh</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3035"/>
+        <source>Paint Rigid Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3037"/>
-        <source>Toggle FX/Stage schematic</source>
+        <source>Build Skeleton Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3044"/>
-        <source>Red Channel</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3039"/>
+        <source>Animate Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3041"/>
+        <source>Inverse Kinematics Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3043"/>
+        <source>None Pick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3045"/>
-        <source>Green Channel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3046"/>
-        <source>Blue Channel</source>
+        <source>Column Pick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3047"/>
-        <source>Alpha Channel</source>
+        <source>Pegbar Pick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3048"/>
-        <source>Red Channel Greyscale</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3049"/>
+        <source>Pick Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3051"/>
-        <source>Green Channel Greyscale</source>
+        <source>Create Mesh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3053"/>
-        <source>Blue Channel Greyscale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3058"/>
-        <source>&amp;Export Stop Motion Image Sequence</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3059"/>
-        <source>Exports the full resolution stop motion image sequence.</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3056"/>
+        <source>Fill Tool - Autopaint Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3060"/>
-        <source>This is especially useful if using a DSLR camera.</source>
+        <source>Auto Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3062"/>
-        <source>Capture Stop Motion Frame</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3061"/>
+        <source>Draw Under</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3064"/>
-        <source>Raise Stop Motion Opacity</source>
+        <source>Flip Selection/Object Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3066"/>
-        <source>Lower Stop Motion Opacity</source>
+        <source>Flip Selection/Object Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3068"/>
-        <source>Toggle Stop Motion Live View</source>
+        <source>Rotate Selection/Object Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3071"/>
-        <source>Toggle Stop Motion Zoom</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3070"/>
+        <source>Rotate Selection/Object Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3073"/>
-        <source>Pick Focus Check Location</source>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3074"/>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3075"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3110"/>
+        <source>Reset View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3076"/>
-        <source>Lower Stop Motion Level Subsampling</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3112"/>
+        <source>Fit to Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3077"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3114"/>
+        <source>Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3078"/>
-        <source>Raise Stop Motion Level Subsampling</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3116"/>
+        <source>Reset Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3080"/>
-        <source>Go to Stop Motion Insert Frame</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3079"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3119"/>
+        <source>Reset Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3081"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3121"/>
+        <source>Actual Pixel Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3082"/>
-        <source>Remove frame before Stop Motion Camera</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3123"/>
+        <source>Flip Viewer Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3085"/>
-        <source>Next Frame including Stop Motion Camera</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3083"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3125"/>
+        <source>Flip Viewer Vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3084"/>
+        <source>Show//Hide Full Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3087"/>
+        <source>Full Screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3088"/>
-        <source>Show original live view images.</source>
+        <source>Exit Full Screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3094"/>
-        <source>Set Cell Mark </source>
+        <location filename="../../toonz/mainwindow.cpp" line="3089"/>
+        <source>Compare to Snapshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3187"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3211"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3224"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3229"/>
-        <source>Clear Cache Folder</source>
+        <location filename="../../toonz/mainwindow.cpp" line="3091"/>
+        <source>&amp;Show Status Bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3095"/>
+        <source>&amp;Toggle Transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3130"/>
+        <source>&amp;Touch Gesture Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3135"/>
+        <source>Refresh Folder Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3136"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3139"/>
+        <source>Toggle FX/Stage schematic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3146"/>
+        <source>Red Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3147"/>
+        <source>Green Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3148"/>
+        <source>Blue Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3149"/>
+        <source>Alpha Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3150"/>
+        <source>Red Channel Greyscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3153"/>
+        <source>Green Channel Greyscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3155"/>
+        <source>Blue Channel Greyscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3160"/>
+        <source>&amp;Export Stop Motion Image Sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3161"/>
+        <source>Exports the full resolution stop motion image sequence.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3162"/>
+        <source>This is especially useful if using a DSLR camera.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3164"/>
+        <source>Capture Stop Motion Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3166"/>
+        <source>Raise Stop Motion Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3168"/>
+        <source>Lower Stop Motion Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3170"/>
+        <source>Toggle Stop Motion Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3172"/>
+        <source>Toggle Stop Motion Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3174"/>
+        <source>Pick Focus Check Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3176"/>
+        <source>Lower Stop Motion Level Subsampling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3178"/>
+        <source>Raise Stop Motion Level Subsampling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3180"/>
+        <source>Go to Stop Motion Insert Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3182"/>
+        <source>Remove frame before Stop Motion Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3185"/>
+        <source>Next Frame including Stop Motion Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/mainwindow.cpp" line="3188"/>
+        <source>Show original live view images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3194"/>
+        <source>Set Cell Mark </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3287"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3311"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3324"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3329"/>
+        <source>Clear Cache Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3288"/>
         <source>There are no unused items in the cache folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3192"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3292"/>
         <source>Deleting the following items:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3196"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3296"/>
         <source>&lt;DIR&gt; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3204"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3304"/>
         <source>   ... and %1 more items
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3207"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3307"/>
         <source>
 Are you sure?
 
@@ -7961,23 +8493,23 @@ or you may delete necessary files for it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3225"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3230"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3325"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3330"/>
         <source>Can&apos;t delete %1 : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3267"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3367"/>
         <source>Tahoma2D Transparency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3269"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3369"/>
         <source>Close to turn off Transparency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3283"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3383"/>
         <source>Amount: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -8204,6 +8736,26 @@ What do you want to do?</source>
         <source>Polygon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="406"/>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="407"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="408"/>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="409"/>
+        <source>Steps</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NavTagEditorPopup</name>
@@ -8314,32 +8866,197 @@ What do you want to do?</source>
 <context>
     <name>OutputSettingsPopup</name>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="186"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="187"/>
         <source>Preview Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="186"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="187"/>
         <source>Output Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="191"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="192"/>
         <source>Render</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="212"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="213"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="213"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="214"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="219"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="239"/>
+        <source>Save and Render</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="250"/>
+        <source>Presets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="299"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="302"/>
+        <source>Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="308"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="311"/>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="332"/>
+        <source>General Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="336"/>
+        <source>Camera Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="342"/>
+        <source>Advanced Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="346"/>
+        <source>More Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="504"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="529"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="664"/>
+        <source>Frame Start:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="534"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="669"/>
+        <source>End:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="539"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="674"/>
+        <source>Step:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="554"/>
+        <source>Save in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="558"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="624"/>
+        <source>Use Sub-Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="626"/>
+        <source>Apply Shrink to Main Viewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="641"/>
+        <source>Output Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="690"/>
+        <source>Shrink:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="747"/>
+        <source>8 bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="748"/>
+        <source>16 bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="828"/>
+        <source>Single</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="828"/>
+        <source>Half</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="828"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="831"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="924"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="934"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="831"/>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="831"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="832"/>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="855"/>
+        <source>Resample Balance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="778"/>
+        <source>Channel Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="196"/>
+        <source>Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="220"/>
         <source>Save current output settings.
 The parameters to be saved are:
 - Camera settings
@@ -8347,376 +9064,303 @@ The parameters to be saved are:
 - File format
 - File options
 - Resample Balance
-- Channel width</source>
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="237"/>
-        <source>Save and Render</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="305"/>
+        <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="248"/>
-        <source>Presets:</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="339"/>
+        <source>Color Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="297"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="300"/>
-        <source>Camera</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="303"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="306"/>
-        <source>More</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="327"/>
-        <source>General Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="330"/>
-        <source>Camera Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="332"/>
-        <source>Advanced Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="335"/>
-        <source>More Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="457"/>
-        <source>Options</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="482"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="617"/>
-        <source>Frame Start:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="487"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="622"/>
-        <source>End:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="492"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="627"/>
-        <source>Step:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="507"/>
-        <source>Save in:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="511"/>
-        <source>Name:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="577"/>
-        <source>Use Sub-Camera</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="579"/>
-        <source>Apply Shrink to Main Viewer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="594"/>
-        <source>Output Camera:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="643"/>
-        <source>Shrink:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="708"/>
-        <source>8 bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="709"/>
-        <source>16 bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="712"/>
-        <source>Single</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="712"/>
-        <source>Half</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="712"/>
-        <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="715"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="813"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="823"/>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="715"/>
-        <source>Large</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="715"/>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="716"/>
-        <source>Small</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="740"/>
-        <source>Resample Balance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="745"/>
-        <source>Channel Width:</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="352"/>
+        <source>Sync with Output Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/outputsettingspopup.cpp" line="749"/>
-        <source>Dedicated CPUs:</source>
+        <source>32 bit Floating point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="753"/>
-        <source>Render Tile:</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="752"/>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="792"/>
-        <source>Add Clapperboard</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="760"/>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="793"/>
-        <source>Edit Clapperboard...</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="765"/>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="808"/>
-        <source>Do stereoscopy</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="784"/>
+        <source>Linear Color Space:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="813"/>
-        <source>Odd (NTSC)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="813"/>
-        <source>Even (PAL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="823"/>
-        <source>Fx Schematic Flows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="824"/>
-        <source>Fx Schematic Terminal Nodes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="843"/>
-        <source>Gamma:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="847"/>
-        <source>Dominant Field:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="852"/>
-        <source>Frame Rate:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="855"/>
-        <source>(linked to Scene Settings)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="858"/>
-        <source>Stretch from FPS:</source>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="788"/>
+        <source>Color Space Gamma:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/outputsettingspopup.cpp" line="861"/>
+        <source>Dedicated CPUs:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="865"/>
+        <source>Render Tile:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="903"/>
+        <source>Add Clapperboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="904"/>
+        <source>Edit Clapperboard...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="919"/>
+        <source>Do stereoscopy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="924"/>
+        <source>Odd (NTSC)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="924"/>
+        <source>Even (PAL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="934"/>
+        <source>Fx Schematic Flows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="935"/>
+        <source>Fx Schematic Terminal Nodes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="954"/>
+        <source>Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="958"/>
+        <source>Dominant Field:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="963"/>
+        <source>Frame Rate:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="966"/>
+        <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="969"/>
+        <source>Stretch from FPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="972"/>
         <source>  To:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="866"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="977"/>
         <source>Multiple Rendering:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="872"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="983"/>
         <source>Camera Shift:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1590"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1783"/>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1810"/>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1866"/>
         <source>Add preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1590"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1866"/>
         <source>Enter the name for the output settings preset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1602"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1878"/>
         <source>Add output settings preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1687"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1879"/>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1967"/>
         <source>&lt;custom&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1704"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1984"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1705"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1985"/>
         <source>Improved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1706"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1986"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1707"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1987"/>
         <source>Triangle filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1708"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1988"/>
         <source>Mitchell-Netravali filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1709"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1989"/>
         <source>Cubic convolution, a = .5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1710"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1990"/>
         <source>Cubic convolution, a = .75</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1711"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1991"/>
         <source>Cubic convolution, a = 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1712"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1992"/>
         <source>Hann window, rad = 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1713"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1993"/>
         <source>Hann window, rad = 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1714"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1994"/>
         <source>Hamming window, rad = 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1715"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1995"/>
         <source>Hamming window, rad = 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1716"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1996"/>
         <source>Lanczos window, rad = 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1717"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1997"/>
         <source>Lanczos window, rad = 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1718"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1998"/>
         <source>Gaussian convolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1720"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2000"/>
         <source>Closest Pixel (Nearest Neighbor)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1721"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2001"/>
         <source>Bilinear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1730"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2010"/>
         <source>Remove preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1756"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1764"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1772"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2011"/>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2036"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2044"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2052"/>
         <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2037"/>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2045"/>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2053"/>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>OverwriteDialog</name>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1464"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1475"/>
         <source>Level &quot;%1&quot; already exists.
 
 What do you want to do?</source>
@@ -8783,67 +9427,67 @@ What do you want to do?</source>
 <context>
     <name>PltGizmoPopup</name>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="603"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="591"/>
         <source>Palette Gizmo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="608"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="596"/>
         <source>Blend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="610"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="598"/>
         <source>Fade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="617"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="605"/>
         <source>Full Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="618"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="606"/>
         <source>Zero Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="628"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="616"/>
         <source>Scale (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="629"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="617"/>
         <source>Shift (value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="631"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="619"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="635"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="623"/>
         <source>Saturation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="639"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="627"/>
         <source>Hue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="643"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="631"/>
         <source>Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="657"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="645"/>
         <source>Fade to Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="666"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="654"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8851,1240 +9495,1305 @@ What do you want to do?</source>
 <context>
     <name>PreferencesPopup</name>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="502"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="510"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="540"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="548"/>
         <source>Please restart to reload the icons.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="556"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="557"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="558"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="559"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1394"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="594"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="595"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="596"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="597"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1440"/>
         <source>pixel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="647"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="691"/>
         <source>Numpad keys are assigned to the following commands.
 Is it OK to release these shortcuts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="653"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="697"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="653"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="697"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="837"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="881"/>
         <source>Life is too short for Comic Sans</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="839"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="883"/>
         <source>Good luck.  You&apos;re on your own from here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="873"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="917"/>
         <source>New Level Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="874"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="918"/>
         <source>Assign the new level format name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="875"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="919"/>
         <source>New Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1147"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1191"/>
         <source>* Changes will take effect the next time you run Tahoma2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1158"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1202"/>
         <source>Use Default Viewer for Movie Formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1159"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1203"/>
         <source>Minimize Raster Memory Fragmentation*</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1160"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1204"/>
         <source>Save Automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1161"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1205"/>
         <source>Interval (Minutes):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1162"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1206"/>
         <source>Automatically Save the Scene File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1163"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1207"/>
         <source>Automatically Save Non-Scene Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1164"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1208"/>
         <source>Show Startup Window when Tahoma2D Starts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1165"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1209"/>
         <source>Undo Memory Size (MB):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1166"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1210"/>
         <source>Render Task Chunk Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1168"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1212"/>
         <source>Replace Vector and Smart Level after SaveLevelAs command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1169"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1213"/>
         <source>Backup Scene and Animation Levels when Saving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1170"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1214"/>
         <source># of backups to keep:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1171"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1215"/>
         <source>Show Info in Rendered Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1173"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1217"/>
         <source>Watch File System and Update File Browser Automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1175"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1219"/>
         <source>Custom Project Path(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1176"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1220"/>
         <source>Path Alias Priority:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1179"/>
-        <source>Theme:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1181"/>
-        <source>All imported images will use the same DPI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1184"/>
-        <source>Unit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1185"/>
-        <source>Camera Unit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1186"/>
-        <source>Rooms*:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1187"/>
-        <source>Function Editor*:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1189"/>
-        <source>Move Current Frame by Clicking on Layer Header / Numerical Columns Cell Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1193"/>
-        <source>Enable Actual Pixel View on Scene Editing Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1195"/>
-        <source>Show Raster Images Darken Blended</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1196"/>
-        <source>Level Strip Thumbnail Size*:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1197"/>
-        <source>Viewer Shrink:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1198"/>
-        <source>Step:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1199"/>
-        <source>Viewer Zoom Center:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1200"/>
-        <source>Language*:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1201"/>
-        <source>Font*:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1202"/>
-        <source>Style*:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1203"/>
-        <source>Color Calibration using 3D Look-up Table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1205"/>
-        <source>3DLUT File for [%1]:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1207"/>
-        <source>30bit Display*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1208"/>
-        <source>Show Icons In Menu*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1209"/>
-        <source>Show Viewer Indicators</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1212"/>
-        <source>Show Lines with Thickness 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1213"/>
-        <source>Antialiased Region Boundaries</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1216"/>
-        <source>Default File Import Behavior:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1217"/>
-        <source>Expose Loaded Levels in the Scene</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1219"/>
-        <source>Automatically Remove Unused Levels From Scene Cast</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1220"/>
-        <source>Create Sub-folder when Importing Sub-Scene</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1222"/>
-        <source>Automatically Remove Scene Number from Loaded Level Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1223"/>
-        <source>Use Camera DPI for All Imported Images</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1221"/>
+        <source>Show Advanced Preferences and Options*</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1224"/>
-        <source>Default TLV Caching Behavior:</source>
+        <source>Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1225"/>
-        <source>Column Icon:</source>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1226"/>
+        <source>All imported images will use the same DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1229"/>
-        <source>Matte color:</source>
+        <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1230"/>
-        <source>Clear Undo History when Saving Levels</source>
+        <source>Camera Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1231"/>
-        <source>Do not show Save Scene popup warning</source>
+        <source>Rooms*:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1232"/>
-        <source>Default Project Path:</source>
+        <source>Function Editor*:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1235"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1239"/>
-        <source>Executable Directory:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1236"/>
-        <source>Import/Export Timeout (seconds):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1237"/>
-        <source>Fast Render Output Directory:</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1234"/>
+        <source>Move Current Frame by Clicking on Layer Header / Numerical Columns Cell Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1238"/>
-        <source>Allow Multi-Thread in FFMPEG Rendering (UNSTABLE)</source>
+        <source>Enable Actual Pixel View on Scene Editing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1240"/>
-        <source>Analyze Audio Timeout (seconds):</source>
+        <source>Show Raster Images Darken Blended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1245"/>
-        <source>Default Level Type:</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1241"/>
+        <source>Level Strip Thumbnail Size*:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1247"/>
-        <source>New Levels Default to the Current Camera Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1248"/>
-        <source>Width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1249"/>
-        <source>Height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1250"/>
-        <source>DPI:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1251"/>
-        <source>Enable Autocreation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1252"/>
-        <source>Numbering System:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1253"/>
-        <source>Enable Auto-stretch Frame</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1254"/>
-        <source>Enable Creation in Hold Cells</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1255"/>
-        <source>Enable Autorenumber</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1257"/>
-        <source>Vector Snapping:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1259"/>
-        <source>Keep Original Cleaned Up Drawings As Backup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1260"/>
-        <source>Minimize Savebox after Editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1262"/>
-        <source>Use Numpad and Tab keys for Switching Styles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1264"/>
-        <source>Down Arrow at End of Level Strip Creates a New Frame</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1266"/>
-        <source>Keep fill when using &quot;Replace Vectors&quot; command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1268"/>
-        <source>Use higher DPI for calculations - Slower but more accurate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1274"/>
-        <source>Multi Layer Style Picker: Switch Levels by Picking</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1275"/>
-        <source>Basic Cursor Type:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1276"/>
-        <source>Cursor Style:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1277"/>
-        <source>Show Cursor Size Outlines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1278"/>
-        <source>Toolbar Display Behaviour:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1279"/>
-        <source>Use Ctrl+Alt to Resize Brush</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1281"/>
-        <source>Temporary Tool Switch Shortcut Hold Time (ms):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1284"/>
-        <source>Column Header Layout*:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1285"/>
-        <source>Next/Previous Step Frames:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1286"/>
-        <source>Autopan during Playback</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1287"/>
-        <source>Cell-dragging Behaviour:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1289"/>
-        <source>Ignore Alpha Channel on Levels in Column 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1290"/>
-        <source>Show Keyframes on Cell Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1291"/>
-        <source>Show Camera Column</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1293"/>
-        <source>Use Arrow Key to Shift Cell Selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1295"/>
-        <source>Enable to Input Cells without Double Clicking</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1297"/>
-        <source>Enable Tahoma2D Commands&apos; Shortcut Keys While Renaming Cell</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1298"/>
-        <source>Show Quick Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1300"/>
-        <source>Expand Function Editor Header to Match Quick Toolbar Height*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1301"/>
-        <source>Show Column Numbers in Column Headers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1305"/>
-        <source>Sync Level Strip Drawing Number Changes with the Scene</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1307"/>
-        <source>Show Current Time Indicator (Timeline Mode only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1308"/>
-        <source>Current Column Color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1317"/>
-        <source>Default Interpolation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1318"/>
-        <source>Animation Step:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1320"/>
-        <source>[Experimental Feature] </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1321"/>
-        <source>Automatically Modify Expression On Moving Referenced Objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1324"/>
-        <source>Blank Frames:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1325"/>
-        <source>Blank Frames Color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1326"/>
-        <source>Rewind after Playback</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1328"/>
-        <source>Display in a New Flipbook Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1329"/>
-        <source>Fit to Flipbook</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1330"/>
-        <source>Open Flipbook after Rendering</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1333"/>
-        <source>Onion Skin ON</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1334"/>
-        <source>Paper Thickness:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1335"/>
-        <source>Previous Frames Correction:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1336"/>
-        <source>Following Frames Correction:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1337"/>
-        <source>Display Lines Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1338"/>
-        <source>Show Onion Skin During Playback</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1340"/>
-        <source>Use Onion Skin Colors for Reference Drawings of Shift and Trace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1341"/>
-        <source>Vector Guided Style:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1344"/>
-        <source>Viewer BG Color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1345"/>
-        <source>Preview BG Color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1347"/>
-        <source>Use the Curent Theme&apos;s Viewer Background Colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1349"/>
-        <source>Chessboard Color 1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1350"/>
-        <source>Chessboard Color 2:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1351"/>
-        <source>Ink Color on White BG:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1352"/>
-        <source>Ink Color on Black BG:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1353"/>
-        <source>Paint Color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1356"/>
-        <source>Enable Version Control*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1358"/>
-        <source>Automatically Refresh Folder Contents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1360"/>
-        <source>Check for the Latest Version of Tahoma2D on Launch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1365"/>
-        <source>Enable Windows Ink Support* (EXPERIMENTAL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1383"/>
-        <source>Project Folder Aliases (+drawings, +scenes, etc.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1385"/>
-        <source>Scene Folder Alias ($scenefolder)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1387"/>
-        <source>Use Project Folder Aliases Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1390"/>
-        <source>cm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1391"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1392"/>
-        <source>inch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1393"/>
-        <source>field</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1396"/>
-        <source>Graph Editor Opens in Popup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1398"/>
-        <source>Spreadsheet Opens in Popup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1400"/>
-        <source>Toggle Between Graph Editor and Spreadsheet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1402"/>
-        <source>Mouse Cursor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1402"/>
-        <source>Viewer Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1404"/>
-        <source>Always ask before loading or importing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1405"/>
-        <source>Always import the file to the current project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1406"/>
-        <source>Always load the file from the current location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1408"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1413"/>
-        <source>On Demand</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1409"/>
-        <source>All Icons</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1410"/>
-        <source>All Icons &amp; Images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1412"/>
-        <source>At Once</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1417"/>
-        <source>Vector Level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1418"/>
-        <source>Smart Raster Level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1419"/>
-        <source>Raster Level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1420"/>
-        <source>Incremental</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1420"/>
-        <source>Animation Sheet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1422"/>
-        <source>Strokes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1422"/>
-        <source>Guides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1422"/>
-        <source>All</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1242"/>
+        <source>Viewer Shrink:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1243"/>
-        <source>Default Raster Level Format:</source>
+        <source>Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1256"/>
-        <source>Enable Implicit Hold</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1244"/>
+        <source>Viewer Zoom Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1303"/>
-        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1245"/>
+        <source>Language*:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1246"/>
+        <source>Font*:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1247"/>
+        <source>Style*:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1248"/>
+        <source>Color Calibration using 3D Look-up Table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1250"/>
+        <source>3DLUT File for [%1]:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1252"/>
+        <source>30bit Display*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1253"/>
+        <source>Show Icons In Menu*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1254"/>
+        <source>Show Viewer Indicators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1257"/>
+        <source>Show Lines with Thickness 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1258"/>
+        <source>Antialiased Region Boundaries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1261"/>
+        <source>Default File Import Behavior:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1262"/>
+        <source>Expose Loaded Levels in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1264"/>
+        <source>Automatically Remove Unused Levels From Scene Cast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1265"/>
+        <source>Create Sub-folder when Importing Sub-Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1267"/>
+        <source>Automatically Remove Scene Number from Loaded Level Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1268"/>
+        <source>Use Camera DPI for All Imported Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1269"/>
+        <source>Default TLV Caching Behavior:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1270"/>
+        <source>Column Icon:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1274"/>
+        <source>Matte color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1275"/>
+        <source>Clear Undo History when Saving Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1276"/>
+        <source>Do not show Save Scene popup warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1277"/>
+        <source>Default Project Path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1280"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1284"/>
+        <source>Executable Directory:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1281"/>
+        <source>Import/Export Timeout (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1282"/>
+        <source>Fast Render Output Directory:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1283"/>
+        <source>Allow Multi-Thread in FFMPEG Rendering (UNSTABLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1285"/>
+        <source>Analyze Audio Timeout (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1290"/>
+        <source>Default Level Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1292"/>
+        <source>New Levels Default to the Current Camera Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1293"/>
+        <source>Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1294"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1295"/>
+        <source>DPI:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1296"/>
+        <source>Enable Autocreation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1297"/>
+        <source>Numbering System:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1298"/>
+        <source>Enable Auto-stretch Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1299"/>
+        <source>Enable Creation in Hold Cells</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1300"/>
+        <source>Enable Autorenumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1302"/>
+        <source>Vector Snapping:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1304"/>
+        <source>Keep Original Cleaned Up Drawings As Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1305"/>
+        <source>Minimize Savebox after Editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1307"/>
+        <source>Use Numpad and Tab keys for Switching Styles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1309"/>
+        <source>Down Arrow at End of Level Strip Creates a New Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1311"/>
+        <source>Keep fill when using &quot;Replace Vectors&quot; command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1313"/>
+        <source>Use higher DPI for calculations - Slower but more accurate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1317"/>
+        <source>Use the TLV Savebox to Limit Filling Operations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1319"/>
+        <source>Multi Layer Style Picker: Switch Levels by Picking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1320"/>
+        <source>Basic Cursor Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1321"/>
+        <source>Cursor Style:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1322"/>
+        <source>Show Cursor Size Outlines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1323"/>
+        <source>Toolbar Display Behaviour:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1324"/>
+        <source>Use Ctrl+Alt to Resize Brush</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1326"/>
+        <source>Temporary Tool Switch Shortcut Hold Time (ms):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1329"/>
+        <source>Column Header Layout*:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1330"/>
+        <source>Next/Previous Step Frames:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1331"/>
+        <source>Autopan during Playback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1332"/>
+        <source>Cell-dragging Behaviour:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1334"/>
+        <source>Ignore Alpha Channel on Levels in Column 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1335"/>
+        <source>Show Keyframes on Cell Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1336"/>
+        <source>Show Camera Column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1338"/>
+        <source>Use Arrow Key to Shift Cell Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1340"/>
+        <source>Enable to Input Cells without Double Clicking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1342"/>
+        <source>Enable Tahoma2D Commands&apos; Shortcut Keys While Renaming Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1343"/>
+        <source>Show Quick Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1345"/>
+        <source>Expand Function Editor Header to Match Quick Toolbar Height*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1351"/>
+        <source>Sync Level Strip Drawing Number Changes with the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1353"/>
+        <source>Show Current Time Indicator (Timeline Mode only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1354"/>
+        <source>Current Column Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1360"/>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1363"/>
+        <source>Default Interpolation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1364"/>
+        <source>Animation Step:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1366"/>
+        <source>[Experimental Feature] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1367"/>
+        <source>Automatically Modify Expression On Moving Referenced Objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1370"/>
+        <source>Blank Frames:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1371"/>
+        <source>Blank Frames Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1372"/>
+        <source>Rewind after Playback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1374"/>
+        <source>Display in a New Flipbook Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1375"/>
+        <source>Fit to Flipbook</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1376"/>
+        <source>Open Flipbook after Rendering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1379"/>
+        <source>Onion Skin ON</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1380"/>
+        <source>Paper Thickness:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1381"/>
+        <source>Previous Frames Correction:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1382"/>
+        <source>Following Frames Correction:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1383"/>
+        <source>Display Lines Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1384"/>
+        <source>Show Onion Skin During Playback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1386"/>
+        <source>Use Onion Skin Colors for Reference Drawings of Shift and Trace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1387"/>
+        <source>Vector Guided Style:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1390"/>
+        <source>Viewer BG Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1391"/>
+        <source>Preview BG Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1393"/>
+        <source>Use the Curent Theme&apos;s Viewer Background Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1395"/>
+        <source>Chessboard Color 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1396"/>
+        <source>Chessboard Color 2:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1397"/>
+        <source>Ink Color on White BG:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1398"/>
+        <source>Ink Color on Black BG:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1399"/>
+        <source>Paint Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1402"/>
+        <source>Enable Version Control*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1404"/>
+        <source>Automatically Refresh Folder Contents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1406"/>
+        <source>Check for the Latest Version of Tahoma2D on Launch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1411"/>
+        <source>Enable Windows Ink Support* (EXPERIMENTAL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1429"/>
+        <source>Project Folder Aliases (+drawings, +scenes, etc.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1431"/>
+        <source>Scene Folder Alias ($scenefolder)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1433"/>
+        <source>Use Project Folder Aliases Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1436"/>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1437"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1438"/>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1439"/>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1442"/>
+        <source>Graph Editor Opens in Popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1444"/>
+        <source>Spreadsheet Opens in Popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1446"/>
+        <source>Toggle Between Graph Editor and Spreadsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1448"/>
+        <source>Mouse Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1448"/>
+        <source>Viewer Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1450"/>
+        <source>Always ask before loading or importing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1451"/>
+        <source>Always import the file to the current project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1452"/>
+        <source>Always load the file from the current location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1454"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1459"/>
+        <source>On Demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1455"/>
+        <source>All Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1456"/>
+        <source>All Icons &amp; Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1458"/>
+        <source>At Once</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1463"/>
+        <source>Vector Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1464"/>
+        <source>Smart Raster Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1465"/>
+        <source>Raster Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1466"/>
+        <source>Incremental</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1466"/>
+        <source>Animation Sheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1468"/>
+        <source>Strokes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1468"/>
+        <source>Guides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1468"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1288"/>
+        <source>Default Raster Level Format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1301"/>
+        <source>Enable Implicit Hold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1346"/>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1348"/>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1349"/>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1355"/>
         <source>Current Cell Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1312"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1358"/>
         <source>Level Name Display:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1314"/>
-        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1327"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1373"/>
         <source>Number of Frames to Play 
 for Short Play:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1348"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1394"/>
         <source>Level Editor Canvas Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1367"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1413"/>
         <source>Use Qt&apos;s Native Windows Ink Support*
 (CAUTION: This options is for maintenance purpose. 
  Do not activate this option or the tablet won&apos;t work properly.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1427"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1473"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1428"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1474"/>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1429"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1475"/>
         <source>Crosshair</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1431"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1435"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1442"/>
-        <source>Default</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1476"/>
+        <source>Triangle Top Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1432"/>
-        <source>Left-Handed</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1477"/>
+        <source>Triangle Top Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1433"/>
-        <source>Simple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1436"/>
-        <source>Enable Tools For Level Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1437"/>
-        <source>Show Tools For Level Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1439"/>
-        <source>Compact</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1439"/>
-        <source>Roomy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1440"/>
-        <source>Minimum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1443"/>
-        <source>Display on Each Marker</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1444"/>
-        <source>Display on Column Header</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1447"/>
-        <source>Cells Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1447"/>
-        <source>Cells and Column Data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1449"/>
-        <source>Constant</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1450"/>
-        <source>Linear</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1451"/>
-        <source>Speed In / Speed Out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1452"/>
-        <source>Ease In / Ease Out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1453"/>
-        <source>Ease In / Ease Out %</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1454"/>
-        <source>Exponential</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1455"/>
-        <source>Expression </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1456"/>
-        <source>File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1458"/>
-        <source>Arrow Markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1458"/>
-        <source>Animated Guide</source>
+        <location filename="../../toonz/preferencespopup.cpp" line="1478"/>
+        <source>Triangle Bottom Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/preferencespopup.cpp" line="1479"/>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1480"/>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1481"/>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1482"/>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1483"/>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1485"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1496"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1486"/>
+        <source>Left-Handed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
+        <source>Simple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
+        <source>Enable Tools For Level Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1491"/>
+        <source>Show Tools For Level Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1493"/>
+        <source>Compact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1493"/>
+        <source>Roomy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1494"/>
+        <source>Minimum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1497"/>
+        <source>Display on Each Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1498"/>
+        <source>Display on Column Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1501"/>
+        <source>Cells Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1501"/>
+        <source>Cells and Column Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1503"/>
+        <source>Constant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1504"/>
+        <source>Linear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1505"/>
+        <source>Speed In / Speed Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1506"/>
+        <source>Ease In / Ease Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1507"/>
+        <source>Ease In / Ease Out %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1508"/>
+        <source>Exponential</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1509"/>
+        <source>Expression </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1510"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1512"/>
+        <source>Arrow Markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1512"/>
+        <source>Animated Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1533"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1541"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1541"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1541"/>
         <source>Visualization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Saving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1543"/>
         <source>Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1543"/>
         <source>Animation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1543"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1544"/>
         <source>Onion Skin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1544"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1544"/>
         <source>3rd Party Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1491"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1545"/>
         <source>Version Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1491"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1545"/>
         <source>Touch/Tablet Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1596"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1652"/>
         <source>This option defines which alias to be used
 if both are possible on coding file path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1600"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1656"/>
         <source>Choosing this option will set initial location of all file browsers to $scenefolder.
 Also the initial output destination for new scenes will be set to $scenefolder as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1656"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1716"/>
         <source>Check Availability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1659"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1719"/>
         <source>Edit Additional Style Sheet..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1759"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1738"/>
+        <source>Pixels Only:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1827"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1784"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1853"/>
         <source>Level Settings by File Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1835"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1904"/>
         <source>Matte color is used for background when overwriting raster levels with transparent pixels
 in non alpha-enabled image format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1861"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1930"/>
         <source>External applications used by Tahoma2D.
 These come bundled with Tahoma2D, but you can set path to a different version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1865"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1934"/>
         <source>FFmpeg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1871"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1940"/>
         <source>Enabling multi-thread rendering will render significantly faster 
 but a random crash might occur, use at your own risk:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1877"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1946"/>
         <source>Rhubarb Lip Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1895"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1964"/>
         <source>Default Frame Filename Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1907"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1977"/>
         <source>Frame Creation Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1924"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1995"/>
         <source>Replace Vectors with Simplified Vectors Command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1962"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2035"/>
         <source>Cursor Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2128"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2206"/>
         <source>Transparency Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2194"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2272"/>
         <source>Enable Touch Gesture Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2230"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2308"/>
         <source>Select the Tahoma2D application that you want to import preferences from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2234"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2312"/>
         <source>Select the folder of the Tahoma2D application that you want to import preferences from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2243"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2321"/>
         <source>Import Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2245"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2323"/>
         <source>Preferences and Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2249"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2327"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2253"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2331"/>
         <source>Room Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2257"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2335"/>
         <source>Sandbox and Projects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2261"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2339"/>
         <source>Fx and Plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2265"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2343"/>
         <source>Studio Palettes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2269"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2347"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2273"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2351"/>
         <source>Toonzfarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2278"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2356"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2627"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2705"/>
         <source>Import complete. Please restart to complete applying the changes.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10092,22 +10801,22 @@ but a random crash might occur, use at your own risk:</source>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="365"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="383"/>
         <source>Additional Style Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="369"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="387"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="370"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="388"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="371"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="389"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10115,17 +10824,17 @@ but a random crash might occur, use at your own risk:</source>
 <context>
     <name>PreferencesPopup::Display30bitChecker</name>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="323"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="341"/>
         <source>Check 30bit display availability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="334"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="352"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="335"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="353"/>
         <source>If the lower gradient looks smooth and has no banding compared to the upper gradient,
 30bit display is available in the current configuration.</source>
         <translation type="unfinished"></translation>
@@ -10272,6 +10981,11 @@ but a random crash might occur, use at your own risk:</source>
     <message>
         <location filename="../../toonz/projectpopup.cpp" line="77"/>
         <source>Create Project In:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/projectpopup.cpp" line="100"/>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10503,7 +11217,7 @@ What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1373"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1415"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10535,18 +11249,22 @@ What would you like to do?</source>
     <message>
         <location filename="../../toonz/autoinputcellnumberpopup.cpp" line="59"/>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="100"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2587"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2657"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="156"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2598"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2668"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="514"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="1922"/>
-        <location filename="../../toonz/flipbook.cpp" line="688"/>
+        <location filename="../../toonz/flipbook.cpp" line="690"/>
         <location filename="../../toonz/iocommand.cpp" line="1499"/>
         <location filename="../../toonz/iocommand.cpp" line="1716"/>
         <location filename="../../toonz/iocommand.cpp" line="1845"/>
         <location filename="../../toonz/iocommand.cpp" line="2897"/>
         <location filename="../../toonz/iocommand.cpp" line="3196"/>
         <location filename="../../toonz/iocommand.cpp" line="3291"/>
-        <location filename="../../toonz/previewer.cpp" line="895"/>
+        <location filename="../../toonz/previewer.cpp" line="913"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1591"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1625"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2849"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10556,8 +11274,8 @@ What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="383"/>
-        <location filename="../../toonz/tpanels.cpp" line="1213"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="379"/>
+        <location filename="../../toonz/tpanels.cpp" line="1214"/>
         <source>Batch Servers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10580,8 +11298,8 @@ What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="929"/>
-        <location filename="../../toonz/tpanels.cpp" line="1247"/>
+        <location filename="../../toonz/castviewer.cpp" line="926"/>
+        <location filename="../../toonz/tpanels.cpp" line="1265"/>
         <source>Scene Cast</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10617,118 +11335,118 @@ What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="504"/>
+        <location filename="../../toonz/cellselection.cpp" line="501"/>
         <source>It is not possible to paste vectors in the current cell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="622"/>
+        <location filename="../../toonz/cellselection.cpp" line="619"/>
         <source>Paste (Strokes)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="705"/>
+        <location filename="../../toonz/cellselection.cpp" line="702"/>
         <source>It is not possible to paste image on the current cell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="819"/>
-        <location filename="../../toonz/cellselection.cpp" line="913"/>
+        <location filename="../../toonz/cellselection.cpp" line="816"/>
+        <location filename="../../toonz/cellselection.cpp" line="910"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="858"/>
+        <location filename="../../toonz/cellselection.cpp" line="855"/>
         <source>Paste (Raster)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1038"/>
+        <location filename="../../toonz/cellselection.cpp" line="1035"/>
         <source>Overwrite Paste Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1151"/>
+        <location filename="../../toonz/cellselection.cpp" line="1148"/>
         <source>Paste Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1242"/>
+        <location filename="../../toonz/cellselection.cpp" line="1239"/>
         <location filename="../../toonz/xshcellviewer.cpp" line="519"/>
         <source>Rename Cell  at Column %1  Frame %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1281"/>
+        <location filename="../../toonz/cellselection.cpp" line="1278"/>
         <source>Create Blank Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1322"/>
+        <location filename="../../toonz/cellselection.cpp" line="1319"/>
         <source>Set Stop Frame Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1361"/>
+        <location filename="../../toonz/cellselection.cpp" line="1358"/>
         <source>Duplicate Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1403"/>
+        <location filename="../../toonz/cellselection.cpp" line="1400"/>
         <source>Fill In Empty Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1459"/>
+        <location filename="../../toonz/cellselection.cpp" line="1456"/>
         <source>Duplicate Frame in Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1833"/>
-        <location filename="../../toonz/cellselection.cpp" line="2283"/>
-        <location filename="../../toonz/cellselection.cpp" line="3521"/>
-        <location filename="../../toonz/cellselection.cpp" line="3620"/>
+        <location filename="../../toonz/cellselection.cpp" line="1825"/>
+        <location filename="../../toonz/cellselection.cpp" line="2275"/>
+        <location filename="../../toonz/cellselection.cpp" line="3513"/>
+        <location filename="../../toonz/cellselection.cpp" line="3612"/>
         <source>No data to paste.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1854"/>
-        <location filename="../../toonz/cellselection.cpp" line="3545"/>
-        <location filename="../../toonz/cellselection.cpp" line="3649"/>
+        <location filename="../../toonz/cellselection.cpp" line="1846"/>
+        <location filename="../../toonz/cellselection.cpp" line="3537"/>
+        <location filename="../../toonz/cellselection.cpp" line="3641"/>
         <source>It is not possible to paste the cells: there is a circular reference.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1923"/>
-        <location filename="../../toonz/cellselection.cpp" line="2248"/>
-        <location filename="../../toonz/cellselection.cpp" line="2531"/>
+        <location filename="../../toonz/cellselection.cpp" line="1915"/>
+        <location filename="../../toonz/cellselection.cpp" line="2240"/>
+        <location filename="../../toonz/cellselection.cpp" line="2523"/>
         <source>It is not possible to paste data: there is nothing to paste.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2102"/>
+        <location filename="../../toonz/cellselection.cpp" line="2094"/>
         <location filename="../../toonz/filmstripcommand.cpp" line="221"/>
         <source>The copied selection cannot be pasted in the current drawing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2151"/>
+        <location filename="../../toonz/cellselection.cpp" line="2143"/>
         <source>Paste in place or create a new level?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2152"/>
+        <location filename="../../toonz/cellselection.cpp" line="2144"/>
         <source>Paste in place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2153"/>
+        <location filename="../../toonz/cellselection.cpp" line="2145"/>
         <source>Create a new level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2154"/>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1502"/>
+        <location filename="../../toonz/cellselection.cpp" line="2146"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1513"/>
         <location filename="../../toonz/cleanuppaletteviewer.cpp" line="216"/>
         <location filename="../../toonz/cleanuppopup.cpp" line="703"/>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="563"/>
@@ -10737,20 +11455,20 @@ What would you like to do?</source>
         <location filename="../../toonz/drawingdata.cpp" line="244"/>
         <location filename="../../toonz/exportlevelcommand.cpp" line="80"/>
         <location filename="../../toonz/exportlevelpopup.cpp" line="90"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2587"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2597"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2657"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2667"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2599"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2609"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2669"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2679"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="630"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="771"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="1028"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="515"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="1923"/>
         <location filename="../../toonz/fileselection.cpp" line="289"/>
-        <location filename="../../toonz/fileselection.cpp" line="438"/>
+        <location filename="../../toonz/fileselection.cpp" line="439"/>
         <location filename="../../toonz/flipbook.cpp" line="319"/>
-        <location filename="../../toonz/flipbook.cpp" line="620"/>
-        <location filename="../../toonz/flipbook.cpp" line="689"/>
+        <location filename="../../toonz/flipbook.cpp" line="622"/>
+        <location filename="../../toonz/flipbook.cpp" line="691"/>
         <location filename="../../toonz/iocommand.cpp" line="159"/>
         <location filename="../../toonz/iocommand.cpp" line="1298"/>
         <location filename="../../toonz/iocommand.cpp" line="1340"/>
@@ -10765,178 +11483,183 @@ What would you like to do?</source>
         <location filename="../../toonz/iocommand.cpp" line="3192"/>
         <location filename="../../toonz/loadfoldercommand.cpp" line="556"/>
         <location filename="../../toonz/loadfolderpopup.cpp" line="30"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1338"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1359"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="145"/>
-        <location filename="../../toonz/previewer.cpp" line="779"/>
-        <location filename="../../toonz/previewer.cpp" line="896"/>
-        <location filename="../../toonz/rendercommand.cpp" line="358"/>
-        <location filename="../../toonz/rendercommand.cpp" line="631"/>
+        <location filename="../../toonz/previewer.cpp" line="797"/>
+        <location filename="../../toonz/previewer.cpp" line="914"/>
+        <location filename="../../toonz/rendercommand.cpp" line="357"/>
+        <location filename="../../toonz/rendercommand.cpp" line="630"/>
         <location filename="../../toonz/separatecolorspopup.cpp" line="1941"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="532"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="581"/>
-        <location filename="../../toonz/startuppopup.cpp" line="601"/>
-        <location filename="../../toonz/startuppopup.cpp" line="872"/>
+        <location filename="../../toonz/startuppopup.cpp" line="627"/>
+        <location filename="../../toonz/startuppopup.cpp" line="898"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="423"/>
         <location filename="../../toonz/xsheetcmd.cpp" line="1444"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1592"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1626"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2850"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4747"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4998"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2275"/>
-        <location filename="../../toonz/cellselection.cpp" line="2576"/>
+        <location filename="../../toonz/cellselection.cpp" line="2267"/>
+        <location filename="../../toonz/cellselection.cpp" line="2568"/>
         <source>There are no copied cells to duplicate.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2302"/>
+        <location filename="../../toonz/cellselection.cpp" line="2294"/>
         <source>Cannot paste cells on locked layers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2309"/>
+        <location filename="../../toonz/cellselection.cpp" line="2301"/>
         <source>Can&apos;t place drawings on the camera column.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2357"/>
-        <location filename="../../toonz/cellselection.cpp" line="3038"/>
+        <location filename="../../toonz/cellselection.cpp" line="2349"/>
+        <location filename="../../toonz/cellselection.cpp" line="3030"/>
         <source>Cannot duplicate a drawing in the current column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2362"/>
+        <location filename="../../toonz/cellselection.cpp" line="2354"/>
         <source>Cannot duplicate frames in read only levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2366"/>
+        <location filename="../../toonz/cellselection.cpp" line="2358"/>
         <source>Can only duplicate frames in image sequence levels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2740"/>
+        <location filename="../../toonz/cellselection.cpp" line="2732"/>
         <source>Unable to create a blank drawing on the camera column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2746"/>
-        <location filename="../../toonz/cellselection.cpp" line="2920"/>
-        <location filename="../../toonz/cellselection.cpp" line="3011"/>
+        <location filename="../../toonz/cellselection.cpp" line="2738"/>
+        <location filename="../../toonz/cellselection.cpp" line="2912"/>
+        <location filename="../../toonz/cellselection.cpp" line="3003"/>
         <source>The current column is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2773"/>
+        <location filename="../../toonz/cellselection.cpp" line="2765"/>
         <source>Cannot create a blank drawing on the current column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2778"/>
-        <location filename="../../toonz/cellselection.cpp" line="3043"/>
+        <location filename="../../toonz/cellselection.cpp" line="2770"/>
+        <location filename="../../toonz/cellselection.cpp" line="3035"/>
         <source>The current level is not editable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2789"/>
+        <location filename="../../toonz/cellselection.cpp" line="2781"/>
         <source>Unable to create a blank drawing on a Single Frame level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2826"/>
+        <location filename="../../toonz/cellselection.cpp" line="2818"/>
         <source>Unable to create a blank drawing on the current column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2841"/>
+        <location filename="../../toonz/cellselection.cpp" line="2833"/>
         <source>Unable to replace a Stop Frame Hold with a blank drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2844"/>
+        <location filename="../../toonz/cellselection.cpp" line="2836"/>
         <source>Unable to replace the current drawing with a blank drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2913"/>
+        <location filename="../../toonz/cellselection.cpp" line="2905"/>
         <source>Unable to create a stop frame hold on the camera column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2943"/>
+        <location filename="../../toonz/cellselection.cpp" line="2935"/>
         <source>Cannot create a stop frame hold on the current column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2949"/>
+        <location filename="../../toonz/cellselection.cpp" line="2941"/>
         <source>Cannot create a stop from hold on a column without a level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2961"/>
+        <location filename="../../toonz/cellselection.cpp" line="2953"/>
         <source>Unable to create a stop frame hold on the current column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3004"/>
+        <location filename="../../toonz/cellselection.cpp" line="2996"/>
         <source>There are no drawings in the camera column to duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3062"/>
+        <location filename="../../toonz/cellselection.cpp" line="3054"/>
         <source>Cannot duplicate a Stop Frame Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3078"/>
+        <location filename="../../toonz/cellselection.cpp" line="3070"/>
         <source>Unable to duplicate a drawing on a Single Frame level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3110"/>
+        <location filename="../../toonz/cellselection.cpp" line="3102"/>
         <source>Unable to duplicate a drawing on the current column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3125"/>
+        <location filename="../../toonz/cellselection.cpp" line="3117"/>
         <source>Unable to replace the current or next drawing with a duplicate drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3599"/>
-        <location filename="../../toonz/cellselection.cpp" line="3676"/>
+        <location filename="../../toonz/cellselection.cpp" line="3591"/>
+        <location filename="../../toonz/cellselection.cpp" line="3668"/>
         <source>Cannot paste data 
  Nothing to paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3639"/>
+        <location filename="../../toonz/cellselection.cpp" line="3631"/>
         <source>It is not possible to paste the cells: Some column is locked or column type is not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3811"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="148"/>
+        <location filename="../../toonz/cellselection.cpp" line="3803"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="153"/>
         <source>Create Level %1  at Column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3830"/>
-        <location filename="../../toonz/cellselection.cpp" line="3836"/>
+        <location filename="../../toonz/cellselection.cpp" line="3822"/>
+        <location filename="../../toonz/cellselection.cpp" line="3828"/>
         <source>This command only works on vector cells.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3842"/>
+        <location filename="../../toonz/cellselection.cpp" line="3834"/>
         <source>Please select only one column for this command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3850"/>
+        <location filename="../../toonz/cellselection.cpp" line="3842"/>
         <source>All selected cells must belong to the same level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3942"/>
+        <location filename="../../toonz/cellselection.cpp" line="3934"/>
         <source>Simplify Vectors : Level %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10986,39 +11709,39 @@ What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1292"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1303"/>
         <source>Roll Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1321"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1332"/>
         <source>Roll Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1422"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1433"/>
         <source>Clone  Level : %1 &gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1428"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1439"/>
         <source>Clone  Levels : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1486"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1497"/>
         <source>Clone Level</source>
         <comment>CloneLevelUndo::LevelNamePopup</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1491"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1502"/>
         <source>Level Name:</source>
         <comment>CloneLevelUndo::LevelNamePopup</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1501"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1512"/>
         <location filename="../../toonz/loadfolderpopup.cpp" line="26"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
@@ -11032,7 +11755,7 @@ What would you like to do?</source>
         <location filename="../../toonz/cleanuppaletteviewer.cpp" line="216"/>
         <location filename="../../toonz/cleanuppopup.cpp" line="702"/>
         <location filename="../../toonz/fileselection.cpp" line="289"/>
-        <location filename="../../toonz/startuppopup.cpp" line="872"/>
+        <location filename="../../toonz/startuppopup.cpp" line="898"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11073,12 +11796,13 @@ Are you sure ?</source>
     <message>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="85"/>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="562"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="141"/>
         <location filename="../../toonz/curveio.cpp" line="79"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="1028"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="390"/>
-        <location filename="../../toonz/flipbook.cpp" line="620"/>
+        <location filename="../../toonz/flipbook.cpp" line="622"/>
         <location filename="../../toonz/iocommand.cpp" line="3023"/>
-        <location filename="../../toonz/previewer.cpp" line="819"/>
+        <location filename="../../toonz/previewer.cpp" line="837"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="422"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
@@ -11091,6 +11815,7 @@ Are you sure ?</source>
     </message>
     <message>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="100"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="156"/>
         <location filename="../../toonz/iocommand.cpp" line="2898"/>
         <location filename="../../toonz/iocommand.cpp" line="3197"/>
         <location filename="../../toonz/iocommand.cpp" line="3292"/>
@@ -11129,7 +11854,7 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <location filename="../../toonz/cleanupsettingspopup.cpp" line="872"/>
-        <location filename="../../toonz/tpanels.cpp" line="1495"/>
+        <location filename="../../toonz/tpanels.cpp" line="1513"/>
         <source>Cleanup Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11190,19 +11915,20 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbar.cpp" line="93"/>
-        <location filename="../../toonz/commandbarpopup.cpp" line="136"/>
+        <location filename="../../toonz/commandbar.cpp" line="130"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="139"/>
         <source>Incorrect file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbar.cpp" line="95"/>
+        <location filename="../../toonz/commandbar.cpp" line="132"/>
         <source>Cannot Read XML File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/commandbarpopup.cpp" line="53"/>
         <location filename="../../toonz/commandbarpopup.cpp" line="69"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="278"/>
         <source>[Drag] to move position</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11212,12 +11938,12 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="333"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="336"/>
         <source>[Drag&amp;Drop] to copy separator to toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="357"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="360"/>
         <source>[Drag&amp;Drop] to copy command to toolbar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11258,8 +11984,8 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <location filename="../../toonz/curveio.cpp" line="159"/>
-        <location filename="../../toonz/tpanels.cpp" line="1281"/>
-        <location filename="../../toonz/tpanels.cpp" line="1292"/>
+        <location filename="../../toonz/tpanels.cpp" line="1299"/>
+        <location filename="../../toonz/tpanels.cpp" line="1310"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11280,109 +12006,110 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <location filename="../../toonz/duplicatepopup.cpp" line="47"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1572"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1562"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1489"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="209"/>
-        <location filename="../../toonz/dvitemview.cpp" line="242"/>
+        <location filename="../../toonz/dvitemview.cpp" line="218"/>
+        <location filename="../../toonz/dvitemview.cpp" line="251"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="212"/>
+        <location filename="../../toonz/dvitemview.cpp" line="221"/>
         <source>Edited</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="215"/>
+        <location filename="../../toonz/dvitemview.cpp" line="224"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="218"/>
+        <location filename="../../toonz/dvitemview.cpp" line="227"/>
         <source>To Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="221"/>
+        <location filename="../../toonz/dvitemview.cpp" line="230"/>
         <source>Modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="224"/>
+        <location filename="../../toonz/dvitemview.cpp" line="233"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="227"/>
+        <location filename="../../toonz/dvitemview.cpp" line="236"/>
         <source>Unversioned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="230"/>
+        <location filename="../../toonz/dvitemview.cpp" line="239"/>
         <source>Missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="233"/>
+        <location filename="../../toonz/dvitemview.cpp" line="242"/>
         <source>Partially Edited</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="236"/>
+        <location filename="../../toonz/dvitemview.cpp" line="245"/>
         <source>Partially Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="239"/>
+        <location filename="../../toonz/dvitemview.cpp" line="248"/>
         <source>Partially Modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="256"/>
+        <location filename="../../toonz/dvitemview.cpp" line="265"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="260"/>
+        <location filename="../../toonz/dvitemview.cpp" line="269"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="266"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1697"/>
+        <location filename="../../toonz/dvitemview.cpp" line="275"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1706"/>
         <source>Date Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="268"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1701"/>
+        <location filename="../../toonz/dvitemview.cpp" line="277"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1710"/>
         <source>Date Modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="270"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1689"/>
+        <location filename="../../toonz/dvitemview.cpp" line="279"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1698"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="272"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1693"/>
+        <location filename="../../toonz/dvitemview.cpp" line="281"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1702"/>
         <source>Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="274"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1709"/>
+        <location filename="../../toonz/dvitemview.cpp" line="283"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1718"/>
         <source>Version Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="276"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1705"/>
+        <location filename="../../toonz/dvitemview.cpp" line="285"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1714"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11421,8 +12148,8 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="288"/>
-        <location filename="../../toonz/exportpanel.cpp" line="296"/>
+        <location filename="../../toonz/exportpanel.cpp" line="287"/>
+        <location filename="../../toonz/exportpanel.cpp" line="295"/>
         <location filename="../../toonz/iocommand.cpp" line="2029"/>
         <source>There were problems loading the scene %1.
  Some files may be missing.</source>
@@ -11430,19 +12157,19 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <location filename="../../toonz/exportpanel.cpp" line="378"/>
-        <location filename="../../toonz/rendercommand.cpp" line="101"/>
+        <location filename="../../toonz/rendercommand.cpp" line="100"/>
         <source>It is not possible to display the file %1: no player associated with its format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/exportscenepopup.cpp" line="52"/>
-        <location filename="../../toonz/fileselection.cpp" line="547"/>
+        <location filename="../../toonz/fileselection.cpp" line="548"/>
         <source>Error loading scene %1 :%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/exportscenepopup.cpp" line="59"/>
-        <location filename="../../toonz/fileselection.cpp" line="554"/>
+        <location filename="../../toonz/fileselection.cpp" line="555"/>
         <source>Error loading scene %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11460,84 +12187,96 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="770"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2069"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2250"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2103"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2284"/>
         <source>Explode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="623"/>
+        <location filename="../../toonz/filebrowser.cpp" line="613"/>
         <source>Skipping frame.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1573"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1563"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1490"/>
         <source>Don&apos;t Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1796"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1781"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1650"/>
         <source>The specified name is already assigned to the %1 file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1837"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1822"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1691"/>
         <source>Warning: level %1 already exists; overwrite?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1839"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="583"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1087"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1098"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1824"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="588"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1146"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1119"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="144"/>
         <location filename="../../toonz/menubar.cpp" line="233"/>
         <location filename="../../toonz/menubar.cpp" line="249"/>
         <location filename="../../toonz/menubar.cpp" line="271"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1693"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="594"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="668"/>
-        <location filename="../../toonz/startuppopup.cpp" line="616"/>
+        <location filename="../../toonz/startuppopup.cpp" line="642"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="497"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1651"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2091"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1839"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1824"/>
         <location filename="../../toonz/iocommand.cpp" line="2503"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="583"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1087"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1098"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="588"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1146"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1119"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="144"/>
         <location filename="../../toonz/menubar.cpp" line="233"/>
         <location filename="../../toonz/menubar.cpp" line="249"/>
         <location filename="../../toonz/menubar.cpp" line="271"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1693"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="594"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="668"/>
-        <location filename="../../toonz/startuppopup.cpp" line="616"/>
+        <location filename="../../toonz/startuppopup.cpp" line="642"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="497"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1651"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2091"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1855"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1840"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1709"/>
         <source>It is not possible to rename the %1 file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1861"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1846"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1715"/>
         <source>It is not possible to copy the %1 file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2436"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2421"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="2294"/>
-        <location filename="../../toonz/tpanels.cpp" line="1227"/>
+        <location filename="../../toonz/tpanels.cpp" line="1228"/>
         <source>File Browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowsermodel.cpp" line="695"/>
-        <location filename="../../toonz/filebrowsermodel.cpp" line="787"/>
+        <location filename="../../toonz/filebrowsermodel.cpp" line="702"/>
+        <location filename="../../toonz/filebrowsermodel.cpp" line="794"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="2096"/>
         <source>Change project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11555,7 +12294,7 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../../toonz/filebrowserpopup.cpp" line="511"/>
         <location filename="../../toonz/iocommand.cpp" line="2893"/>
-        <location filename="../../toonz/previewer.cpp" line="893"/>
+        <location filename="../../toonz/previewer.cpp" line="911"/>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
@@ -11665,79 +12404,79 @@ Do you want to overwrite it?</source>
         </translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="423"/>
+        <location filename="../../toonz/fileselection.cpp" line="424"/>
         <source>A conversion task is in progress! wait until it stops or cancel it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="434"/>
+        <location filename="../../toonz/fileselection.cpp" line="435"/>
         <source>You are going to premultiply selected files.
 The operation cannot be undone: are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="437"/>
+        <location filename="../../toonz/fileselection.cpp" line="438"/>
         <source>Premultiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="495"/>
+        <location filename="../../toonz/fileselection.cpp" line="496"/>
         <source>Collecting assets...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="496"/>
-        <location filename="../../toonz/fileselection.cpp" line="586"/>
+        <location filename="../../toonz/fileselection.cpp" line="497"/>
+        <location filename="../../toonz/fileselection.cpp" line="587"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="510"/>
+        <location filename="../../toonz/fileselection.cpp" line="511"/>
         <source>There are no assets to collect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="512"/>
+        <location filename="../../toonz/fileselection.cpp" line="513"/>
         <source>One asset imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="514"/>
+        <location filename="../../toonz/fileselection.cpp" line="515"/>
         <source>%1 assets imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="528"/>
+        <location filename="../../toonz/fileselection.cpp" line="529"/>
         <source>A separation task is in progress! wait until it stops or cancel it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="561"/>
+        <location filename="../../toonz/fileselection.cpp" line="562"/>
         <source>There was an error saving the %1 scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="585"/>
+        <location filename="../../toonz/fileselection.cpp" line="586"/>
         <source>Importing scenes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="602"/>
+        <location filename="../../toonz/fileselection.cpp" line="603"/>
         <source>No scene imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="604"/>
+        <location filename="../../toonz/fileselection.cpp" line="605"/>
         <source>One scene imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="607"/>
+        <location filename="../../toonz/fileselection.cpp" line="608"/>
         <source>%1 scenes imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="2035"/>
+        <location filename="../../toonz/filmstrip.cpp" line="2023"/>
         <source>Level: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11819,25 +12558,25 @@ The operation cannot be undone: are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstripselection.cpp" line="277"/>
+        <location filename="../../toonz/filmstripselection.cpp" line="279"/>
         <source>Can&apos;t delete the last drawing in a level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/flipbook.cpp" line="319"/>
-        <location filename="../../toonz/previewer.cpp" line="779"/>
+        <location filename="../../toonz/previewer.cpp" line="797"/>
         <source>Saving previewed frames....</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="631"/>
-        <location filename="../../toonz/rendercommand.cpp" line="433"/>
-        <location filename="../../toonz/rendercommand.cpp" line="707"/>
+        <location filename="../../toonz/flipbook.cpp" line="633"/>
+        <location filename="../../toonz/rendercommand.cpp" line="432"/>
+        <location filename="../../toonz/rendercommand.cpp" line="706"/>
         <source>The resolution of the output camera does not fit with the options chosen for the output file format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="2248"/>
+        <location filename="../../toonz/flipbook.cpp" line="2277"/>
         <source>%1  has an invalid extension format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11861,8 +12600,8 @@ Do you want to import it or load it from its original location?</source>
     <message>
         <location filename="../../toonz/iocommand.cpp" line="385"/>
         <location filename="../../toonz/levelcommand.cpp" line="553"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="601"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="975"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="606"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1034"/>
         <source>Removed unused level %1 from the scene cast. (This behavior can be disabled in Preferences.)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12017,7 +12756,7 @@ Do you wish to continue loading the last good save or stop and try to salvage th
     </message>
     <message>
         <location filename="../../toonz/iocommand.cpp" line="1943"/>
-        <location filename="../../toonz/main.cpp" line="709"/>
+        <location filename="../../toonz/main.cpp" line="717"/>
         <source>It is not possible to load the scene %1 because it does not belong to any project.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12158,12 +12897,14 @@ Are you sure you want to revert to previous version?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2711"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2723"/>
         <location filename="../../toonz/iocommand.cpp" line="3192"/>
+        <location filename="../../toonz/ocaio.cpp" line="523"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="532"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="581"/>
         <location filename="../../toonz/tvpjson_io.cpp" line="506"/>
-        <location filename="../../toonz/xdtsio.cpp" line="751"/>
+        <location filename="../../toonz/xdtsio.cpp" line="757"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4998"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12233,12 +12974,12 @@ Are you sure you want to revert to previous version?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="302"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="320"/>
         <source>Edit Level Settings : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="76"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="77"/>
         <source>Apply Lip Sync Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12274,58 +13015,118 @@ Do you want to import them or load from their original location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="120"/>
+        <location filename="../../toonz/main.cpp" line="122"/>
         <source>Installing %1 again could fix the problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="165"/>
+        <location filename="../../toonz/main.cpp" line="167"/>
         <source>The qualifier %1 is not a valid key name. Skipping.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="733"/>
+        <location filename="../../toonz/main.cpp" line="559"/>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="571"/>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="658"/>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="672"/>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="678"/>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="685"/>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="698"/>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="741"/>
         <source>Script file %1 does not exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1011"/>
+        <location filename="../../toonz/main.cpp" line="768"/>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="777"/>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="787"/>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="790"/>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="833"/>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1032"/>
         <source>No more Undo operations available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1018"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1039"/>
         <source>No more Redo operations available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1080"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1101"/>
         <source>Report a Bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1081"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1102"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1337"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1358"/>
         <source>Visit Web Site</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1341"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1362"/>
         <source>An update is available for this software.
 Visit the Web site for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1343"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1364"/>
         <source>Check for the latest version on launch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1351"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1372"/>
         <source>https://github.com/tahoma2d/tahoma2d/releases/latest</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12413,39 +13214,39 @@ Visit the Web site for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="452"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="451"/>
         <source>It is not possible to merge tlv columns because no column was selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="461"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="460"/>
         <source>It is not possible to merge tlv columns because at least two columns have to be selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="491"/>
-        <location filename="../../toonz/matchlinecommand.cpp" line="495"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="490"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="494"/>
         <source>Merging Tlv Levels...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="554"/>
-        <location filename="../../toonz/matchlinecommand.cpp" line="584"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="553"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="583"/>
         <source>It is not possible to delete lines because no column, cell or level strip frame was selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="562"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="561"/>
         <source>The selected column is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="572"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="571"/>
         <source>Selected cells must be in the same column.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="589"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="588"/>
         <source>Match lines can be deleted from Smart Raster levels only</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12552,51 +13353,51 @@ Visit the Web site for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="818"/>
+        <location filename="../../toonz/previewer.cpp" line="836"/>
         <source>Save Previewed Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="856"/>
+        <location filename="../../toonz/previewer.cpp" line="874"/>
         <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? &quot;  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="863"/>
+        <location filename="../../toonz/previewer.cpp" line="881"/>
         <source>Unsopporter raster format, cannot save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="879"/>
+        <location filename="../../toonz/previewer.cpp" line="897"/>
         <source>Cannot create %1 : %2</source>
         <comment>Previewer warning %1:path %2:message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="885"/>
+        <location filename="../../toonz/previewer.cpp" line="903"/>
         <source>Cannot create %1</source>
         <comment>Previewer warning %1:path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="962"/>
+        <location filename="../../toonz/previewer.cpp" line="980"/>
         <source>Saved %1 frames out of %2 in %3</source>
         <comment>Previewer %1:savedframes %2:framecount %3:filepath</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="968"/>
+        <location filename="../../toonz/previewer.cpp" line="986"/>
         <source>Canceled! </source>
         <comment>Previewer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="1103"/>
+        <location filename="../../toonz/previewer.cpp" line="1184"/>
         <source>No frame to save!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="1107"/>
+        <location filename="../../toonz/previewer.cpp" line="1188"/>
         <source>Already saving!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12613,7 +13414,7 @@ Visit the Web site for more information.</source>
     </message>
     <message>
         <location filename="../../toonz/projectpopup.cpp" line="443"/>
-        <location filename="../../toonz/startuppopup.cpp" line="709"/>
+        <location filename="../../toonz/startuppopup.cpp" line="735"/>
         <source>Change Project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12643,124 +13444,124 @@ Visit the Web site for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="218"/>
+        <location filename="../../toonz/rendercommand.cpp" line="217"/>
         <source>The command cannot be executed because the scene is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="253"/>
+        <location filename="../../toonz/rendercommand.cpp" line="252"/>
         <source>The scene is not yet saved and the output destination is set to $scenefolder.
 Save the scene first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="274"/>
+        <location filename="../../toonz/rendercommand.cpp" line="273"/>
         <source>It is not possible to create folder : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="278"/>
+        <location filename="../../toonz/rendercommand.cpp" line="277"/>
         <source>It is not possible to create a folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="343"/>
+        <location filename="../../toonz/rendercommand.cpp" line="342"/>
         <source>Rendering frame %1 / %2</source>
         <comment>RenderListener</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="355"/>
+        <location filename="../../toonz/rendercommand.cpp" line="354"/>
         <source>Precomputing %1 Frames</source>
         <comment>RenderListener</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="356"/>
-        <location filename="../../toonz/rendercommand.cpp" line="374"/>
+        <location filename="../../toonz/rendercommand.cpp" line="355"/>
+        <location filename="../../toonz/rendercommand.cpp" line="373"/>
         <source> of %1</source>
         <comment>RenderListener</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="334"/>
+        <location filename="../../toonz/rendercommand.cpp" line="333"/>
         <source>Finalizing render, please wait.</source>
         <comment>RenderListener</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="402"/>
+        <location filename="../../toonz/rendercommand.cpp" line="401"/>
         <source>Aborting render...</source>
         <comment>RenderListener</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="519"/>
+        <location filename="../../toonz/rendercommand.cpp" line="518"/>
         <source>Building Schematic...</source>
         <comment>RenderCommand</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="608"/>
+        <location filename="../../toonz/rendercommand.cpp" line="607"/>
         <source>column </source>
         <comment>MultimediaProgressBar label (mode name)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="610"/>
+        <location filename="../../toonz/rendercommand.cpp" line="609"/>
         <source>layer </source>
         <comment>MultimediaProgressBar label (mode name)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="612"/>
+        <location filename="../../toonz/rendercommand.cpp" line="611"/>
         <source>Rendering %1%2, frame %3 / %4</source>
         <comment>MultimediaProgressBar label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="628"/>
+        <location filename="../../toonz/rendercommand.cpp" line="627"/>
         <source>Rendering %1 frames of %2</source>
         <comment>MultimediaProgressBar</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="646"/>
+        <location filename="../../toonz/rendercommand.cpp" line="645"/>
         <source>%1 of %2</source>
         <comment>MultimediaProgressBar - [totalframe] of [path]</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="683"/>
+        <location filename="../../toonz/rendercommand.cpp" line="682"/>
         <source>Aborting render...</source>
         <comment>MultimediaProgressBar</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="795"/>
+        <location filename="../../toonz/rendercommand.cpp" line="794"/>
         <source>FFmpeg not found, please set the location in the Preferences and restart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="847"/>
+        <location filename="../../toonz/rendercommand.cpp" line="846"/>
         <source>It is not possible to write the output:  the file</source>
         <comment>RenderCommand</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="849"/>
+        <location filename="../../toonz/rendercommand.cpp" line="848"/>
         <source>s are read only.</source>
         <comment>RenderCommand</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="850"/>
+        <location filename="../../toonz/rendercommand.cpp" line="849"/>
         <source> is read only.</source>
         <comment>RenderCommand</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="869"/>
+        <location filename="../../toonz/rendercommand.cpp" line="868"/>
         <source>It is not possible to complete the rendering.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12810,8 +13611,8 @@ Save the scene first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scriptconsolepanel.cpp" line="135"/>
-        <location filename="../../toonz/tpanels.cpp" line="1381"/>
+        <location filename="../../toonz/scriptconsolepanel.cpp" line="130"/>
+        <location filename="../../toonz/tpanels.cpp" line="1399"/>
         <source>Script Console</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12822,14 +13623,14 @@ Save the scene first.</source>
     </message>
     <message>
         <location filename="../../toonz/separatecolorspopup.cpp" line="1937"/>
-        <location filename="../../toonz/startuppopup.cpp" line="597"/>
+        <location filename="../../toonz/startuppopup.cpp" line="623"/>
         <source>The chosen folder path does not exist.
 Do you want to create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/separatecolorspopup.cpp" line="1940"/>
-        <location filename="../../toonz/startuppopup.cpp" line="600"/>
+        <location filename="../../toonz/startuppopup.cpp" line="626"/>
         <source>Create</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12839,19 +13640,19 @@ Do you want to create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="613"/>
+        <location filename="../../toonz/startuppopup.cpp" line="639"/>
         <source>The file name already exists.
 Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="870"/>
+        <location filename="../../toonz/startuppopup.cpp" line="896"/>
         <source>Deleting &quot;%1&quot;.
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="1068"/>
+        <location filename="../../toonz/startuppopup.cpp" line="1094"/>
         <source>The selected scene could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12861,65 +13662,65 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1056"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1057"/>
         <source>Close Sub-Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1150"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1151"/>
         <source>Select a sub-scene cell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1689"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1723"/>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1780"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1814"/>
         <source>Collapse (Fx)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2288"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2399"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2322"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2433"/>
         <source>Collapsing columns: what you want to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2291"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2401"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2325"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2435"/>
         <source>Maintain parenting relationships in the sub-scene as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2293"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2327"/>
         <source>Include only selected columns in the sub-scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2404"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2438"/>
         <source>Include the selected columns in the sub-scene without parenting info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2478"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2512"/>
         <source>Exploding Sub-Scene: what you want to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2481"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2515"/>
         <source>Maintain parenting relationships in the main scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2483"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2517"/>
         <source>Bring columns in the main scene without parenting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1013"/>
-        <location filename="../../toonz/tpanels.cpp" line="1201"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="996"/>
+        <location filename="../../toonz/tpanels.cpp" line="1202"/>
         <source>Tasks</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12929,364 +13730,406 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="184"/>
-        <location filename="../../toonz/tpanels.cpp" line="381"/>
+        <location filename="../../toonz/tpanels.cpp" line="185"/>
+        <location filename="../../toonz/tpanels.cpp" line="382"/>
         <source>Schematic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="312"/>
+        <location filename="../../toonz/tpanels.cpp" line="313"/>
         <source>Stage Schematic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="314"/>
+        <location filename="../../toonz/tpanels.cpp" line="315"/>
         <source>Fx Schematic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="719"/>
+        <location filename="../../toonz/tpanels.cpp" line="720"/>
         <source>Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="782"/>
-        <location filename="../../toonz/tpanels.cpp" line="796"/>
+        <location filename="../../toonz/tpanels.cpp" line="783"/>
+        <location filename="../../toonz/tpanels.cpp" line="797"/>
         <source>Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="996"/>
-        <location filename="../../toonz/tpanels.cpp" line="1009"/>
+        <location filename="../../toonz/tpanels.cpp" line="997"/>
+        <location filename="../../toonz/tpanels.cpp" line="1010"/>
         <source>Style Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1058"/>
+        <location filename="../../toonz/tpanels.cpp" line="1059"/>
         <source>Command Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1099"/>
+        <location filename="../../toonz/tpanels.cpp" line="1100"/>
         <source>Tool Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1186"/>
+        <location filename="../../toonz/tpanels.cpp" line="1187"/>
         <location filename="../../toonz/viewerpopup.cpp" line="78"/>
         <source>FlipBook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1321"/>
-        <location filename="../../toonz/tpanels.cpp" line="1334"/>
+        <location filename="../../toonz/tpanels.cpp" line="1339"/>
+        <location filename="../../toonz/tpanels.cpp" line="1352"/>
         <source>Function Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1344"/>
-        <location filename="../../toonz/tpanels.cpp" line="1354"/>
+        <location filename="../../toonz/tpanels.cpp" line="1362"/>
+        <location filename="../../toonz/tpanels.cpp" line="1372"/>
         <source>Message Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1418"/>
-        <location filename="../../toonz/tpanels.cpp" line="1427"/>
+        <location filename="../../toonz/tpanels.cpp" line="1436"/>
+        <location filename="../../toonz/tpanels.cpp" line="1445"/>
         <source>Combo Viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1463"/>
-        <location filename="../../toonz/tpanels.cpp" line="1472"/>
+        <location filename="../../toonz/tpanels.cpp" line="1481"/>
+        <location filename="../../toonz/tpanels.cpp" line="1490"/>
         <source>Viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1510"/>
-        <location filename="../../toonz/tpanels.cpp" line="1519"/>
+        <location filename="../../toonz/tpanels.cpp" line="1528"/>
+        <location filename="../../toonz/tpanels.cpp" line="1537"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1536"/>
-        <location filename="../../toonz/tpanels.cpp" line="1547"/>
+        <location filename="../../toonz/tpanels.cpp" line="1554"/>
+        <location filename="../../toonz/tpanels.cpp" line="1565"/>
         <source>Stop Motion Controller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1564"/>
-        <location filename="../../toonz/tpanels.cpp" line="1575"/>
+        <location filename="../../toonz/tpanels.cpp" line="1582"/>
+        <location filename="../../toonz/tpanels.cpp" line="1593"/>
         <source>Motion Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1633"/>
-        <location filename="../../toonz/tpanels.cpp" line="1648"/>
+        <location filename="../../toonz/tpanels.cpp" line="1651"/>
+        <location filename="../../toonz/tpanels.cpp" line="1666"/>
         <source>Fx Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1672"/>
-        <location filename="../../toonz/tpanels.cpp" line="1686"/>
+        <location filename="../../toonz/tpanels.cpp" line="1690"/>
+        <location filename="../../toonz/tpanels.cpp" line="1704"/>
         <source>Vector Guided Tweening Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="754"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="750"/>
         <source>It is not possible to track the level:
 allocation error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="758"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="754"/>
         <source>It is not possible to track the level:
 no region defined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="762"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="758"/>
         <source>It is not possible to track specified regions:
 more than 30 regions defined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="767"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="763"/>
         <source>It is not possible to track specified regions:
 defined regions are not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="772"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="768"/>
         <source>It is not possible to track specified regions:
 some regions are too wide.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="777"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="773"/>
         <source>It is not possible to track specified regions:
 some regions are too high.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="782"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="778"/>
         <source>Frame Start Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="785"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="781"/>
         <source>Frame End Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="788"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="784"/>
         <source>Threshold Distance Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="791"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="787"/>
         <source>Sensitivity Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="794"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="790"/>
         <source>No Frame Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="797"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="793"/>
         <source>It is not possible to track specified regions:
 the selected level is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="802"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="798"/>
         <source>It is not possible to track the level:
 no level selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="806"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="802"/>
         <source>It is not possible to track specified regions:
 the level has to be saved first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="812"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="808"/>
         <source>It is not possible to track the level:
 undefined error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="647"/>
-        <location filename="../../toonz/xdtsio.cpp" line="737"/>
+        <location filename="../../toonz/ocaio.cpp" line="378"/>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="459"/>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="506"/>
+        <location filename="../../toonz/xdtsio.cpp" line="651"/>
+        <location filename="../../toonz/xdtsio.cpp" line="743"/>
         <source>No columns can be exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="709"/>
+        <location filename="../../toonz/ocaio.cpp" line="520"/>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="691"/>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="692"/>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="700"/>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="704"/>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="707"/>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="715"/>
         <source>Export Exchange Digital Time Sheet (XDTS)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="174"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="176"/>
         <source>+</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="175"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="177"/>
         <source>&apos;</source>
         <comment>XSheetPDF:second</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="176"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="178"/>
         <source>&quot;</source>
         <comment>XSheetPDF:frame</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="218"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="220"/>
         <source>TOT</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="219"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="221"/>
         <source>th</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="316"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="318"/>
         <source>None</source>
         <comment>XSheetPDF CellMark</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="368"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="370"/>
         <source>Dot</source>
         <comment>XSheetPDF CellMark</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="370"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="372"/>
         <source>Circle</source>
         <comment>XSheetPDF CellMark</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="372"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="374"/>
         <source>Filled circle</source>
         <comment>XSheetPDF CellMark</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="375"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="377"/>
         <source>Asterisk</source>
         <comment>XSheetPDF CellMark</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="620"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="622"/>
         <source>ACTION</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="712"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="714"/>
         <source>S</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="802"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="804"/>
         <source>CELL</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="839"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="841"/>
         <source>CAMERA</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1653"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2204"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1656"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2214"/>
         <source>EPISODE</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1654"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2205"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1657"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2215"/>
         <source>SEQ.</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1655"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2206"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1658"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2216"/>
         <source>SCENE</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1656"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2207"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1659"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2217"/>
         <source>TIME</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1657"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2208"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1660"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2218"/>
         <source>NAME</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1658"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2209"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1661"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2219"/>
         <source>SHEET</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2210"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2220"/>
         <source>TITLE</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2211"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2221"/>
         <source>CAMERAMAN</source>
         <comment>XSheetPDF</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2596"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2666"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2608"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2678"/>
         <source>Create folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2708"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2720"/>
         <location filename="../../toonz/tvpjson_io.cpp" line="503"/>
-        <location filename="../../toonz/xdtsio.cpp" line="748"/>
+        <location filename="../../toonz/xdtsio.cpp" line="754"/>
         <source>The file %1 has been exported successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2712"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2724"/>
+        <location filename="../../toonz/ocaio.cpp" line="524"/>
         <location filename="../../toonz/tvpjson_io.cpp" line="507"/>
-        <location filename="../../toonz/xdtsio.cpp" line="752"/>
+        <location filename="../../toonz/xdtsio.cpp" line="758"/>
         <source>Open containing folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellmover.cpp" line="461"/>
+        <location filename="../../toonz/xshcellmover.cpp" line="464"/>
         <source>Move Level</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13307,7 +14150,7 @@ undefined error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3368"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3309"/>
         <source>Toggle cycle of  %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13317,7 +14160,7 @@ undefined error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.h" line="206"/>
+        <location filename="../../toonz/xshcolumnviewer.h" line="201"/>
         <source>Camera Column Switch :  </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13460,6 +14303,33 @@ Do you want to continue?</source>
         <source>Export TVPaint JSON File</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="138"/>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="153"/>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="305"/>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="2200"/>
+        <location filename="../../toonz/tpanels.cpp" line="1248"/>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4747"/>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -13507,38 +14377,38 @@ Do you want to continue?</source>
 <context>
     <name>RenameAsToonzPopup</name>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1640"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1629"/>
         <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? &quot;  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1650"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1687"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1639"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1676"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1656"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1645"/>
         <source>Renaming File </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1659"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1648"/>
         <source>Creating an animation level of %1 frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1668"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1657"/>
         <source>Delete Original Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1680"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1669"/>
         <source>Level Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1689"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1678"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13546,55 +14416,55 @@ Do you want to continue?</source>
 <context>
     <name>RenderController</name>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="232"/>
+        <location filename="../../toonz/exportpanel.cpp" line="231"/>
         <source>Please specify an file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="236"/>
-        <location filename="../../toonz/exportpanel.cpp" line="250"/>
+        <location filename="../../toonz/exportpanel.cpp" line="235"/>
+        <location filename="../../toonz/exportpanel.cpp" line="249"/>
         <source>Drag a scene into the box to export a scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="275"/>
+        <location filename="../../toonz/exportpanel.cpp" line="274"/>
         <source>The %1  scene has a different resolution from the %2 scene.
                            The output result may differ from what you expect. What do you want to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="279"/>
+        <location filename="../../toonz/exportpanel.cpp" line="278"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="279"/>
+        <location filename="../../toonz/exportpanel.cpp" line="278"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="306"/>
+        <location filename="../../toonz/exportpanel.cpp" line="305"/>
         <source>Exporting ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="306"/>
+        <location filename="../../toonz/exportpanel.cpp" line="305"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="309"/>
+        <location filename="../../toonz/exportpanel.cpp" line="308"/>
         <source>Exporting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="343"/>
+        <location filename="../../toonz/exportpanel.cpp" line="342"/>
         <source>The %1 scene contains an audio file with different characteristics from the one used in the first exported scene.
 The audio file will not be included in the rendered clip.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="361"/>
+        <location filename="../../toonz/exportpanel.cpp" line="360"/>
         <source>The %1 scene contains a plastic deformed level.
 These levels can&apos;t be exported with this tool.</source>
         <translation type="unfinished"></translation>
@@ -13657,6 +14527,44 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="231"/>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="233"/>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="235"/>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="237"/>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="239"/>
+        <source>Browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="241"/>
+        <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="243"/>
+        <source>New Room</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <location filename="../../toonz/menubar.cpp" line="167"/>
@@ -13670,17 +14578,13 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <location filename="../../toonz/menubar.cpp" line="191"/>
+        <location filename="../../toonz/menubar.cpp" line="222"/>
         <source>New Room</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/menubar.cpp" line="197"/>
         <source>Delete Room &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/menubar.cpp" line="222"/>
-        <source>Room</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14724,12 +15628,12 @@ Please commit or revert changes first.</source>
 <context>
     <name>SaveImagesPopup</name>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="530"/>
+        <location filename="../../toonz/flipbook.cpp" line="532"/>
         <source>Save Flipbook Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="531"/>
+        <location filename="../../toonz/flipbook.cpp" line="533"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14744,6 +15648,14 @@ Please commit or revert changes first.</source>
     <message>
         <location filename="../../toonz/filebrowserpopup.cpp" line="1570"/>
         <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="166"/>
+        <source>Failed to open the file %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14843,6 +15755,229 @@ Please commit or revert changes first.</source>
     </message>
 </context>
 <context>
+    <name>SceneBrowser</name>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="142"/>
+        <source>Folder: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="281"/>
+        <source>Open folder failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="282"/>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="976"/>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="982"/>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="997"/>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1019"/>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1085"/>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1087"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1137"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1151"/>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1157"/>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1184"/>
+        <source>Version Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1190"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1202"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1197"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1293"/>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1209"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1255"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1322"/>
+        <source>Put...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1213"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1326"/>
+        <source>Revert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1220"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1271"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1289"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1303"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1317"/>
+        <source>Get</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1225"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1233"/>
+        <source>Get Revision...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1249"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1261"/>
+        <source>Unlock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1265"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1297"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1312"/>
+        <source>Edit Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1277"/>
+        <source>Revision History...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1308"/>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1469"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="2065"/>
+        <source>Save Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1469"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="2065"/>
+        <source>Scene name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1522"/>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1755"/>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1769"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1863"/>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1771"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1865"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1771"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1865"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1831"/>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1851"/>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1909"/>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="2103"/>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="2114"/>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowserversioncontrol.cpp" line="185"/>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowserversioncontrol.cpp" line="409"/>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="120"/>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="121"/>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SceneSettingsPopup</name>
     <message>
         <location filename="../../toonz/scenesettingspopup.cpp" line="244"/>
@@ -14865,42 +16000,42 @@ Please commit or revert changes first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="299"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="300"/>
         <source>Camera BG Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="303"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="304"/>
         <source>Field Guide Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="306"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="307"/>
         <source>A/R:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="310"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="312"/>
         <source>Image Subsampling:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="314"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="316"/>
         <source>TLV Subsampling:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="319"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="321"/>
         <source>Marker Interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="322"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="324"/>
         <source>  Start Frame:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="330"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="332"/>
         <source>Cell Marks:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14908,52 +16043,52 @@ Please commit or revert changes first.</source>
 <context>
     <name>SceneViewer</name>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1877"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1932"/>
         <source>FROZEN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1885"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1940"/>
         <source>Motion Path Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1892"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1947"/>
         <source>Transparency Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1893"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1948"/>
         <source>Ink Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1894"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1949"/>
         <source>Ink#1 Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1895"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1950"/>
         <source>Paint Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1896"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1951"/>
         <source>Inks Only Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1897"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1952"/>
         <source>Black BG Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1898"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1953"/>
         <source>Fill Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1899"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1954"/>
         <source>Gap Check</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15083,112 +16218,6 @@ Please commit or revert changes first.</source>
     <message>
         <location filename="../../toonz/sceneviewercontextmenu.cpp" line="360"/>
         <source>Select Column</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SceneViewerPanel</name>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="231"/>
-        <source>GUI Show / Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="234"/>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="235"/>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="439"/>
-        <source>Safe Area (Right Click to Select)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="453"/>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="468"/>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="477"/>
-        <source>Camera Stand View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="485"/>
-        <source>3D View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="492"/>
-        <source>Camera View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="500"/>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="515"/>
-        <source>Freeze</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="525"/>
-        <source>Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="534"/>
-        <source>Sub-camera Preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="638"/>
-        <source>Untitled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="640"/>
-        <source>Scene: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="643"/>
-        <source>   ::   Frame: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="660"/>
-        <location filename="../../toonz/viewerpane.cpp" line="688"/>
-        <source>  ::  Zoom : </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="663"/>
-        <location filename="../../toonz/viewerpane.cpp" line="691"/>
-        <source> (Flipped)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="673"/>
-        <source>   ::   Level: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonz/viewerpane.cpp" line="680"/>
-        <source>Level: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15395,27 +16424,27 @@ Right click to adjust.</source>
 <context>
     <name>SeparateSwatch</name>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="299"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="303"/>
         <source>Sub Color 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="305"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="309"/>
         <source>Original</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="306"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="310"/>
         <source>Main Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="311"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="315"/>
         <source>Sub Color 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="312"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="316"/>
         <source>Sub Color 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15562,141 +16591,169 @@ Right click to adjust.</source>
 <context>
     <name>ShortcutTree</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="300"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="303"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="325"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="236"/>
         <source>Menu Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="304"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="307"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="329"/>
         <location filename="../../toonz/menubar.cpp" line="309"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="240"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="305"/>
-        <location filename="../../toonz/menubar.cpp" line="370"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="308"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="330"/>
+        <location filename="../../toonz/menubar.cpp" line="371"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="241"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="306"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="309"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="331"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="242"/>
         <source>Scan &amp; Cleanup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="308"/>
-        <location filename="../../toonz/menubar.cpp" line="443"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="311"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="333"/>
+        <location filename="../../toonz/menubar.cpp" line="444"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="244"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="309"/>
-        <location filename="../../toonz/menubar.cpp" line="405"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="312"/>
+        <location filename="../../toonz/menubar.cpp" line="406"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="245"/>
         <source>Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="311"/>
-        <location filename="../../toonz/menubar.cpp" line="499"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="314"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="336"/>
+        <location filename="../../toonz/menubar.cpp" line="500"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="246"/>
         <source>Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="312"/>
-        <location filename="../../toonz/menubar.cpp" line="552"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="315"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="337"/>
+        <location filename="../../toonz/menubar.cpp" line="553"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="247"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="313"/>
-        <location filename="../../toonz/menubar.cpp" line="572"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="316"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="338"/>
+        <location filename="../../toonz/menubar.cpp" line="573"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="248"/>
         <source>Render</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="315"/>
-        <location filename="../../toonz/menubar.cpp" line="592"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="318"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="340"/>
+        <location filename="../../toonz/menubar.cpp" line="593"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="249"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="316"/>
-        <location filename="../../toonz/menubar.cpp" line="628"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="319"/>
+        <location filename="../../toonz/menubar.cpp" line="629"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="250"/>
         <source>Panels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="318"/>
-        <location filename="../../toonz/menubar.cpp" line="676"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="321"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="343"/>
+        <location filename="../../toonz/menubar.cpp" line="679"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="251"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="320"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="323"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="345"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="257"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="321"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="324"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="346"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="239"/>
         <source>Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="322"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="325"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="347"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="253"/>
         <source>Right-click Menu Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="324"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="327"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="352"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="258"/>
         <source>Tool Modifiers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="325"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="328"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="353"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="260"/>
         <source>Visualization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="326"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="329"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="354"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="261"/>
         <source>Misc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="327"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="330"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="355"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="262"/>
         <source>RGBA Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="328"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="331"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="259"/>
         <source>Stop Motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="585"/>
+        <location filename="../../toonz/menubar.cpp" line="586"/>
         <source>Cleanup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="334"/>
+        <source>Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="341"/>
+        <source>Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="351"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="255"/>
         <source>Cell Mark</source>
         <translation type="unfinished"></translation>
@@ -15765,6 +16822,11 @@ Assign shortcut sequence anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="118"/>
+        <source>DPI:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../toonz/startuppopup.cpp" line="120"/>
         <source>X</source>
         <translation type="unfinished"></translation>
@@ -15780,153 +16842,183 @@ Assign shortcut sequence anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="129"/>
-        <source>Add</source>
+        <location filename="../../toonz/startuppopup.cpp" line="128"/>
+        <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/startuppopup.cpp" line="130"/>
-        <source>Remove</source>
+        <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/startuppopup.cpp" line="131"/>
-        <source>Show this at startup</source>
+        <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/startuppopup.cpp" line="132"/>
+        <source>Show this at startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/startuppopup.cpp" line="133"/>
         <source>Automatically Save Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="134"/>
+        <location filename="../../toonz/startuppopup.cpp" line="135"/>
         <source>Create Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="135"/>
+        <location filename="../../toonz/startuppopup.cpp" line="136"/>
         <source>New Project...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="138"/>
+        <location filename="../../toonz/startuppopup.cpp" line="139"/>
         <source>Open Another Scene...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="222"/>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/startuppopup.cpp" line="226"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="245"/>
+        <location filename="../../toonz/startuppopup.cpp" line="249"/>
         <source>fps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="278"/>
+        <location filename="../../toonz/startuppopup.cpp" line="289"/>
         <source>Minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="415"/>
+        <location filename="../../toonz/startuppopup.cpp" line="441"/>
         <source>No Recent Scenes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="477"/>
+        <location filename="../../toonz/startuppopup.cpp" line="503"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="478"/>
+        <location filename="../../toonz/startuppopup.cpp" line="504"/>
         <source>Open a different project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="571"/>
+        <location filename="../../toonz/startuppopup.cpp" line="597"/>
         <source>The name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="576"/>
+        <location filename="../../toonz/startuppopup.cpp" line="602"/>
         <source>The width must be greater than zero.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="581"/>
+        <location filename="../../toonz/startuppopup.cpp" line="607"/>
         <source>The height must be greater than zero.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="586"/>
+        <location filename="../../toonz/startuppopup.cpp" line="612"/>
         <source>The frame rate must be 1 or more.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="607"/>
+        <location filename="../../toonz/startuppopup.cpp" line="633"/>
         <source>Failed to create the folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="658"/>
+        <location filename="../../toonz/startuppopup.cpp" line="684"/>
         <source>This is not a valid folder.  Please choose an existing location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="674"/>
+        <location filename="../../toonz/startuppopup.cpp" line="700"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="675"/>
+        <location filename="../../toonz/startuppopup.cpp" line="701"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="676"/>
+        <location filename="../../toonz/startuppopup.cpp" line="702"/>
         <source>No project found at this location 
 What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="678"/>
+        <location filename="../../toonz/startuppopup.cpp" line="704"/>
         <source>Make a new project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="678"/>
+        <location filename="../../toonz/startuppopup.cpp" line="704"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="841"/>
+        <location filename="../../toonz/startuppopup.cpp" line="867"/>
         <source>Preset name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="842"/>
+        <location filename="../../toonz/startuppopup.cpp" line="868"/>
         <source>Enter the name for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="847"/>
+        <location filename="../../toonz/startuppopup.cpp" line="873"/>
         <source>Error : Preset Name is Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="848"/>
+        <location filename="../../toonz/startuppopup.cpp" line="874"/>
         <source>The preset name must not use &apos;,&apos;(comma).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="911"/>
+        <location filename="../../toonz/startuppopup.cpp" line="937"/>
         <source>Bad camera preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="912"/>
+        <location filename="../../toonz/startuppopup.cpp" line="938"/>
         <source>&apos;%1&apos; doesn&apos;t seem to be a well formed camera preset. 
 Possibly the preset file has been corrupted</source>
         <translation type="unfinished"></translation>
@@ -16226,6 +17318,7 @@ Possibly the preset file has been corrupted</source>
     </message>
     <message>
         <location filename="../../toonz/statusbar.cpp" line="353"/>
+        <location filename="../../toonz/statusbar.cpp" line="371"/>
         <source>%1%2Move entire object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16245,13 +17338,1062 @@ Possibly the preset file has been corrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/statusbar.cpp" line="369"/>
+        <location filename="../../toonz/statusbar.cpp" line="370"/>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/statusbar.cpp" line="375"/>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/statusbar.cpp" line="377"/>
         <source>Finger Tool: Smudges small areas to cover with line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/statusbar.cpp" line="370"/>
+        <location filename="../../toonz/statusbar.cpp" line="378"/>
         <source>This tool doesn&apos;t work on this layer type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotion</name>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="143"/>
+        <source>No</source>
+        <comment>frame id</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="649"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="678"/>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1520"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2067"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2746"/>
+        <source>No level name specified: please choose a valid level name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1566"/>
+        <source>The level name specified is already used: please choose a different level name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1575"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2786"/>
+        <source>The save in path specified does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1581"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1614"/>
+        <source>The captured image size does not match with the existing level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1589"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1623"/>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1604"/>
+        <source>Failed to load %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1649"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2089"/>
+        <source>Folder %1 doesn&apos;t exist.
+Do you want to create it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1657"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1667"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1676"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2097"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2107"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2116"/>
+        <source>Unable to create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1828"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3437"/>
+        <source>No camera selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1859"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2022"/>
+        <source>Please start live view before capturing an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1921"/>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2769"/>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2775"/>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2779"/>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2807"/>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2819"/>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2841"/>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2848"/>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2859"/>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2863"/>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2864"/>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2960"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2965"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2972"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2977"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2996"/>
+        <source>UNDEFINED WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2987"/>
+        <source>The level is not registered in the scene, but exists in the file system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3003"/>
+        <source>
+WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3007"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3057"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3067"/>
+        <source>WARNING </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3013"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3074"/>
+        <source>
+Frame %1 exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3016"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3077"/>
+        <source>
+Frames %1 exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3020"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3089"/>
+        <source>OVERWRITE 1 of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3023"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3094"/>
+        <source>ADD to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3027"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3098"/>
+        <source> %1 frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3029"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3100"/>
+        <source> %1 frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3035"/>
+        <source>The level will be newly created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3036"/>
+        <source>NEW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3044"/>
+        <source>The level is already registered in the scene.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3045"/>
+        <source>
+NOTE : The level is not saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3055"/>
+        <source>
+WARNING : Failed to get image size of the existing level %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3063"/>
+        <source>
+WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3110"/>
+        <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
+          %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3118"/>
+        <source>
+WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3128"/>
+        <source>WARNING : Level path conflicts. There already is a level with the path %1                        
+          in the scene with the name %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3136"/>
+        <source>
+WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3142"/>
+        <source>WARNING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3448"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3456"/>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionController</name>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="821"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="822"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2225"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="823"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="883"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="824"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="825"/>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="826"/>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="845"/>
+        <source>Resolution: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="846"/>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="847"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="850"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="895"/>
+        <source>Next Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="896"/>
+        <source>Next New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="903"/>
+        <source>Previous Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="906"/>
+        <source>Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="907"/>
+        <source>Last Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="913"/>
+        <source>Previous Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="918"/>
+        <source>Next XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="921"/>
+        <source>Previous XSheet Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="924"/>
+        <source>Current Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="930"/>
+        <source>Set to the Current Playhead Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="935"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2618"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4337"/>
+        <source>Start Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="938"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1401"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4422"/>
+        <source>Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="952"/>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="960"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="964"/>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="966"/>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="970"/>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="972"/>
+        <source>&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="974"/>
+        <source>&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="976"/>
+        <source>&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="978"/>
+        <source>&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="980"/>
+        <source>&lt;&lt;&lt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="982"/>
+        <source>&gt;&gt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="999"/>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1026"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1039"/>
+        <source>Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1090"/>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1093"/>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1124"/>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1144"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3064"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3855"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3885"/>
+        <source>Temperature: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1154"/>
+        <source>Camera Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1155"/>
+        <source>Camera Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1157"/>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1190"/>
+        <source>White Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1199"/>
+        <source>Picture Style: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1202"/>
+        <source>Image Quality: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1205"/>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1208"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1311"/>
+        <source>Exposure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1248"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1676"/>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1253"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1284"/>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1266"/>
+        <source>Image adjust</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1274"/>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1274"/>
+        <source>Grayscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1274"/>
+        <source>Black &amp; White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1292"/>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1321"/>
+        <source>Brightness: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1331"/>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1341"/>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1351"/>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1363"/>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1365"/>
+        <source>Webcam Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1375"/>
+        <source>Color type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1400"/>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1402"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1403"/>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1404"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1405"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1410"/>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1414"/>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1456"/>
+        <source>Webcam Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1457"/>
+        <source>DSLR Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1458"/>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1474"/>
+        <source>Place on XSheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1475"/>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1477"/>
+        <source>Use Direct Show Webcam Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1478"/>
+        <source>Use MJPG with Webcam</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1479"/>
+        <source>Use Numpad Shortcuts When Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1481"/>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1496"/>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1498"/>
+        <source>Show Live View on All Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1499"/>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1500"/>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1529"/>
+        <source>Interval(sec):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1551"/>
+        <source>Capture Review Time: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1565"/>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1567"/>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1584"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1585"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1586"/>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1587"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1588"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1589"/>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1596"/>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1607"/>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1618"/>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1644"/>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1646"/>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1727"/>
+        <source>Opacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2612"/>
+        <source>No camera detected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2613"/>
+        <source>No camera detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2621"/>
+        <source>- Select camera -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2733"/>
+        <source>Mode: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2765"/>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2770"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3579"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3609"/>
+        <source>Aperture: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2816"/>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2821"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3646"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3681"/>
+        <source>Shutter Speed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2868"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2873"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3714"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3744"/>
+        <source>Iso: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2868"/>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2917"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2964"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3105"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3152"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3199"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4027"/>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4334"/>
+        <source>Stop Live View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4420"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4438"/>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4428"/>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4735"/>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4745"/>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4848"/>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4926"/>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4992"/>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4997"/>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="5034"/>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSaveInFolderPopup</name>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="278"/>
+        <source>Create the Destination Subfolder to Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="282"/>
+        <source>Set As Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="284"/>
+        <source>Set the current &quot;Save In&quot; path as the default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="286"/>
+        <source>Create Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="290"/>
+        <source>Infomation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="291"/>
+        <source>Subfolder Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="298"/>
+        <source>Auto Format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="303"/>
+        <source>Show This on Launch of the Camera Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="304"/>
+        <source>Save Scene in Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="306"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="307"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="334"/>
+        <source>C- + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="334"/>
+        <source>Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="335"/>
+        <source>Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="336"/>
+        <source>Project + Episode + Sequence + Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="344"/>
+        <source>Save the current scene in the subfolder.
+Set the output folder path to the subfolder as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="358"/>
+        <source>Save In:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="378"/>
+        <source>Project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="381"/>
+        <source>Episode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="384"/>
+        <source>Sequence:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="387"/>
+        <source>Scene:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="403"/>
+        <source>Subfolder Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="575"/>
+        <source>Subfolder name should not be empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="582"/>
+        <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="594"/>
+        <source>Folder %1 already exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="613"/>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <location filename="../../stopmotion/stopmotionserial.cpp" line="16"/>
+        <source>No Device</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16398,7 +18540,7 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>TPanelTitleBarButtonForCameraView</name>
     <message>
-        <location filename="../../toonz/pane.cpp" line="388"/>
+        <location filename="../../toonz/pane.cpp" line="393"/>
         <source>Opacity: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16406,252 +18548,275 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>TPanelTitleBarButtonForGrids</name>
     <message>
-        <location filename="../../toonz/pane.cpp" line="420"/>
+        <location filename="../../toonz/pane.cpp" line="425"/>
         <source>Rule of Thirds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pane.cpp" line="426"/>
+        <location filename="../../toonz/pane.cpp" line="431"/>
         <source>Golden Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pane.cpp" line="433"/>
+        <location filename="../../toonz/pane.cpp" line="438"/>
         <source>Field Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/pane.cpp" line="440"/>
+        <location filename="../../toonz/pane.cpp" line="445"/>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="452"/>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="499"/>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="500"/>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="501"/>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TaskSheet</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="207"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="190"/>
         <source>Suspended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="209"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="192"/>
         <source>Waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="211"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="194"/>
         <source>Running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="213"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="196"/>
         <source>Completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="215"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="198"/>
         <source>Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="217"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="200"/>
         <source>TaskUnknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="825"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="808"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="826"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="809"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="827"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="810"/>
         <source>Command Line:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="828"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="811"/>
         <source>Server:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="829"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="812"/>
         <source>Submitted By:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="830"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="813"/>
         <source>Submitted On:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="831"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="814"/>
         <source>Submission Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="832"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="815"/>
         <source>Start Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="833"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="816"/>
         <source>Completion Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="834"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="817"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="836"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="819"/>
         <source>Step Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="838"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="821"/>
         <source>Failed Steps:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="840"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="823"/>
         <source>Successful Steps:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="842"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="825"/>
         <source>Priority:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="860"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="843"/>
         <source>Output:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="862"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="845"/>
         <source>Frames per Chunk:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="846"/>
         <source>Multimedia:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="865"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="848"/>
         <source>From:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="865"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="848"/>
         <source>To:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="851"/>
         <source>Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="851"/>
         <source>Shrink:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="874"/>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="857"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="874"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="857"/>
         <source>Fx Schematic Flows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="875"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="858"/>
         <source>Fx Schematic Terminal Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="878"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="861"/>
         <source>Dedicated CPUs:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="880"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
         <source>Single</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="880"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
         <source>Half</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="880"/>
-        <location filename="../../toonz/tasksviewer.cpp" line="910"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="893"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="883"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="866"/>
         <source>Render Tile:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="906"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="889"/>
         <source>Visible Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="907"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="890"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="910"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="893"/>
         <source>NoPaint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="910"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="893"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="920"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="903"/>
         <source>Dependencies:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="937"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="920"/>
         <source>Remove &gt;&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="940"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="923"/>
         <source>&lt;&lt; Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16659,17 +18824,17 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>TaskTreeModel</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1292"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1275"/>
         <source>Are you sure you want to remove ALL tasks?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1293"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1276"/>
         <source>Remove All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1293"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1276"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16677,17 +18842,17 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>TaskTreeView</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1078"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1061"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1082"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1065"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1086"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1069"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16695,82 +18860,82 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>TasksViewer</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="86"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="73"/>
         <source>&amp;Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="86"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="73"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="87"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="74"/>
         <source>&amp;Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="87"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="74"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="89"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="76"/>
         <source>&amp;Add Render Task</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="90"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="77"/>
         <source>Add Render</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="91"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="78"/>
         <source>&amp;Add Cleanup Task</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="92"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="79"/>
         <source>Add Cleanup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="98"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="85"/>
         <source>&amp;Save Task List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="98"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="85"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="99"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="86"/>
         <source>&amp;Save Task List As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="100"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="87"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="101"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="88"/>
         <source>&amp;Load Task List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="101"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="88"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="103"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="90"/>
         <source>&amp;Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="103"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="90"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16778,12 +18943,12 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>TestPanel</name>
     <message>
-        <location filename="../../toonz/testpanel.cpp" line="53"/>
+        <location filename="../../toonz/testpanel.cpp" line="48"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/testpanel.cpp" line="54"/>
+        <location filename="../../toonz/testpanel.cpp" line="49"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16852,13 +19017,18 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>Toolbar</name>
     <message>
-        <location filename="../../toonz/toolbar.cpp" line="191"/>
+        <location filename="../../toonz/toolbar.cpp" line="187"/>
         <source>Collapse toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/toolbar.cpp" line="195"/>
+        <location filename="../../toonz/toolbar.cpp" line="191"/>
         <source>Expand toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/toolbar.cpp" line="273"/>
+        <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16885,72 +19055,72 @@ Possibly the preset file has been corrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="356"/>
+        <location filename="../../toonz/menubar.cpp" line="357"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="388"/>
+        <location filename="../../toonz/menubar.cpp" line="389"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="396"/>
+        <location filename="../../toonz/menubar.cpp" line="397"/>
         <source>Arrange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="444"/>
+        <location filename="../../toonz/menubar.cpp" line="445"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="468"/>
+        <location filename="../../toonz/menubar.cpp" line="469"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="477"/>
+        <location filename="../../toonz/menubar.cpp" line="478"/>
         <source>Optimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="482"/>
+        <location filename="../../toonz/menubar.cpp" line="483"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="506"/>
+        <location filename="../../toonz/menubar.cpp" line="507"/>
         <source>Reframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="514"/>
+        <location filename="../../toonz/menubar.cpp" line="515"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="523"/>
+        <location filename="../../toonz/menubar.cpp" line="524"/>
         <source>Each</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="534"/>
+        <location filename="../../toonz/menubar.cpp" line="535"/>
         <source>Drawing Substitution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="729"/>
+        <location filename="../../toonz/menubar.cpp" line="732"/>
         <source>Lock Rooms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="732"/>
+        <location filename="../../toonz/menubar.cpp" line="735"/>
         <source>Unlocking this enables creating new rooms and rearranging the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="735"/>
+        <location filename="../../toonz/menubar.cpp" line="738"/>
         <source>Locking this prevents the workspace from being changed and prevents new rooms from being created.  Unlock this to change the workspace or create new rooms.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16958,42 +19128,42 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>TrackerPopup</name>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="158"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="154"/>
         <source>Tracking Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="167"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="163"/>
         <source>Threshold:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="173"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="169"/>
         <source>Sensitivity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="175"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="171"/>
         <source>Variable Region Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="179"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="175"/>
         <source>Include Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="186"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="182"/>
         <source>Track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="240"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="236"/>
         <source>Processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="240"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="236"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17001,104 +19171,104 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>VectorGuidedDrawingPane</name>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>Closest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>Farthest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="41"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
         <source>Auto Inbetween</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>Ease In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>Ease Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>EaseIn/Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="61"/>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="105"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="55"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="99"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="66"/>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="100"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="60"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="94"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="71"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="65"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="76"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="70"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="82"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="76"/>
         <source>Tween Selected Guide Strokes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="88"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="82"/>
         <source>Tween Guide Strokes to Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="95"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="89"/>
         <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="115"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="109"/>
         <source>Use Onion Skin Frames:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="120"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="114"/>
         <source>Select Stroke:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="134"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="128"/>
         <source>Flip Stroke Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="150"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="144"/>
         <source>Interpolation:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17106,224 +19276,224 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>VectorizerPopup</name>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="457"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="453"/>
         <source>Convert-to-Vector Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="522"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="518"/>
         <source>Centerline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="522"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="518"/>
         <source>Outline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="529"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="532"/>
         <location filename="../../toonz/vectorizerpopup.cpp" line="533"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="536"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="537"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="544"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="550"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="540"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="546"/>
         <source>Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="553"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="559"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="662"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="668"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="549"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="555"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="658"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="664"/>
         <source>Accuracy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="562"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="568"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="671"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="677"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="558"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="564"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="667"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="673"/>
         <source>Despeckling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="571"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="578"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="567"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="574"/>
         <source>Max Thickness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="581"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="609"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="577"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="605"/>
         <source>Thickness Calibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="591"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="587"/>
         <source>Start:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="598"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="594"/>
         <source>End:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="613"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="681"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="609"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="677"/>
         <source>Preserve Painted Areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="622"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="690"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="618"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="686"/>
         <source>Align Boundary Strokes Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="628"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="696"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="624"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="692"/>
         <source>Align boundary strokes direction to be the same.
 (clockwise, i.e. left to right as viewed from inside of the shape)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="634"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="630"/>
         <source>Add Border</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="644"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="640"/>
         <source>Full color non-AA images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="648"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="644"/>
         <source>Enhanced ink recognition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="702"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="698"/>
         <source>Corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="706"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="712"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="702"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="708"/>
         <source>Adherence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="715"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="721"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="711"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="717"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="724"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="730"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="720"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="726"/>
         <source>Curve Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="734"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="730"/>
         <source>Raster Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="738"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="744"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="734"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="740"/>
         <source>Max Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="747"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="752"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="743"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="748"/>
         <source>Transparent Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="756"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="752"/>
         <source>TLV Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="760"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="766"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="756"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="762"/>
         <source>Tone Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="782"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="778"/>
         <source>Toggle Swatch Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="787"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="783"/>
         <source>Toggle Centerlines Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="793"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="789"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="803"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="799"/>
         <source>Save Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="806"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="802"/>
         <source>Load Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="811"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="807"/>
         <source>Reset Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="827"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="823"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="942"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="938"/>
         <source>The current selection is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="994"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="990"/>
         <source>Cannot convert to vector the current selection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1087"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1083"/>
         <source>Conversion in progress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1476"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1538"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1472"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1534"/>
         <source>File could not be opened for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1492"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1488"/>
         <source>File could not be opened for write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1510"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1506"/>
         <source>Save Vectorizer Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1565"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1561"/>
         <source>Load Vectorizer Parameters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17361,7 +19531,7 @@ Please refer to the user guide for details.</source>
 <context>
     <name>ViewerHistogramPopup</name>
     <message>
-        <location filename="../../toonz/histogrampopup.cpp" line="119"/>
+        <location filename="../../toonz/histogrampopup.cpp" line="163"/>
         <source>Viewer Histogram</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17404,115 +19574,115 @@ Please refer to the user guide for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsimportpopup.cpp" line="104"/>
-        <source>Inbetween symbol mark</source>
+        <location filename="../../toonz/xdtsimportpopup.cpp" line="105"/>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsimportpopup.cpp" line="108"/>
-        <source>Reverse sheet symbol mark</source>
+        <location filename="../../toonz/xdtsimportpopup.cpp" line="110"/>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>XsheetGUI::CellArea</name>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3731"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3672"/>
         <source>Click to select keyframe, drag to move it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3740"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3681"/>
         <source>Click and drag to set the acceleration range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3742"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3683"/>
         <source>Click and drag to set the deceleration range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3751"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3692"/>
         <source>Set the cycle of previous keyframes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3756"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3697"/>
         <source>Click and drag to move the selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3792"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3733"/>
         <source>Click and drag to play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3794"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3735"/>
         <source>Click and drag to repeat selected cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4095"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4036"/>
         <source>Reframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4106"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4047"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4116"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4057"/>
         <source>Each</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4125"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4066"/>
         <source>Edit Cell Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4150"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4091"/>
         <source>Replace Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4167"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4108"/>
         <source>Replace with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4212"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4153"/>
         <source>Paste Special</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4247"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4188"/>
         <source>Edit Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4261"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4202"/>
         <source>Lip Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4294"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4235"/>
         <source>Cell Mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4296"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4237"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4475"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4416"/>
         <source>Open Memo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4476"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4417"/>
         <source>Delete Memo</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17520,7 +19690,7 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::ChangeObjectParent</name>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="516"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="512"/>
         <source>Table</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17528,175 +19698,175 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::ColumnArea</name>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1474"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1464"/>
         <source>&amp;Subsampling 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1475"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1465"/>
         <source>&amp;Subsampling 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1476"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1466"/>
         <source>&amp;Subsampling 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1477"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1467"/>
         <source>&amp;Subsampling 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2277"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2267"/>
         <source>Unlock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2277"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2267"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2606"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2596"/>
         <source>Click to select camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2608"/>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2611"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2598"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2601"/>
         <source>Click to select column, drag to move it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2613"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2603"/>
         <source>Click to select column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2617"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2607"/>
         <source>Click to select column, drag to move it, double-click to edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2621"/>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2640"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2611"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2630"/>
         <source>Click to play the soundtrack back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2624"/>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2643"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2614"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2633"/>
         <source>Set the volume of the soundtrack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2626"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2616"/>
         <source>Click to select column, double-click to edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2628"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2618"/>
         <source>Lock Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2630"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2620"/>
         <source>Additional column settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2632"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2622"/>
         <source>Preview Visibility Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2635"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2625"/>
         <source>Camera Stand Visibility Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2646"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2636"/>
         <source>Alt + Click to Toggle Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2936"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2926"/>
         <source>Hide Camera Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2938"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2928"/>
         <source>Show Camera Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2944"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2934"/>
         <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2946"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2936"/>
         <source>Toggle Between Timeline and Xsheet View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2961"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2951"/>
         <source>Reframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2976"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2966"/>
         <source>Subsampling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3010"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3000"/>
         <source>Show Column Parent Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3015"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3005"/>
         <source>Show the column parent&apos;s color in the Xsheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3033"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3023"/>
         <source>&amp;Insert After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3034"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3024"/>
         <source>&amp;Insert Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3035"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3025"/>
         <source>&amp;Paste Insert After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3036"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3026"/>
         <source>&amp;Paste Insert Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3038"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3028"/>
         <source>&amp;Insert Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3039"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3029"/>
         <source>&amp;Insert Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3040"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3030"/>
         <source>&amp;Paste Insert Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3041"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3031"/>
         <source>&amp;Paste Insert Below</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17704,63 +19874,83 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::ColumnTransparencyPopup</name>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1964"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1954"/>
         <source>Lock Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1999"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1989"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1987"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1977"/>
         <source>Opacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="784"/>
+        <source>Add New Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="793"/>
+        <source>Previous Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="802"/>
+        <source>Next Memo</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>XsheetGUI::NoteArea</name>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="499"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="488"/>
+        <source>Toggle Xsheet/Timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="494"/>
         <source>Add New Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="510"/>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="788"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="505"/>
         <source>Add New Memo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="516"/>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="797"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="511"/>
         <source>Previous Memo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="522"/>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="806"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="517"/>
         <source>Next Memo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="525"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="520"/>
         <source>Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="525"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="520"/>
         <source>Sec Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="525"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="520"/>
         <source>6sec Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="526"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="521"/>
         <source>3sec Sheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17786,7 +19976,7 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::QuickToolbar</name>
     <message>
-        <location filename="../../toonz/quicktoolbar.cpp" line="69"/>
+        <location filename="../../toonz/quicktoolbar.cpp" line="65"/>
         <source>Customize Quick Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17794,75 +19984,82 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::RowArea</name>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1156"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1214"/>
         <source>Click to Reset Shift &amp; Trace Markers to Neighbor Frames
 Hold F2 Key on the Viewer to Show This Frame Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1160"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1218"/>
         <source>Click to Hide This Frame from Shift &amp; Trace
 Hold F1 Key on the Viewer to Show This Frame Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1164"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1222"/>
         <source>Click to Hide This Frame from Shift &amp; Trace
 Hold F3 Key on the Viewer to Show This Frame Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1167"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1225"/>
         <source>Click to Move Shift &amp; Trace Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1229"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1296"/>
         <source>Playback Start Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1231"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1298"/>
         <source>Playback End Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1233"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1300"/>
         <source>Pinned Center : Col%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1242"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1309"/>
         <source>Tag: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1248"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1315"/>
         <source>Double Click to Toggle Onion Skin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1250"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1317"/>
         <source>Current Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1252"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1319"/>
         <source>Fixed Onion Skin Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1254"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1321"/>
         <source>Relative Onion Skin Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1333"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1323"/>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1411"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1343"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1421"/>
         <source>Frame %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17870,7 +20067,7 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
 <context>
     <name>XsheetGUI::SoundColumnPopup</name>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2133"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2123"/>
         <source>Volume:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17878,7 +20075,7 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
 <context>
     <name>XsheetPdfPreviewArea</name>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1828"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1831"/>
         <source>Fit To Window</source>
         <translation type="unfinished"></translation>
     </message>

--- a/toonz/sources/translations/norwegian_bokmal/toonzlib.ts
+++ b/toonz/sources/translations/norwegian_bokmal/toonzlib.ts
@@ -157,27 +157,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="268"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="264"/>
         <source>frame index (%1) must be a number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="272"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="268"/>
         <source>frame index (%1) is out of range (0-%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="295"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="291"/>
         <source>second argument (%1) is not an image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="308"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="304"/>
         <source>can not insert a %1 image into a level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="329"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="325"/>
         <source>can not insert a %1 image to a %2 level</source>
         <translation type="unfinished"></translation>
     </message>
@@ -213,17 +213,17 @@
 <context>
     <name>Preferences</name>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="101"/>
+        <location filename="../../toonzlib/preferences.cpp" line="102"/>
         <source>Retas Level Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="107"/>
+        <location filename="../../toonzlib/preferences.cpp" line="108"/>
         <source>Adobe Photoshop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="204"/>
+        <location filename="../../toonzlib/preferences.cpp" line="208"/>
         <source>PNG</source>
         <translation type="unfinished"></translation>
     </message>
@@ -268,6 +268,7 @@
     </message>
     <message>
         <location filename="../../toonzlib/cleanupcolorstyles.cpp" line="95"/>
+        <location filename="../../toonzlib/imagestyles.cpp" line="554"/>
         <source>Contrast</source>
         <translation type="unfinished"></translation>
     </message>
@@ -297,108 +298,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/doubleparamcmd.cpp" line="816"/>
+        <location filename="../../toonzlib/doubleparamcmd.cpp" line="817"/>
         <source>Remove Keyframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/doubleparamcmd.cpp" line="856"/>
+        <location filename="../../toonzlib/doubleparamcmd.cpp" line="857"/>
         <source>Cycle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="908"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="917"/>
         <source>Add Fx  : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="909"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="918"/>
         <source>Insert Fx  : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1073"/>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1076"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1082"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1085"/>
         <source>Create Linked Fx  : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1298"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1307"/>
         <source>Replace Fx  : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1364"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1373"/>
         <source>Unlink Fx  : %1 - - %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1405"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1414"/>
         <source>Make Macro Fx  : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1548"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1557"/>
         <source>Explode Macro Fx  : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1611"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1620"/>
         <source>Create Output Fx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1702"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1711"/>
         <source>Connect to Xsheet  : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1762"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1771"/>
         <source>Disconnect from Xsheet  : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2035"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2044"/>
         <source>Delete Link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2322"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2331"/>
         <source>Delete Fx Node : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2747"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2756"/>
         <source>Paste Fx  :  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3116"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3125"/>
         <source>Disconnect Fx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3368"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3377"/>
         <source>Connect Fx : %1 - %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3550"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3559"/>
         <source>Rename Fx : %1 &gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3602"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3611"/>
         <source>Group Fx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3706"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3715"/>
         <source>Ungroup Fx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3808"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3817"/>
         <source>Rename Group  : %1 &gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -525,7 +526,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="235"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="231"/>
         <source>Argument &apos;%1&apos; does not look like a FrameId</source>
         <translation type="unfinished"></translation>
     </message>
@@ -721,14 +722,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="742"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="770"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="760"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="788"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="28"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="744"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="762"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -749,7 +750,7 @@
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="32"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="746"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="764"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
@@ -760,7 +761,7 @@
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="34"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="748"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="766"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -790,18 +791,53 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="750"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="768"/>
         <source>DarkYellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="752"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="770"/>
         <source>DarkCyan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="754"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="772"/>
         <source>DarkMagenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="540"/>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="542"/>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="544"/>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="546"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="548"/>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="550"/>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="552"/>
+        <source>Y displ</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/norwegian_bokmal/toonzqt.ts
+++ b/toonz/sources/translations/norwegian_bokmal/toonzqt.ts
@@ -19,17 +19,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="248"/>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="484"/>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="620"/>
         <source>Insert </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
         <source>Add </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="629"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
         <source>Replace </source>
         <translation type="unfinished"></translation>
     </message>
@@ -91,12 +101,12 @@
 <context>
     <name>CameraPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="506"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="518"/>
         <source>&amp;Reset Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="509"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="521"/>
         <source>&amp;Activate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -104,80 +114,112 @@
 <context>
     <name>CameraSettingsWidget</name>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="195"/>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="199"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="210"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="215"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="198"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="214"/>
         <source>DPI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="200"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="216"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="204"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="221"/>
         <source>Use Current Level Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="207"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="224"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="208"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="225"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="245"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="262"/>
         <source>Force Squared Pixel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="406"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="210"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="215"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="432"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="414"/>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="846"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="186"/>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="187"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="188"/>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="189"/>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="190"/>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="217"/>
+        <source>A/R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="441"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="873"/>
         <source>&lt;custom&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="892"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="919"/>
         <source>Bad camera preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="893"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="920"/>
         <source>&apos;%1&apos; doesn&apos;t seem a well formed camera preset. 
 Possibly the preset file has been corrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="926"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="953"/>
         <source>Preset name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="927"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="954"/>
         <source>Enter the name for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="932"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="959"/>
         <source>Error : Preset Name is Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="933"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="960"/>
         <source>The preset name must not use &apos;,&apos;(comma).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,27 +227,27 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>ChannelHisto</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="262"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="282"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="266"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="286"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="270"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="290"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="274"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="294"/>
         <source>Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="278"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="298"/>
         <source>RGB</source>
         <translation type="unfinished"></translation>
     </message>
@@ -220,51 +262,6 @@ Possibly the preset file has been corrupted</source>
     <message>
         <location filename="../../toonzqt/cleanupcamerasettingswidget.cpp" line="60"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorChannelControl</name>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1379"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1381"/>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -309,7 +306,7 @@ Zero is fully transparent.</source>
 <context>
     <name>ColumnPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="208"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="220"/>
         <source>&amp;Reset Center</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,47 +314,59 @@ Zero is fully transparent.</source>
 <context>
     <name>ComboHistoRGBLabel</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="393"/>
-        <location filename="../../toonzqt/combohistogram.cpp" line="401"/>
-        <location filename="../../toonzqt/combohistogram.cpp" line="408"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="418"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="427"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="436"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="442"/>
         <source>R:%1 G:%2 B:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/combohistogram.cpp" line="422"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="431"/>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/combohistogram.cpp" line="446"/>
+        <source>A:%1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ComboHistogram</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="445"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="496"/>
         <source>8bit (0-255)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="447"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="498"/>
         <source>16bit (0-65535)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="450"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="501"/>
         <source>0.0-1.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="463"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="522"/>
         <source>Picked Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="471"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="530"/>
         <source>Average Color (Ctrl + Drag)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="479"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="538"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="483"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="541"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -501,292 +510,319 @@ Zero is fully transparent.</source>
 <context>
     <name>FlipConsole</name>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="805"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="924"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1651"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1714"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="816"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="941"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1698"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1763"/>
         <source> FPS </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="829"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="842"/>
         <source>This value is different than the scene framerate.
 Control click to reset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="908"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="925"/>
         <source>Cannot set the scene fps to a negative value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1197"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1223"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1201"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1227"/>
         <source>Snapshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1204"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1230"/>
         <source>Define Sub-camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1206"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1232"/>
         <source>Define Loading Box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1208"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1234"/>
         <source>Use Loading Box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1213"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1239"/>
         <source>Background Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1215"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1241"/>
         <source>Playback Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1219"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1245"/>
         <source>Color Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1222"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1248"/>
         <source>Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1225"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1251"/>
         <source>Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1228"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1254"/>
         <source>Locator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1230"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1256"/>
         <source>Set Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1233"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1259"/>
         <source>Display Areas as Filled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1240"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1266"/>
         <source>Viewer Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1243"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1269"/>
         <source>Framerate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1269"/>
-        <source>&amp;Save Images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1276"/>
-        <source>&amp;Snapshot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1280"/>
-        <source>&amp;Compare to Snapshot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1289"/>
-        <source>&amp;Define Sub-camera</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1294"/>
-        <source>&amp;Define Loading Box</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1272"/>
+        <source>Gain Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonzqt/flipconsole.cpp" line="1298"/>
-        <source>&amp;Use Loading Box</source>
+        <source>&amp;Save Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1307"/>
-        <source>&amp;White Background</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1305"/>
+        <source>&amp;Snapshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1310"/>
-        <source>&amp;Black Background</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1309"/>
+        <source>&amp;Compare to Snapshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1314"/>
-        <source>&amp;Checkered Background</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1321"/>
-        <source>&amp;First Frame</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1318"/>
+        <source>&amp;Define Sub-camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonzqt/flipconsole.cpp" line="1323"/>
-        <source>&amp;Previous Frame</source>
+        <source>&amp;Define Loading Box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1325"/>
-        <source>Pause</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1327"/>
+        <source>&amp;Use Loading Box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1328"/>
-        <source>Play</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1336"/>
+        <source>&amp;White Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1331"/>
-        <source>Loop</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1339"/>
+        <source>&amp;Black Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1335"/>
-        <source>&amp;Next Frame</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1337"/>
-        <source>&amp;Last Frame</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1346"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1349"/>
-        <source>Red Channel</source>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1343"/>
+        <source>&amp;Checkered Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonzqt/flipconsole.cpp" line="1350"/>
+        <source>&amp;First Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1352"/>
+        <source>&amp;Previous Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1354"/>
+        <source>Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1357"/>
+        <source>Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1360"/>
+        <source>Loop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1364"/>
+        <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1366"/>
+        <source>&amp;Last Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1375"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1378"/>
+        <source>Red Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1379"/>
         <source>Red Channel in Grayscale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1353"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1357"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1382"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1386"/>
         <source>Green Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1358"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1387"/>
         <source>Green Channel in Grayscale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1361"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1364"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1390"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1393"/>
         <source>Blue Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1365"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1394"/>
         <source>Blue Channel in Grayscale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1371"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1400"/>
         <source>Alpha Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1381"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1410"/>
         <source>&amp;Soundtrack </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1385"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1414"/>
         <source>&amp;Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1387"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1416"/>
         <source>&amp;Locator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1394"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1423"/>
         <source>&amp;Display Areas as Filled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1408"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1437"/>
         <source>&amp;Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1410"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1439"/>
         <source>&amp;Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1412"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1441"/>
         <source>&amp;Flip Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1414"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1443"/>
         <source>&amp;Flip Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1416"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1445"/>
         <source>&amp;Reset View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1657"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1451"/>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1457"/>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1462"/>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1704"/>
         <source> FPS	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1842"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1905"/>
         <source>Set the current frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1846"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1909"/>
         <source>Drag to play the animation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1906"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1976"/>
         <source>Set the playback frame rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="2238"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="2254"/>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FontParamField</name>
     <message>
-        <location filename="../../toonzqt/paramfield.cpp" line="1678"/>
+        <location filename="../../toonzqt/paramfield.cpp" line="1681"/>
         <source>Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paramfield.cpp" line="1682"/>
+        <location filename="../../toonzqt/paramfield.cpp" line="1685"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,132 +862,132 @@ Control click to reset.</source>
 <context>
     <name>FunctionPanel</name>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="255"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="256"/>
         <source>Function Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1548"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1579"/>
         <source>Link Handles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1549"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1580"/>
         <source>Unlink Handles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1550"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1581"/>
         <source>Reset Handles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1551"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1582"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1552"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1583"/>
         <source>Set Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1553"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1584"/>
         <source>Activate Cycle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1554"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1585"/>
         <source>Deactivate Cycle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1555"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1586"/>
         <source>Linear Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1556"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1587"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1557"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1588"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1558"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1589"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1559"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1590"/>
         <source>Exponential Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1560"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1591"/>
         <source>Expression Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1561"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1592"/>
         <source>File Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1562"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1593"/>
         <source>Constant Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1563"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1594"/>
         <source>Similar Shape Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1564"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1595"/>
         <source>Fit Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1565"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1596"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1566"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1597"/>
         <source>Step 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1567"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1598"/>
         <source>Step 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1568"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1599"/>
         <source>Step 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1569"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1600"/>
         <source>Step 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1641"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1672"/>
         <source>Smooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1642"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1673"/>
         <source>Frame Based</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1643"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1674"/>
         <source>Curve Shape</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1100,7 +1136,7 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheet</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1196"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1206"/>
         <source>Function Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1116,87 +1152,87 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheetCellViewer</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1038"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1048"/>
         <source>Delete Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1039"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1049"/>
         <source>Set Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1042"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
         <source>Constant Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1042"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
         <source>Linear Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1043"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1053"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1044"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1054"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1045"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1055"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1046"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1056"/>
         <source>Exponential Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1047"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1057"/>
         <source>Expression Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1047"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1057"/>
         <source>File Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1048"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1058"/>
         <source>Similar Shape Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1049"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1059"/>
         <source>Activate Cycle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1050"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1060"/>
         <source>Deactivate Cycle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1051"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1061"/>
         <source>Show Inbetween Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1062"/>
         <source>Hide Inbetween Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1102"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1112"/>
         <source>Change Interpolation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1117"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1127"/>
         <source>Change Step</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,7 +1240,7 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheetColumnHeadViewer</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="456"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="465"/>
         <source>Some key(s) in this parameter loses original reference in expression.
 Manually changing any keyframe will clear the warning.</source>
         <translation type="unfinished"></translation>
@@ -1226,17 +1262,17 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FunctionTreeModel</name>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="895"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="859"/>
         <source>Stage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="896"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="860"/>
         <source>FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1060"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1024"/>
         <source>Plastic Skeleton</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1244,7 +1280,7 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FunctionTreeModel::Channel</name>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="668"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="632"/>
         <source>Some key(s) in this parameter loses original reference in expression.
 Manually changing any keyframe will clear the warning.</source>
         <translation type="unfinished"></translation>
@@ -1253,19 +1289,19 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FunctionTreeView</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="581"/>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1677"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="590"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1637"/>
         <source>Show Animated Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="582"/>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1678"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="591"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1638"/>
         <source>Show All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="583"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="592"/>
         <source>Hide Selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1275,17 +1311,17 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1649"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1609"/>
         <source>Save Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1650"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1610"/>
         <source>Load Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1651"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1611"/>
         <source>Export Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,32 +1329,32 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxColumnPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="267"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="280"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="271"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="286"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="278"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="294"/>
         <source>&amp;Paste Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="281"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="298"/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="288"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="305"/>
         <source>&amp;Uncache Fx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="288"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="305"/>
         <source>&amp;Cache FX</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,17 +1362,17 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxOutputPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1055"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1117"/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1073"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1136"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1076"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1139"/>
         <source>&amp;Activate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1344,77 +1380,77 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="703"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="747"/>
         <source>&amp;Open Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="706"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="751"/>
         <source>&amp;Paste Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="709"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="755"/>
         <source>&amp;Paste Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="715"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="762"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="719"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="767"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="723"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="773"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="727"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="778"/>
         <source>&amp;Create Linked FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="730"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="782"/>
         <source>&amp;Unlink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="733"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="786"/>
         <source>&amp;Make Macro FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="736"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="790"/>
         <source>&amp;Explode Macro FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="740"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="795"/>
         <source>&amp;Open Macro FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="743"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="799"/>
         <source>&amp;Save As Preset...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="746"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="803"/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="752"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="811"/>
         <source>&amp;Uncache FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="752"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="811"/>
         <source>&amp;Cache FX</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1422,17 +1458,17 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxPalettePainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="483"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="512"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="487"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="518"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="491"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="523"/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1440,12 +1476,12 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxPassThroughPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3842"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3913"/>
         <source>&amp;Paste Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3845"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3917"/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1453,12 +1489,12 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicLink</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1121"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1185"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1124"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1189"/>
         <source>&amp;Paste Insert</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1466,7 +1502,7 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicOutputNode</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="2248"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="2316"/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1474,8 +1510,8 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicPassThroughNode</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3896"/>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="4007"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3968"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="4079"/>
         <source> (Pass Through)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,12 +1519,12 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicPort</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1590"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1656"/>
         <source>&amp;Disconnect from Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1594"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1662"/>
         <source>&amp;Connect to Scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1496,19 +1532,19 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicScene</name>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1787"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1776"/>
         <source>Cannot Paste Insert a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1797"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1786"/>
         <source>Cannot Paste Add a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1807"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1796"/>
         <source>Cannot Paste Replace a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation type="unfinished"></translation>
@@ -1517,7 +1553,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>FxSchematicXSheetNode</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="2325"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="2393"/>
         <source>Scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1525,37 +1561,37 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>FxSettings</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1318"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1351"/>
         <source>&amp;Camera Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1324"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1357"/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1337"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1370"/>
         <source>&amp;White Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1345"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1378"/>
         <source>&amp;Black Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1352"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1385"/>
         <source>&amp;Checkered Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1424"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1470"/>
         <source>Fx Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1426"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1472"/>
         <source> : </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1563,17 +1599,17 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>FxXSheetPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="951"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1011"/>
         <source>Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="985"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1046"/>
         <source>&amp;Paste Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="988"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1050"/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1581,7 +1617,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>GroupPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="349"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="361"/>
         <source>&amp;Open Group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1649,42 +1685,42 @@ Select FX nodes and related links before copying or cutting the selection you wa
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="890"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="894"/>
         <source>Open Color Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="891"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
         <source>Text or XML (*.txt *.xml);;Text files (*.txt);;XML files (*.xml)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="899"/>
         <source>Hex Color Names Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="899"/>
         <source>Do you want to merge with existing entries?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="901"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="905"/>
         <source>Error importing color names XML</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="917"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="921"/>
         <source>Save Color Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="918"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="922"/>
         <source>XML files (*.xml);;Text files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="927"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="931"/>
         <source>Error exporting color names XML</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1730,7 +1766,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>InfoViewer</name>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="117"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="118"/>
         <source>File Info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1766,32 +1802,32 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>NewStyleSetPopup</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6960"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7190"/>
         <source>New Style Set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6963"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7193"/>
         <source>Style Set Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6965"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7195"/>
         <source>Create as Favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6968"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7198"/>
         <source>Style Set Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6994"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7224"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6995"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7225"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1817,34 +1853,23 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>PageViewer</name>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="609"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="613"/>
         <source>- No Styles -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="686"/>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="942"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="690"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="955"/>
         <source> + </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1179"/>
-        <source>Name Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1233"/>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1417"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1436"/>
         <source>New Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1235"/>
-        <source>New Page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1403"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1422"/>
         <source>Style 0 is set to full transparent. 
 It can&apos;t be changed.  Ever.</source>
         <translation type="unfinished"></translation>
@@ -1853,193 +1878,216 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>PaletteViewer</name>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="152"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="154"/>
         <source>&amp;New Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="320"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="624"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="666"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="354"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="659"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="754"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="796"/>
         <source>&amp;Save Palette As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="321"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="512"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="625"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="667"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="355"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="640"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="653"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="755"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="797"/>
         <source>&amp;Save Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="322"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="628"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="670"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="722"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="356"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="758"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="800"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="852"/>
         <source>&amp;Save As Default Vector Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="323"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="629"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="671"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="725"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="357"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="759"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="801"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="855"/>
         <source>&amp;Save As Default Smart Raster Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="324"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="630"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="672"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="728"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="358"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="760"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="802"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="858"/>
         <source>&amp;Save As Default Raster Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="325"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="631"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="673"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="731"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="359"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="761"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="803"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="861"/>
         <source>&amp;Save As Default Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="376"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="401"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="442"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="478"/>
         <source>Lock Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="389"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="455"/>
         <source>Stay on Current Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="405"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="482"/>
         <source>&amp;Lock Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="453"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="499"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="618"/>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="545"/>
         <source>Drag this icon to a Studio or Project palette to add it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="457"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="925"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="549"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1057"/>
         <source>&amp;Move Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="463"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="555"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="484"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="576"/>
         <source>&amp;Small Thumbnails View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="485"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="577"/>
         <source>&amp;Medium Thumbnails View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="486"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="578"/>
         <source>&amp;Large Thumbnails View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="487"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="579"/>
         <source>&amp;List View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="490"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="582"/>
         <source>Show Style Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="513"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="604"/>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="606"/>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="614"/>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="641"/>
         <source>Save the palette.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="592"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="602"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="722"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="732"/>
         <source>&amp;New Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="626"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="668"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="756"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="798"/>
         <source>&amp;Palette Gizmo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="743"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="874"/>
         <source>New Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="755"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="887"/>
         <source>Delete Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1137"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1269"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1137"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1269"/>
         <source>Don&apos;t Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1146"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1278"/>
         <source>Failed to save palette.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1284"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1416"/>
         <source>Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1288"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1420"/>
         <source>Level Palette: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1295"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1427"/>
         <source>Cleanup Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1306"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1438"/>
         <source>Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1313"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1445"/>
         <source>     (Color Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1315"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1447"/>
         <source>)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1354"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1486"/>
         <source>Hide New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1355"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1487"/>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2075,7 +2123,7 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>ParamViewer</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1058"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1082"/>
         <source>Swatch Viewer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2083,15 +2131,22 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>ParamsPageSet</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="746"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="723"/>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1062"/>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PegbarPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="416"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="428"/>
         <source>&amp;Reset Center</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2099,12 +2154,12 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>PlaneViewer</name>
     <message>
-        <location filename="../../toonzqt/planeviewer.cpp" line="303"/>
+        <location filename="../../toonzqt/planeviewer.cpp" line="309"/>
         <source>Reset View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/planeviewer.cpp" line="308"/>
+        <location filename="../../toonzqt/planeviewer.cpp" line="314"/>
         <source>Fit To Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,28 +2188,28 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="953"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="980"/>
         <source>Deleting &quot;%1&quot;.
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="955"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="982"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="955"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="982"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="856"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1350"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1436"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2026"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2045"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2153"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6423"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="773"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="1076"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="775"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1078"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2211,10 +2266,10 @@ Are you sure?</source>
     </message>
     <message>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2026"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2045"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2153"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6423"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2245,12 +2300,12 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/gutil.cpp" line="608"/>
+        <location filename="../../toonzqt/gutil.cpp" line="676"/>
         <source>The file name cannot be empty or contain any of the following characters: (new line) \ / : * ? &quot; |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/gutil.cpp" line="635"/>
+        <location filename="../../toonzqt/gutil.cpp" line="703"/>
         <source>That is a reserved file name and cannot be used.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2300,182 +2355,187 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="174"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="175"/>
         <source>Current Frame: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="177"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="178"/>
         <source>File History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="185"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="186"/>
         <source>Fullpath:     </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="186"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="187"/>
         <source>File Type:    </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="187"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="188"/>
         <source>Frames:       </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="188"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="189"/>
         <source>Owner:        </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="189"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="190"/>
         <source>Size:         </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="191"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="192"/>
         <source>Created:      </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="192"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="193"/>
         <source>Modified:     </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="193"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="194"/>
         <source>Last Access:  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="197"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="198"/>
         <source>Image Size:   </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="198"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="199"/>
         <source>SaveBox:      </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="199"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="200"/>
         <source>Bits/Sample:  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="200"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="201"/>
         <source>Sample/Pixel: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="201"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="202"/>
         <source>Dpi:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="202"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="203"/>
         <source>Orientation:  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="203"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="204"/>
         <source>Compression:  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="204"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="205"/>
         <source>Quality:      </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="205"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="206"/>
         <source>Smoothing:    </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="206"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="207"/>
         <source>Codec:        </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="207"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="208"/>
         <source>Alpha Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="208"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="209"/>
         <source>Byte Ordering:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="209"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="210"/>
         <source>H Pos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="210"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="211"/>
         <source>Palette Pages:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="211"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="212"/>
         <source>Palette Styles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="213"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="214"/>
         <source>Camera Size:      </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="214"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="215"/>
         <source>Camera Dpi:       </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="215"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="216"/>
         <source>Number of Frames: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="216"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="217"/>
         <source>Number of Levels: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="217"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="218"/>
         <source>Output Path:      </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="218"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="219"/>
         <source>Endianess:      </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="221"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="222"/>
         <source>Length:       </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="222"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="223"/>
         <source>Channels: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="223"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="224"/>
         <source>Sample Rate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="224"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="225"/>
         <source>Sample Size:      </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="549"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="226"/>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/infoviewer.cpp" line="579"/>
         <source>The file %1 does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2542,28 +2602,43 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/lutcalibrator.cpp" line="520"/>
-        <location filename="../../toonzqt/lutcalibrator.cpp" line="537"/>
+        <location filename="../../toonzqt/lutcalibrator.cpp" line="524"/>
+        <location filename="../../toonzqt/lutcalibrator.cpp" line="545"/>
         <source>Failed to Load 3DLUT File.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/menubarcommand.cpp" line="292"/>
+        <location filename="../../toonzqt/menubarcommand.cpp" line="293"/>
         <source>It is not possible to assign a shortcut with modifiers to the visualization commands.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1114"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1246"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1115"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1247"/>
         <source>Don&apos;t Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1705"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1196"/>
+        <source>Name Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1252"/>
+        <source>New Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1255"/>
+        <source>New Page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1720"/>
         <source>Click &amp; Drag Palette into Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2629,12 +2704,12 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1124"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1219"/>
         <source>Stage Schematic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1146"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1241"/>
         <source>FX Schematic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2644,28 +2719,28 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1007"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="999"/>
         <source>Save Motion Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1009"/>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1059"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1001"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1051"/>
         <source>Motion Path files (*.mpath)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1047"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1039"/>
         <source>It is not possible to save the motion path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1057"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1049"/>
         <source>Load Motion Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1087"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1079"/>
         <source>It is not possible to load the motion path.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2675,175 +2750,322 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2023"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1363"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1380"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1382"/>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2032"/>
         <source>Removing a Style will permanently delete the style file. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2041"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2050"/>
         <source>Emptying Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2149"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2162"/>
         <source>Removing Style Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2607"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2251"/>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2307"/>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2314"/>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2318"/>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2326"/>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2341"/>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2358"/>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2380"/>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2388"/>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2396"/>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2413"/>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2431"/>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2442"/>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2448"/>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2460"/>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2465"/>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2472"/>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2480"/>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2488"/>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2639"/>
         <source>Plain color</source>
         <comment>CustomStyleChooserPage</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2822"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2856"/>
         <source>Plain color</source>
         <comment>VectorBrushStyleChooserPage</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3075"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3115"/>
         <source>Plain color</source>
         <comment>TextureStyleChooserPage</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3087"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3127"/>
         <source>Custom Texture</source>
         <comment>TextureStyleChooserPage</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3253"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3300"/>
         <source>Plain color</source>
         <comment>MyPaintBrushStyleChooserPage</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3447"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3551"/>
         <source>Plain color</source>
         <comment>SpecialStyleChooserPage</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6420"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3725"/>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3883"/>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6639"/>
         <source>Removing the selected Styles will permanently delete style files from their sets. This cannot be undone!
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="186"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="187"/>
         <source>It is not possible to delete the style #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="321"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="323"/>
         <source>Paste Style  in Palette : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="397"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="399"/>
         <source>Delete Style  from Palette : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="466"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="468"/>
         <source>Cut Style  from Palette : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="587"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="659"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="589"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="661"/>
         <source>It is not possible to delete styles #0 and #1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="638"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="640"/>
         <source>Can&apos;t paste styles there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="759"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="761"/>
         <source>There are no unused styles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="766"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="768"/>
         <source>and %1 more styles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="769"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="771"/>
         <source>Erasing unused styles with following indices. Are you sure?
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="773"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="775"/>
         <source>Erase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1037"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1039"/>
         <source>  to Palette : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1040"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1042"/>
         <source>Paste Color &amp;&amp; Name%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1042"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1044"/>
         <source>Paste Name%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1044"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1046"/>
         <source>Paste Color%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1046"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1048"/>
         <source>Paste%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1062"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1064"/>
         <source>Can&apos;t modify color #0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1072"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1074"/>
         <source>There are more cut/copied styles than selected. Paste anyway (adding styles)?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1076"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1317"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1319"/>
         <source>Blend Colors  in Palette : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1447"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1449"/>
         <source>Toggle Link  in Palette : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1637"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1639"/>
         <source>Remove Reference  in Palette : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1754"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1756"/>
         <source>Get Color from Studio Palette</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2867,9 +3089,9 @@ Are you sure?</source>
 <context>
     <name>RenameStyleSet</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7152"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7167"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7179"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7385"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7400"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7412"/>
         <source> (Favorites)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2918,76 +3140,76 @@ Are you sure?</source>
 <context>
     <name>SchematicViewer</name>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="971"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1066"/>
         <source>&amp;Fit to Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="977"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1072"/>
         <source>&amp;Focus on Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="982"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1077"/>
         <source>&amp;Reorder Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="988"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1083"/>
         <source>&amp;Reset Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="995"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1171"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1227"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1090"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1266"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1322"/>
         <source>&amp;Minimize Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="995"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1172"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1228"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1090"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1267"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1323"/>
         <source>&amp;Maximize Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1001"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1096"/>
         <source>&amp;Selection Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1006"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1101"/>
         <source>&amp;Zoom Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1011"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1106"/>
         <source>&amp;Hand Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1019"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1114"/>
         <source>&amp;New Pegbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1026"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1121"/>
         <source>&amp;New Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1033"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1128"/>
         <source>&amp;New Motion Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1041"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1136"/>
         <source>&amp;Switch output port display mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1056"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1151"/>
         <source>&amp;Toggle node icons</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2995,21 +3217,8 @@ Are you sure?</source>
 <context>
     <name>SchematicWindowEditor</name>
     <message>
-        <location filename="../../toonzqt/schematicgroupeditor.cpp" line="170"/>
+        <location filename="../../toonzqt/schematicgroupeditor.cpp" line="164"/>
         <source>&amp;Close Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SettingsPage</name>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3621"/>
-        <source>Autopaint for Lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3779"/>
-        <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3074,17 +3283,17 @@ Are you sure?</source>
 <context>
     <name>SplinePainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="680"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="692"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="683"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="695"/>
         <source>&amp;Save Motion Path...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="685"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="697"/>
         <source>&amp;Load Motion Path...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3105,17 +3314,17 @@ Are you sure?</source>
 <context>
     <name>StageSchematicScene</name>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1179"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1171"/>
         <source>&amp;New Pegbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1183"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1175"/>
         <source>&amp;New Motion Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1187"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1179"/>
         <source>&amp;New Camera</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3266,296 +3475,221 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2238"/>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2283"/>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2290"/>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2294"/>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2302"/>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2317"/>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2334"/>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2356"/>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2364"/>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2372"/>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2389"/>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2407"/>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2418"/>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2424"/>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2436"/>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2441"/>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2448"/>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2456"/>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2464"/>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4215"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4324"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4216"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4325"/>
         <source>HSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4217"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4326"/>
         <source>Alpha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4218"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4327"/>
         <source>RGB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4255"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4373"/>
         <source>Show or hide parts of the Color Page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4176"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4286"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4179"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4289"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4186"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4295"/>
         <source>Apply changes to current style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4191"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4300"/>
         <source>Automatically update style changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4195"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4304"/>
         <source>Return To Previous Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4200"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4309"/>
         <source>Current Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5622"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6943"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7173"/>
         <source>Generated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4499"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4505"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4507"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4754"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4760"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4762"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4501"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4756"/>
         <source>Texture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4502"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4757"/>
         <source>Vector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4500"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4755"/>
         <source>Raster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4219"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4328"/>
         <source>Hex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4244"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4329"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4357"/>
         <source>Toggle Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4247"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4361"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5562"/>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4365"/>
         <source>Hex Color Names...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4261"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4379"/>
         <source>Show or hide style sets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4503"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4508"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4488"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4560"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4633"/>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4758"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4763"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4768"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5033"/>
         <source>No Style Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4785"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5050"/>
         <source>Cleanup </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4787"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5052"/>
         <source>Studio </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4789"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5054"/>
         <source>Level </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5057"/>
         <source>Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4806"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5071"/>
         <source>Style Editor - No Valid Style Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5623"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5563"/>
+        <source>Show Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5793"/>
         <source>My Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5626"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6862"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5796"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7090"/>
         <source> (Favorites)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5629"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5799"/>
         <source> (External)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5892"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5915"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5938"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6074"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6097"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6120"/>
         <source>Show All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5897"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5920"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5943"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6079"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6102"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6125"/>
         <source>Hide All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5902"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5925"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5948"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6084"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6107"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6130"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5907"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5930"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5953"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6089"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6112"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6135"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6900"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7128"/>
         <source>Style Set Name cannot be empty or contain any of the following characters:
  \ / : * ? &quot; &lt; &gt; |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6945"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7175"/>
         <source>Style Set Name already exists. Please try another name.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3563,8 +3697,9 @@ Are you sure ?</source>
 <context>
     <name>StyleIndexLineEdit</name>
     <message>
-        <location filename="../../toonzqt/styleindexlineedit.cpp" line="19"/>
-        <location filename="../../toonzqt/styleindexlineedit.cpp" line="37"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="20"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="23"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="42"/>
         <source>current</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3610,12 +3745,12 @@ Are you sure ?</source>
 <context>
     <name>SwatchViewer</name>
     <message>
-        <location filename="../../toonzqt/swatchviewer.cpp" line="845"/>
+        <location filename="../../toonzqt/swatchviewer.cpp" line="846"/>
         <source>Reset View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/swatchviewer.cpp" line="850"/>
+        <location filename="../../toonzqt/swatchviewer.cpp" line="851"/>
         <source>Fit To Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3651,12 +3786,12 @@ Are you sure ?</source>
 <context>
     <name>TablePainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="586"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="598"/>
         <source>Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="596"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="608"/>
         <source>&amp;Reset Center</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3664,22 +3799,22 @@ Are you sure ?</source>
 <context>
     <name>ToneCurveField</name>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="902"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="906"/>
         <source>Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="905"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="909"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="923"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="927"/>
         <source>Output:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="926"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="930"/>
         <source>Input:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/toonz/sources/translations/release.sh
+++ b/toonz/sources/translations/release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Usage: release.sh LANGUAGE DESTINATION
+
+BASE_DIR=$(cd `dirname "$0"`; pwd)
+TOONZLANG=$1
+DESTINATION=$2
+
+
+[ -d "${BASE_DIR}/${TOONZLANG}" ] || mkdir -p ../../../stuff/config/loc/${DESTINATION}
+cd "${BASE_DIR}/${TOONZLANG}"
+lrelease colorfx.ts -qm colorfx.qm
+lrelease tnzcore.ts -qm tnzcore.qm
+lrelease toonz.ts -qm toonz.qm
+lrelease toonzqt.ts -qm toonzqt.qm
+lrelease image.ts -qm image.qm
+lrelease tnztools.ts -qm tnztools.qm
+lrelease toonzlib.ts -qm toonzlib.qm
+
+mv *.qm ../../../../stuff/config/loc/${DESTINATION}

--- a/toonz/sources/translations/releaseAll.sh
+++ b/toonz/sources/translations/releaseAll.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Usage: releaseAll.sh
+
+BASE_DIR=$(cd `dirname "$0"`; pwd)
+
+./release.sh brazilian-portuguese 'Português(Brasil)'
+./release.sh chinese 中文
+./release.sh czech Čeština
+./release.sh french Français
+./release.sh german Deutsch
+./release.sh italian Italiano
+./release.sh japanese 日本語
+./release.sh korean 한국어
+./release.sh russian Русский
+./release.sh spanish Español

--- a/toonz/sources/translations/russian/colorfx.ts
+++ b/toonz/sources/translations/russian/colorfx.ts
@@ -19,9 +19,37 @@
         <translation>Шум</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="460"/>
+        <location filename="../../colorfx/regionstyles.h" line="467"/>
         <source>Irregular</source>
         <translation>Нерегулярный</translation>
+    </message>
+</context>
+<context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="129"/>
+        <source>Density</source>
+        <translation type="unfinished">Плотность</translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="131"/>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="133"/>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.cpp" line="135"/>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../colorfx/flowlinestrokestyle.h" line="58"/>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -70,7 +98,7 @@
         <translation>расстояние</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1240"/>
+        <location filename="../../colorfx/strokestyles.h" line="1275"/>
         <source>OutlineViewer(OnlyDebug)</source>
         <translation>OutlineViewer(OnlyDebug)</translation>
     </message>
@@ -93,7 +121,7 @@
         <translation>Длина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="120"/>
+        <location filename="../../colorfx/regionstyles.h" line="121"/>
         <source>Hatched Shading</source>
         <translation>Заштрихованная заливка</translation>
     </message>
@@ -111,7 +139,7 @@
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="169"/>
+        <location filename="../../colorfx/regionstyles.h" line="171"/>
         <source>Plain Shadow</source>
         <translation>Обычная тень</translation>
     </message>
@@ -124,7 +152,7 @@
         <translation>Аэрограф</translation>
     </message>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="69"/>
+        <location filename="../../colorfx/rasterstyles.h" line="70"/>
         <source>Blur value</source>
         <translation>Величина размытия</translation>
     </message>
@@ -132,7 +160,7 @@
 <context>
     <name>TBiColorStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="577"/>
+        <location filename="../../colorfx/strokestyles.h" line="594"/>
         <source>Shade</source>
         <translation>Тень</translation>
     </message>
@@ -140,7 +168,7 @@
 <context>
     <name>TBlendRasterStyle</name>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="122"/>
+        <location filename="../../colorfx/rasterstyles.h" line="123"/>
         <source>Blend</source>
         <translation>Смешение</translation>
     </message>
@@ -163,7 +191,7 @@
         <translation>Fade Out</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="725"/>
+        <location filename="../../colorfx/strokestyles.h" line="745"/>
         <source>Fade</source>
         <translation>Затухание</translation>
     </message>
@@ -176,7 +204,7 @@
         <translation>Вращение</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="385"/>
+        <location filename="../../colorfx/strokestyles.h" line="398"/>
         <source>Plait</source>
         <translation>Заплетание</translation>
     </message>
@@ -184,7 +212,7 @@
 <context>
     <name>TBubbleStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="475"/>
+        <location filename="../../colorfx/strokestyles.h" line="490"/>
         <source>Bubbles</source>
         <translation>Пузыри</translation>
     </message>
@@ -192,7 +220,7 @@
 <context>
     <name>TChainStrokeStyle</name>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="133"/>
+        <location filename="../../colorfx/strokestyles.h" line="134"/>
         <source>Chain</source>
         <translation>Цепь</translation>
     </message>
@@ -210,7 +238,7 @@
         <translation>Размер точки</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="508"/>
+        <location filename="../../colorfx/regionstyles.h" line="516"/>
         <source>Chalk</source>
         <translation>Мел</translation>
     </message>
@@ -243,7 +271,7 @@
         <translation>Шум</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="672"/>
+        <location filename="../../colorfx/strokestyles.h" line="691"/>
         <source>Chalk</source>
         <translation>Мел</translation>
     </message>
@@ -276,7 +304,7 @@
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="399"/>
+        <location filename="../../colorfx/regionstyles.h" line="405"/>
         <source>Square</source>
         <translation>Квадрат</translation>
     </message>
@@ -299,7 +327,7 @@
         <translation>Угол</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="559"/>
+        <location filename="../../colorfx/regionstyles.h" line="569"/>
         <source>Chessboard</source>
         <translation>Шахматная доска</translation>
     </message>
@@ -327,7 +355,7 @@
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="766"/>
+        <location filename="../../colorfx/regionstyles.h" line="780"/>
         <source>Concentric</source>
         <translation>Концентрический</translation>
     </message>
@@ -345,7 +373,7 @@
         <translation>Непрозрачность</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="342"/>
+        <location filename="../../colorfx/strokestyles.h" line="352"/>
         <source>Tulle</source>
         <translation>Тюль</translation>
     </message>
@@ -363,7 +391,7 @@
         <translation>Расстояние между точек</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="346"/>
+        <location filename="../../colorfx/regionstyles.h" line="351"/>
         <source>Polka Dots</source>
         <translation>В горошек</translation>
     </message>
@@ -391,7 +419,7 @@
         <translation>Щель</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="254"/>
+        <location filename="../../colorfx/strokestyles.h" line="260"/>
         <source>Vanishing</source>
         <translation>Исчезающий</translation>
     </message>
@@ -404,7 +432,7 @@
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1090"/>
+        <location filename="../../colorfx/strokestyles.h" line="1119"/>
         <source>Striped</source>
         <translation>В полоску</translation>
     </message>
@@ -422,7 +450,7 @@
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1029"/>
+        <location filename="../../colorfx/strokestyles.h" line="1057"/>
         <source>Curl</source>
         <translation>Завивка</translation>
     </message>
@@ -453,7 +481,7 @@
         <translation>Плотность</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="206"/>
+        <location filename="../../colorfx/strokestyles.h" line="209"/>
         <source>Dashes</source>
         <translation>Черточки</translation>
     </message>
@@ -481,7 +509,7 @@
         <translation>Гладкость</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="665"/>
+        <location filename="../../colorfx/regionstyles.h" line="677"/>
         <source>Linear Gradient</source>
         <translation>Линейный градиент</translation>
     </message>
@@ -494,7 +522,7 @@
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1152"/>
+        <location filename="../../colorfx/strokestyles.h" line="1184"/>
         <source>Watercolor</source>
         <translation>Акварель</translation>
     </message>
@@ -507,7 +535,7 @@
         <translation>Полосы</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="1304"/>
+        <location filename="../../colorfx/strokestyles.h" line="1340"/>
         <source>Toothpaste</source>
         <translation>Зубная паста</translation>
     </message>
@@ -535,7 +563,7 @@
         <translation>Максимальная толщина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="822"/>
+        <location filename="../../colorfx/regionstyles.h" line="839"/>
         <source>Stained Glass</source>
         <translation>Витражное стекло</translation>
     </message>
@@ -563,7 +591,7 @@
         <translation>Шум</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="872"/>
+        <location filename="../../colorfx/strokestyles.h" line="895"/>
         <source>Gouache</source>
         <translation>Гуашь</translation>
     </message>
@@ -571,7 +599,7 @@
 <context>
     <name>TNoColorRasterStyle</name>
     <message>
-        <location filename="../../colorfx/rasterstyles.h" line="151"/>
+        <location filename="../../colorfx/rasterstyles.h" line="153"/>
         <source>Markup</source>
         <translation>Markup</translation>
     </message>
@@ -600,7 +628,7 @@
     </message>
     <message>
         <location filename="../../colorfx/strokestyles.cpp" line="2022"/>
-        <location filename="../../colorfx/strokestyles.h" line="629"/>
+        <location filename="../../colorfx/strokestyles.h" line="647"/>
         <source>Bump</source>
         <translation>Выпуклость</translation>
     </message>
@@ -623,7 +651,7 @@
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="872"/>
+        <location filename="../../colorfx/regionstyles.h" line="890"/>
         <source>Beehive</source>
         <translation>Улей</translation>
     </message>
@@ -651,7 +679,7 @@
         <translation>Размер точки</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="283"/>
+        <location filename="../../colorfx/regionstyles.h" line="287"/>
         <source>Sponge Shading</source>
         <translation>Затенение губкой</translation>
     </message>
@@ -679,7 +707,7 @@
         <translation>Гладкость</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="718"/>
+        <location filename="../../colorfx/regionstyles.h" line="731"/>
         <source>Radial Gradient</source>
         <translation>Радиальный градиент</translation>
     </message>
@@ -692,7 +720,7 @@
         <translation>Наклон</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="299"/>
+        <location filename="../../colorfx/strokestyles.h" line="308"/>
         <source>Rope</source>
         <translation>Rope</translation>
     </message>
@@ -705,7 +733,7 @@
         <translation>Интенсивность</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="230"/>
+        <location filename="../../colorfx/regionstyles.h" line="233"/>
         <source>Blob</source>
         <translation>Капля</translation>
     </message>
@@ -718,7 +746,7 @@
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="827"/>
+        <location filename="../../colorfx/strokestyles.h" line="849"/>
         <source>Jagged</source>
         <translation>Зубчатый</translation>
     </message>
@@ -731,7 +759,7 @@
         <translation>Частота</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="990"/>
+        <location filename="../../colorfx/strokestyles.h" line="1017"/>
         <source>Wave</source>
         <translation>Волна</translation>
     </message>
@@ -744,7 +772,7 @@
         <translation>Плотность</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="433"/>
+        <location filename="../../colorfx/strokestyles.h" line="447"/>
         <source>Fuzz</source>
         <translation>Fuzz</translation>
     </message>
@@ -767,7 +795,7 @@
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="164"/>
+        <location filename="../../colorfx/strokestyles.h" line="166"/>
         <source>Circlets</source>
         <translation>Кружки</translation>
     </message>
@@ -790,7 +818,7 @@
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/regionstyles.h" line="610"/>
+        <location filename="../../colorfx/regionstyles.h" line="621"/>
         <source>Banded</source>
         <translation>Окаймленный</translation>
     </message>
@@ -808,7 +836,7 @@
         <translation>Размер границы</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="530"/>
+        <location filename="../../colorfx/strokestyles.h" line="546"/>
         <source>Gauze</source>
         <translation>Дымка</translation>
     </message>
@@ -826,7 +854,7 @@
         <translation>Тень</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="775"/>
+        <location filename="../../colorfx/strokestyles.h" line="796"/>
         <source>Ribbon</source>
         <translation>Лента</translation>
     </message>
@@ -867,7 +895,7 @@
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../../colorfx/strokestyles.h" line="942"/>
+        <location filename="../../colorfx/strokestyles.h" line="968"/>
         <source>Zigzag</source>
         <translation>Зигзаг</translation>
     </message>

--- a/toonz/sources/translations/russian/image.ts
+++ b/toonz/sources/translations/russian/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished">Масштаб</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished">Зациклить</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -12,6 +30,97 @@
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
         <translation>Без сжатия</translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished">Битов на пиксель</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished">Тип сжатия</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished">Качество</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
+        <translation type="unfinished">Масштаб</translation>
     </message>
 </context>
 <context>
@@ -110,14 +219,12 @@
 <context>
     <name>MovWriterProperties</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
         <source>Quality</source>
-        <translation>Качество</translation>
+        <translation type="vanished">Качество</translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
         <source>Scale</source>
-        <translation>Масштаб</translation>
+        <translation type="vanished">Масштаб</translation>
     </message>
 </context>
 <context>
@@ -144,12 +251,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation>FFmpeg вернул код ошибки: %1</translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/russian/tnzcore.ts
+++ b/toonz/sources/translations/russian/tnzcore.ts
@@ -30,7 +30,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../common/tvrender/tpalette.cpp" line="256"/>
+        <location filename="../../common/tvrender/tpalette.cpp" line="265"/>
         <source>colors</source>
         <translation>цвета</translation>
     </message>
@@ -51,12 +51,12 @@
 <context>
     <name>TCenterLineStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="886"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="899"/>
         <source>Constant</source>
         <translation>Постоянная</translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="919"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="938"/>
         <source>Thickness</source>
         <translation>Толщина</translation>
     </message>
@@ -64,12 +64,12 @@
 <context>
     <name>TRasterImagePatternStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1046"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1088"/>
         <source>Distance</source>
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1048"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1090"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>
@@ -77,12 +77,12 @@
 <context>
     <name>TVectorImagePatternStrokeStyle</name>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1478"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1551"/>
         <source>Distance</source>
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1480"/>
+        <location filename="../../common/tvrender/tsimplecolorstyles.cpp" line="1553"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>

--- a/toonz/sources/translations/russian/tnztools.ts
+++ b/toonz/sources/translations/russian/tnztools.ts
@@ -14,125 +14,125 @@
         <translation type="vanished">N/S:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="461"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="464"/>
         <source>SO:</source>
         <translatorcomment>порядок размещения:</translatorcomment>
         <translation>Порядок:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="629"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="632"/>
         <source>Position</source>
         <translation>Положение</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="443"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="446"/>
         <source>Z:</source>
         <translatorcomment>глубина</translatorcomment>
         <translation>Z:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="652"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="655"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="654"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="657"/>
         <source>)</source>
         <translation>)</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="677"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="680"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="701"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="704"/>
         <source>Scale</source>
         <translation>Масштаб</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="482"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="485"/>
         <source>Global:</source>
         <translation>Глобальный:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="444"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="447"/>
         <source>Position:</source>
         <translation>Положение:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="445"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="528"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="448"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="531"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="446"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="529"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="449"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="532"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="466"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="469"/>
         <source>Rotation:</source>
         <translation>Вращение:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="483"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="509"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="486"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="512"/>
         <source>H:</source>
         <translatorcomment>горизонтально</translatorcomment>
         <translation>H:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="484"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="510"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="487"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="513"/>
         <source>V:</source>
         <translatorcomment>вертикально</translatorcomment>
         <translation>V:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="589"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="592"/>
         <source>Flip Object Horizontally</source>
         <translation>Отразить объект по горизонтали</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="590"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="593"/>
         <source>Flip Object Vertically</source>
         <translation>Отразить объект по вертикали</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="591"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="594"/>
         <source>Rotate Object Left</source>
         <translation>Повернуть объект влево</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="592"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="595"/>
         <source>Rotate Object Right</source>
         <translation>Повернуть объект вправо</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="726"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="729"/>
         <source>Maintain:</source>
         <translation>Поддерживать:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="746"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="749"/>
         <source>Shear</source>
         <translation>Скос</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="778"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="781"/>
         <source>Center Position</source>
         <translation>Центральное положение</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="991"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="994"/>
         <source>Table</source>
         <translation>Стол</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="612"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="615"/>
         <source>Pick:</source>
         <translation>Выбрать:</translation>
     </message>
@@ -538,117 +538,117 @@
 <context>
     <name>EraserTool</name>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="775"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="428"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="863"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="435"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="790"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="429"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="878"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="436"/>
         <source>Selective</source>
         <translation>Избирательно</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="791"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="430"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="879"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="437"/>
         <source>Invert</source>
         <translation>Инвертировать</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="792"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="431"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="880"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="438"/>
         <source>Frame Range</source>
         <translation>Диапазон кадров</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="778"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="432"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="866"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="439"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="779"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="433"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="867"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="440"/>
         <source>Normal</source>
         <translation>Обычный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="780"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="434"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="868"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="441"/>
         <source>Rectangular</source>
         <translation>Прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="781"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="435"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="869"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="442"/>
         <source>Freehand</source>
         <translation>От руки</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="782"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="436"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="870"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="443"/>
         <source>Polyline</source>
         <translation>Полилиния</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="776"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="864"/>
         <source>Hardness:</source>
         <translation>Жесткость:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="783"/>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="437"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="871"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="444"/>
         <source>Segment</source>
         <translation>Сегмент</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="785"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="873"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="786"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="874"/>
         <source>Lines</source>
         <translation>Линии</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="787"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="875"/>
         <source>Areas</source>
         <translation>Области</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="788"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="876"/>
         <source>Lines &amp; Areas</source>
         <translation>Линии и области</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="793"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="881"/>
         <source>Pencil Mode</source>
         <translation>Режим карандаша</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastererasertool.cpp" line="794"/>
+        <location filename="../../tnztools/rastererasertool.cpp" line="882"/>
         <source>Savebox</source>
         <translation>Сейвбокс</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="440"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="447"/>
         <source>Linear</source>
         <translation>Линейный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="441"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="448"/>
         <source>Ease In</source>
         <translation>Замедление</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="442"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="449"/>
         <source>Ease Out</source>
         <translation>Ускорение</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectorerasertool.cpp" line="443"/>
+        <location filename="../../tnztools/vectorerasertool.cpp" line="450"/>
         <source>Ease In/Out</source>
         <translation>Замедл. в начале/в конце</translation>
     </message>
@@ -656,112 +656,117 @@
 <context>
     <name>FillTool</name>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2128"/>
+        <location filename="../../tnztools/filltool.cpp" line="2399"/>
         <source>Frame Range</source>
         <translation>Диапазон кадров</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2130"/>
+        <location filename="../../tnztools/filltool.cpp" line="2401"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2131"/>
+        <location filename="../../tnztools/filltool.cpp" line="2402"/>
         <source>Normal</source>
         <translation>Обычная</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2132"/>
+        <location filename="../../tnztools/filltool.cpp" line="2403"/>
         <source>Rectangular</source>
         <translation>Прямоугольная</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2133"/>
+        <location filename="../../tnztools/filltool.cpp" line="2404"/>
         <source>Freehand</source>
         <translation>От руки</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2134"/>
+        <location filename="../../tnztools/filltool.cpp" line="2405"/>
         <source>Polyline</source>
         <translation>Полилиния</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2136"/>
+        <location filename="../../tnztools/filltool.cpp" line="2406"/>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/filltool.cpp" line="2408"/>
         <source>Selective</source>
         <translation>Избирательно</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2138"/>
+        <location filename="../../tnztools/filltool.cpp" line="2410"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2139"/>
+        <location filename="../../tnztools/filltool.cpp" line="2411"/>
         <source>Lines</source>
         <translation>Линии</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2140"/>
+        <location filename="../../tnztools/filltool.cpp" line="2412"/>
         <source>Areas</source>
         <translation>Области</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2141"/>
+        <location filename="../../tnztools/filltool.cpp" line="2413"/>
         <source>Lines &amp; Areas</source>
         <translation>Линии и области</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2143"/>
+        <location filename="../../tnztools/filltool.cpp" line="2415"/>
         <source>Onion Skin</source>
         <translation>Калька</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2144"/>
+        <location filename="../../tnztools/filltool.cpp" line="2416"/>
         <source>Refer Visible</source>
         <translation>Учитывать видимые</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2145"/>
+        <location filename="../../tnztools/filltool.cpp" line="2417"/>
         <source>Fill Depth</source>
         <translation>Глубина заливки</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2146"/>
+        <location filename="../../tnztools/filltool.cpp" line="2418"/>
         <source>Segment</source>
         <translation>Сегмент</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2147"/>
+        <location filename="../../tnztools/filltool.cpp" line="2419"/>
         <source>Maximum Gap</source>
         <translation>Максимальный зазор</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2148"/>
+        <location filename="../../tnztools/filltool.cpp" line="2420"/>
         <source>Autopaint Lines</source>
         <translation>Автозаливка линий</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2149"/>
+        <location filename="../../tnztools/filltool.cpp" line="2421"/>
         <source>Savebox</source>
         <translation>Сейвбокс</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2150"/>
+        <location filename="../../tnztools/filltool.cpp" line="2422"/>
         <source>Distance:</source>
         <translation>Расстояние:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2151"/>
+        <location filename="../../tnztools/filltool.cpp" line="2423"/>
         <source>Style Index:</source>
         <translation>Номер cтиля:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2152"/>
+        <location filename="../../tnztools/filltool.cpp" line="2424"/>
         <source>Gaps:</source>
         <translation>Разрывы:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2153"/>
+        <location filename="../../tnztools/filltool.cpp" line="2425"/>
         <source>Ignore Gaps</source>
         <translation>Игнорировать разрывы</translation>
     </message>
@@ -770,12 +775,12 @@
         <translation type="vanished">Игнорировать разрывы</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2154"/>
+        <location filename="../../tnztools/filltool.cpp" line="2426"/>
         <source>Fill Gaps</source>
         <translation>Заполнить разрывы</translation>
     </message>
     <message>
-        <location filename="../../tnztools/filltool.cpp" line="2155"/>
+        <location filename="../../tnztools/filltool.cpp" line="2427"/>
         <source>Close and Fill</source>
         <translation>Замкнуть и залить</translation>
     </message>
@@ -783,12 +788,12 @@
 <context>
     <name>FingerTool</name>
     <message>
-        <location filename="../../tnztools/fingertool.cpp" line="333"/>
+        <location filename="../../tnztools/fingertool.cpp" line="352"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fingertool.cpp" line="334"/>
+        <location filename="../../tnztools/fingertool.cpp" line="353"/>
         <source>Invert</source>
         <translation>Инвертировать</translation>
     </message>
@@ -796,49 +801,49 @@
 <context>
     <name>FullColorBrushTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="192"/>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="197"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="191"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="196"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="193"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="192"/>
         <source>Pressure</source>
         <translation>Нажим</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="194"/>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="198"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="193"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="197"/>
         <source>Opacity</source>
         <translation>Непрозрачность</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="195"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="194"/>
         <source>Hardness:</source>
         <translation>Жесткость:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="196"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="195"/>
         <source>Preset:</source>
         <translation>Предустановка:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="199"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="198"/>
         <source>Eraser</source>
         <translation>Ластик</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="200"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="199"/>
         <source>Lock Alpha</source>
         <translation>Заблокировать альфа канал</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="201"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="200"/>
         <source>Grid</source>
         <translation>Сетка</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="904"/>
+        <location filename="../../tnztools/fullcolorbrushtool.cpp" line="914"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;пользовательская&gt;</translation>
     </message>
@@ -846,52 +851,52 @@
 <context>
     <name>FullColorEraserTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="414"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="435"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="415"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="436"/>
         <source>Opacity:</source>
         <translation>Непрозрачность:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="416"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="437"/>
         <source>Hardness:</source>
         <translation>Жесткость:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="418"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="439"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="419"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="440"/>
         <source>Normal</source>
         <translation>Обычный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="420"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="441"/>
         <source>Rectangular</source>
         <translation>Прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="421"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="442"/>
         <source>Freehand</source>
         <translation>От руки</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="422"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="443"/>
         <source>Polyline</source>
         <translation>Полилиния</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="424"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="445"/>
         <source>Invert</source>
         <translation>Обратить</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorerasertool.cpp" line="425"/>
+        <location filename="../../tnztools/fullcolorerasertool.cpp" line="446"/>
         <source>Frame Range</source>
         <translation>Диапазон кадров</translation>
     </message>
@@ -899,20 +904,50 @@
 <context>
     <name>FullColorFillTool</name>
     <message>
-        <location filename="../../tnztools/fullcolorfilltool.cpp" line="158"/>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="181"/>
         <source>Fill Depth</source>
         <translation>Глубина заливки</translation>
     </message>
     <message>
-        <location filename="../../tnztools/fullcolorfilltool.cpp" line="159"/>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="182"/>
         <source>Refer Visible</source>
         <translation>Учитывать видимые</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="183"/>
+        <source>Distance:</source>
+        <translation type="unfinished">Расстояние:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="184"/>
+        <source>Style Index:</source>
+        <translation type="unfinished">Номер cтиля:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="185"/>
+        <source>Gaps:</source>
+        <translation type="unfinished">Разрывы:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="186"/>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished">Игнорировать разрывы</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="187"/>
+        <source>Fill Gaps</source>
+        <translation type="unfinished">Заполнить разрывы</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/fullcolorfilltool.cpp" line="188"/>
+        <source>Close and Fill</source>
+        <translation type="unfinished">Замкнуть и залить</translation>
     </message>
 </context>
 <context>
     <name>HandToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3320"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3617"/>
         <source>Reset Position</source>
         <translation>Сбросить расположение</translation>
     </message>
@@ -936,42 +971,42 @@
 <context>
     <name>PaintBrushTool</name>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="380"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="399"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="382"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="401"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="383"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="402"/>
         <source>Lines</source>
         <translation>Линии</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="384"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="403"/>
         <source>Areas</source>
         <translation>Области</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="385"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="404"/>
         <source>Lines &amp; Areas</source>
         <translation>Линии и области</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="387"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="406"/>
         <source>Selective</source>
         <translation>Избирательно</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="389"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="408"/>
         <source>Pressure</source>
         <translation>Нажим</translation>
     </message>
     <message>
-        <location filename="../../tnztools/paintbrushtool.cpp" line="391"/>
+        <location filename="../../tnztools/paintbrushtool.cpp" line="410"/>
         <source>Lock Alpha</source>
         <translation>Заблокировать альфа канал</translation>
     </message>
@@ -979,42 +1014,42 @@
 <context>
     <name>PerspectiveGridToolOptionBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2969"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3030"/>
         <source>Spacing:</source>
         <translation>Расстояние:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2974"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3035"/>
         <source>Rotation:</source>
         <translation>Вращение:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2990"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3051"/>
         <source>Rotate Perspective Left</source>
         <translation>Повернуть перспективу влево</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2991"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3052"/>
         <source>Rotate Perspective Right</source>
         <translation>Повернуть перспективу вправо</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3024"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3085"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3029"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3090"/>
         <source>Opacity:</source>
         <translation>Непрозрачность:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3046"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3107"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3063"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3124"/>
         <source>Preset:</source>
         <translation>Предустановка:</translation>
     </message>
@@ -1569,14 +1604,14 @@ Do you want to proceed?</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="224"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="236"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="225"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="237"/>
         <source>Min:</source>
         <translation>Мин:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="224"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="236"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="225"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="237"/>
         <source>Max:</source>
         <translation>Макс:</translation>
     </message>
@@ -1586,7 +1621,7 @@ Do you want to proceed?</source>
         <translation>Задать окно сохранения : (X%1,Y%2,W%3,H%4)-&gt;(X%5,Y%6,W%7,H%8)</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="307"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="308"/>
         <source>Move Center</source>
         <translation>Переместить центр</translation>
     </message>
@@ -1669,7 +1704,7 @@ Do you want to proceed?</source>
         <translation type="vanished">Нет</translation>
     </message>
     <message>
-        <location filename="../../tnztools/edittoolgadgets.cpp" line="89"/>
+        <location filename="../../tnztools/edittoolgadgets.cpp" line="287"/>
         <source>Modify Fx Gadget  </source>
         <translation>Изменить Fx-гаджет  </translation>
     </message>
@@ -1729,7 +1764,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="../../tnztools/tool.cpp" line="1057"/>
-        <location filename="../../tnztools/tool.cpp" line="1124"/>
+        <location filename="../../tnztools/tool.cpp" line="1119"/>
         <source>The current level is not editable.</source>
         <translation>Текущий уровень не редактируется.</translation>
     </message>
@@ -1764,12 +1799,12 @@ Do you want to proceed?</source>
         <translation>Текущий кадр заблокирован: любое редактирование запрещено.</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tool.cpp" line="1135"/>
+        <location filename="../../tnztools/tool.cpp" line="1130"/>
         <source>The current tool cannot be used on empty frames of a Single Frame level.</source>
         <translation>Текущий инструмент нельзя использовать с пустыми кадрами на уровне одного кадра.</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tool.cpp" line="1144"/>
+        <location filename="../../tnztools/tool.cpp" line="1139"/>
         <source>The current tool cannot be used on a stop frame.</source>
         <translation>Текущий инструмент нельзя использовать в стоп-кадре.</translation>
     </message>
@@ -1837,7 +1872,7 @@ Do you want to proceed?</source>
 <context>
     <name>RGBPickerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2651"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2712"/>
         <source>Pick Screen</source>
         <translation>Экранный выбор</translation>
     </message>
@@ -1845,12 +1880,12 @@ Do you want to proceed?</source>
 <context>
     <name>RasterSelectionTool</name>
     <message>
-        <location filename="../../tnztools/rasterselectiontool.cpp" line="1038"/>
+        <location filename="../../tnztools/rasterselectiontool.cpp" line="1086"/>
         <source>Modify Savebox</source>
         <translation>Изменить Savebox</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rasterselectiontool.cpp" line="1040"/>
+        <location filename="../../tnztools/rasterselectiontool.cpp" line="1088"/>
         <source>No Antialiasing</source>
         <translation>Без сглаживания</translation>
     </message>
@@ -1858,57 +1893,57 @@ Do you want to proceed?</source>
 <context>
     <name>RasterTapeTool</name>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="188"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="189"/>
         <source>current</source>
         <translation>текущий</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="180"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="181"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="181"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="182"/>
         <source>Normal</source>
         <translation>Обычный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="182"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="183"/>
         <source>Rectangular</source>
         <translation>Прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="183"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="184"/>
         <source>Freehand</source>
         <translation>От руки</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="184"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="185"/>
         <source>Polyline</source>
         <translation>Полилиния</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="186"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="187"/>
         <source>Distance:</source>
         <translation>Расстояние:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="187"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="188"/>
         <source>Style Index:</source>
         <translation>Номер cтиля:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="189"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="190"/>
         <source>Opacity:</source>
         <translation>Непрозрачность:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="190"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="191"/>
         <source>Frame Range</source>
         <translation>Диапазон кадров</translation>
     </message>
     <message>
-        <location filename="../../tnztools/rastertapetool.cpp" line="191"/>
+        <location filename="../../tnztools/rastertapetool.cpp" line="192"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
@@ -1924,7 +1959,7 @@ Do you want to proceed?</source>
 <context>
     <name>RotateToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3293"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3590"/>
         <source>Reset Rotation</source>
         <translation>Сбросить вращение</translation>
     </message>
@@ -1932,37 +1967,37 @@ Do you want to proceed?</source>
 <context>
     <name>RulerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2412"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2473"/>
         <source>X:</source>
         <comment>ruler tool option</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2418"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2479"/>
         <source>Y:</source>
         <comment>ruler tool option</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2426"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2487"/>
         <source>W:</source>
         <comment>ruler tool option</comment>
         <translation>Ш:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2432"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2493"/>
         <source>H:</source>
         <comment>ruler tool option</comment>
         <translation>В:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2440"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2501"/>
         <source>A:</source>
         <comment>ruler tool option</comment>
         <translation>У:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2445"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2506"/>
         <source>L:</source>
         <comment>ruler tool option</comment>
         <translation>Д:</translation>
@@ -1971,22 +2006,22 @@ Do you want to proceed?</source>
 <context>
     <name>SelectionTool</name>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="926"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="927"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="927"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="928"/>
         <source>Rectangular</source>
         <translation>Прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="928"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="929"/>
         <source>Freehand</source>
         <translation>От руки</translation>
     </message>
     <message>
-        <location filename="../../tnztools/selectiontool.cpp" line="929"/>
+        <location filename="../../tnztools/selectiontool.cpp" line="930"/>
         <source>Polyline</source>
         <translation>Полилиния</translation>
     </message>
@@ -1994,53 +2029,53 @@ Do you want to proceed?</source>
 <context>
     <name>SelectionToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1142"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1145"/>
         <source>H:</source>
         <translation>H:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1144"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1147"/>
         <source>V:</source>
         <translation>V:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1146"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1149"/>
         <source>Link</source>
         <translation>Связать</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1149"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="1150"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1152"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1153"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1152"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1155"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1154"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1157"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1186"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1189"/>
         <source>Flip Selection Horizontally</source>
         <translation>Отразить выделение по горизонтали</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1187"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1190"/>
         <source>Flip Selection Vertically</source>
         <translation>Отразить выделение по вертикали</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1188"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1191"/>
         <source>Rotate Selection Left</source>
         <translation>Повернуть выделение влево</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1189"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1192"/>
         <source>Rotate Selection Right</source>
         <translation>Повернуть выделение вправо</translation>
     </message>
@@ -2053,18 +2088,18 @@ Do you want to proceed?</source>
         <translation type="vanished">N/S:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1205"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1208"/>
         <source>Scale</source>
         <translation>Масштаб</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1226"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1229"/>
         <source>Position</source>
         <translation>Положение</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="1243"/>
-        <location filename="../../tnztools/tooloptions.cpp" line="1244"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1246"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="1247"/>
         <source>Thickness</source>
         <translation>Толщина</translation>
     </message>
@@ -2072,22 +2107,22 @@ Do you want to proceed?</source>
 <context>
     <name>ShiftTraceToolOptionBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2788"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2849"/>
         <source>Reset Previous</source>
         <translation>Сбросить изменения</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2789"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2850"/>
         <source>Reset Following</source>
         <translation>Сбросить изменения</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2795"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2856"/>
         <source>Previous Drawing</source>
         <translation>Предыдущий рисунок</translation>
     </message>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2796"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2857"/>
         <source>Following Drawing</source>
         <translation>Следующий рисунок</translation>
     </message>
@@ -2125,7 +2160,7 @@ Do you want to proceed?</source>
         <translation>Обратная кинематика</translation>
     </message>
     <message>
-        <location filename="../../tnztools/skeletontool.cpp" line="1615"/>
+        <location filename="../../tnztools/skeletontool.cpp" line="1614"/>
         <source>Reset Pinned Center</source>
         <translation>Сбросить закрепленный центр</translation>
     </message>
@@ -2189,78 +2224,189 @@ Do you want to proceed?</source>
 <context>
     <name>StylePickerToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="2737"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="2798"/>
         <source>With this option being activated, the picked style will be
 moved to the end of the first page of the palette.</source>
         <translation>При активации этого параметра, выбранный стиль будет перемещен в конец первой страницы палитры.</translation>
     </message>
 </context>
 <context>
+    <name>SymmetryTool</name>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="258"/>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="260"/>
+        <source>Opacity</source>
+        <translation type="unfinished">Непрозрачность</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="262"/>
+        <source>Color:</source>
+        <translation type="unfinished">Цвет:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="263"/>
+        <source>Magenta</source>
+        <translation type="unfinished">Magenta</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="264"/>
+        <source>Red</source>
+        <translation type="unfinished">Красный</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="265"/>
+        <source>Green</source>
+        <translation type="unfinished">Зелёный</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="266"/>
+        <source>Blue</source>
+        <translation type="unfinished">Синий</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="267"/>
+        <source>Yellow</source>
+        <translation type="unfinished">Жёлтый</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="268"/>
+        <source>Cyan</source>
+        <translation type="unfinished">Cyan</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="269"/>
+        <source>Black</source>
+        <translation type="unfinished">Чёрный</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="271"/>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="273"/>
+        <source>Preset:</source>
+        <translation type="unfinished">Предустановка:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/symmetrytool.cpp" line="372"/>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished">&lt;пользовательская&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3357"/>
+        <source>Rotation:</source>
+        <translation type="unfinished">Вращение:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3373"/>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished">Повернуть перспективу влево</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3374"/>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished">Повернуть перспективу вправо</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3384"/>
+        <source>Reset Position</source>
+        <translation type="unfinished">Сбросить расположение</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3403"/>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3408"/>
+        <source>Opacity:</source>
+        <translation type="unfinished">Непрозрачность:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3420"/>
+        <source>Color:</source>
+        <translation type="unfinished">Цвет:</translation>
+    </message>
+    <message>
+        <location filename="../../tnztools/tooloptions.cpp" line="3429"/>
+        <source>Preset:</source>
+        <translation type="unfinished">Предустановка:</translation>
+    </message>
+</context>
+<context>
     <name>ToonzRasterBrushTool</name>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1104"/>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1111"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1139"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1146"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1105"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1140"/>
         <source>Hardness:</source>
         <translation>Жесткость:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1106"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1141"/>
         <source>Smooth:</source>
         <translation>Плавность:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1107"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1142"/>
         <source>Draw Order:</source>
         <translation>Порядок рисовки:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1108"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1143"/>
         <source>Over All</source>
         <translation>Над всеми</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1109"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1144"/>
         <source>Under All</source>
         <translation>Под всеми</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1110"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1145"/>
         <source>Palette Order</source>
         <translation>Порядок палитры</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1114"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1149"/>
         <source>Preset:</source>
         <translation>Предустановка:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1115"/>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="2404"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1150"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="2531"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;пользовательская&gt;</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1116"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1151"/>
         <source>Pencil</source>
         <translation>Карандаш</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1117"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1152"/>
         <source>Pressure</source>
         <translation>Нажим</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1118"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1153"/>
         <source>Lock Alpha</source>
         <translation>Заблокировать альфа канал</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1119"/>
+        <location filename="../../tnztools/toonzrasterbrushtool.cpp" line="1154"/>
         <source>Grid</source>
         <translation>Сетка</translation>
     </message>
@@ -2268,153 +2414,153 @@ moved to the end of the first page of the palette.</source>
 <context>
     <name>ToonzVectorBrushTool</name>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="620"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="616"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="621"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="617"/>
         <source>Accuracy:</source>
         <translation>Точность:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="622"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="618"/>
         <source>Smooth:</source>
         <translation>Плавность:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="623"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="619"/>
         <source>Preset:</source>
         <translation>Предустановка:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="624"/>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="2016"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="620"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="2091"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;пользовательская&gt;</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="625"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="621"/>
         <source>Break</source>
         <translation>Разрыв</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="626"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="622"/>
         <source>Pressure</source>
         <translation>Нажим</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="627"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="623"/>
         <source>Cap</source>
         <translation>Конец</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="628"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="624"/>
         <source>Join</source>
         <translation>Изгиб</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="629"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="625"/>
         <source>Miter:</source>
         <translation>Скос:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="630"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="626"/>
         <source>Range:</source>
         <translation>Диапазон:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="631"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="627"/>
         <source>Snap</source>
         <translation>Привязка</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="633"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="629"/>
         <source>Off</source>
         <translation>Выкл</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="634"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="630"/>
         <source>Linear</source>
         <translation>Линейный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="635"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="631"/>
         <source>In</source>
         <translation>Замедл. в начале</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="636"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="632"/>
         <source>Out</source>
         <translation>Замедл. в конце</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="637"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="633"/>
         <source>In&amp;Out</source>
         <translation>В начале &amp;в конце</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="638"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="634"/>
         <source>Low</source>
         <translation>Низкий</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="639"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="635"/>
         <source>Med</source>
         <translation>Средний</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="640"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="636"/>
         <source>High</source>
         <translation>Высокий</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="641"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="637"/>
         <source>Butt cap</source>
         <translation>Обрубок</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="642"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="638"/>
         <source>Round cap</source>
         <translation>Закругленный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="643"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="639"/>
         <source>Projecting cap</source>
         <translation>Плоский колпачок</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="644"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="640"/>
         <source>Miter join</source>
         <translation>Острый изгиб</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="645"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="641"/>
         <source>Round join</source>
         <translation>Закругленный изгиб</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="646"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="642"/>
         <source>Bevel join</source>
         <translation>Скошенный изгиб</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="647"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="643"/>
         <source>Draw Under</source>
         <translation>Рисовать позади</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="648"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="644"/>
         <source>Auto Close</source>
         <translation>Авто замыкание</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="649"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="645"/>
         <source>Auto Fill</source>
         <translation>Автозаливка</translation>
     </message>
     <message>
-        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="650"/>
+        <location filename="../../tnztools/toonzvectorbrushtool.cpp" line="646"/>
         <source>Auto Group</source>
         <translation>Автогруппировать</translation>
     </message>
@@ -2576,52 +2722,52 @@ moved to the end of the first page of the palette.</source>
 <context>
     <name>VectorTapeTool</name>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="260"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="264"/>
         <source>Smooth</source>
         <translation>Плавность</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="261"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="265"/>
         <source>Join Vectors</source>
         <translation>Соединять векторы</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="262"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="266"/>
         <source>Distance</source>
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="264"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="268"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="265"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="269"/>
         <source>Endpoint to Endpoint</source>
         <translation>Вершина к вершине</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="266"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="270"/>
         <source>Endpoint to Line</source>
         <translation>Вершина к линии</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="267"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="271"/>
         <source>Line to Line</source>
         <translation>Линия к линии</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="269"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="273"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="270"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="274"/>
         <source>Normal</source>
         <translation>Обычный</translation>
     </message>
     <message>
-        <location filename="../../tnztools/vectortapetool.cpp" line="271"/>
+        <location filename="../../tnztools/vectortapetool.cpp" line="275"/>
         <source>Rectangular</source>
         <translation>Прямоугольный</translation>
     </message>
@@ -2629,7 +2775,7 @@ moved to the end of the first page of the palette.</source>
 <context>
     <name>ZoomToolOptionsBox</name>
     <message>
-        <location filename="../../tnztools/tooloptions.cpp" line="3266"/>
+        <location filename="../../tnztools/tooloptions.cpp" line="3563"/>
         <source>Reset Zoom</source>
         <translation>Сбросить приближение</translation>
     </message>

--- a/toonz/sources/translations/russian/toonz.ts
+++ b/toonz/sources/translations/russian/toonz.ts
@@ -193,132 +193,157 @@ Special thanks to:</source>
 <context>
     <name>AudioRecordingPopup</name>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="59"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="65"/>
         <source>Audio Recording</source>
         <translation>Запись аудио</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="66"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="72"/>
         <source>Save and Insert</source>
         <translation>Сохранить и вставить</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="74"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="80"/>
         <source>Sync with XSheet/Timeline</source>
         <translation>Синхронизация с Xsheet/тамлайн</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="80"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="86"/>
         <source>Device: </source>
         <translation>Устройство: </translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="81"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="87"/>
         <source>Sample rate: </source>
         <translation>Частота дискретизации: </translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="82"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="88"/>
         <source>Sample format: </source>
         <translation>Образец формата: </translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="85"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="91"/>
         <source>8000 Hz</source>
         <translation>8000 Гц</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="86"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="92"/>
         <source>11025 Hz</source>
         <translation>11025 Гц</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="87"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="93"/>
         <source>22050 Hz</source>
         <translation>22050 Гц</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="88"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="94"/>
         <source>44100 Hz</source>
         <translation>44100 Гц</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="89"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="95"/>
         <source>48000 Hz</source>
         <translation>48000 Гц</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="90"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="96"/>
         <source>96000 Hz</source>
         <translation>96000 Гц</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="92"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="97"/>
+        <source>192000 Hz</source>
+        <translation type="unfinished">96000 Гц {192000 ?}</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="99"/>
         <source>Mono 8-Bits</source>
         <translation>Моно 8-бит</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="93"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="100"/>
         <source>Stereo 8-Bits</source>
         <translation>Стерео 8-бит</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="94"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="101"/>
         <source>Mono 16-Bits</source>
         <translation>Моно 16-бит</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="95"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="102"/>
         <source>Stereo 16-Bits</source>
         <translation>Стерео 16-бит</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="149"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="103"/>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished">Моно 16-бит {24-?}</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="104"/>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished">Стерео 16-бит {24-?}</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="105"/>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished">Моно 16-бит {32-?}</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="106"/>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished">Стерео 16-бит {32-?}</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="162"/>
         <source>Audio input device to record</source>
         <translation>Устройство ввода звука для записи</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="150"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="164"/>
         <source>Number of samples per second, 44.1KHz = CD Quality</source>
         <translation>Количество выборок в секунду, 44,1 кГц = качество CD</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="151"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="166"/>
         <source>Number of channels and bits per sample, 16-bits recommended</source>
         <translation>Количество каналов и битов на выборку, рекомендуется 16 бит</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="152"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="168"/>
         <source>Play animation from current frame while recording/playback</source>
         <translation>Воспроизведение анимации с текущего кадра во время записи/воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="153"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="169"/>
         <source>Save recording and insert into new column</source>
         <translation>Сохранить запись и вставить в новый столбец</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="154"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="171"/>
         <source>Refresh list of connected audio input devices</source>
         <translation>Обновить список подключенных устройств аудиоввода</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="261"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="284"/>
         <source>Record failed: 
 Make sure there&apos;s XSheet or Timeline in the room.</source>
         <translation>Запись не удалась:
 Убедитесь, что в комнате есть XSheet или таймлайн.</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="292"/>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="345"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="308"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="362"/>
         <source>Failed to save WAV file:
 Make sure you have write permissions in folder.</source>
         <translation>Не удалось сохранить файл WAV:
 Убедитесь, что у вас есть права на запись в папку.</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="695"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="713"/>
         <source>Audio format unsupported:
 Nearest format will be internally used.</source>
         <translation>Аудио формат не поддерживается:
@@ -333,16 +358,14 @@ Nearest format will be internally used.</source>
         <translation type="vanished">Синхронизация с Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="202"/>
+        <location filename="../../toonz/audiorecordingpopup.cpp" line="219"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="255"/>
-        <location filename="../../toonz/audiorecordingpopup.cpp" line="267"/>
         <source>The microphone is not available: 
 Please select a different device or check the microphone.</source>
-        <translation>Микрофон недоступен:
+        <translation type="vanished">Микрофон недоступен:
 Выберите другое устройство или проверьте микрофон.</translation>
     </message>
 </context>
@@ -460,76 +483,183 @@ pick up all frames in the selected level.</source>
     </message>
 </context>
 <context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="210"/>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished">Показать / скрыть GUI</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="213"/>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished">Панель инструментов воспроизведения</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="214"/>
+        <source>Frame Slider</source>
+        <translation type="unfinished">Бегунок кадра</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="399"/>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished">Безопасная зона (Щелкните правой кнопкой мыши, чтобы выбрать)</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="413"/>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished">Сетки и наложения
+Щелкните правой кнопкой мыши, чтобы настроить.</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="428"/>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished">Настройки сеток и наложений</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="437"/>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">Стандартный вид с камеры</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="445"/>
+        <source>3D View</source>
+        <translation type="unfinished">3D-просмотр</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="452"/>
+        <source>Camera View</source>
+        <translation type="unfinished">Вид с  камеры</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="460"/>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished">Изменить прозрачность обзора камеры.</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="475"/>
+        <source>Freeze</source>
+        <translation type="unfinished">Заморозить</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="485"/>
+        <source>Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="495"/>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">Предпросмотр суб-камеры</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="650"/>
+        <source>Untitled</source>
+        <translation type="unfinished">Безымянный</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="652"/>
+        <source>Scene: </source>
+        <translation type="unfinished">Сцена: </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="655"/>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished">   ::   Кадр: </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="672"/>
+        <location filename="../../toonz/viewerpane.cpp" line="702"/>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished">  ::  Зум : </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="675"/>
+        <location filename="../../toonz/viewerpane.cpp" line="705"/>
+        <source> (Flipped)</source>
+        <translation type="unfinished"> (Перевёрнутый)</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="685"/>
+        <source>   ::   Level: </source>
+        <translation type="unfinished">   ::   Уровень: </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/viewerpane.cpp" line="694"/>
+        <source>Level: </source>
+        <translation type="unfinished">Уровень: </translation>
+    </message>
+</context>
+<context>
     <name>BatchServersViewer</name>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="273"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="269"/>
         <source>Process with:</source>
         <translation>Обработать:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="276"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="272"/>
         <source>Local</source>
         <translation>Локально</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="276"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="272"/>
         <source>Render Farm</source>
         <translation>На рендер ферме</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="282"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="278"/>
         <source>Farm Global Root:</source>
         <translation>Корневая папка фермы:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="301"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="297"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="302"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="298"/>
         <source>IP Address:</source>
         <translation>IP Адрес:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="303"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="299"/>
         <source>Port Number:</source>
         <translation>Номер порта:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="304"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="300"/>
         <source>Tasks:</source>
         <translation>Задания:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="305"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="301"/>
         <source>State:</source>
         <translation>Состояние:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="306"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="302"/>
         <source>Number of CPU:</source>
         <translation>Количество процессоров:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="307"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="303"/>
         <source>Physical Memory:</source>
         <translation>Физическая память:</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="339"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="335"/>
         <source>In order to use the render farm you have to define the Farm Global Root first.</source>
         <translation>Чтобы использовать рендер ферму, сначала необходимо определить корневую папку фермы.</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="345"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="341"/>
         <source>The Farm Global Root folder doesn&apos;t exist
 Please create this folder before using the render farm.</source>
         <translation>Папка Farm Global Root не существует
 Создайте эту папку перед использованием рендер фермы.</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="360"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="356"/>
         <source>Unable to connect to the ToonzFarm Controller
    The Controller should run on %1 at port %2
    Please start the Controller before using the ToonzFarm</source>
@@ -541,45 +671,45 @@ Please create this folder before using the render farm.</source>
 <context>
     <name>BatchesController</name>
     <message>
-        <location filename="../../toonz/batches.cpp" line="424"/>
+        <location filename="../../toonz/batches.cpp" line="439"/>
         <source>The %1 task is currently active.
 Stop it or wait for its completion before removing it.</source>
         <translation>Задача %1 в данный момент выполняется.
 Остановите задачу перед ее удалением или подождите, пока она завершится.</translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="766"/>
-        <location filename="../../toonz/batches.cpp" line="797"/>
+        <location filename="../../toonz/batches.cpp" line="781"/>
+        <location filename="../../toonz/batches.cpp" line="812"/>
         <source>The current task list has been modified.
 Do you want to save your changes?</source>
         <translation>Текущий список задач изменен.
 Хотите сохранить изменения?</translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="768"/>
-        <location filename="../../toonz/batches.cpp" line="799"/>
+        <location filename="../../toonz/batches.cpp" line="783"/>
+        <location filename="../../toonz/batches.cpp" line="814"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="768"/>
-        <location filename="../../toonz/batches.cpp" line="799"/>
+        <location filename="../../toonz/batches.cpp" line="783"/>
+        <location filename="../../toonz/batches.cpp" line="814"/>
         <source>Discard</source>
         <translation>Сбросить</translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="768"/>
-        <location filename="../../toonz/batches.cpp" line="799"/>
+        <location filename="../../toonz/batches.cpp" line="783"/>
+        <location filename="../../toonz/batches.cpp" line="814"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="859"/>
+        <location filename="../../toonz/batches.cpp" line="874"/>
         <source>Tasks</source>
         <translation>Задания</translation>
     </message>
     <message>
-        <location filename="../../toonz/batches.cpp" line="868"/>
+        <location filename="../../toonz/batches.cpp" line="883"/>
         <source>The Task List is empty!</source>
         <translation>Список задач пуст!</translation>
     </message>
@@ -843,88 +973,112 @@ Do you want to save your changes?</source>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <location filename="../../stopmotion/canon.cpp" line="567"/>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/canon.cpp" line="569"/>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/canon.cpp" line="1027"/>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="519"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="520"/>
         <source>Canvas Size</source>
         <translation>Размер холста</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="524"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="525"/>
         <source>Current Size</source>
         <translation>Текущий размер</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="532"/>
-        <location filename="../../toonz/canvassizepopup.cpp" line="557"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="533"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="560"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="538"/>
-        <location filename="../../toonz/canvassizepopup.cpp" line="564"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="539"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="567"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="540"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="541"/>
         <source>New Size</source>
         <translation>Новый размер</translation>
     </message>
     <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="545"/>
         <source>pixel</source>
-        <translation type="vanished">пиксель</translation>
+        <translation>пиксель</translation>
     </message>
     <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="546"/>
         <source>mm</source>
-        <translation type="vanished">мм</translation>
+        <translation>мм</translation>
     </message>
     <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="547"/>
         <source>cm</source>
-        <translation type="vanished">см</translation>
+        <translation>см</translation>
     </message>
     <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="548"/>
         <source>field</source>
-        <translation type="vanished">поле</translation>
+        <translation>поле</translation>
     </message>
     <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="549"/>
         <source>inch</source>
-        <translation type="vanished">дюйм</translation>
+        <translation>дюйм</translation>
     </message>
     <message>
+        <location filename="../../toonz/canvassizepopup.cpp" line="552"/>
         <source>Unit:</source>
-        <translation type="vanished">Ед. изм:</translation>
+        <translation>Ед. изм:</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="569"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="572"/>
         <source>Relative</source>
         <translation>Относительный</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="575"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="578"/>
         <source>Anchor</source>
         <translation>Анкер</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="583"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="586"/>
         <source>Resize</source>
         <translation>Изменить размер</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="585"/>
-        <location filename="../../toonz/canvassizepopup.cpp" line="700"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="588"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="703"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="698"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="701"/>
         <source>The new canvas size is smaller than the current one.
 Do you want to crop the canvas?</source>
         <translation>Новый размер холста меньше текущего.
 Вы хотите обрезать холст?</translation>
     </message>
     <message>
-        <location filename="../../toonz/canvassizepopup.cpp" line="700"/>
+        <location filename="../../toonz/canvassizepopup.cpp" line="703"/>
         <source>Crop</source>
         <translation>Обрезать</translation>
     </message>
@@ -983,27 +1137,27 @@ Do you want to crop the canvas?</source>
 <context>
     <name>CastBrowser</name>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="826"/>
+        <location filename="../../toonz/castviewer.cpp" line="822"/>
         <source>It is not possible to edit the selected file.</source>
         <translation>Редактировать выбранный файл невозможно.</translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="828"/>
+        <location filename="../../toonz/castviewer.cpp" line="824"/>
         <source>It is not possible to edit more than one file at once.</source>
         <translation>Невозможно одновременно редактировать несколько файлов.</translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="851"/>
+        <location filename="../../toonz/castviewer.cpp" line="847"/>
         <source>It is not possible to show the folder containing the selected file, as the file has not been saved yet.</source>
         <translation>Невозможно показать папку, содержащую выбранный файл, поскольку файл еще не сохранен.</translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="881"/>
+        <location filename="../../toonz/castviewer.cpp" line="877"/>
         <source>It is not possible to view the selected file, as the file has not been saved yet.</source>
         <translation>Невозможно просмотреть выбранный файл, так как файл еще не сохранен.</translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="916"/>
+        <location filename="../../toonz/castviewer.cpp" line="913"/>
         <source>It is not possible to show the info of the selected file, as the file has not been saved yet.</source>
         <translation>Невозможно показать информацию о выбранном файле, так как файл еще не сохранен.</translation>
     </message>
@@ -1795,17 +1949,17 @@ What do you want to do? </source>
 <context>
     <name>ComboViewerPanel</name>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="253"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="109"/>
         <source>GUI Show / Hide</source>
         <translation>Показать / скрыть GUI</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="255"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="111"/>
         <source>Toolbar</source>
         <translation>Панель инструментов</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="256"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="112"/>
         <source>Tool Options Bar</source>
         <translation>Панель настройки инструментов</translation>
     </message>
@@ -1814,75 +1968,64 @@ What do you want to do? </source>
         <translation type="vanished">Консоль</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="461"/>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>Безопасная зона (Щелкните правой кнопкой мыши, чтобы выбрать)</translation>
+        <translation type="vanished">Безопасная зона (Щелкните правой кнопкой мыши, чтобы выбрать)</translation>
     </message>
     <message>
         <source>Field Guide</source>
         <translation type="vanished">Направляющая сетка</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="257"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="113"/>
         <source>Playback Toolbar</source>
         <translation>Панель инструментов воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="258"/>
+        <location filename="../../toonz/comboviewerpane.cpp" line="114"/>
         <source>Frame Slider</source>
         <translation>Бегунок кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="475"/>
         <source>Grids and Overlays
 Right click to adjust.</source>
-        <translation>Сетки и наложения
+        <translation type="vanished">Сетки и наложения
 Щелкните правой кнопкой мыши, чтобы настроить.</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="490"/>
         <source>Grids and Overlays Settings</source>
-        <translation>Настройки сеток и наложений</translation>
+        <translation type="vanished">Настройки сеток и наложений</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="499"/>
         <source>Camera Stand View</source>
-        <translation>Стандартный вид с камеры</translation>
+        <translation type="vanished">Стандартный вид с камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="507"/>
         <source>3D View</source>
-        <translation>3D-просмотр</translation>
+        <translation type="vanished">3D-просмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="514"/>
         <source>Camera View</source>
-        <translation>Вид с  камеры</translation>
+        <translation type="vanished">Вид с  камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="522"/>
         <source>Change camera view transparency.</source>
-        <translation>Изменить прозрачность обзора камеры.</translation>
+        <translation type="vanished">Изменить прозрачность обзора камеры.</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="537"/>
         <source>Freeze</source>
-        <translation>Заморозить</translation>
+        <translation type="vanished">Заморозить</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="547"/>
         <source>Preview</source>
-        <translation>Предпросмотр</translation>
+        <translation type="vanished">Предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="556"/>
         <source>Sub-camera Preview</source>
-        <translation>Предпросмотр суб-камеры</translation>
+        <translation type="vanished">Предпросмотр суб-камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="659"/>
         <source>Untitled</source>
-        <translation>Безымянный</translation>
+        <translation type="vanished">Безымянный</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -1893,37 +2036,30 @@ Right click to adjust.</source>
         <translation type="vanished">[УРОВЕНЬ]: </translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="662"/>
         <source>Scene: </source>
-        <translation>Сцена: </translation>
+        <translation type="vanished">Сцена: </translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="665"/>
         <source>   ::   Frame: </source>
-        <translation>   ::   Кадр: </translation>
+        <translation type="vanished">   ::   Кадр: </translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="670"/>
-        <location filename="../../toonz/comboviewerpane.cpp" line="680"/>
-        <location filename="../../toonz/comboviewerpane.cpp" line="741"/>
         <source> (Flipped)</source>
-        <translation> (Перевёрнутый)</translation>
+        <translation type="vanished"> (Перевёрнутый)</translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="689"/>
         <source>   ::   Level: </source>
-        <translation>   ::   Уровень: </translation>
+        <translation type="vanished">   ::   Уровень: </translation>
     </message>
     <message>
-        <location filename="../../toonz/comboviewerpane.cpp" line="728"/>
         <source>Level: </source>
-        <translation>Уровень: </translation>
+        <translation type="vanished">Уровень: </translation>
     </message>
 </context>
 <context>
     <name>CommandBar</name>
     <message>
-        <location filename="../../toonz/commandbar.cpp" line="151"/>
+        <location filename="../../toonz/commandbar.cpp" line="201"/>
         <source>Customize Command Bar</source>
         <translation>Настройка панели команд</translation>
     </message>
@@ -1931,7 +2067,7 @@ Right click to adjust.</source>
 <context>
     <name>CommandBarListTree</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="380"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="383"/>
         <source>----Separator----</source>
         <translation>----Разделитель----</translation>
     </message>
@@ -1939,47 +2075,52 @@ Right click to adjust.</source>
 <context>
     <name>CommandBarPopup</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="479"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="483"/>
         <source>Quick Toolbar</source>
         <translation>Панель инструментов Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="480"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="484"/>
         <source>Customize Quick Toolbar</source>
         <translation>Настроить панель инструментов Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="483"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="493"/>
         <source>Command Bar</source>
         <translation>Панель команд</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="484"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="494"/>
         <source>Customize Command Bar</source>
         <translation>Настройка панели команд</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="490"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="500"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="491"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="501"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="496"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="503"/>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/commandbarpopup.cpp" line="508"/>
         <source>Commands</source>
         <translation>Команды</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="503"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="515"/>
         <source>Duplicated commands will be ignored. Only the last one will appear in the toolbar.</source>
         <translation>Дублированные команды будут проигнорированы. На панели инструментов появится только последний.</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="531"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="542"/>
         <source>Search:</source>
         <translation>Поиск:</translation>
     </message>
@@ -1995,7 +2136,7 @@ Right click to adjust.</source>
 <context>
     <name>CommandBarTree</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="260"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="263"/>
         <source>Remove &quot;%1&quot;</source>
         <translation>Удалить &quot;%1&quot;</translation>
     </message>
@@ -2018,6 +2159,160 @@ Right click to adjust.</source>
         <location filename="../../toonz/versioncontrolwidget.cpp" line="179"/>
         <source>Theirs</source>
         <translation>Их</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="76"/>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="83"/>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="91"/>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished">Конвертация уровня %1 из %2: %3</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="99"/>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="116"/>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">Уровень %1 не имеет кадров; пропуск.</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="228"/>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="230"/>
+        <source>Convert</source>
+        <translation type="unfinished">Конвертировать</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="231"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="235"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="236"/>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">Пропустить существующие файлы</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="237"/>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="247"/>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="260"/>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="357"/>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="359"/>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="375"/>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="379"/>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="384"/>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="385"/>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="401"/>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="402"/>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="403"/>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="405"/>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="407"/>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="408"/>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="436"/>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="438"/>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="441"/>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="445"/>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2091,7 +2386,7 @@ Right click to adjust.</source>
     <message>
         <location filename="../../toonz/convertpopup.cpp" line="354"/>
         <location filename="../../toonz/convertpopup.cpp" line="360"/>
-        <location filename="../../toonz/convertpopup.cpp" line="965"/>
+        <location filename="../../toonz/convertpopup.cpp" line="966"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -2191,22 +2486,22 @@ Right click to adjust.</source>
         <translation>Удаление неиспользуемых стилей из палитры ввода</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="591"/>
+        <location filename="../../toonz/convertpopup.cpp" line="592"/>
         <source>Keep Original Antialiasing</source>
         <translation>Сохранять оригинальное сглаживание</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="592"/>
+        <location filename="../../toonz/convertpopup.cpp" line="593"/>
         <source>Add Antialiasing with Intensity:</source>
         <translation>Добавить сглаживание с интенсивностью:</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="593"/>
+        <location filename="../../toonz/convertpopup.cpp" line="594"/>
         <source>Remove Antialiasing using Threshold:</source>
         <translation>Удалить сглаживание с использованием порога:</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="603"/>
+        <location filename="../../toonz/convertpopup.cpp" line="604"/>
         <source>When activated, styles of the default palette
 ($TOONZSTUDIOPALETTE\cleanup_default.tpl) will 
 be appended to the palette after conversion in 
@@ -2218,22 +2513,22 @@ before color designing.</source>
  сохранить попытки по созданию стилей перед рисованием цветом.</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="614"/>
+        <location filename="../../toonz/convertpopup.cpp" line="615"/>
         <source>Image DPI</source>
         <translation>DPI изображения</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="614"/>
+        <location filename="../../toonz/convertpopup.cpp" line="615"/>
         <source>Current Camera DPI</source>
         <translation>Текущее разрешение камеры в DPI</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="614"/>
+        <location filename="../../toonz/convertpopup.cpp" line="615"/>
         <source>Custom DPI</source>
         <translation>Пользовательское значение DPI</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="616"/>
+        <location filename="../../toonz/convertpopup.cpp" line="617"/>
         <source>Specify the policy for setting DPI of converted tlv. 
 If you select the &quot;Image DPI&quot; option and the source image does not 
 contain the dpi information, then the current camera dpi will be used.
@@ -2244,103 +2539,103 @@ contain the dpi information, then the current camera dpi will be used.
 </translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="626"/>
+        <location filename="../../toonz/convertpopup.cpp" line="627"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="638"/>
+        <location filename="../../toonz/convertpopup.cpp" line="639"/>
         <source>Antialias:</source>
         <translation>Сглаживание:</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="643"/>
+        <location filename="../../toonz/convertpopup.cpp" line="644"/>
         <source>Palette:</source>
         <translation>Палитра:</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="646"/>
+        <location filename="../../toonz/convertpopup.cpp" line="647"/>
         <source>Tolerance:</source>
         <translation>Допуск:</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="654"/>
+        <location filename="../../toonz/convertpopup.cpp" line="655"/>
         <source>Dpi:</source>
         <translation>DPI:</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="829"/>
+        <location filename="../../toonz/convertpopup.cpp" line="830"/>
         <source>Convert 1 Level</source>
         <translation>Конвертировать 1 уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="862"/>
+        <location filename="../../toonz/convertpopup.cpp" line="863"/>
         <source>Convert %1 Levels</source>
         <translation>Конвертировать%1 уровней</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="945"/>
-        <location filename="../../toonz/convertpopup.cpp" line="1000"/>
+        <location filename="../../toonz/convertpopup.cpp" line="946"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1001"/>
         <source>Level </source>
         <translation>Уровень </translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="948"/>
+        <location filename="../../toonz/convertpopup.cpp" line="949"/>
         <source> already exists; skipped</source>
         <translation> уже существует; пропущено</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="980"/>
+        <location filename="../../toonz/convertpopup.cpp" line="981"/>
         <source>Generating level </source>
         <translation>Генерирование уровня </translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1003"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1004"/>
         <source> converted to tlv.</source>
         <translation> конвертировано в tlv.</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1018"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1019"/>
         <source>Level %1 converted to TLV Format</source>
         <translation>Уровень %1 конвертирован в формат TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1023"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1024"/>
         <source>Warning: Level %1 NOT converted to TLV Format</source>
         <translation>Внимание: Уровень %1 НЕ конвертирован в формат TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1028"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1029"/>
         <source>Converted %1 out of %2 Levels to TLV Format</source>
         <translation>Конвертировано %1 из%2 Уровни в формат TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1089"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1090"/>
         <source>Warning: Can&apos;t read palette &apos;%1&apos; </source>
         <translation>Внимание: не удается прочитать палитру &quot;%1&quot; </translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1133"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1134"/>
         <source>No output filename specified: please choose a valid level name.</source>
         <translation>Не указано имя выходного файла: выберите допустимое имя уровня.</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1140"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1141"/>
         <source>No unpainted suffix specified: cannot convert.</source>
         <translation>Нет неокрашенного суффикса: нельзя конвертировать.</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1225"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1221"/>
         <source>Convert completed with %1 error(s) and %2 level(s) skipped</source>
         <translation>Конвертирование выполнено с ошибкой %1 и %2 уровни пропущены</translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1229"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1225"/>
         <source>Convert completed with %1 error(s) </source>
         <translation>Конвертирование выполнено с ошибкой %1 </translation>
     </message>
     <message>
-        <location filename="../../toonz/convertpopup.cpp" line="1231"/>
+        <location filename="../../toonz/convertpopup.cpp" line="1227"/>
         <source>%1 level(s) skipped</source>
         <translation>Уровень %1 пропущен</translation>
     </message>
@@ -2366,6 +2661,123 @@ contain the dpi information, then the current camera dpi will be used.
     <message>
         <source>Level %1 has no frame; skipped.</source>
         <translation type="vanished">Уровень %1 не имеет кадров; пропуск.</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="183"/>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="184"/>
+        <source>Close</source>
+        <translation type="unfinished">Закрыть</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="194"/>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="401"/>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="408"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="423"/>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="436"/>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="471"/>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="471"/>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="756"/>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="764"/>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="766"/>
+        <source>Overwrite</source>
+        <translation type="unfinished">Перезаписать</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="766"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="828"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="774"/>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="782"/>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="796"/>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="814"/>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="818"/>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="827"/>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="842"/>
+        <source>Template:</source>
+        <translation type="unfinished">Шаблон:</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="867"/>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="63"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="86"/>
+        <source>Drag and set command</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2510,79 +2922,79 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>DvDirTreeView</name>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="463"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="449"/>
         <source>There was an error copying %1 to %2</source>
         <translation>Произошла ошибка при копировании %1 в %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="510"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="496"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="524"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="510"/>
         <source>Get</source>
         <translation>Получить</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="529"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="515"/>
         <source>Put...</source>
         <translation>Поместить...</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="537"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="523"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="545"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="531"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="552"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="538"/>
         <source>Cleanup</source>
         <translation>Очистка</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="556"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="542"/>
         <source>Purge</source>
         <translation>Чистка</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="646"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="632"/>
         <source>Delete folder </source>
         <translation>Удалить папку </translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="646"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="632"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="647"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="633"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="654"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="640"/>
         <source>It is not possible to delete the folder.</source>
         <translation>Невозможно удалить папку.</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="693"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="679"/>
         <source>The local path does not exist:</source>
         <translation>Не существует локального пути:</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="905"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="891"/>
         <source>Refreshing...</source>
         <translation>Обновление...</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="1251"/>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="1386"/>
-        <location filename="../../toonz/dvdirtreeview.cpp" line="1416"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="1237"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="1372"/>
+        <location filename="../../toonz/dvdirtreeview.cpp" line="1402"/>
         <source>Refresh operation failed:
 </source>
         <translation>Сбой операции обновления:
@@ -2592,57 +3004,57 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>DvItemViewerButtonBar</name>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1833"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1842"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1836"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1845"/>
         <source>Forward</source>
         <translation>Вперед</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1841"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1850"/>
         <source>Up One Level</source>
         <translation>Открыть родительскую папку</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1842"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1851"/>
         <source>Up</source>
         <translation>Вверх</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1847"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1856"/>
         <source>New Folder</source>
         <translation>Новая папка</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1848"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1857"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1857"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1866"/>
         <source>Icons View</source>
         <translation>Просмотр в виде значков</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1859"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1868"/>
         <source>Icon</source>
         <translation>Значок</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1868"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1877"/>
         <source>List View</source>
         <translation>Просмотр в виде списка</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1870"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1879"/>
         <source>List</source>
         <translation>Список</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1886"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1895"/>
         <source>Export File List</source>
         <translation>Экспорт списка файлов</translation>
     </message>
@@ -2650,20 +3062,28 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>DvItemViewerPanel</name>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1430"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1439"/>
         <source>Save File List</source>
         <translation>Сохранить список файлов</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="1430"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1439"/>
         <source>File List (*.csv)</source>
         <translation>Список файлов (* .csv)</translation>
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="5069"/>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="665"/>
+        <location filename="../../toonz/fileselection.cpp" line="666"/>
         <source>You must save the current scene first.</source>
         <translation>Сначала необходимо сохранить текущую сцену.</translation>
     </message>
@@ -2806,35 +3226,86 @@ contain the dpi information, then the current camera dpi will be used.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="418"/>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="419"/>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="422"/>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="426"/>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="429"/>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="431"/>
+        <location filename="../../toonz/ocaio.cpp" line="432"/>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="452"/>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="453"/>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="478"/>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="785"/>
-        <location filename="../../toonz/exportpanel.cpp" line="885"/>
+        <location filename="../../toonz/exportpanel.cpp" line="781"/>
+        <location filename="../../toonz/exportpanel.cpp" line="881"/>
         <source>Export</source>
         <translation>Экспортировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="828"/>
+        <location filename="../../toonz/exportpanel.cpp" line="824"/>
         <source>Save in:</source>
         <translation>Сохранить в:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="840"/>
+        <location filename="../../toonz/exportpanel.cpp" line="836"/>
         <source>File Name:</source>
         <translation>Имя файла:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="860"/>
+        <location filename="../../toonz/exportpanel.cpp" line="856"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="864"/>
+        <location filename="../../toonz/exportpanel.cpp" line="860"/>
         <source>File Format:</source>
         <translation>Формат файла:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="873"/>
+        <location filename="../../toonz/exportpanel.cpp" line="869"/>
         <source>Use Markers</source>
         <translation>Использовать маркеры</translation>
     </message>
@@ -2919,246 +3390,254 @@ contain the dpi information, then the current camera dpi will be used.
 <context>
     <name>ExportXDTSCommand</name>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="667"/>
+        <location filename="../../toonz/xdtsio.cpp" line="671"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="687"/>
         <source>All columns</source>
-        <translation>Все столбцы</translation>
+        <translation type="vanished">Все столбцы</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="688"/>
         <source>Only active columns</source>
-        <translation>Только активные столбцы</translation>
+        <translation type="vanished">Только активные столбцы</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="695"/>
         <source>Inbetween symbol mark</source>
-        <translation>Промежуточная метка</translation>
+        <translation type="vanished">Промежуточная метка</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="698"/>
         <source>Reverse sheet symbol mark</source>
-        <translation>Знак обратного листа</translation>
+        <translation type="vanished">Знак обратного листа</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="701"/>
         <source>Target column</source>
-        <translation>Целевой столбец</translation>
+        <translation type="vanished">Целевой столбец</translation>
     </message>
 </context>
 <context>
     <name>ExportXsheetPdfPopup</name>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1883"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1886"/>
         <source>Export Xsheet PDF</source>
         <translation>Экспорт Xsheet PDF</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1896"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1900"/>
         <source>Print Export DateTime</source>
         <translation>Печать экспорта даты и времени</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1897"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1901"/>
         <source>Print Scene Path</source>
         <translation>Печать пути к сцене</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1898"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1902"/>
         <source>Print Soundtrack</source>
         <translation>Печать саундтрека</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1899"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1903"/>
         <source>Print Scene Name</source>
         <translation>Печать названия сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1901"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1905"/>
         <source>Put Serial Frame Numbers Over Pages</source>
         <translation>Поместить серийные номера кадров на страницы</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1903"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1907"/>
         <source>Print Level Names On The Bottom</source>
         <translation>Печатать названия уровней внизу</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1904"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1908"/>
         <source>Print Dialogue</source>
         <translation>Печать диалога</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1909"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1913"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1910"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1914"/>
         <source>Image</source>
         <translation>Изображение</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1917"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1921"/>
         <source>&lt; Prev</source>
         <translation>&lt; Предыдущий</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1918"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1922"/>
         <source>Next &gt;</source>
         <translation>Следующий &gt;</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1920"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1924"/>
         <source>Export PDF</source>
         <translation>Экспорт PDF</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1921"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1925"/>
         <source>Export PNG</source>
         <translation>Экспорт PNG</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1922"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1926"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1942"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1946"/>
         <source>ACTIONS</source>
         <translation>ДЕЙСТВИЯ</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1943"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1947"/>
         <source>CELLS</source>
         <translation>ЯЧЕЙКИ</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1952"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1956"/>
         <source>Always</source>
         <translation>Всегда</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1953"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1957"/>
         <source>More Than 3 Continuous Cells</source>
         <translation>Более 3 непрерывных ячеек</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1955"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1959"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2005"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2009"/>
         <source>Template Settings</source>
         <translation>Настройки шаблона</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2012"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2016"/>
         <source>Template:</source>
         <translation>Шаблон:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2017"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2021"/>
         <source>Line color:</source>
         <translation>Цвет линии:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2021"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2025"/>
         <source>Template font:</source>
         <translation>Шрифт шаблона:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2026"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2030"/>
         <source>Logo:</source>
         <translation>Лого:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2039"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2043"/>
         <source>Export Settings</source>
         <translation>Экспорт настроек</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2046"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2050"/>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2054"/>
         <source>Output area:</source>
         <translation>Область вывода:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2051"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2059"/>
         <source>Output font:</source>
         <translation>Выходной шрифт:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2056"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2064"/>
         <source>Continuous line:</source>
         <translation>Непрерывная линия:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2082"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2090"/>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2095"/>
+        <source>Inbetween mark 2:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Inbetween mark:</source>
-        <translation>Промежуточная метка:</translation>
+        <translation type="vanished">Промежуточная метка:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2087"/>
         <source>Reverse sheet mark:</source>
-        <translation>Метка оборотного листа:</translation>
+        <translation type="vanished">Метка оборотного листа:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2092"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2100"/>
         <source>Keyframe mark:</source>
         <translation>Ключевая метка:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2096"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2104"/>
         <source>Memo:</source>
         <translation>Мемо:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2115"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2123"/>
         <source>Save in:</source>
         <translation>Сохранить в:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2119"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2127"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2213"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2223"/>
         <source>B4 size, 3 seconds sheet</source>
         <translation>Размер B4, лист 3 секунды</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2214"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2249"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2224"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2259"/>
         <source>B4 size, 6 seconds sheet</source>
         <translation>Размер B4, лист 6 секунд</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2215"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2225"/>
         <source>A3 size, 3 seconds sheet</source>
         <translation>Формат А3, лист 3 секунды</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2216"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2226"/>
         <source>A3 size, 6 seconds sheet</source>
         <translation>Формат А3, лист 6 секунд</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2328"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2340"/>
         <source>Col%1</source>
         <translation>Столбец%1</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2447"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2459"/>
         <source>The preset file %1 is not valid.</source>
         <translation>Предустановленный файл %1 недействителен.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2558"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2570"/>
         <source>%n page(s)</source>
         <translation>
             <numerusform>%n страниц</numerusform>
@@ -3167,35 +3646,35 @@ contain the dpi information, then the current camera dpi will be used.
         </translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2562"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2574"/>
         <source>%1 x %2 pages</source>
         <translation>%1 x %2 страниц</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2574"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2644"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2586"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2656"/>
         <source>Please specify the file name.</source>
         <translation>Пожалуйста, укажите имя файла.</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2584"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2654"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2596"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2666"/>
         <source>The file %1 already exists.
 Do you want to overwrite it?</source>
         <translation>Файл %1 уже существует.
 Вы хотите перезаписать его?</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2594"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2664"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2606"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2676"/>
         <source>A folder %1 does not exist.
 Do you want to create it?</source>
         <translation>Папка %1 не существует.
 Вы хотите создать его?</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2604"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2674"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2616"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2686"/>
         <source>Failed to create folder %1.</source>
         <translation>Не удалось создать папку %1.</translation>
     </message>
@@ -3287,37 +3766,37 @@ Do you want to explode anyway ?</source>
         <translation>Некоторые файлы, которые вы хотите разблокировать, в настоящее время открыты. Закройте их сначала.</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="171"/>
+        <location filename="../../toonz/filebrowser.cpp" line="161"/>
         <source>Folder: </source>
         <translation>Папка: </translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="307"/>
+        <location filename="../../toonz/filebrowser.cpp" line="297"/>
         <source>Open folder failed</source>
         <translation>Не удалось открыть папку</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="308"/>
+        <location filename="../../toonz/filebrowser.cpp" line="298"/>
         <source>The input folder path was invalid.</source>
         <translation>Недопустимый путь к папке ввода.</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1060"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1050"/>
         <source>Can&apos;t change file extension</source>
         <translation>Не удалось расширение файла</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1066"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1056"/>
         <source>Can&apos;t set a drawing number</source>
         <translation>Не удалось установить номер рисунка</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1081"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1071"/>
         <source>Can&apos;t rename. File already exists: </source>
         <translation>Не удалось переименовать. Файл уже существует: </translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1103"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1093"/>
         <source>Couldn&apos;t rename </source>
         <translation>Не удалось переименовать </translation>
     </message>
@@ -3334,162 +3813,162 @@ Do you want to explode anyway ?</source>
         <translation type="vanished">Загрузить как Sub-xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1169"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1159"/>
         <source>Load As Sub-Scene</source>
         <translation>Загрузить как суб-сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1171"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1161"/>
         <source>Load</source>
         <translation>Загрузить</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1224"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1214"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1238"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1228"/>
         <source>Convert to Painted TLV</source>
         <translation>Конвертировать в окрашенный TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1244"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1234"/>
         <source>Convert to Unpainted TLV</source>
         <translation>Конвертировать в неокрашенный TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1271"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1261"/>
         <source>Version Control</source>
         <translation>Управление версиями</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1277"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1289"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1267"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1279"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1284"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1380"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1274"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1370"/>
         <source>Edit Frame Range...</source>
         <translation>Изменить диапазон кадров...</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1296"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1342"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1409"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1286"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1332"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1399"/>
         <source>Put...</source>
         <translation>Поместить...</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1300"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1413"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1290"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1403"/>
         <source>Revert</source>
         <translation>Вернуть</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1307"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1358"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1376"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1390"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1404"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1297"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1348"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1366"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1380"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1394"/>
         <source>Get</source>
         <translation>Получить</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1312"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1302"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1320"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1310"/>
         <source>Get Revision...</source>
         <translation>Пересмотреть...</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1336"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1348"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1326"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1338"/>
         <source>Unlock</source>
         <translation>Разблокировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1352"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1384"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1399"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1342"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1374"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1389"/>
         <source>Edit Info</source>
         <translation>Изменить инфо</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1364"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1354"/>
         <source>Revision History...</source>
         <translation>Пересмотреть историю...</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1395"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1385"/>
         <source>Unlock Frame Range</source>
         <translation>Разблокировать диапазон кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1552"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1542"/>
         <source>Save Scene</source>
         <translation>Сохранить сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1552"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1542"/>
         <source>Scene name:</source>
         <translation>Название сцены:</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1606"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1595"/>
         <source>There was an error copying %1 to %2</source>
         <translation>Произошла ошибка при копировании %1 в %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1901"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1886"/>
         <source>Convert To Unpainted Tlv</source>
         <translation>Конвертировать в неокрашенный TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1915"/>
-        <location filename="../../toonz/filebrowser.cpp" line="2009"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1900"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1994"/>
         <source>Warning: level %1 already exists; overwrite?</source>
         <translation>Внимание: уровень %1 уже существует; перезаписать?</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1917"/>
-        <location filename="../../toonz/filebrowser.cpp" line="2011"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1902"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1996"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1917"/>
-        <location filename="../../toonz/filebrowser.cpp" line="2011"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1902"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1996"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1977"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1962"/>
         <source>Done: All Levels  converted to TLV Format</source>
         <translation>Выполнено: все уровни конвертированы в формат TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1997"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1982"/>
         <source>Convert To Painted Tlv</source>
         <translation>Конвертировать в окрашенный TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2055"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2040"/>
         <source>Done: 2 Levels  converted to TLV Format</source>
         <translation>Выполнено: 2 уровня, конвертированы в формат TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2214"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2199"/>
         <source>New Folder</source>
         <translation>Новая папка</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2225"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2210"/>
         <source>It is not possible to create the %1 folder.</source>
         <translation>Не удалось создать папку %1.</translation>
     </message>
@@ -3577,10 +4056,10 @@ Do you want to explode anyway ?</source>
 <context>
     <name>Filmstrip</name>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1592"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1681"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1703"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1721"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1580"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1669"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1691"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1709"/>
         <source>- No Level -</source>
         <translation>- Нет уровня -</translation>
     </message>
@@ -3589,12 +4068,12 @@ Do you want to explode anyway ?</source>
         <translation type="vanished">- Нет текущего уровня -</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1833"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1821"/>
         <source>Level Strip</source>
         <translation>Level Strip</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1841"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1829"/>
         <source>Level:  </source>
         <translation>Уровень:  </translation>
     </message>
@@ -3646,50 +4125,50 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
 <context>
     <name>FilmstripFrames</name>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="789"/>
-        <location filename="../../toonz/filmstrip.cpp" line="798"/>
-        <location filename="../../toonz/filmstrip.cpp" line="810"/>
+        <location filename="../../toonz/filmstrip.cpp" line="785"/>
+        <location filename="../../toonz/filmstrip.cpp" line="794"/>
+        <location filename="../../toonz/filmstrip.cpp" line="806"/>
         <source>INBETWEEN</source>
         <translation>АВТОФАЗОВКА</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="818"/>
+        <location filename="../../toonz/filmstrip.cpp" line="814"/>
         <source>no icon</source>
         <translation>нет значка</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1138"/>
-        <location filename="../../toonz/filmstrip.cpp" line="1144"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1134"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1140"/>
         <source>Auto Inbetween</source>
         <translation>Автофазовка</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1308"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1301"/>
         <source>Panel Settings</source>
         <translation>Настройки панели</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1309"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1302"/>
         <source>Toggle Orientation</source>
         <translation>Переключить ориентацию</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1310"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1303"/>
         <source>Show/Hide Drop Down Menu</source>
         <translation>Показать/Скрыть выпадающий список</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1312"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1305"/>
         <source>Show/Hide Level Navigator</source>
         <translation>Показать/Скрыть навигатор уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1345"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1338"/>
         <source>Select Level</source>
         <translation>Выбрать уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1496"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1489"/>
         <source>Linear</source>
         <translation>Линейный</translation>
     </message>
@@ -3698,68 +4177,73 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
     <name>FlipBook</name>
     <message>
         <location filename="../../toonz/flipbook.cpp" line="252"/>
-        <location filename="../../toonz/flipbook.cpp" line="1912"/>
+        <location filename="../../toonz/flipbook.cpp" line="1940"/>
         <source>Flipbook</source>
         <translation>Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="645"/>
+        <location filename="../../toonz/flipbook.cpp" line="647"/>
         <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? &quot;  |</source>
         <translation>Имя файла не может быть пустым или содержать любой из следующих символов: (новая строка) \ /: *? &quot;|</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="652"/>
+        <location filename="../../toonz/flipbook.cpp" line="654"/>
         <source>It is not possible to save because the selected file format is not supported.</source>
         <translation>Это невозможно сохранить, потому что выбранный формат файла не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="686"/>
+        <location filename="../../toonz/flipbook.cpp" line="688"/>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
         <translation>Файл «%1» уже существует.
 Хотите перезаписать его?</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="734"/>
+        <location filename="../../toonz/flipbook.cpp" line="736"/>
         <source>It is not possible to save Flipbook content.</source>
         <translation>Невозможно сохранить содержимое Flipbook.</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="751"/>
+        <location filename="../../toonz/flipbook.cpp" line="753"/>
         <source>Saved %1 frames out of %2 in %3</source>
         <translation>Сохранено %1 кадр из %2 в %3</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="783"/>
+        <location filename="../../toonz/flipbook.cpp" line="785"/>
         <source>There are no rendered images to save.</source>
         <translation>Нет отрендеренных изображений для сохранения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="787"/>
-        <location filename="../../toonz/flipbook.cpp" line="810"/>
+        <location filename="../../toonz/flipbook.cpp" line="789"/>
+        <location filename="../../toonz/flipbook.cpp" line="812"/>
         <source>It is not possible to take or compare snapshots for Toonz vector levels.</source>
         <translation>Невозможно получить или сравнить snapshots для векторных уровней Toonz.</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="1229"/>
+        <location filename="../../toonz/flipbook.cpp" line="1232"/>
         <source>Rendered Frames  ::  From %1 To %2  ::  Step %3</source>
         <translation>Рендер кадров  :: От %1 до %2  :: Шаг %3</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="1234"/>
+        <location filename="../../toonz/flipbook.cpp" line="1237"/>
         <source>  ::  Shrink </source>
         <translation>  ::  Сокращать </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/flipbook.cpp" line="1571"/>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1133"/>
+        <location filename="../../toonz/tpanels.cpp" line="1134"/>
         <source>Safe Area (Right Click to Select)</source>
         <translation>Безопасная зона (Щелкните правой кнопкой мыши, чтобы выбрать)</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1149"/>
+        <location filename="../../toonz/tpanels.cpp" line="1150"/>
         <source>Minimize</source>
         <translation>Уменьшить</translation>
     </message>
@@ -3834,87 +4318,95 @@ Do you want to overwrite it?</source>
     </message>
 </context>
 <context>
+    <name>GPhotoCam</name>
+    <message>
+        <location filename="../../stopmotion/gphotocam.cpp" line="729"/>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="244"/>
-        <location filename="../../toonz/imageviewer.cpp" line="444"/>
-        <location filename="../../toonz/imageviewer.cpp" line="454"/>
+        <location filename="../../toonz/imageviewer.cpp" line="245"/>
+        <location filename="../../toonz/imageviewer.cpp" line="446"/>
+        <location filename="../../toonz/imageviewer.cpp" line="456"/>
         <source>Flipbook Histogram</source>
         <translation>Гистограмма Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="270"/>
+        <location filename="../../toonz/imageviewer.cpp" line="271"/>
         <source>Clone Preview</source>
         <translation>Клонировать предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="277"/>
+        <location filename="../../toonz/imageviewer.cpp" line="278"/>
         <source>Unfreeze Preview</source>
         <translation>Разморозить предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="283"/>
+        <location filename="../../toonz/imageviewer.cpp" line="284"/>
         <source>Freeze Preview</source>
         <translation>Заморозить предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="289"/>
+        <location filename="../../toonz/imageviewer.cpp" line="290"/>
         <source>Regenerate Preview</source>
         <translation>Регенерировать предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="294"/>
+        <location filename="../../toonz/imageviewer.cpp" line="295"/>
         <source>Regenerate Frame Preview</source>
         <translation>Регенерировать предпросмотр кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="302"/>
+        <location filename="../../toonz/imageviewer.cpp" line="303"/>
         <source>Load / Append Images</source>
         <translation>Загрузка / Добавление изображений</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="310"/>
+        <location filename="../../toonz/imageviewer.cpp" line="311"/>
         <source>Clear Images</source>
         <translation>Очистить изображения</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="363"/>
+        <location filename="../../toonz/imageviewer.cpp" line="364"/>
         <source>Save Images</source>
         <translation>Сохранить изображения</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="316"/>
+        <location filename="../../toonz/imageviewer.cpp" line="317"/>
         <source>Reset View</source>
         <translation>Вид по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="321"/>
+        <location filename="../../toonz/imageviewer.cpp" line="322"/>
         <source>Fit To Window</source>
         <translation>По размеру окна</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="332"/>
+        <location filename="../../toonz/imageviewer.cpp" line="333"/>
         <source>Exit Full Screen Mode</source>
         <translation>Выход из полноэкранного режима</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="333"/>
+        <location filename="../../toonz/imageviewer.cpp" line="334"/>
         <source>Full Screen Mode</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="348"/>
+        <location filename="../../toonz/imageviewer.cpp" line="349"/>
         <source>Show Histogram</source>
         <translation>Показать гистограмму</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="357"/>
+        <location filename="../../toonz/imageviewer.cpp" line="358"/>
         <source>Swap Compared Images</source>
         <translation>Поменять сравниваемые изображения</translation>
     </message>
     <message>
-        <location filename="../../toonz/imageviewer.cpp" line="531"/>
         <location filename="../../toonz/imageviewer.cpp" line="533"/>
+        <location filename="../../toonz/imageviewer.cpp" line="535"/>
         <source>  ::  Zoom : </source>
         <translation>  ::  Зум : </translation>
     </message>
@@ -3944,39 +4436,39 @@ Do you want to overwrite it?</source>
 <context>
     <name>InbetweenDialog</name>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1991"/>
-        <location filename="../../toonz/filmstrip.cpp" line="2006"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1979"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1994"/>
         <source>Inbetween</source>
         <translatorcomment>промежуточные кадры</translatorcomment>
         <translation>Автофазовка</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1993"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1981"/>
         <source>Linear</source>
         <translation>Линейная</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1994"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1982"/>
         <source>Ease In</source>
         <translation>Замедл. в начале</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1995"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1983"/>
         <source>Ease Out</source>
         <translation>Замедл. в конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="1996"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1984"/>
         <source>Ease In / Ease Out</source>
         <translation>Замедл. в начале/в конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="2003"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1991"/>
         <source>Interpolation:</source>
         <translation>Интерполяция:</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="2007"/>
+        <location filename="../../toonz/filmstrip.cpp" line="1995"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -3994,6 +4486,11 @@ Do you want to overwrite it?</source>
         <translation>Поиск:</translation>
     </message>
     <message>
+        <location filename="../../toonz/insertfxpopup.cpp" line="255"/>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../toonz/insertfxpopup.cpp" line="278"/>
         <source>Insert</source>
         <translation>Вставить</translation>
@@ -4009,37 +4506,37 @@ Do you want to overwrite it?</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="413"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="414"/>
         <source>Macro</source>
         <translation>Macro</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="561"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="562"/>
         <source>Remove Macro FX</source>
         <translation>Удалить Macro FX</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="569"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="570"/>
         <source>Remove Preset</source>
         <translation>Удалить пресет</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="620"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Вы действительно хотите удалить %1?</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="622"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="621"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="622"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/insertfxpopup.cpp" line="627"/>
+        <location filename="../../toonz/insertfxpopup.cpp" line="628"/>
         <source>It is not possible to delete %1.</source>
         <translation>Удалить %1 невозможно.</translation>
     </message>
@@ -4163,17 +4660,17 @@ Do you want to overwrite it?</source>
 <context>
     <name>LayerHeaderPanel</name>
     <message>
-        <location filename="../../toonz/layerheaderpanel.cpp" line="182"/>
+        <location filename="../../toonz/layerheaderpanel.cpp" line="177"/>
         <source>Preview Visibility Toggle All</source>
         <translation>Переключить видимость</translation>
     </message>
     <message>
-        <location filename="../../toonz/layerheaderpanel.cpp" line="187"/>
+        <location filename="../../toonz/layerheaderpanel.cpp" line="182"/>
         <source>Camera Stand Visibility Toggle All</source>
         <translation>Переключить видимость камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/layerheaderpanel.cpp" line="192"/>
+        <location filename="../../toonz/layerheaderpanel.cpp" line="187"/>
         <source>Lock Toggle All</source>
         <translation>Переключить замки</translation>
     </message>
@@ -4181,37 +4678,37 @@ Do you want to overwrite it?</source>
 <context>
     <name>LevelCreatePopup</name>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="169"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="174"/>
         <source>New Level</source>
         <translation>Новый уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="179"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="184"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="181"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="186"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="183"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="188"/>
         <source>DPI:</source>
         <translation>DPI:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="190"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="195"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="191"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="196"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="192"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="197"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
@@ -4224,7 +4721,7 @@ Do you want to overwrite it?</source>
         <translation type="vanished">Растровый уровень Toonz</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="199"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="204"/>
         <source>Raster Level</source>
         <translation>Растровый уровень</translation>
     </message>
@@ -4233,99 +4730,99 @@ Do you want to overwrite it?</source>
         <translation type="vanished">Уровень сканирования</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="201"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="206"/>
         <source>Vector Level</source>
         <translation>Векторный уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="200"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="205"/>
         <source>Smart Raster Level</source>
         <translation>Уровень Smart Raster</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="186"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="191"/>
         <source>Format:</source>
         <translation>Формат:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="188"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="193"/>
         <source>Frame Format</source>
         <translation>Формат кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="232"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="237"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="237"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="242"/>
         <source>From:</source>
         <translation>От:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="240"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="245"/>
         <source>To:</source>
         <translation>До:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="245"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="250"/>
         <source>Step:</source>
         <translation>Шаг:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="248"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="253"/>
         <source>Increment:</source>
         <translation>Прирост:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="253"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="258"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="258"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="263"/>
         <source>Save In:</source>
         <translation>Сохранить в:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="506"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="511"/>
         <source>No level name specified: please choose a valid level name</source>
         <translation>Имя уровня не определено: выберите допустимое имя уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="514"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="519"/>
         <source>Invalid frame range</source>
         <translation>Недопустимый диапазон кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="518"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="523"/>
         <source>Invalid increment value</source>
         <translation>Недопустимое значение прироста</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="522"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="527"/>
         <source>Invalid step value</source>
         <translation>Недопустимое значение шага</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="534"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="539"/>
         <source>The level name specified is already used: please choose a different level name</source>
         <translation>Указанное имя уровня уже используется: выберите другое имя уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="570"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="575"/>
         <source>The level name specified is already used as a file by another level: please choose a different level name</source>
         <translation>Указанное имя уровня уже используется как файл другим уровнем: выберите другое имя уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="581"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="586"/>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
         <translation>Папки %1 не существует.
 Вы хотите создать ее?</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="589"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="594"/>
         <source>Unable to create</source>
         <translation>Не удалось создать</translation>
     </message>
@@ -4333,123 +4830,129 @@ Do you want to create it?</source>
 <context>
     <name>LevelSettingsPopup</name>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="336"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="358"/>
         <location filename="../../toonz/preferencespopup.cpp" line="170"/>
         <source>DPI:</source>
         <translation>DPI:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="358"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="380"/>
         <location filename="../../toonz/preferencespopup.cpp" line="180"/>
         <source>Premultiply</source>
         <translation>Умножение</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="360"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="382"/>
         <location filename="../../toonz/preferencespopup.cpp" line="184"/>
         <source>White As Transparent</source>
         <translation>Белый как прозрачный</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="362"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="384"/>
         <location filename="../../toonz/preferencespopup.cpp" line="188"/>
         <source>Add Antialiasing</source>
         <translation>Добавить сглаживание</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="363"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="385"/>
         <location filename="../../toonz/preferencespopup.cpp" line="192"/>
         <source>Antialias Softness:</source>
         <translation>Мягкость сглаживания:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="355"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="377"/>
         <location filename="../../toonz/preferencespopup.cpp" line="199"/>
         <source>Subsampling:</source>
         <translation>Субсемплинг:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="323"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="341"/>
         <source>Level Settings</source>
         <translation>Настройки уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="331"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="353"/>
         <source>Scan Path:</source>
         <translation>Путь сканирования:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="338"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="360"/>
         <source>Forced Squared Pixel</source>
         <translation>Принудительно квадратные пиксели</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="340"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="362"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="342"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="364"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="345"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="367"/>
         <source>Use Camera DPI</source>
         <translation>Использовать DPI камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="350"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="372"/>
         <source>Camera DPI:</source>
         <translation>Камера DPI:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="351"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="373"/>
         <source>Image DPI:</source>
         <translation>DPI изображения:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="352"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="374"/>
         <source>Resolution:</source>
         <translation>Разрешение:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="371"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="388"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="205"/>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="397"/>
         <source>Image DPI</source>
         <translation>DPI изображения</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="372"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="398"/>
         <source>Custom DPI</source>
         <translation>Пользовательское значение DPI</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="434"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="464"/>
         <source>Name &amp;&amp; Path</source>
         <translation>Имя и путь</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="439"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="469"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="442"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="472"/>
         <source>Path:</source>
         <translation>Путь:</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="461"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="491"/>
         <source>Resolution</source>
         <translation>Разрешение</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="463"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="493"/>
         <source>DPI &amp;&amp; Resolution</source>
         <translation>DPI и разрешение</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1075"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1134"/>
         <source>The file you entered is already used by another level.
 Please choose a different file</source>
         <translation>Введенный вами файл уже используется другим уровнем.
@@ -4471,53 +4974,54 @@ Please choose a different file</source>
         <location filename="../../toonz/levelsettingspopup.cpp" line="74"/>
         <location filename="../../toonz/levelsettingspopup.cpp" line="95"/>
         <location filename="../../toonz/levelsettingspopup.cpp" line="96"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="913"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="918"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="961"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="966"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="989"/>
         <source>[Various]</source>
         <translation>[различные]</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="698"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="741"/>
         <source>Smart Raster level</source>
         <translation>Уровень Smart Raster</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="701"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="745"/>
         <source>Raster level</source>
         <translation>Растровый уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="704"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="748"/>
         <source>Mesh level</source>
         <translation>Уровень полисетки</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="707"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="751"/>
         <source>Vector level</source>
         <translation>Векторный уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="710"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="754"/>
         <source>Palette level</source>
         <translation>Уровень палитры</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="713"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="757"/>
         <source>SubXsheet Level</source>
         <translation>Уровень subxsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="716"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="760"/>
         <source>Sound Column</source>
         <translation>Столбец со звуковой дорожкой</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="719"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="763"/>
         <source>Another Level Type</source>
         <translation>Уровень другого типа</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1027"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1086"/>
         <source>The file %1 is not a sound level.</source>
         <translation>Файл %1 не является уровнем звука.</translation>
     </message>
@@ -4663,154 +5167,154 @@ Please choose a different file</source>
         <translation type="vanished">Применить данные липсинг</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="229"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="230"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="230"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="231"/>
         <source>A I Drawing</source>
         <translation>A I рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="231"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="232"/>
         <source>O Drawing</source>
         <translation>O рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="232"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="233"/>
         <source>E Drawing</source>
         <translation>E рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="233"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="234"/>
         <source>U Drawing</source>
         <translation>U рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="234"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="235"/>
         <source>L Drawing</source>
         <translation>L рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="235"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="236"/>
         <source>W Q Drawing</source>
         <translation>W Q рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="236"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="237"/>
         <source>M B P Drawing</source>
         <translation>M B P рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="237"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="238"/>
         <source>F V Drawing</source>
         <translation>F V рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="238"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="239"/>
         <source>Rest Drawing</source>
         <translation>Закрытый рот</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="239"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="240"/>
         <source>C D G K N R S Th Y Z</source>
         <translation>C D G K N R S Th Y Z</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="241"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="242"/>
         <source>Extend Rest Drawing to End Marker</source>
         <translation>Растянуть рисунок закрытого рта до конца маркера</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="258"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="259"/>
         <source>Audio Source: </source>
         <translation>Источник аудио: </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="266"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="267"/>
         <source>Audio Script (Optional, Improves accuracy): </source>
         <translation>Аудио скрипт (необязательно, повышает точность): </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="268"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="269"/>
         <source>A script significantly increases the accuracy of the lip sync.</source>
         <translation>Скрипт значительно увеличивает точность синхронизации губ.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="321"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="322"/>
         <source>Previous Drawing</source>
         <translation>Предыдущий рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="324"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="325"/>
         <source>Next Drawing</source>
         <translation>Следующий рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="451"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="452"/>
         <source>Insert at Frame: </source>
         <translation>Вставить в кадр: </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="298"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="299"/>
         <source>Lip Sync Data File: </source>
         <translation>Файл данных липсинк: </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="199"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="200"/>
         <source>Lip Sync</source>
         <translation>Синхронизация губ</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="205"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="206"/>
         <source>From Audio</source>
         <translation>Из аудио</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="206"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="207"/>
         <source>From Data File</source>
         <translation>Из файла данных</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="207"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="208"/>
         <source>Use audio from a column or external file to lip sync.</source>
         <translation>Используйте звук из столбца или внешнего файла для синхронизации губ.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="208"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="209"/>
         <source>Use a file generated in Papagayo to lip sync.</source>
         <translation>Используйте файл, созданный в Papagayo, для синхронизации губ.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="546"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="547"/>
         <source>Thumbnails are not available for sub-Xsheets.
 Please use the frame numbers for reference.</source>
         <translation>Эскиз недоступны для subXsheen.
 Пожалуйста, используйте номера кадров для ссылок.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="549"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="550"/>
         <source>Unable to apply lip sync data to this column type</source>
         <translation>Не удалось применить данные липсинк к этому типу столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="583"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="584"/>
         <source>Column </source>
         <translation>Столбец </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="586"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="587"/>
         <source>Choose File</source>
         <translation>Выбрать файл</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="674"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="675"/>
         <source>Please choose an audio file and try again.</source>
         <translation>Пожалуйста, выберите аудиофайл и попробуйте еще раз.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="811"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="772"/>
         <source>Rhubarb Processing Error:
 
 </source>
@@ -4819,41 +5323,41 @@ Please use the frame numbers for reference.</source>
 </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="844"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="805"/>
         <source>Rhubarb not found, please set the location in Preferences and restart.</source>
         <translation>Rhubarb не найден, укажите его местоположение в настройках и перезапустите.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="877"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="838"/>
         <source>Please choose a lip sync data file to continue.</source>
         <translation>Чтобы продолжить, выберите файл данных синхронизации губ.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="886"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="847"/>
         <source>Cannot find the file specified. 
 Please choose a valid lip sync data file to continue.</source>
         <translation>Не удается найти указанный файл.
 Чтобы продолжить, выберите допустимый файл данных синхронизации губ.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="913"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="874"/>
         <source>Invalid data file.
  Please choose a valid lip sync data file to continue.</source>
         <translation>Неверный файл данных.
   Чтобы продолжить, выберите допустимый файл данных синхронизации губ.</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="1010"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="971"/>
         <source>SubXSheet Frame </source>
         <translation>Кадр Sub-xsheet </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="1018"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="979"/>
         <source>Drawing: </source>
         <translation>Рисунок: </translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="892"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="853"/>
         <source>Unable to open the file: 
 </source>
         <translation>Не удается открыть файл: 
@@ -4870,6 +5374,14 @@ Please choose a valid lip sync data file to continue.</source>
         <location filename="../../toonz/boardsettingspopup.cpp" line="1078"/>
         <source>Load Clapperboard Settings Preset</source>
         <translation>Загрузить предустановку хлопушки-нумератора</translation>
+    </message>
+</context>
+<context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="5085"/>
+        <source>Load Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4922,32 +5434,32 @@ Please choose a valid lip sync data file to continue.</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="397"/>
+        <location filename="../../toonz/flipbook.cpp" line="399"/>
         <source>From:</source>
         <translation>От:</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="402"/>
+        <location filename="../../toonz/flipbook.cpp" line="404"/>
         <source>To:</source>
         <translation>До:</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="407"/>
+        <location filename="../../toonz/flipbook.cpp" line="409"/>
         <source>Step:</source>
         <translation>Шаг:</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="412"/>
+        <location filename="../../toonz/flipbook.cpp" line="414"/>
         <source>Shrink:</source>
         <translation>Сокращение:</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="434"/>
+        <location filename="../../toonz/flipbook.cpp" line="436"/>
         <source>Load</source>
         <translation>Загрузить</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="436"/>
+        <location filename="../../toonz/flipbook.cpp" line="438"/>
         <source>Load / Append Images</source>
         <translation>Загрузка / Добавление изображений</translation>
     </message>
@@ -5215,6 +5727,11 @@ Please choose a valid lip sync data file to continue.</source>
         <source>Locator</source>
         <translation>Локатор</translation>
     </message>
+    <message>
+        <location filename="../../toonz/locatorpopup.cpp" line="111"/>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MagpieFileImportPopup</name>
@@ -5282,7 +5799,7 @@ Please choose a valid lip sync data file to continue.</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="517"/>
+        <location filename="../../toonz/mainwindow.cpp" line="537"/>
         <source>Untitled</source>
         <translation>Безымянный</translation>
     </message>
@@ -5319,42 +5836,42 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Для отправки отчёта об ошибке нажмите кнопку ниже, чтобы открыть страницу &quot;OpenToonz issues&quot; на сайте https://github.com. Кликните &quot;New issue&quot; и заполните форму.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1223"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1244"/>
         <source>Cannot delete</source>
         <translation>Не удается удалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1724"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1768"/>
         <source>&amp;New Scene</source>
         <translation>&amp;Новая сцена</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1726"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1770"/>
         <source>&amp;Load Scene...</source>
         <translation>&amp;Загрузить сцену...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1728"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1772"/>
         <source>&amp;Save Scene</source>
         <translation>&amp;Сохранить сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1731"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1775"/>
         <source>&amp;Save Scene As...</source>
         <translation>&amp;Сохранить сцену как...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1734"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1778"/>
         <source>&amp;Save All</source>
         <translation>&amp;Сохранить все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1737"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1781"/>
         <source>&amp;Revert Scene</source>
         <translation>&amp;Откатить сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1742"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1786"/>
         <source>&amp;Load Folder...</source>
         <translation>&amp;Загрузить папку ...</translation>
     </message>
@@ -5363,32 +5880,32 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Загрузить как Sub-xsheet...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1747"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1791"/>
         <source>&amp;Open Recent Scene File</source>
         <translation>&amp;Открыть предыдущую сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1749"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1793"/>
         <source>&amp;Open Recent Level File</source>
         <translation>&amp;Открыть предыдущий уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1752"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1796"/>
         <source>&amp;Clear Recent Scene File List</source>
         <translation>&amp;Очистить список предыдущих сцен</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1755"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1799"/>
         <source>&amp;Clear Recent level File List</source>
         <translation>&amp;Очистить список предыдущих уровней</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1879"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1936"/>
         <source>&amp;New Level...</source>
         <translation>&amp;Новый уровень...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1881"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1938"/>
         <source>&amp;New Vector Level</source>
         <translation>&amp;Новый векторный уровень</translation>
     </message>
@@ -5405,7 +5922,7 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Новый растровый уровень Toonz</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1890"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1947"/>
         <source>&amp;New Raster Level</source>
         <translation>&amp;Новый растровый уровень</translation>
     </message>
@@ -5414,47 +5931,47 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Новый растровый уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1894"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1951"/>
         <source>&amp;Load Level...</source>
         <translation>&amp;Загрузить уровень...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1896"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1953"/>
         <source>&amp;Save Level</source>
         <translation>&amp;Сохранить уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1899"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1956"/>
         <source>&amp;Save All Levels</source>
         <translation>&amp;Сохранить все уровни</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1902"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1959"/>
         <source>&amp;Save Level As...</source>
         <translation>&amp;Сохранить уровень как...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1905"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1962"/>
         <source>&amp;Export Level...</source>
         <translation>&amp;Экспортировать уровень...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1757"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1801"/>
         <source>&amp;Convert File...</source>
         <translation>&amp;Конвертировать файл...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2322"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2396"/>
         <source>&amp;Save Palette As...</source>
         <translation>&amp;Сохранить палитру как...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2324"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2398"/>
         <source>&amp;Save Palette</source>
         <translation>&amp;Сохранить палитру</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1759"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1805"/>
         <source>&amp;Load Color Model...</source>
         <translation>&amp;Загрузить цветовую модель...</translation>
     </message>
@@ -5463,172 +5980,172 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="obsolete">&amp;Импортировать файл Magpie...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1764"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1810"/>
         <source>&amp;New Project...</source>
         <translation>&amp;Новый проект...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1772"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1819"/>
         <source>&amp;Project Settings...</source>
         <translation>&amp;Настройки проекта...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1774"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1822"/>
         <source>&amp;Save Default Settings</source>
         <translation>&amp;Сохранить настройки по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2139"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2199"/>
         <source>&amp;Output Settings...</source>
         <translation>&amp;Настройки вывода ...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2143"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2203"/>
         <source>&amp;Preview Settings...</source>
         <translation>&amp;Настройки предпросмотра...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2146"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2206"/>
         <source>&amp;Render</source>
         <translation>&amp;Рендер</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2149"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2209"/>
         <source>&amp;Fast Render to MP4</source>
         <translation>&amp;Рендер в MP4</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2154"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2214"/>
         <source>&amp;Preview</source>
         <translation>&amp;Предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1777"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1826"/>
         <source>&amp;Export Soundtrack</source>
         <translation>&amp;Экспортировать звуковую дорожку</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2157"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2217"/>
         <source>&amp;Save Previewed Frames</source>
         <translation>&amp;Сохранить кадры предпросмотра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2327"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2401"/>
         <source>&amp;Regenerate Preview</source>
         <translation>&amp;Регенерировать предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2330"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2404"/>
         <source>&amp;Regenerate Frame Preview</source>
         <translation>&amp;Регенерировать предпросмотр кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2332"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2406"/>
         <source>&amp;Clone Preview</source>
         <translation>&amp;Клонировать предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2335"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2409"/>
         <source>&amp;Freeze//Unfreeze Preview</source>
         <translation>&amp;Заморозить//разморозить предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2412"/>
         <source>Freeze Preview</source>
         <translation>Заморозить предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2412"/>
         <source>Unfreeze Preview</source>
         <translation>Разморозить предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2339"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2413"/>
         <source>&amp;Save As Preset</source>
         <translation>&amp;Сохранить как предустановку</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1779"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1828"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;Настройки программы...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1781"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1830"/>
         <source>&amp;Configure Shortcuts...</source>
         <translation>&amp;Настройка горячих клавиш...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1783"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1832"/>
         <source>&amp;Print Xsheet</source>
         <translation>&amp;Экспортировать Xsheet в HTML</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1797"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1849"/>
         <source>Run Script...</source>
         <translation>Запустить скрипт...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1800"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1852"/>
         <source>Open Script Console...</source>
         <translation>Открыть командную строку ...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1802"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1854"/>
         <source>&amp;Print Current Frame...</source>
         <translation>&amp;Распечатать текущий кадр...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1804"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
         <source>&amp;Quit</source>
         <translation>&amp;Выйти</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1806"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1858"/>
         <source>Reload qss</source>
         <translation>Обновить qss</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1808"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1860"/>
         <source>&amp;Load Recent Image Files</source>
         <translation>&amp;Загрузить предыдущие файлы изображений</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1811"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1863"/>
         <source>&amp;Clear Recent Flipbook Image List</source>
         <translation>&amp;Очистить список предыдущих изображений Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2340"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2414"/>
         <source>Preview Fx</source>
         <translation>Предпросмотр Fx</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1820"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1872"/>
         <source>&amp;Select All</source>
         <translation>&amp;Выбрать все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1822"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1874"/>
         <source>&amp;Invert Selection</source>
         <translation>&amp;Обратить выделенное</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1824"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1876"/>
         <source>&amp;Undo</source>
         <translation>&amp;Отменить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1825"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1877"/>
         <source>&amp;Redo</source>
         <translation>&amp;Повторить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1826"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1878"/>
         <source>&amp;Cut</source>
         <translation>&amp;Вырезать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1827"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1879"/>
         <source>&amp;Copy</source>
         <translation>&amp;Копировать</translation>
     </message>
@@ -5637,62 +6154,62 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="obsolete">&amp;Вставить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2052"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2110"/>
         <source>&amp;Merge</source>
         <translation>&amp;Слить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1834"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1886"/>
         <source>&amp;Paste Into</source>
         <translation>&amp;Поместить в</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2341"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2415"/>
         <source>&amp;Paste Color &amp;&amp; Name</source>
         <translation>&amp;Вставить цвет и имя</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2343"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2417"/>
         <source>Paste Color</source>
         <translation>Вставить цвет</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2344"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2419"/>
         <source>Paste Name</source>
         <translation>Вставить имя</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2346"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2422"/>
         <source>Get Color from Studio Palette</source>
         <translation>Взять цвет из Studio Palette</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2348"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2424"/>
         <source>Toggle Link to Studio Palette</source>
         <translation>Переключить линк на Studio Palette</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2350"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2426"/>
         <source>Remove Reference to Studio Palette</source>
         <translation>Удалить референс на Studio Palette</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1836"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1893"/>
         <source>&amp;Delete</source>
         <translation>&amp;Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1837"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1894"/>
         <source>&amp;Insert</source>
         <translation>&amp;Вставить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1840"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1897"/>
         <source>&amp;Group</source>
         <translation>&amp;Сгруппировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1841"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1898"/>
         <source>&amp;Ungroup</source>
         <translation>&amp;Разгруппировать</translation>
     </message>
@@ -5713,22 +6230,22 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;На задний план</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1843"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1900"/>
         <source>&amp;Enter Group</source>
         <translation>&amp;Войти в группу</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1845"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1902"/>
         <source>&amp;Exit Group</source>
         <translation>&amp;Выйти из группы</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1908"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1965"/>
         <source>&amp;Remove Vector Overflow</source>
         <translation>&amp;Удалить векторные излишки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3028"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3130"/>
         <source>&amp;Touch Gesture Control</source>
         <translation>&amp;Управление сенсорными жестами</translation>
     </message>
@@ -5757,27 +6274,27 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Сбросить область обрезки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1864"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1921"/>
         <source>&amp;Cleanup Settings...</source>
         <translation>&amp;Настройки очистки...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1866"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1923"/>
         <source>&amp;Preview Cleanup</source>
         <translation>&amp;Просмотр очистки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1869"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1926"/>
         <source>&amp;Camera Test</source>
         <translation>&amp;Тестирование камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1872"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1929"/>
         <source>&amp;Opacity Check</source>
         <translation>&amp;Opacity Check</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1874"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1931"/>
         <source>&amp;Cleanup</source>
         <translation>&amp;Очистка</translation>
     </message>
@@ -5786,32 +6303,32 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Захват камеры...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1910"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1967"/>
         <source>&amp;Add Frames...</source>
         <translation>&amp;Добавить кадры...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1912"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1969"/>
         <source>&amp;Renumber...</source>
         <translation>&amp;Пересчитать...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1914"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1971"/>
         <source>&amp;Replace Level...</source>
         <translation>&amp;Заменить уровень ...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1917"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1974"/>
         <source>&amp;Revert to Cleaned Up</source>
         <translation>&amp;Возврат к очистке</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2486"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2566"/>
         <source>Separate Colors...</source>
         <translation>Разделить цвета...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2527"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2608"/>
         <source>Animate Tool</source>
         <translation>Инструмент анимирования</translation>
     </message>
@@ -5820,7 +6337,7 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="obsolete">&amp;Возврат к последней сохраненной версии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1828"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1880"/>
         <source>&amp;Paste Insert</source>
         <translation>&amp;Вставить вставку</translation>
     </message>
@@ -5837,42 +6354,42 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Экспонировать в Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1922"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1979"/>
         <source>&amp;Display in Level Strip</source>
         <translation>&amp;Отобразить в Level Strip</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1924"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1981"/>
         <source>&amp;Level Settings...</source>
         <translation>&amp;Настройки уровня...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1926"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1983"/>
         <source>Adjust Levels...</source>
         <translation>Коррекция цветовых уровней...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1928"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1985"/>
         <source>Adjust Thickness...</source>
         <translation>Отрегулировать толщину...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1930"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1987"/>
         <source>&amp;Antialias...</source>
         <translation>&amp;Сглаживание...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1932"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1989"/>
         <source>&amp;Binarize...</source>
         <translation>&amp;Бинаризация...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1935"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1992"/>
         <source>&amp;Brightness and Contrast...</source>
         <translation>&amp;Яркость и контрастность...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1937"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1994"/>
         <source>&amp;Color Fade...</source>
         <translation>&amp;Спад цвета...</translation>
     </message>
@@ -5881,38 +6398,38 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Захват</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1939"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1996"/>
         <source>&amp;Canvas Size...</source>
         <translation>&amp;Размер холста...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1942"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1999"/>
         <source>&amp;Info...</source>
         <translation>&amp;Инфо...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2352"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2428"/>
         <source>&amp;View...</source>
         <translation>&amp;Вид...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1944"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2001"/>
         <source>&amp;Remove All Unused Levels</source>
         <translation>&amp;Удалить все неиспользуемые в сцене уровни</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1947"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2004"/>
         <source>&amp;Replace Parent Directory...</source>
         <translation>&amp;Заменить родительский каталог ...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1969"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2025"/>
         <source>&amp;Scene Settings...</source>
         <translation>&amp;Настройки сцены...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1971"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3031"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2027"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3133"/>
         <source>&amp;Camera Settings...</source>
         <translation>&amp;Настройки камеры...</translation>
     </message>
@@ -5929,7 +6446,7 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Разбить Sub-xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1979"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2035"/>
         <source>Collapse</source>
         <translation>Коллапс</translation>
     </message>
@@ -5942,7 +6459,7 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Сохранить Sub-xsheet как...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2028"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2084"/>
         <source>Resequence</source>
         <translation>Пересчитать секвенцию</translation>
     </message>
@@ -5951,37 +6468,37 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Клонировать Sub-xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1990"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2046"/>
         <source>&amp;Apply Match Lines...</source>
         <translation>&amp;Применить разделительные линии...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1992"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2048"/>
         <source>&amp;Merge Tlv Levels...</source>
         <translation>&amp;Объединить уровни Tlv ...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1994"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2050"/>
         <source>&amp;Delete Match Lines</source>
         <translation>&amp;Удалить разделительные линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1996"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2052"/>
         <source>&amp;Delete Lines...</source>
         <translation>&amp;Удалить линии...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1998"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2054"/>
         <source>&amp;Merge Levels</source>
         <translation>&amp;Объединить уровни</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2000"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2056"/>
         <source>&amp;New FX...</source>
         <translation>&amp;Новый FX...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2002"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2058"/>
         <source>&amp;New Output</source>
         <translation>&amp;Новый вывод</translation>
     </message>
@@ -5990,42 +6507,42 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="obsolete">&amp;Редактировать FX...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1762"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1808"/>
         <source>&amp;Import Toonz Lip Sync File...</source>
         <translation>&amp;Импортировать липсинк файл (TLS)...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1791"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1840"/>
         <source>Export Exchange Digital Time Sheet (XDTS)</source>
         <translation>Экспорт Exchange Digital Time Sheet (XDTS)</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1812"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1864"/>
         <source>&amp;Clear Cache Folder</source>
         <translation>&amp;Очистить кэш</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2004"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2060"/>
         <source>Insert Frame</source>
         <translation>Вставить кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2006"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2062"/>
         <source>Remove Frame</source>
         <translation>Удалить кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2009"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2065"/>
         <source>Insert Multiple Keys</source>
         <translation>Вставить несколько ключей</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2012"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2068"/>
         <source>Remove Multiple Keys</source>
         <translation>Удаление нескольких ключей</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2019"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2075"/>
         <source>Remove Empty Columns</source>
         <translation>Удалить пустые столбцы</translation>
     </message>
@@ -6034,103 +6551,103 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Показывать/скрывать столбец камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2053"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2111"/>
         <source>&amp;Reverse</source>
         <translation>&amp;Обратить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2054"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2112"/>
         <source>&amp;Swing</source>
         <translation>&amp;Добавить в обратном порядке</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2055"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2113"/>
         <source>&amp;Random</source>
         <translation>&amp;Случайно</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2056"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2114"/>
         <source>&amp;Autoexpose</source>
         <translation>&amp;Автоэкспонирование</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2058"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2116"/>
         <source>&amp;Repeat...</source>
         <translation>&amp;Повторение...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2059"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2117"/>
         <source>&amp;Reset Step</source>
         <translation>&amp;Сбросить шаг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2061"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2119"/>
         <source>&amp;Increase Step</source>
         <translation>&amp;Увеличить шаг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2063"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2121"/>
         <source>&amp;Decrease Step</source>
         <translation>&amp;Уменьшить шаг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2065"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2123"/>
         <source>&amp;Step 2</source>
         <translation>&amp;Шаг 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2066"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2124"/>
         <source>&amp;Step 3</source>
         <translation>&amp;Шаг 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2067"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2125"/>
         <source>&amp;Step 4</source>
         <translation>&amp;Шаг 4</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2068"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2126"/>
         <source>&amp;Each 2</source>
         <translation>&amp;Каждые 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2069"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2127"/>
         <source>&amp;Each 3</source>
         <translation>&amp;Каждые 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2070"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2128"/>
         <source>&amp;Each 4</source>
         <translation>&amp;Каждые 4</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2071"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2129"/>
         <source>&amp;Roll Up</source>
         <translatorcomment>думаю, так будет понятнее, чем &quot;все кадры кроме первого наверх&quot;</translatorcomment>
         <translation>&amp;Первый вниз</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2072"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2130"/>
         <source>&amp;Roll Down</source>
         <translation>&amp;Последний наверх</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2073"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2131"/>
         <source>&amp;Time Stretch...</source>
         <translation>&amp;Растяжение времени...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2134"/>
         <source>&amp;Create Blank Drawing</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2080"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2138"/>
         <source>&amp;Duplicate Drawing  </source>
         <translation>&amp;Дублировать рисунок  </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2082"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2140"/>
         <source>&amp;Autorenumber</source>
         <translation>&amp;Автопересчет</translation>
     </message>
@@ -6139,22 +6656,22 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Клонировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2087"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2145"/>
         <source>Drawing Substitution Forward</source>
         <translation>Заправка чертежа вперед</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2089"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2147"/>
         <source>Drawing Substitution Backward</source>
         <translation>Заправка чертежа назад</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2091"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2149"/>
         <source>Similar Drawing Substitution Forward</source>
         <translation>Заправка аналогичных чертежей вперед</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2094"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2152"/>
         <source>Similar Drawing Substitution Backward</source>
         <translation>Заправка аналогичных чертежей назад</translation>
     </message>
@@ -6175,32 +6692,32 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">по 4</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2106"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2164"/>
         <source>&amp;Fill In Empty Cells</source>
         <translation>&amp;Заполнить пустые ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2358"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2434"/>
         <source>&amp;Set Key</source>
         <translation>&amp;Установить ключ</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2361"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2437"/>
         <source>&amp;Shift Keys Down</source>
         <translation>&amp;Сместить ключи вниз</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2362"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2438"/>
         <source>&amp;Shift Keys Up</source>
         <translation>&amp;Сместить ключи вверх</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2165"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2231"/>
         <source>&amp;Camera Box</source>
         <translation>&amp;Граница камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2167"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2233"/>
         <source>&amp;Table</source>
         <translation>&amp;Таблица</translation>
     </message>
@@ -6209,7 +6726,7 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Направляющая сетка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2171"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2237"/>
         <source>&amp;Raster Bounding Box</source>
         <translation>&amp;Растровая граница</translation>
     </message>
@@ -6218,82 +6735,82 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Направляющая сетка в окне захвата</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2173"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2239"/>
         <source>&amp;Safe Area</source>
         <translation>&amp;Безопасная зона</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2175"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2241"/>
         <source>&amp;Camera BG Color</source>
         <translation>&amp;Цвет фона камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2177"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2243"/>
         <source>&amp;Guide</source>
         <translation>&amp;Ориентир</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2179"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2245"/>
         <source>&amp;Ruler</source>
         <translation>&amp;Линейка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2181"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2247"/>
         <source>&amp;Transparency Check  </source>
         <translation>&amp;Проверка прозрачности  </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2184"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2250"/>
         <source>&amp;Ink Check</source>
         <translation>&amp;Проверка штриха</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2190"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2256"/>
         <source>&amp;Ink#1 Check</source>
         <translation>&amp;Проверка штриха#1</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2196"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2262"/>
         <source>&amp;Paint Check</source>
         <translation>&amp;Проверка цвета</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2198"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2264"/>
         <source>Inks &amp;Only</source>
         <translation>Только &amp;линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2200"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2266"/>
         <source>&amp;Fill Check</source>
         <translation>&amp;Проверка заполнения</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2202"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2268"/>
         <source>&amp;Black BG Check</source>
         <translation>&amp;На чёрном фоне</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2205"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2271"/>
         <source>&amp;Gap Check</source>
         <translation>&amp;Проверка замкнутости</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2207"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2273"/>
         <source>Shift and Trace</source>
         <translation>Сдвинуть и калькировать (Shift and Trace) </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2209"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2275"/>
         <source>Edit Shift</source>
         <translation>Редактировать сдвиг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2211"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2277"/>
         <source>No Shift</source>
         <translation>Без сдвига</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2215"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2281"/>
         <source>Reset Shift</source>
         <translation>Сбросить сдвиг</translation>
     </message>
@@ -6302,62 +6819,62 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Векторный гид</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2221"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2287"/>
         <source>&amp;Visualize Vector As Raster</source>
         <translation>&amp;Отображать вектор как растр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2366"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2442"/>
         <source>&amp;Histogram</source>
         <translation>&amp;Гистограмма</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2111"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2169"/>
         <source>Link Flipbooks</source>
         <translation>Link Flipbooks</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2113"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2171"/>
         <source>Play</source>
         <translation>Воспроизведение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2114"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2172"/>
         <source>Short Play</source>
         <translation>Воспроизведение последних кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2115"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2173"/>
         <source>Loop</source>
         <translation>По кругу</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2116"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2174"/>
         <source>Pause</source>
         <translation>Пауза</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2117"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2175"/>
         <source>First Frame</source>
         <translation>Первый кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2119"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2177"/>
         <source>Last Frame</source>
         <translation>Последний кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2121"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2179"/>
         <source>Previous Frame</source>
         <translation>Предыдущий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2123"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2181"/>
         <source>Next Frame</source>
         <translation>Следующий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2125"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2183"/>
         <source>Next Drawing</source>
         <translation>Следующий рисунок</translation>
     </message>
@@ -6366,7 +6883,7 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Предыдущий рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2129"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2187"/>
         <source>Next Step</source>
         <translation>Следующий шаг</translation>
     </message>
@@ -6375,7 +6892,7 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Предыдущий шаг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2132"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2190"/>
         <source>Next Key</source>
         <translation>Следующий ключевой кадр</translation>
     </message>
@@ -6384,42 +6901,42 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">Предыдущий ключевой кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3044"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3146"/>
         <source>Red Channel</source>
         <translation>Красный канал</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3045"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3147"/>
         <source>Green Channel</source>
         <translation>Зеленый канал</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3046"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3148"/>
         <source>Blue Channel</source>
         <translation>Голубой канал</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2250"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2318"/>
         <source>&amp;FX Editor</source>
         <translation>&amp;Редактор эффектов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2265"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2333"/>
         <source>&amp;Stop Motion Controls</source>
         <translation>&amp;Открыть панель управления стоп-моушн</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2298"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2372"/>
         <source>&amp;Online Manual...</source>
         <translation>&amp;Онлайн руководство...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2300"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2374"/>
         <source>&amp;What&apos;s New...</source>
         <translation>&amp;Что нового...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2302"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2376"/>
         <source>&amp;Community Forum...</source>
         <translation>&amp;Форум сообщества...</translation>
     </message>
@@ -6428,141 +6945,141 @@ Please choose a valid lip sync data file to continue.</source>
         <translation type="vanished">&amp;Сообщить о проблеме...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2977"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3014"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3077"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3114"/>
         <source>Reset Zoom</source>
         <translation>Сбросить приближение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2978"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3015"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3078"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3116"/>
         <source>Reset Rotation</source>
         <translation>Сбросить вращение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2979"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3017"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3079"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3119"/>
         <source>Reset Position</source>
         <translation>Сбросить расположение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2982"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3021"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3082"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3123"/>
         <source>Flip Viewer Horizontally</source>
         <translation>Отзеркалить горизонтально</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2991"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3091"/>
         <source>&amp;Show Status Bar</source>
         <translation>&amp;Показать строку состояния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2995"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3095"/>
         <source>&amp;Toggle Transparency</source>
         <translation>&amp;Переключить прозрачность</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3058"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3160"/>
         <source>&amp;Export Stop Motion Image Sequence</source>
         <translation>&amp;Экспорт стоп-моушн секвенции</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3059"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3161"/>
         <source>Exports the full resolution stop motion image sequence.</source>
         <translation>Экспортирует последовательность покадровых изображений с полным разрешением.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3060"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3162"/>
         <source>This is especially useful if using a DSLR camera.</source>
         <translation>Это особенно полезно при использовании цифровой зеркальной камеры.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3062"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3164"/>
         <source>Capture Stop Motion Frame</source>
         <translation>Захват кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3064"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3166"/>
         <source>Raise Stop Motion Opacity</source>
         <translation>Увеличить непрозрачность</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3066"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3168"/>
         <source>Lower Stop Motion Opacity</source>
         <translation>Снизить непрозрачность</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3068"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3170"/>
         <source>Toggle Stop Motion Live View</source>
         <translation>Переключить отображение в реальном времени</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3071"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3172"/>
         <source>Toggle Stop Motion Zoom</source>
         <translation>Переключить приближение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3073"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3174"/>
         <source>Pick Focus Check Location</source>
         <translation>Выбрать место для проверки фокуса</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3176"/>
         <source>Lower Stop Motion Level Subsampling</source>
         <translation>Снизить субдискретизацию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3078"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3178"/>
         <source>Raise Stop Motion Level Subsampling</source>
         <translation>Поднять субдискретизацию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3080"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3180"/>
         <source>Go to Stop Motion Insert Frame</source>
         <translation>Перейти к вставке кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3082"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3182"/>
         <source>Remove frame before Stop Motion Camera</source>
         <translation>Удалить кадр перед стоп-моушн  камерой</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3085"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3185"/>
         <source>Next Frame including Stop Motion Camera</source>
         <translation>Следующий кадр, включая стоп-иоушн камеру</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3088"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3188"/>
         <source>Show original live view images.</source>
         <translation>Показать исходные изображения в режиме реального времени.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3187"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3211"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3224"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3229"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3287"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3311"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3324"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3329"/>
         <source>Clear Cache Folder</source>
         <translation>Очистить папку кэша</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3188"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3288"/>
         <source>There are no unused items in the cache folder.</source>
         <translation>В папке кеша нет неиспользуемых элементов.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3192"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3292"/>
         <source>Deleting the following items:
 </source>
         <translation>Удаление следующих элементов:
 </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3196"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3296"/>
         <source>&lt;DIR&gt; </source>
         <translation>&lt;ДИР&gt; </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3204"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3304"/>
         <source>   ... and %1 more items
 </source>
         <translation>   ... и еще %1 элементов
@@ -6581,8 +7098,8 @@ or you may delete necessary files for it.</source>
  в противном случае вы можете потерять необходимые для этого файлы.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3225"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3230"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3325"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3330"/>
         <source>Can&apos;t delete %1 : </source>
         <translation>Не удалось удалить %1 : </translation>
     </message>
@@ -6591,27 +7108,27 @@ or you may delete necessary files for it.</source>
         <translation type="obsolete">Матовый канал</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3048"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3150"/>
         <source>Red Channel Greyscale</source>
         <translation>Красный канал в оттенках серого</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3051"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3153"/>
         <source>Green Channel Greyscale</source>
         <translation>Зеленый канал в оттенках серого</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3053"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3155"/>
         <source>Blue Channel Greyscale</source>
         <translation>Голубой канал в оттенках серого</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2989"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3089"/>
         <source>Compare to Snapshot</source>
         <translation>Сравнить с Snapshot</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2315"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2389"/>
         <source>Toggle Autofill on Current Palette Color</source>
         <translation>Переключить автозаливку на текущий цвет палитры</translation>
     </message>
@@ -6620,122 +7137,122 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">&amp;Заблокировать Room Panes</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2293"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2367"/>
         <source>&amp;Export</source>
         <translation>&amp;Экспортировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2229"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2295"/>
         <source>&amp;File Browser</source>
         <translation>&amp;Браузер файлов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2231"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2299"/>
         <source>&amp;Flipbook</source>
         <translation>&amp;Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2233"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2301"/>
         <source>&amp;Function Editor</source>
         <translation>&amp;Редактор функций</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2235"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2303"/>
         <source>&amp;Level Strip</source>
         <translation>&amp;Level Strip</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2237"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2305"/>
         <source>&amp;Palette</source>
         <translation>&amp;Палитра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2488"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2568"/>
         <source>&amp;Palette Gizmo</source>
         <translation>&amp;Палитра Gizmo</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2491"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2571"/>
         <source>&amp;Delete Unused Styles</source>
         <translation>&amp;Удалить неиспользуемые стили</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2239"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2307"/>
         <source>&amp;Tasks</source>
         <translation>&amp;Задания</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1063"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1084"/>
         <source>https://tahoma2d.readthedocs.io/en/latest/whats_new.html</source>
         <translation>https://tahoma2d.readthedocs.io/en/latest/whats_new.html</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1768"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1815"/>
         <source>&amp;Open Recent Project</source>
         <translation>&amp;Открыть недавний проект</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1770"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1817"/>
         <source>&amp;Load Project...</source>
         <translation>&amp;Загрузить проект...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1771"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1818"/>
         <source>Load an existing project.</source>
         <translation>Загрузите существующий проект.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2240"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2308"/>
         <source>&amp;Batch Servers</source>
         <translation>&amp;Пакетные серверы</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2242"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2310"/>
         <source>&amp;Message Center</source>
         <translation>&amp;Центр сообщений</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2244"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2312"/>
         <source>&amp;Color Model</source>
         <translation>&amp;Цветовая модель</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2246"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2314"/>
         <source>&amp;Studio Palette</source>
         <translation>&amp;Палитра Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2248"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2316"/>
         <source>&amp;Schematic</source>
         <translation>&amp;Схема</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2253"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2321"/>
         <source>&amp;Cleanup Settings</source>
         <translation>&amp;Настройки очистки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2255"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2323"/>
         <source>&amp;Scene Cast</source>
         <translation>&amp;Состав сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2257"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2325"/>
         <source>&amp;Style Editor</source>
         <translation>&amp;Редактор стилей</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2259"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2327"/>
         <source>&amp;Toolbar</source>
         <translation>&amp;Панель инструментов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2260"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2328"/>
         <source>&amp;Tool Option Bar</source>
         <translation>&amp;Панель настройки инструментов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2267"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2335"/>
         <source>&amp;Viewer</source>
         <translation>&amp;Просмотрщик</translation>
     </message>
@@ -6748,27 +7265,27 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">&amp;LineTest просмотрщик</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2269"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2337"/>
         <source>&amp;Xsheet</source>
         <translation>&amp;Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2270"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2338"/>
         <source>&amp;Timeline</source>
         <translation>&amp;Таймлайн</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2272"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2340"/>
         <source>&amp;ComboViewer</source>
         <translation>&amp;ComboViewer</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2274"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2342"/>
         <source>&amp;History</source>
         <translation>&amp;История</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2276"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2344"/>
         <source>Record Audio</source>
         <translation>Запись аудио</translation>
     </message>
@@ -6777,12 +7294,12 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">&amp;Сбросить вкладки по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2280"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2348"/>
         <source>Toggle Maximize Panel</source>
         <translation>Переключить максимизацию панелей</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2283"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2351"/>
         <source>Toggle Main Window&apos;s Full Screen Mode</source>
         <translation>Переключить главное окно в полноэкранный режим</translation>
     </message>
@@ -6791,12 +7308,12 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">&amp;О программе...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2285"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2353"/>
         <source>&amp;Startup Popup...</source>
         <translation>&amp;Стартовое окно...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2304"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2378"/>
         <source>&amp;Report a Bug...</source>
         <translation>&amp;Сообщить об ошибке...</translation>
     </message>
@@ -6805,77 +7322,77 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">Контроллер векторного гида</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2367"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2448"/>
         <source>&amp;Blend colors</source>
         <translation>&amp;Смешивание цветов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2368"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2449"/>
         <source>Onion Skin Toggle</source>
         <translation>Переключение видимости кальки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2370"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2451"/>
         <source>Zero Thick Lines</source>
         <translation>Линии нулевой толщины</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2372"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2453"/>
         <source>Toggle Cursor Size Outline</source>
         <translation>Переключить размер контура курсора</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2376"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2457"/>
         <source>Duplicate</source>
         <translation>Дублировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2379"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2460"/>
         <source>Show Folder Contents</source>
         <translation>Показать содержимое папки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2381"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2462"/>
         <source>Convert...</source>
         <translation>Конвертировать... </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2383"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2464"/>
         <source>Collect Assets</source>
         <translation>Сбор активов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2385"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2466"/>
         <source>Import Scene</source>
         <translation>Импортировать сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2387"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2468"/>
         <source>Export Scene...</source>
         <translation>Экспортировать сцену...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1952"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2009"/>
         <source>Convert to Vectors...</source>
         <translation>Конвертировать в вектор...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1960"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2017"/>
         <source>Tracking...</source>
         <translation>Трекинг...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2389"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2470"/>
         <source>Remove Level</source>
         <translation>Удалить уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2392"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2473"/>
         <source>Add As Render Task</source>
         <translation>Добавить как задачу рендеринга</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2395"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2475"/>
         <source>Add As Cleanup Task</source>
         <translation>Добавить как задачу очистки</translation>
     </message>
@@ -6884,32 +7401,32 @@ or you may delete necessary files for it.</source>
         <translation type="obsolete">Выделить все ключи в этом ряду</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2400"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2480"/>
         <source>Select All Keys in this Column</source>
         <translation>Выделить все ключи в этом столбце</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2402"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2482"/>
         <source>Select All Keys</source>
         <translation>Выделить все ключи</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2404"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2484"/>
         <source>Select All Following Keys</source>
         <translation>Выделить все следующие ключи</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2406"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2486"/>
         <source>Select All Previous Keys</source>
         <translation>Выделить все предыдущие ключи</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2408"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2488"/>
         <source>Select Previous Keys in this Column</source>
         <translation>Выделить предыдущие ключи в этом столбце</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2411"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2491"/>
         <source>Select Following Keys in this Column</source>
         <translation>Выделить все следующие ключи в этом столбце</translation>
     </message>
@@ -6922,17 +7439,17 @@ or you may delete necessary files for it.</source>
         <translation type="obsolete">Выделить все следующие ключи в этом ряду</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1919"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1976"/>
         <source>&amp;Reload</source>
         <translation>&amp;Перезагрузить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1981"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2037"/>
         <source>&amp;Toggle Edit In Place</source>
         <translation>&amp;Редактировать на месте</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1949"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2006"/>
         <source>New Note Level</source>
         <translation>Новый уровень заметок</translation>
     </message>
@@ -6941,37 +7458,37 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">&amp;Применить данные липсинга к столбцу</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2355"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2431"/>
         <source>Toggle Quick Toolbar</source>
         <translation>Показать/скрыть панель Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2101"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2159"/>
         <source>Reframe with Empty Inbetweens...</source>
         <translation>Перекадрировать с пустыми промежутками...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2104"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2162"/>
         <source>Auto Input Cell Number...</source>
         <translation>Автоматический ввод номера ячейки...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2364"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2440"/>
         <source>&amp;Paste Numbers</source>
         <translation>&amp;Вставлять номер видео</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3047"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3149"/>
         <source>Alpha Channel</source>
         <translation>Альфа-канал</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2262"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2330"/>
         <source>&amp;Command Bar</source>
         <translation>&amp;Панель команд</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2375"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2456"/>
         <source>Toggle Current Time Indicator</source>
         <translation>Скрыть/показать индикатор кадра</translation>
     </message>
@@ -6980,187 +7497,187 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">Конвертировать вектор в Toonz растр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1957"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2014"/>
         <source>Replace Vectors with Simplified Vectors</source>
         <translation>Заменить вектора упрощенными векторами</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2398"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2478"/>
         <source>Select All Keys in this Frame</source>
         <translation>Выделить все ключи в этом кадре</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2414"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2494"/>
         <source>Select Previous Keys in this Frame</source>
         <translation>Выделить все предыдущие ключи перед кадром</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2417"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2497"/>
         <source>Select Following Keys in this Frame</source>
         <translation>Выделить все последующие ключи после кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2420"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2500"/>
         <source>Invert Key Selection</source>
         <translation>Инвертировать выбор ключей</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2421"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2501"/>
         <source>Set Acceleration</source>
         <translation>Установка ускорения</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2423"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2503"/>
         <source>Set Deceleration</source>
         <translation>Установка замедления</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2426"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2506"/>
         <source>Set Constant Speed</source>
         <translation>Установить постоянную скорость</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2428"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2508"/>
         <source>Reset Interpolation</source>
         <translation>Сбросить интерполяцию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2430"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2510"/>
         <source>Linear Interpolation</source>
         <translation>Линейная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2432"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2512"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation>Интерполяция ускорения в начале/в конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2435"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2515"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation>Интерполяция замедления в начале/в конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2438"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2518"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation>Интерполяция замедления в начале/в конце (%)</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2441"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2521"/>
         <source>Exponential Interpolation</source>
         <translation>Экспоненциальная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2443"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2523"/>
         <source>Expression Interpolation</source>
         <translation>Интерполяция выражений</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2445"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2525"/>
         <source>File Interpolation</source>
         <translation>Интерполяция из файла</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2447"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2527"/>
         <source>Constant Interpolation</source>
         <translation>Постоянная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2448"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2528"/>
         <source>Fold Column</source>
         <translation>Свернуть столбцы</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2451"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2531"/>
         <source>Show This Only</source>
         <translation>Показать только это</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2453"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2533"/>
         <source>Show Selected</source>
         <translation>Показать выбранные</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2454"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2534"/>
         <source>Show All</source>
         <translation>Показать все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2456"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2536"/>
         <source>Hide Selected</source>
         <translation>Скрыть выбранные</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2457"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2537"/>
         <source>Hide All</source>
         <translation>Скрыть все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2460"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2540"/>
         <source>Toggle Show/Hide</source>
         <translation>Переключить: Показать/Спрятать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2462"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2542"/>
         <source>ON This Only</source>
         <translation>ВКЛ только это</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2464"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2544"/>
         <source>ON Selected</source>
         <translation>ВКЛ выбранные</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2465"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2545"/>
         <source>ON All</source>
         <translation>ВКЛ все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2466"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2546"/>
         <source>OFF All</source>
         <translation>ВЫКЛ все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2468"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2548"/>
         <source>OFF Selected</source>
         <translation>ВЫКЛ выбранные</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2469"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2549"/>
         <source>Swap ON/OFF</source>
         <translation>Переключить ВКЛ/ВЫКЛ</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2472"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2552"/>
         <source>Lock This Only</source>
         <translation>Заблокировать это только</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2474"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2554"/>
         <source>Lock Selected</source>
         <translation>Заблокировать выбранные</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2475"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2555"/>
         <source>Lock All</source>
         <translation>Заблокировать все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2478"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2558"/>
         <source>Unlock Selected</source>
         <translation>Разблокировать выбранные</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2479"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2559"/>
         <source>Unlock All</source>
         <translation>Разблокировать все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2482"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2562"/>
         <source>Swap Lock/Unlock</source>
         <translation>Переключатель Блокировать/Разблокировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2484"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2564"/>
         <source>Hide Upper Columns</source>
         <translation>Скрыть верхние столбцы</translation>
     </message>
@@ -7169,12 +7686,12 @@ or you may delete necessary files for it.</source>
         <translation type="obsolete">Инструмент редактирования</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2530"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2611"/>
         <source>Selection Tool</source>
         <translation>Инструмент выделения</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2532"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2613"/>
         <source>Brush Tool</source>
         <translation>Кисть</translation>
     </message>
@@ -7183,12 +7700,12 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">Геометрический инструмент</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2536"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2617"/>
         <source>Type Tool</source>
         <translation>Инструмент шрифта</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2538"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2619"/>
         <source>Fill Tool</source>
         <translation>Заливка</translation>
     </message>
@@ -7197,200 +7714,200 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">Инструмент покраски</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2542"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2623"/>
         <source>Eraser Tool</source>
         <translation>Ластик</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2544"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2625"/>
         <source>Tape Tool</source>
         <translation>Скотч</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2547"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2628"/>
         <source>Style Picker Tool</source>
         <translation>Пипетка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2549"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2630"/>
         <source>RGB Picker Tool</source>
         <translation>Инструмент RGB пипетка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2552"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2633"/>
         <source>Control Point Editor Tool</source>
         <translation>Редактор контрольных точек</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2555"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2636"/>
         <source>Pinch Tool</source>
         <translation>Щипок</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2557"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2638"/>
         <source>Pump Tool</source>
         <translation>Насос</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2559"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2640"/>
         <source>Magnet Tool</source>
         <translation>Магнит</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2561"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2642"/>
         <source>Bender Tool</source>
         <translation>Клещи</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2563"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2644"/>
         <source>Iron Tool</source>
         <translation>Утюг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2566"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2647"/>
         <source>Cutter Tool</source>
         <translation>Нож</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2568"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2649"/>
         <source>Skeleton Tool</source>
         <translation>Скелет</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2571"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2652"/>
         <source>Tracker Tool</source>
         <translation>Трекер</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2573"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2654"/>
         <source>Hook Tool</source>
         <translation>Крюк</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2574"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2655"/>
         <source>Zoom Tool</source>
         <translation>Лупа</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2576"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2657"/>
         <source>Rotate Tool</source>
         <translation>Поворот</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2578"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2659"/>
         <source>Hand Tool</source>
         <translation>Рука</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2580"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2661"/>
         <source>Plastic Tool</source>
         <translation>Plastic Tool</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2583"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2664"/>
         <source>Ruler Tool</source>
         <translation>Рулетка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2588"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2671"/>
         <source>Finger Tool</source>
         <translation>Палец</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2870"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2966"/>
         <source>Mode - Lines &amp;&amp; Areas</source>
         <translation>Режим - Линии &amp;&amp; Области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2873"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2969"/>
         <source>Mode - Endpoint to Endpoint</source>
         <translation>Режим - вершина к вершине</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2875"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2971"/>
         <source>Mode - Endpoint to Line</source>
         <translation>Режим - вершина к линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2877"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2973"/>
         <source>Mode - Line to Line</source>
         <translation>Режим - линия к линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2897"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2997"/>
         <source>Type - Segment</source>
         <translation>Тип - Сегмент</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2907"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3007"/>
         <source>TypeTool Style - Oblique</source>
         <translation>Стиль шрифта - Наклонный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2909"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3009"/>
         <source>TypeTool Style - Regular</source>
         <translation>Стиль шрифта - Обычный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2911"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3011"/>
         <source>TypeTool Style - Bold Oblique</source>
         <translation>Стиль шрифта - жирный наклонный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2913"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3013"/>
         <source>TypeTool Style - Bold</source>
         <translation>Стиль шрифта - жирный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2931"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3031"/>
         <source>Skeleton Mode</source>
         <translation>Режим скелета</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2933"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3033"/>
         <source>Edit Mesh Mode</source>
         <translation>Редактировать полисетку</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2935"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3035"/>
         <source>Paint Rigid Mode</source>
         <translation>Покрасить жесткость</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2960"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3060"/>
         <source>Auto Close</source>
         <translation>Автозамыкание</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2961"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3061"/>
         <source>Draw Under</source>
         <translation>Рисовать позади</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2973"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3073"/>
         <source>Zoom In</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2974"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3074"/>
         <source>Zoom Out</source>
         <translation>Отдалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2975"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3010"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3075"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3110"/>
         <source>Reset View</source>
         <translation>Вид по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2976"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3012"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3112"/>
         <source>Fit to Window</source>
         <translation>По размеру окна</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2981"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3019"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3081"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3121"/>
         <source>Actual Pixel Size</source>
         <translation>Фактический пиксельный размер</translation>
     </message>
@@ -7399,88 +7916,88 @@ or you may delete necessary files for it.</source>
         <translation type="obsolete">Повернуть просмотр горизонтально</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2983"/>
-        <location filename="../../toonz/mainwindow.cpp" line="3023"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3083"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3125"/>
         <source>Flip Viewer Vertically</source>
         <translation>Повернуть просмотр вертикально</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2984"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3084"/>
         <source>Show//Hide Full Screen</source>
         <translation>Показать // Скрыть полный экран</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2987"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3087"/>
         <source>Full Screen Mode</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2988"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3088"/>
         <source>Exit Full Screen Mode</source>
         <translation>Выход из полноэкранного режима</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2761"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2857"/>
         <source>Select Next Frame Guide Stroke</source>
         <translation>Выбрать направляющую на следующем кадре</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2763"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2859"/>
         <source>Select Previous Frame Guide Stroke</source>
         <translation>Выбрать направляющую на предыдущем кадре</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2766"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2862"/>
         <source>Select Prev &amp;&amp; Next Frame Guide Strokes</source>
         <translation>Выбрать направляющие на предыдущем и следующем кадрах</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2770"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2866"/>
         <source>Reset Guide Stroke Selections</source>
         <translation>Сбросить направляющие по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2772"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2868"/>
         <source>Tween Selected Guide Strokes</source>
         <translation>Промежуточные кадры между выбранными направляющими</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2774"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2870"/>
         <source>Tween Guide Strokes to Selected</source>
         <translation>Промежуточные кадры от направляющих до выделенных</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2776"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2872"/>
         <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
         <translation>Выберите режим промежуточных кадров и направляющих</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2778"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2874"/>
         <source>Flip Next Guide Stroke Direction</source>
         <translation>Перевернуть направление следующего штриха</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2780"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2876"/>
         <source>Flip Previous Guide Stroke Direction</source>
         <translation>Перевернуть направление предыдущего штриха</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3033"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3135"/>
         <source>Refresh Folder Tree</source>
         <translation>Обновить дерево папок</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3034"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3136"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2782"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2878"/>
         <source>Global Key</source>
         <translation>Глобальный ключ</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1050"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1071"/>
         <source>http://tahoma2d.readthedocs.io</source>
         <translation>http://tahoma2d.readthedocs.io</translation>
     </message>
@@ -7489,120 +8006,125 @@ or you may delete necessary files for it.</source>
         <translation type="vanished">https://tahoma.readthedocs.io/en/latest/whats_new.html</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1069"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1090"/>
         <source>https://groups.google.com/g/tahoma2d</source>
         <translation>https://groups.google.com/g/tahoma2d</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1076"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1097"/>
         <source>To report a bug, click on the button below to open a web browser window for Tahoma2D&apos;s Issues page on https://github.com.  Click on the &apos;New issue&apos; button and fill out the form.</source>
         <translation>Чтобы сообщить об ошибке, нажмите кнопку ниже, чтобы открыть окно веб-браузера для страницы вопросов по Tahoma2D на https://github.com. Нажмите кнопку «New issue» и заполните форму.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1096"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1117"/>
         <source>Are you sure you want to reload and restore default rooms?
 Custom rooms will not be touched.</source>
         <translation>Вы уверены, что хотите перезагрузить и восстановить комнаты по умолчанию?
 Пользовательские комнаты не будут затронуты.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1725"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1769"/>
         <source>Create a new scene.</source>
         <translation>Создать новую сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1727"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1771"/>
         <source>Load an existing scene.</source>
         <translation>Загрузите существующую сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1729"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1773"/>
         <source>Save ONLY the scene.</source>
         <translation>Сохранить ТОЛЬКО сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1730"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1733"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1774"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1777"/>
         <source>This does NOT save levels or images.</source>
         <translation>Это НЕ сохраняет уровни или изображения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1732"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1776"/>
         <source>Save ONLY the scene with a new name.</source>
         <translation>Сохраните ТОЛЬКО сцену с новым именем.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1735"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1779"/>
         <source>Save the scene info and the levels and images.</source>
         <translation>Сохраните информацию о сцене, а также уровни и изображения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1736"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1780"/>
         <source>Saves everything.</source>
         <translation>Сохранить всё.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1739"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1783"/>
         <source>Revert the scene to its previously saved state.</source>
         <translation>Вернуть сцену в ее ранее сохраненное состояние.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1743"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1787"/>
         <source>Load the contents of a folder into the current scene.</source>
         <translation>Загрузить содержимое папки в текущую сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1745"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1789"/>
         <source>&amp;Load As Sub-Scene...</source>
         <translation>&amp;Загрузить как суб-сцену...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1746"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1790"/>
         <source>Load an existing scene into the current scene as a sub-scene</source>
         <translation>Загрузить существующую сцену в текущую сцену как суб-сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1748"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1792"/>
         <source>Load a recently used scene.</source>
         <translation>Загрузите недавно использованную сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1750"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1794"/>
         <source>Load a recently used level.</source>
         <translation>Загрузите недавно использованный уровень.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1753"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1797"/>
         <source>Remove everything from the recent scene list.</source>
         <translation>Удалите все из списка недавних сцен.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1756"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1800"/>
         <source>Remove everything from the recent level list.</source>
         <translation>Удалите все из списка последних уровней.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1758"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1802"/>
         <source>Convert an existing file or image sequence to another format.</source>
         <translation>Преобразуйте существующий файл или последовательность изображений в другой формат.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1760"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1804"/>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1806"/>
         <source>Load an image as a color guide.</source>
         <translation>Загрузите изображение в качествецветового гида.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1763"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1809"/>
         <source>Import a lip sync file to be applied to a level.</source>
         <translation>Импортируйте файл синхронизации губ для применения к уровню.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1765"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1812"/>
         <source>Create a new project.</source>
         <translation>Создать новый проект.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1766"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1813"/>
         <source>A project is a container for a collection of related scenes and drawings.</source>
         <translation>Проект - это контейнер для набора связанных сцен и рисунков.</translation>
     </message>
@@ -7611,439 +8133,479 @@ Custom rooms will not be touched.</source>
         <translation type="vanished">&amp;Сменить проект</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1775"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1824"/>
         <source>Use the current scene&apos;s settings as a template for all new scenes in the current project.</source>
         <translation>Используйте настройки текущей сцены в качестве шаблона для всех новых сцен в текущем проекте.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1778"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1827"/>
         <source>Exports the soundtrack to the current scene as a wav file.</source>
         <translation>Экспортировать саундтрек в текущую сцену в виде файла wav.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1780"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1829"/>
         <source>Change Tahoma2D&apos;s settings.</source>
         <translation>Изменить настройки Tahoma2D.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1782"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1831"/>
         <source>Change the shortcuts of Tahoma2D.</source>
         <translation>Изменить горячие клавиши Tahoma2D.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1784"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1833"/>
         <source>Print the scene&apos;s exposure sheet.</source>
         <translation>Распечатать лист экспозиции сцены.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1786"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1835"/>
         <source>&amp;Export Xsheet to PDF</source>
         <translation>&amp;Экспорт Xsheet в PDF</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1796"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1845"/>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="1848"/>
         <source>Export TVPaint JSON File</source>
         <translation>Экспорт файла TVPaint JSON</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1798"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1850"/>
         <source>Run a script to perform a series of actions on a scene.</source>
         <translation>Запустите скрипт, чтобы выполнить серию действий в сцене.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1801"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1853"/>
         <source>Open a console window where you can enter script commands.</source>
         <translation>Откройте окно консоли, в котором вы можете вводить команды скрипта.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1804"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
         <source>Bye.</source>
         <translation>Пока.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1815"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1867"/>
         <source>&amp;Export Current Scene</source>
         <translation>&amp;Экспортировать текущую сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1816"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1868"/>
         <source>Export the current scene to another project.</source>
         <translation>Экспортируйте текущую сцену в другой проект.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1830"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1882"/>
         <source>&amp;Paste Insert Below/Before</source>
         <translation>&amp;Вставить копию сзади/спереди</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1832"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1884"/>
         <source>&amp;Paste as a Copy</source>
         <translation>&amp;Вставить как копию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1838"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1895"/>
         <source>&amp;Insert Below/Before</source>
         <translation>&amp;Вставить сзади/ спереди</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1847"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1904"/>
         <source>&amp;Move to Back</source>
         <translation>&amp;На задний план</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1849"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1906"/>
         <source>&amp;Move Back One</source>
         <translation>&amp;Поместить ниже</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1851"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1908"/>
         <source>&amp;Move Forward One</source>
         <translation>&amp;Поместить выше</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1853"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1910"/>
         <source>&amp;Move to Front</source>
         <translation>&amp;На передний план</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1856"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1913"/>
         <source>&amp;Clear Recent Project List</source>
         <translation>&amp;Очистить список недавних проектов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1857"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1914"/>
         <source>Remove everything from the recent project list.</source>
         <translation>Удалите все из списка недавних проектов.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1859"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1916"/>
         <source>&amp;Clear Frames</source>
         <translation>&amp;Очистить кадры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1880"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1937"/>
         <source>Create a new drawing layer.</source>
         <translation>Создать новый слой с рисунком.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1882"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1939"/>
         <source>Create a new vector level.</source>
         <translation>Создать новый векторный уровень.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1883"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1940"/>
         <source>Vectors can be manipulated easily and have some extra tools and features.</source>
         <translation>Векторы можно легко манипулировать, и у них есть некоторые дополнительные инструменты и функции.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1886"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1943"/>
         <source>&amp;New Smart Raster Level</source>
         <translation>&amp;Новый уровень Smart- растра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1887"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1944"/>
         <source>Create a new Smart Raster level.</source>
         <translation>Создать новый уровень Smart растра.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1888"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1945"/>
         <source>Smart Raster levels are color mapped making the colors easier to adjust at any time.</source>
         <translation>Уровни Smart-растра имеют цветовую карту, что упрощает настройку цветов в любое время.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1891"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1948"/>
         <source>Create a new raster level</source>
         <translation>Создать новый растровый уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1892"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1949"/>
         <source>Raster levels are traditional drawing levels</source>
         <translation>Растровые уровни - это традиционные уровни рисования</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1893"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1950"/>
         <source>Imported images will be imported as raster levels.</source>
         <translation>Импортированные изображения будут импортированы как растровые уровни.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1895"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1952"/>
         <source>Load an existing level.</source>
         <translation>Загрузить существующий уровень.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1897"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1954"/>
         <source>Save the current level.</source>
         <translation>Сохранить текущий уровень.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1898"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1901"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1904"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1955"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1958"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1961"/>
         <source>This does not save the scene info.</source>
         <translation>Это не сохраняет информацию о сцене.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1900"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1957"/>
         <source>Save all levels loaded into the scene.</source>
         <translation>Сохраните все уровни, загруженные в сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1903"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1960"/>
         <source>Save the current level as a different name.</source>
         <translation>Сохраните текущий уровень под другим именем.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1906"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1963"/>
         <source>Export the current level as an image sequence.</source>
         <translation>Экспортируйте текущий уровень как последовательность изображений.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1921"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1978"/>
         <source>&amp;Expose in Scene</source>
         <translation>&amp;Экспонировать в сцене</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1954"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2011"/>
         <source>Vectors to Smart Raster</source>
         <translation>Векторы в Smart- растр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1962"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2018"/>
         <source>&amp;New Motion Path</source>
         <translation>&amp;Новый путь движения</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1963"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2019"/>
         <source>Create a new motion path.</source>
         <translation>Создайте новый путь движения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1964"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2020"/>
         <source>Motion paths can be used as animation guides, or you can animate objects along a motion path.</source>
         <translation>Пути движения можно использовать в качестве направляющих для анимации, или вы можете анимировать объекты по пути движения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1973"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2029"/>
         <source>&amp;Open Sub-Scene</source>
         <translation>&amp;Открыть суб- сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1975"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2031"/>
         <source>&amp;Close Sub-Scene</source>
         <translation>&amp;Закрыть суб- сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1977"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2033"/>
         <source>Explode Sub-Scene</source>
         <translation>Разбить суб-сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1985"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2041"/>
         <source>&amp;Save Sub-Scene As...</source>
         <translation>&amp;Сохранить суб-сцену как...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1987"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2043"/>
         <source>Clone Sub-Scene</source>
         <translation>Клонировать суб- сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2015"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2071"/>
         <source>Set Multiple Stop Frames</source>
         <translation>Установить несколько стоп-кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2017"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2073"/>
         <source>Remove Multiple Stop Frames</source>
         <translation>Удалить несколько стоп-кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2022"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2078"/>
         <source>Convert to use Implicit Holds</source>
         <translation>Конвертировать для использования неявных ячеек</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2024"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2080"/>
         <source>Convert to use Explicit Holds</source>
         <translation>Конвертировать для использования явных ячеек</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2026"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2082"/>
         <source>&amp;Apply Lip Sync to Column</source>
         <translation>&amp;Применить синхронизацию губ к столбцу</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2030"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2086"/>
         <source>Set Start Marker</source>
         <translation>Установить стартовый маркер</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2031"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2087"/>
         <source>Set Stop Marker</source>
         <translation>Установить конечный маркер</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2032"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2088"/>
         <source>Remove Markers</source>
         <translation>Удалить маркеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2033"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2089"/>
         <source>Set Auto Markers</source>
         <translation>Установить авто-маркеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2035"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2091"/>
         <source>Set Markers to Current Frame</source>
         <translation>Установить маркеры на текущий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2037"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2093"/>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2095"/>
         <source>Toggle Navigation Tag</source>
         <translation>Переключить тег навигации</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2039"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2097"/>
         <source>Next Tag</source>
         <translation>Следующий тег</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2041"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2099"/>
         <source>Previous Tag</source>
         <translation>Предыдущий тег</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2043"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2101"/>
         <source>Edit Tag</source>
         <translation>Изменить тег</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2044"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2102"/>
         <source>Remove Tags</source>
         <translation>Удалить тег</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2078"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2136"/>
         <source>&amp;Stop Frame Hold</source>
         <translation>&amp;Остановить удержание кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2084"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2142"/>
         <source>&amp;Clone Cells</source>
         <translation>&amp;Клонировать ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2096"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2154"/>
         <source>Reframe on 1&apos;s</source>
         <translation>Рекадрировать по 1</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2097"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2155"/>
         <source>Reframe on 2&apos;s</source>
         <translation>Рекадрировать по 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2098"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2156"/>
         <source>Reframe on 3&apos;s</source>
         <translation>Рекадрировать по 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2099"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2157"/>
         <source>Reframe on 4&apos;s</source>
         <translation>Рекадрировать по 4</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2127"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2185"/>
         <source>Previous Drawing</source>
         <translation>Предыдущий рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2130"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2188"/>
         <source>Previous Step</source>
         <translation>Предыдущий шаг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2134"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2192"/>
         <source>Previous Key</source>
         <translation>Предыдущий ключ</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2141"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2194"/>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2201"/>
         <source>Control the output settings for the current scene.</source>
         <translation>Натройки вывода для текущей сцены.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2142"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2202"/>
         <source>You can render from the output settings window also.</source>
         <translation>Вы также можете выполнить рендеринг из окна настроек вывода.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2145"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2205"/>
         <source>Control the settings that will be used to preview the scene.</source>
         <translation>Управление настройками, которые будут использоваться для предварительного просмотра сцены.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2147"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2207"/>
         <source>Renders according to the settings and location set in Output Settings.</source>
         <translation>Рендер в соответствии с настройками и местоположением, заданными в настройках вывода.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2150"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2210"/>
         <source>Exports an MP4 file to the location specified in the preferences.</source>
         <translation>Экспортировать файл MP4 в папку, указанную в настройках.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2151"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2211"/>
         <source>This is quicker than going into the Output Settings and setting up an MP4 render.</source>
         <translation>Это быстрее, чем заходить в настройки вывода и настраивать рендеринг MP4.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2155"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2215"/>
         <source>Previews the current scene with all effects applied.</source>
         <translation>Предварительный просмотр текущей сцены со всеми примененными эффектами.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2158"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2218"/>
         <source>Save the images created during preview to a specified location.</source>
         <translation>Сохраните изображения, созданные во время предварительного просмотра, в указанном месте.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2159"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2219"/>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2222"/>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2225"/>
         <source>&amp;Save and Render</source>
         <translation>&amp;Сохранить и отрендерить</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2160"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2226"/>
         <source>Saves the current scene and renders according to the settings and location set in Output Settings.</source>
         <translation>Сохраняет текущую сцену и выполняет рендеринг в соответствии с настройками и местоположением, заданными в настройках вывода.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2169"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2235"/>
         <source>&amp;Grids and Overlays</source>
         <translation>&amp;Сетки и наложения</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2217"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2283"/>
         <source>Vector Guided Tweening</source>
         <translation>Векторный гид-твининг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2279"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2297"/>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2347"/>
         <source>&amp;Reset All Default Rooms</source>
         <translation>&amp;Сбросить все вкладки по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2288"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2356"/>
         <source>Guided Tweening Controls</source>
         <translation>Настройки гид-твининга</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2294"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2359"/>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2362"/>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2368"/>
         <source>&amp;Motion Paths</source>
         <translation>&amp;Пути движения</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2306"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2380"/>
         <source>&amp;About Tahoma2D...</source>
         <translation>&amp;Про Tahoma2D...</translation>
     </message>
@@ -8052,812 +8614,857 @@ Custom rooms will not be touched.</source>
         <translation type="vanished">&amp;Поддержка Tahoma2D...</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2323"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2397"/>
         <source>Save the current style palette as a separate file with a new name.</source>
         <translation>Сохранить текущую палитру стилей как отдельный файл с новым именем.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2325"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2399"/>
         <source>Save the current style palette as a separate file.</source>
         <translation>Сохранить текущую палитру стилей как отдельный файл.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2328"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2402"/>
         <source>Recreates a set of preview images.</source>
         <translation>Воссоздать набор изображений для предварительного просмотра.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2331"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2405"/>
         <source>Regenerate the frame preview.</source>
         <translation>Восстановите предварительный просмотр кадра.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2333"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2407"/>
         <source>Creates a clone of the previewed images.</source>
         <translation>Создает клон предварительно просматриваемых изображений.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2336"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2410"/>
         <source>Prevent the preview from being updated.</source>
         <translation>Запретить обновление предварительного просмотра.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2357"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2433"/>
         <source>Show/Hide Camera Column</source>
         <translation>Показать / скрыть столбец камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2496"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2445"/>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2577"/>
         <source>&amp;Save Studio Palette</source>
         <translation>&amp;Сохранить палитру Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2497"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2578"/>
         <source>Save the current Studio Palette.</source>
         <translation>Сохраните текущую палитру Studio.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2499"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2580"/>
         <source>&amp;Save As Default Palette</source>
         <translation>&amp;Сохранить как палитру по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2500"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2581"/>
         <source>Save the current style palette as the default for new levels of the current level type.</source>
         <translation>Сохраните текущую палитру стилей как палитру по умолчанию для новых уровней текущего типа уровня.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2502"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2583"/>
         <source>Toggle Auto-Creation</source>
         <translation>Переключить автоматическое создание</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2505"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2586"/>
         <source>Toggles the auto-creation of frames when drawing in blank cells on the timeline/xsheet.</source>
         <translation>Переключает автоматическое создание кадров при рисовании пустых ячеек на временной шкале/xsheet.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2508"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2589"/>
         <source>Toggle Creation In Hold Cells</source>
         <translation>Переключить создание в ячейках удержания</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2511"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2592"/>
         <source>Toggles the auto-creation of frames when drawing in held cells on the timeline/xsheet.</source>
         <translation>Переключает автоматическое создание кадров при рисовании удерживаемых ячеек на таймлайн/xsheet.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2513"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2594"/>
         <source>Toggle Auto-Stretch</source>
         <translation>Включить автоматическое растяжение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2516"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2597"/>
         <source>Toggles the auto-stretch of a frame to the next frame</source>
         <translation>Переключает автоматическое растягивание кадра до следующего кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2517"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2598"/>
         <source>Toggle Viewer Indicators</source>
         <translation>Переключить индикаторы средства просмотра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2520"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2601"/>
         <source>Toggle Implicit Hold</source>
         <translation>Переключить неявное удержание</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2523"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2604"/>
         <source>Toggles the implicit hold of a frame to the next frame</source>
         <translation>Переключает неявное удержание кадра на следующий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2528"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2609"/>
         <source>Animate Tool: Modifies the position, rotation and size of the current column</source>
         <translation>Инструмент «Анимация»: изменяет положение, поворот и размер текущего столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2531"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2612"/>
         <source>Selection Tool: Select parts of your image to transform it.</source>
         <translation>Инструмент выделения: выделите части изображения, чтобы преобразовать его.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2533"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2614"/>
         <source>Brush Tool: Draws in the work area freehand</source>
         <translation>Инструмент «Кисть»: рисует в рабочей области от руки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2534"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2615"/>
         <source>Geometry Tool</source>
         <translation>Геометрический инструмент</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2535"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2616"/>
         <source>Geometry Tool: Draws geometric shapes</source>
         <translation>Геометрический инструмент: рисует геометрические фигуры</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2537"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2618"/>
         <source>Type Tool: Adds text</source>
         <translation>Инструмент шрифта: добавляет текст</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2539"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2620"/>
         <source>Fill Tool: Fills drawing areas with the current style</source>
         <translation>Инструмент «Заливка»: заполняет области рисования текущим стилем</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2540"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2621"/>
         <source>Smart Raster Paint Tool</source>
         <translation>Инструмент Smart Raster Paint</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2541"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2622"/>
         <source>Smart Raster Paint: Paints areas in Smart Raster levels</source>
         <translation>Smart Raster Paint: закрашивает области на уровнях Smart Raster</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2543"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2624"/>
         <source>Eraser Tool: Erases lines and areas</source>
         <translation>Ластик: стирает линии и области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2545"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2626"/>
         <source>Tape Tool: Closes gaps in raster, joins edges in vector</source>
         <translation>Скотч: закрывает пробелы в растре, соединяет края в векторе</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2548"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2629"/>
         <source>Style Picker: Selects style on current drawing</source>
         <translation>Пипетка выбора стиля: выбор стиля на текущем чертеже</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2550"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2631"/>
         <source>RGB Picker: Picks color on screen and applies to current style</source>
         <translation>Пипетка RGB: выбирает цвет на экране и применяет его к текущему стилю</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2553"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2634"/>
         <source>Control Point Editor: Modifies vector lines by editing its control points</source>
         <translation>Редактор контрольных точек: изменяет векторные линии, редактируя их контрольные точки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2556"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2637"/>
         <source>Pinch Tool: Pulls vector drawings</source>
         <translation>Инструмент &quot;Щипок&quot;: растягивает векторные рисунки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2558"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2639"/>
         <source>Pump Tool: Changes vector thickness</source>
         <translation>Инструмент &quot;Насос&quot;: изменяет толщину вектора</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2560"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2641"/>
         <source>Magnet Tool: Deforms vector lines</source>
         <translation>Инструмент &quot;Магнит&quot;: деформирует векторные линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2562"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2643"/>
         <source>Bender Tool: Bends vector shapes around the first click</source>
         <translation>Инструмент &quot;Клещи&quot;: сгибает векторные фигуры вокруг первого щелчка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2564"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2645"/>
         <source>Iron Tool: Smooths out vector lines</source>
         <translation>Инструмент &quot;Утюг&quot;: сглаживает векторные линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2567"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2648"/>
         <source>Cutter Tool: Splits vector lines</source>
         <translation>Инструмент &quot;Нож&quot;: разбивает векторные линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2569"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2650"/>
         <source>Skeleton Tool: Allows to build a skeleton and animate in a cut-out workflow</source>
         <translation>Инструмент «Скелет»: позволяет построить скелет и анимировать его</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2572"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2653"/>
         <source>Tracker Tool: Tracks specific regions in a sequence of images</source>
         <translation>Трекер: отслеживает определенные регионы в последовательности изображений</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2575"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2656"/>
         <source>Zoom Tool: Zooms viewer</source>
         <translation>Инструмент &quot;Лупа&quot;: масштабирование средства просмотра</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2577"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2658"/>
         <source>Rotate Tool: Rotate the viewer</source>
         <translation>Инструмент &quot;Поворот&quot;: поворот рабочей области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2579"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2660"/>
         <source>Hand Tool: Pans the workspace</source>
         <translation>Инструмент &quot;Рука&quot;: панорамирует рабочее пространство</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2581"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2662"/>
         <source>Plastic Tool: Builds a mesh that allows to deform and animate a level</source>
         <translation>Plastic Tool: строит сетку, которая позволяет деформировать и анимировать уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2584"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2665"/>
         <source>Ruler Tool: Measure distances on the canvas</source>
         <translation>Инструмент &quot;Рулетка&quot;: измеряет расстояния на холсте</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2586"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2667"/>
         <source>Perspective Grid Tool</source>
         <translation>Инструмент перспективной сетки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2587"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2668"/>
         <source>Perspective Grid Tool: Set up perspective grids</source>
         <translation>Инструмент перспективной сетки: настройка сетки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2589"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2669"/>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2670"/>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2672"/>
         <source>Finger Tool: Smudges small areas to cover with line</source>
         <translation>Инструмент &quot;Палец&apos;&apos;: размазывает небольшие участки, чтобы покрыть линией</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2592"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2675"/>
         <source>Animate Tool - Next Mode</source>
         <translation>Инструмент анимации - следующий режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2594"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2677"/>
         <source>Animate Tool - Position</source>
         <translation>Инструмент анимации - положение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2596"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2679"/>
         <source>Animate Tool - Rotation</source>
         <translation>Инструмент анимации - вращение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2598"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2681"/>
         <source>Animate Tool - Scale</source>
         <translation>Инструмент анимации - Масштаб</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2600"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2683"/>
         <source>Animate Tool - Shear</source>
         <translation>Инструмент анимации - сдвиг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2602"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2685"/>
         <source>Animate Tool - Center</source>
         <translation>Инструмент анимации - Центр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2604"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2687"/>
         <source>Animate Tool - All</source>
         <translation>Инструмент анимации - Все режимы</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2608"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2691"/>
         <source>Selection Tool - Next Type</source>
         <translation>Инструмент выделения - следующий тип</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2611"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2694"/>
         <source>Selection Tool - Rectangular</source>
         <translation>Инструмент выделения - прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2613"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2696"/>
         <source>Selection Tool - Freehand</source>
         <translation>Инструмент выделения - от руки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2615"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2698"/>
         <source>Selection Tool - Polyline</source>
         <translation>Инструмент выделения - полилиния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2619"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2702"/>
         <source>Brush Tool - Auto Fill On</source>
         <translation>Инструмент Кисть - Автозаполнение включено</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2621"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2704"/>
         <source>Brush Tool - Auto Fill Off</source>
         <translation>Инструмент Кисть - Автозаполнение выключено</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2625"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2708"/>
         <source>Geometric Tool - Next Shape</source>
         <translation>Геометрический инструмент - следующая фигура</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2627"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2710"/>
         <source>Geometric Tool - Rectangle</source>
         <translation>Геометрический инструмент - прямоугольник</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2629"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2712"/>
         <source>Geometric Tool - Circle</source>
         <translation>Геометрический инструмент - круг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2631"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2714"/>
         <source>Geometric Tool - Ellipse</source>
         <translation>Геометрический инструмент - эллипс</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2633"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2716"/>
         <source>Geometric Tool - Line</source>
         <translation>Геометрический инструмент - линия</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2635"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2718"/>
         <source>Geometric Tool - Polyline</source>
         <translation>Инструмент &quot;Геометрический рисунок&quot; - полилиния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2637"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2720"/>
         <source>Geometric Tool - Arc</source>
         <translation>Геометрический инструмент - дуга</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2639"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2722"/>
         <source>Geometric Tool - MultiArc</source>
         <translation>Геометрический инструмент - мультидуга</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2641"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2724"/>
         <source>Geometric Tool - Polygon</source>
         <translation>Геометрический инструмент - многоугольник</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2645"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2728"/>
         <source>Type Tool - Next Style</source>
         <translation>Инструмент шрифта- следующий стиль</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2647"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2730"/>
         <source>Type Tool - Oblique</source>
         <translation>Инструмент шрифта - наклонный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2649"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2732"/>
         <source>Type Tool - Regular</source>
         <translation>Инструмент шрифта - обычный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2651"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2734"/>
         <source>Type Tool - Bold Oblique</source>
         <translation>Инструмент шрифта - жирный наклонный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2653"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2736"/>
         <source>Type Tool - Bold</source>
         <translation>Инструмент шрифта - жирный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2657"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2740"/>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2742"/>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2744"/>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2747"/>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2751"/>
         <source>Fill Tool - Next Type</source>
         <translation>Инструмент заливки - следующий тип</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2659"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2753"/>
         <source>Fill Tool - Normal</source>
         <translation>Инструмент Заливка - нормальный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2661"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2755"/>
         <source>Fill Tool - Rectangular</source>
         <translation>Инструмент заливки - прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2663"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2757"/>
         <source>Fill Tool - Freehand</source>
         <translation>Инструмент заливки - от руки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2665"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2759"/>
         <source>Fill Tool - Polyline</source>
         <translation>Инструмент заливки - полилиния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2667"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2761"/>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="2763"/>
         <source>Fill Tool - Next Mode</source>
         <translation>Инструмент заливки - следующий режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2673"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2769"/>
         <source>Fill Tool - Lines &amp; Areas</source>
         <translation>Инструмент заливки - линии и области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2677"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2773"/>
         <source>Eraser Tool - Next Type</source>
         <translation>Инструмент Ластик - следующий тип</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2679"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2775"/>
         <source>Eraser Tool - Normal</source>
         <translation>Инструмент Ластик - Нормальный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2681"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2777"/>
         <source>Eraser Tool - Rectangular</source>
         <translation>Инструмент Ластик - Прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2683"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2779"/>
         <source>Eraser Tool - Freehand</source>
         <translation>Инструмент Ластик - от руки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2685"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2781"/>
         <source>Eraser Tool - Polyline</source>
         <translation>Инструмент Ластик - полилиния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2687"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2783"/>
         <source>Eraser Tool - Segment</source>
         <translation>Инструмент Ластик - Сегмент</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2691"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2787"/>
         <source>Tape Tool - Next Type</source>
         <translation>Инструмент &quot;Скотч&quot; - следующий тип</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2693"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2789"/>
         <source>Tape Tool - Normal</source>
         <translation>Инструмент &quot;Скотч&quot; - нормальный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2695"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2791"/>
         <source>Tape Tool - Rectangular</source>
         <translation>Инструмент &quot;Скотч&quot; прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2697"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2793"/>
         <source>Tape Tool - Next Mode</source>
         <translation>Инструмент &quot;Скотч&quot; - следующий режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2700"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2796"/>
         <source>Tape Tool - Endpoint to Endpoint</source>
         <translation>Инструмент &quot;Скотч&quot; - вершина к вершине</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2703"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2799"/>
         <source>Tape Tool - Endpoint to Line</source>
         <translation>Инструмент &quot;Скотч&quot; - вершина к линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2705"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2801"/>
         <source>Tape Tool - Line to Line</source>
         <translation>Инструмент &quot;Скотч&quot; - линия к линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2710"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2806"/>
         <source>Style Picker Tool - Next Mode</source>
         <translation>Инструмент выбора стиля - следующий режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2717"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2813"/>
         <source>Style Picker Tool - Lines &amp; Areas</source>
         <translation>Инструмент выбора стиля - линии и области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2721"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2817"/>
         <source>RGB Picker Tool - Next Type</source>
         <translation>Инструмент &quot;RGB Пипетка&quot; - следующий тип</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2723"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2819"/>
         <source>RGB Picker Tool - Normal</source>
         <translation>Инструмент &quot;RGB Пипетка&quot; - нормальная</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2726"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2822"/>
         <source>RGB Picker Tool - Rectangular</source>
         <translation>Инструмент &quot;RGB Пипетка&quot; - прямоугольная</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2728"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2824"/>
         <source>RGB Picker Tool - Freehand</source>
         <translation>Инструмент &quot;RGB Пипетка&quot; - от руки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2730"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2826"/>
         <source>RGB Picker Tool - Polyline</source>
         <translation>Инструмент &quot;RGB Пипетка&quot; - полилиния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2734"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2830"/>
         <source>Skeleton Tool - Next Mode</source>
         <translation>Инструмент &quot;Скелет&quot; - следующий режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2737"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2833"/>
         <source>Skeleton Tool - Build Skeleton</source>
         <translation>Инструмент &quot;Скелет&quot; - создать скелет</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2739"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2835"/>
         <source>Skeleton Tool - Animate</source>
         <translation>Инструмент &quot;Скелет&quot; - Анимация</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2742"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2838"/>
         <source>Skeleton Tool - Inverse Kinematics</source>
         <translation>Инструмент &quot;Скелет&quot; - обратная кинематика</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2746"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2842"/>
         <source>Plastic Tool - Next Mode</source>
         <translation>Plastic Tool - следующий режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2748"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2844"/>
         <source>Plastic Tool - Edit Mesh</source>
         <translation>Plastic Tool - редактировать сетку</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2750"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2846"/>
         <source>Plastic Tool - Paint Rigid</source>
         <translation>Plastic Tool - покрасить жёсткость</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2753"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2849"/>
         <source>Plastic Tool - Build Skeleton</source>
         <translation>Plastic Tool - создать скелет</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2755"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2851"/>
         <source>Plastic Tool - Animate</source>
         <translation>Plastic Tool - Анимация</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2786"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2882"/>
         <source>Brush size - Increase max</source>
         <translation>Размер кисти - Увеличить макс</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2788"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2884"/>
         <source>Brush size - Decrease max</source>
         <translation>Размер кисти - Уменьшение макс</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2790"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2886"/>
         <source>Brush size - Increase min</source>
         <translation>Размер кисти - Увеличить мин</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2792"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2888"/>
         <source>Brush size - Decrease min</source>
         <translation>Размер кисти - Уменьшение мин</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2794"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2890"/>
         <source>Brush hardness - Increase</source>
         <translation>Жесткость кисти - увеличение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2796"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2892"/>
         <source>Brush hardness - Decrease</source>
         <translation>Жесткость кисти - уменьшение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2798"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2894"/>
         <source>Snap Sensitivity</source>
         <translation>Чувствительность</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2799"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2895"/>
         <source>Auto Group</source>
         <translation>Автогруппа</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2802"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2898"/>
         <source>Break sharp angles</source>
         <translation>Разрыв острых углов</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2803"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2899"/>
         <source>Frame range</source>
         <translation>Диапазон кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2805"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2901"/>
         <source>Inverse Kinematics</source>
         <translation>Инверсная кинематика</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2807"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2903"/>
         <source>Invert</source>
         <translation>Инвертировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2808"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2904"/>
         <source>Manual</source>
         <translation>Вручную</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2809"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2905"/>
         <source>Onion skin</source>
         <translation>Калька</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2811"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2907"/>
         <source>Orientation</source>
         <translation>Ориентация</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2813"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2909"/>
         <source>Pencil Mode</source>
         <translation>Режим карандаша</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2816"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2912"/>
         <source>Preserve Thickness</source>
         <translation>Сохранять толщину</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2818"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2914"/>
         <source>Pressure Sensitivity</source>
         <translation>Чувствительность к давлению</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2819"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2915"/>
         <source>Segment Ink</source>
         <translation>Сегмент Ink</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2821"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2917"/>
         <source>Selective</source>
         <translation>Избирательно</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2824"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2920"/>
         <source>Brush Tool - Draw Order</source>
         <translation>Кисть - порядок рисования</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2825"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2921"/>
         <source>Smooth</source>
         <translation>Гладкий</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2826"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2922"/>
         <source>Snap</source>
         <translation>Привязка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2828"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2924"/>
         <source>Auto Select Drawing</source>
         <translation>Автоматический выбор рисунка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2829"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2925"/>
         <source>Auto Fill</source>
         <translation>Автозаливка</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2831"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2927"/>
         <source>Join Vectors</source>
         <translation>Объединить векторы</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2833"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2929"/>
         <source>Show Only Active Skeleton</source>
         <translation>Показать только активный скелет</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2835"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2931"/>
         <source>Brush Tool - Eraser (Raster option)</source>
         <translation>Кисть - Ластик</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2838"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2934"/>
         <source>Brush Tool - Lock Alpha</source>
         <translation>Кисть - Заблокировать альфа канал</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2841"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2937"/>
         <source>Brush Preset</source>
         <translation>Предустановка кисти</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2843"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2939"/>
         <source>Geometric Shape</source>
         <translation>Геометрическая форма</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2845"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2941"/>
         <source>Geometric Shape Rectangle</source>
         <translation>Геометрическая фигура: прямоугольник</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2847"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2943"/>
         <source>Geometric Shape Circle</source>
         <translation>Геометрическая фигура: круг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2849"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2945"/>
         <source>Geometric Shape Ellipse</source>
         <translation>Геометрическая фигура: эллипс</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2851"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2947"/>
         <source>Geometric Shape Line</source>
         <translation>Геометрическая фигура: линия</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2853"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2949"/>
         <source>Geometric Shape Polyline</source>
         <translation>Геометрическая фигура: полилиния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2855"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2951"/>
         <source>Geometric Shape Arc</source>
         <translation>Геометрическая фигура: дуга</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2857"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2953"/>
         <source>Geometric Shape MultiArc</source>
         <translation>Геометрическая фигура: мультидуга</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2859"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2955"/>
         <source>Geometric Shape Polygon</source>
         <translation>Геометрическая фигура: полигон</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2861"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2957"/>
         <source>Geometric Edge</source>
         <translation>Геометрический край</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2862"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2958"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2864"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2960"/>
         <source>Mode - Areas</source>
         <translation>Режим - Области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2867"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2963"/>
         <source>Mode - Lines</source>
         <translation>Режим - Линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2964"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2993"/>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="3064"/>
         <source>Flip Selection/Object Horizontally</source>
         <translation>Отразить выделение/объект по горизонтали</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2966"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3066"/>
         <source>Flip Selection/Object Vertically</source>
         <translation>Отразить выделение/объект по вертикали</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2968"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3068"/>
         <source>Rotate Selection/Object Left</source>
         <translation>Повернуть выделение/объект влево</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2970"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3070"/>
         <source>Rotate Selection/Object Right</source>
         <translation>Повернуть выделение/объект вправо</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3094"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3194"/>
         <source>Set Cell Mark </source>
         <translation>Установить метку ячейки </translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3207"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3307"/>
         <source>
 Are you sure?
 
@@ -8870,17 +9477,17 @@ N.B. Убедитесь, что вы не запускаете другой пр
 или вы можете удалить для этого необходимые файлы.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3267"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3367"/>
         <source>Tahoma2D Transparency</source>
         <translation>Tahoma2D Прозрачность</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3269"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3369"/>
         <source>Close to turn off Transparency.</source>
         <translation>Закройте, чтобы отключить прозрачность.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3283"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3383"/>
         <source>Amount: </source>
         <translation>Количество: </translation>
     </message>
@@ -8889,147 +9496,147 @@ N.B. Убедитесь, что вы не запускаете другой пр
         <translation type="vanished">Режим - Линии и Области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2878"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2974"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2881"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2977"/>
         <source>Type - Normal</source>
         <translation>Тип - обычный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2885"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2981"/>
         <source>Type - Rectangular</source>
         <translation>Тип - Прямоугольный</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2889"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2985"/>
         <source>Type - Freehand</source>
         <translation>Тип - От руки</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2893"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2989"/>
         <source>Type - Polyline</source>
         <translation>Тип - Полилиния</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2900"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3000"/>
         <source>TypeTool Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2902"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3002"/>
         <source>TypeTool Size</source>
         <translation>Размер шрифта</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2905"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3005"/>
         <source>TypeTool Style</source>
         <translation>Стиль шрифта</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2916"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3016"/>
         <source>Active Axis</source>
         <translation>Активная ось</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2918"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3018"/>
         <source>Active Axis - Position</source>
         <translation>Активная ось - расположение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2920"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3020"/>
         <source>Active Axis - Rotation</source>
         <translation>Активная ось - вращение</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2922"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3022"/>
         <source>Active Axis - Scale</source>
         <translation>Активная ось - масштаб</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2924"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3024"/>
         <source>Active Axis - Shear</source>
         <translation>Активная ось - сдвиг</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2926"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3026"/>
         <source>Active Axis - Center</source>
         <translation>Активная ось - центр</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2928"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3028"/>
         <source>Active Axis - All</source>
         <translation>Активные оси - все</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2937"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3037"/>
         <source>Build Skeleton Mode</source>
         <translation>Режим создания скелета</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2939"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3039"/>
         <source>Animate Mode</source>
         <translation>Режим анимации</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2941"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3041"/>
         <source>Inverse Kinematics Mode</source>
         <translation>Режим инверсной кинематики</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2943"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3043"/>
         <source>None Pick Mode</source>
         <translation>Объектов выделения - нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2945"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3045"/>
         <source>Column Pick Mode</source>
         <translation>Режим выбора столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2947"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3047"/>
         <source>Pegbar Pick Mode</source>
         <translation>Режим выбора Pegbar</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2949"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3049"/>
         <source>Pick Screen</source>
         <translation>Кликнуть по экрану</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2951"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3051"/>
         <source>Create Mesh</source>
         <translation>Создать полисетку</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2956"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3056"/>
         <source>Fill Tool - Autopaint Lines</source>
         <translation>Заливка - авторисовка линий</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2669"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2765"/>
         <source>Fill Tool - Areas</source>
         <translation>Заливка - Области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2671"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2767"/>
         <source>Fill Tool - Lines</source>
         <translation>Заливка - Линиии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2712"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2808"/>
         <source>Style Picker Tool - Areas</source>
         <translation>Инструмент выбора стиля - Области</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="2714"/>
+        <location filename="../../toonz/mainwindow.cpp" line="2810"/>
         <source>Style Picker Tool - Lines</source>
         <translation>Инструмент выбора стиля - Линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="3037"/>
+        <location filename="../../toonz/mainwindow.cpp" line="3139"/>
         <source>Toggle FX/Stage schematic</source>
         <translation>Переключение Схемы Fx</translation>
     </message>
@@ -9335,6 +9942,26 @@ What do you want to do?</source>
         <source>Polygon</source>
         <translation>Полигон</translation>
     </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="406"/>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="407"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="408"/>
+        <source>Color</source>
+        <translation type="unfinished">Цвет</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/motionpathpanel.cpp" line="409"/>
+        <source>Steps</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MyScannerListener</name>
@@ -9536,17 +10163,17 @@ What do you want to do?</source>
 <context>
     <name>OutputSettingsPopup</name>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="186"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="187"/>
         <source>Preview Settings</source>
         <translation>Настройки предпросмотра</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="186"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="187"/>
         <source>Output Settings</source>
         <translation>Настройки вывода</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="330"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="336"/>
         <source>Camera Settings</source>
         <translation>Настройки камеры</translation>
     </message>
@@ -9555,17 +10182,17 @@ What do you want to do?</source>
         <translation type="vanished">Настройки файла</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="457"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="504"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="577"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="624"/>
         <source>Use Sub-Camera</source>
         <translation>Использовать суб-камеру</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="579"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="626"/>
         <source>Apply Shrink to Main Viewer</source>
         <translatorcomment>?</translatorcomment>
         <translation>Применить Shrink к Main Viewer</translation>
@@ -9575,210 +10202,307 @@ What do you want to do?</source>
         <translation type="vanished">Другие настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="191"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="192"/>
         <source>Render</source>
         <translation>Рендер</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="212"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="196"/>
+        <source>Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="213"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="213"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="214"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="237"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="220"/>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="239"/>
         <source>Save and Render</source>
         <translation>Сохранить и отрендерить</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="297"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="299"/>
         <source>General</source>
         <translation>Общие</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="300"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="302"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="303"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="305"/>
+        <source>Color</source>
+        <translation type="unfinished">Цвет</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="308"/>
         <source>Advanced</source>
         <translation>Продвинутый</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="306"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="311"/>
         <source>More</source>
         <translation>Больше</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="327"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="332"/>
         <source>General Settings</source>
         <translation>Общие настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="332"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="339"/>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="342"/>
         <source>Advanced Settings</source>
         <translation>Продвинутые настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="335"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="346"/>
         <source>More Settings</source>
         <translation>Больше настроек</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="808"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="352"/>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="749"/>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="752"/>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="760"/>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="765"/>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="784"/>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="788"/>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="919"/>
         <source>Do stereoscopy</source>
         <translation>Сделать стереоскопию</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="852"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="963"/>
         <source>Frame Rate:</source>
         <translation>Частота кадров:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="855"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="966"/>
         <source>(linked to Scene Settings)</source>
         <translation>(связано с настройками сцены)</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1704"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1783"/>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1810"/>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1879"/>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1984"/>
         <source>Standard</source>
         <translation>Простое</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1705"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1985"/>
         <source>Improved</source>
         <translation>Улучшенный</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1706"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1986"/>
         <source>High</source>
         <translation>Высокий</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1707"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1987"/>
         <source>Triangle filter</source>
         <translation>Треугольный фильтр</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1708"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1988"/>
         <source>Mitchell-Netravali filter</source>
         <translation>Фильтр Митчелла-Нетравали</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1709"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1989"/>
         <source>Cubic convolution, a = .5</source>
         <translation>Кубическая свертка, a = .5</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1710"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1990"/>
         <source>Cubic convolution, a = .75</source>
         <translation>Кубическая свертка, a = .75</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1711"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1991"/>
         <source>Cubic convolution, a = 1</source>
         <translation>Кубическая свертка, a = 1</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1712"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1992"/>
         <source>Hann window, rad = 2</source>
         <translatorcomment>?</translatorcomment>
         <translation>Hann window, rad = 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1713"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1993"/>
         <source>Hann window, rad = 3</source>
         <translation>Hann window, rad = 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1714"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1994"/>
         <source>Hamming window, rad = 2</source>
         <translation>Hamming window, rad = 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1715"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1995"/>
         <source>Hamming window, rad = 3</source>
         <translation>Hamming window, rad = 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1716"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1996"/>
         <source>Lanczos window, rad = 2</source>
         <translation>Lanczos window, rad = 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1717"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1997"/>
         <source>Lanczos window, rad = 3</source>
         <translation>Lanczos window, rad = 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1718"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1998"/>
         <source>Gaussian convolution</source>
         <translation>Гауссова свертка</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1720"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2000"/>
         <source>Closest Pixel (Nearest Neighbor)</source>
         <translation>Ближайший пиксель (ближайший соседний)</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1721"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2001"/>
         <source>Bilinear</source>
         <translation>Билинейный</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="708"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2037"/>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2045"/>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2053"/>
+        <source>Bad file format: %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="747"/>
         <source>8 bit</source>
         <translation>8 бит</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="792"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="903"/>
         <source>Add Clapperboard</source>
         <translation>Добавить хлопушку-нумератор</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="793"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="904"/>
         <source>Edit Clapperboard...</source>
         <translation>редактироапть хлопушку-нумератор...</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="709"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="748"/>
         <source>16 bit</source>
         <translation>16 бит</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="813"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="924"/>
         <source>Odd (NTSC)</source>
         <translation>Odd (NTSC)</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="813"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="924"/>
         <source>Even (PAL)</source>
         <translation>Even (PAL)</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="715"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="813"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="823"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="831"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="924"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="934"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="823"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="934"/>
         <source>Fx Schematic Flows</source>
         <translation>Схемы Fx</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="824"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="935"/>
         <source>Fx Schematic Terminal Nodes</source>
         <translation>Fx Схематические терминальные узлы</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="219"/>
         <source>Save current output settings.
 The parameters to be saved are:
 - Camera settings
@@ -9787,7 +10511,7 @@ The parameters to be saved are:
 - File options
 - Resample Balance
 - Channel width</source>
-        <translation>Сохранить текущие настройки вывода.
+        <translation type="vanished">Сохранить текущие настройки вывода.
 Параметры для сохранения:
 - Настройки камеры
 - Папка проекта для сохранения в
@@ -9797,105 +10521,105 @@ The parameters to be saved are:
 - Ширина канала</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="712"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="828"/>
         <source>Single</source>
         <translation>Один</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="712"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="828"/>
         <source>Half</source>
         <translation>Половина</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="712"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="828"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="715"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="831"/>
         <source>Large</source>
         <translation>Большой</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="715"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="831"/>
         <source>Medium</source>
         <translation>Средний</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="716"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="832"/>
         <source>Small</source>
         <translation>Маленький</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="248"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="250"/>
         <source>Presets:</source>
         <translation>Предустановки:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="594"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="641"/>
         <source>Output Camera:</source>
         <translation>Камера вывода:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="482"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="617"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="529"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="664"/>
         <source>Frame Start:</source>
         <translation>Начальный кадр:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="487"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="622"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="534"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="669"/>
         <source>End:</source>
         <translation>Конец:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="492"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="627"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="539"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="674"/>
         <source>Step:</source>
         <translation>Шаг:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="643"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="690"/>
         <source>Shrink:</source>
         <translation>Сокращение:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="507"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="554"/>
         <source>Save in:</source>
         <translation>Сохранить в:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="511"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="558"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="740"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="855"/>
         <source>Resample Balance:</source>
         <translation>Ресемплировать баланс:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="745"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="778"/>
         <source>Channel Width:</source>
         <translation>Ширина канала:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="749"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="861"/>
         <source>Dedicated CPUs:</source>
         <translation>Выделенные процессоры:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="753"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="865"/>
         <source>Render Tile:</source>
         <translation>Паттерн рендера:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="843"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="954"/>
         <source>Gamma:</source>
         <translation>Гамма:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="847"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="958"/>
         <source>Dominant Field:</source>
         <translation>Доминантное поле:</translation>
     </message>
@@ -9904,54 +10628,61 @@ The parameters to be saved are:
         <translation type="vanished">Частота кадров (связанная с настройками сцены):</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="858"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="969"/>
         <source>Stretch from FPS:</source>
         <translation>Растяжка по FPS:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="861"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="972"/>
         <source>  To:</source>
         <translation>  До:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="866"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="977"/>
         <source>Multiple Rendering:</source>
         <translation>Многократный рендеринг:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="872"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="983"/>
         <source>Camera Shift:</source>
         <translation>Сдвиг камеры:</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1590"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1866"/>
         <source>Add preset</source>
         <translation>Добавить предустановку</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1590"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1866"/>
         <source>Enter the name for the output settings preset.</source>
         <translation>Введите имя для заданных параметров вывода.</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1602"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1878"/>
         <source>Add output settings preset</source>
         <translation>Добавить предустановку настроек вывода</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1687"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="1967"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;пользовательский&gt;</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1730"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2010"/>
         <source>Remove preset</source>
         <translation>Удалить пресет</translation>
     </message>
     <message>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1756"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1764"/>
-        <location filename="../../toonz/outputsettingspopup.cpp" line="1772"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2011"/>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished">Удаление «%1».
+Вы уверены?</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2036"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2044"/>
+        <location filename="../../toonz/outputsettingspopup.cpp" line="2052"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
@@ -9959,7 +10690,7 @@ The parameters to be saved are:
 <context>
     <name>OverwriteDialog</name>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1464"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1475"/>
         <source>Level &quot;%1&quot; already exists.
 
 What do you want to do?</source>
@@ -10474,17 +11205,17 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>PltGizmoPopup</name>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="603"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="591"/>
         <source>Palette Gizmo</source>
         <translation>Палитра Gizmo</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="608"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="596"/>
         <source>Blend</source>
         <translation>Однородно</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="610"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="598"/>
         <source>Fade</source>
         <translation>Спад</translation>
     </message>
@@ -10497,42 +11228,42 @@ Set the output folder path to the subfolder as well.</source>
         <translation type="obsolete">Zero Matte</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="617"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="605"/>
         <source>Full Alpha</source>
         <translation>Непрозрачный</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="618"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="606"/>
         <source>Zero Alpha</source>
         <translation>Прозрачный</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="628"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="616"/>
         <source>Scale (%)</source>
         <translation>Масштаб (%)</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="629"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="617"/>
         <source>Shift (value)</source>
         <translation>Сдвиг(значения)</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="631"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="619"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="635"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="623"/>
         <source>Saturation</source>
         <translation>Насыщенность</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="639"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="627"/>
         <source>Hue</source>
         <translation>Оттенок</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="643"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="631"/>
         <source>Alpha</source>
         <translation>Альфа</translation>
     </message>
@@ -10541,12 +11272,12 @@ Set the output folder path to the subfolder as well.</source>
         <translation type="obsolete">Matte</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="657"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="645"/>
         <source>Fade to Color</source>
         <translation>Спад цвета</translation>
     </message>
     <message>
-        <location filename="../../toonz/pltgizmopopup.cpp" line="666"/>
+        <location filename="../../toonz/pltgizmopopup.cpp" line="654"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
@@ -10554,69 +11285,69 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>PreferencesPopup</name>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="873"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="917"/>
         <source>New Level Format</source>
         <translation>Формат нового уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="874"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="918"/>
         <source>Assign the new level format name:</source>
         <translation>Назначьте имя формата нового уровня:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="875"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="919"/>
         <source>New Format</source>
         <translation>Новый формат</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="647"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="691"/>
         <source>Numpad keys are assigned to the following commands.
 Is it OK to release these shortcuts?</source>
         <translation>Клавиши Numpad назначаются следующим командам.
 Хотите их изменить?</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="653"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="697"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="653"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="697"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1479"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1533"/>
         <source>Preferences</source>
         <translation>Настройки программы</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1541"/>
         <source>General</source>
         <translation>Общие</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1158"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1202"/>
         <source>Use Default Viewer for Movie Formats</source>
         <translation>Использовать средство просмотра по умолчанию для форматов видео</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1159"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1203"/>
         <source>Minimize Raster Memory Fragmentation*</source>
         <translation>Минимизировать фрагментацию памяти в растре*</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1160"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1204"/>
         <source>Save Automatically</source>
         <translation>Сохранять автоматически</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1162"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1206"/>
         <source>Automatically Save the Scene File</source>
         <translation>Сохранять файл сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1163"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1207"/>
         <source>Automatically Save Non-Scene Files</source>
         <translation>Сохранять файлы без сцены</translation>
     </message>
@@ -10633,12 +11364,12 @@ Is it OK to release these shortcuts?</source>
         <translation type="obsolete">Делать резервные копии уровней при сохранении</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1171"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1215"/>
         <source>Show Info in Rendered Frames</source>
         <translation>Показывать информацию в отрендереных кадрах</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1173"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1217"/>
         <source>Watch File System and Update File Browser Automatically</source>
         <translation>Автоматически просматривать файловую систему и обновлять браузер файлов</translation>
     </message>
@@ -10660,7 +11391,7 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">другое*</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1175"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1219"/>
         <source>Custom Project Path(s):</source>
         <translation>Пользовательский путь(и) проекта:</translation>
     </message>
@@ -10673,12 +11404,12 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">* Изменения вступят в силу после перезапуска OpenToonz</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1541"/>
         <source>Interface</source>
         <translation>Интерфейс</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1181"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1226"/>
         <source>All imported images will use the same DPI</source>
         <translation>Все импортированные изображения будут использовать один и тот же DPI</translation>
     </message>
@@ -10687,7 +11418,7 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">Переместить текущий кадр, нажав на ячейку Xsheet / числовую область ячейки столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1195"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1240"/>
         <source>Show Raster Images Darken Blended</source>
         <translation>Отображать растровые изображения в режиме наложения Darken</translation>
     </message>
@@ -10696,12 +11427,12 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">Коррекция цвета с помощью 3D-таблицы поиска*</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1213"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1258"/>
         <source>Antialiased Region Boundaries</source>
         <translation>Границы области с сглаживанием</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1264"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1309"/>
         <source>Down Arrow at End of Level Strip Creates a New Frame</source>
         <translation>Стрелка вниз в конце Level Strip создает новый кадр</translation>
     </message>
@@ -10710,22 +11441,22 @@ Is it OK to release these shortcuts?</source>
         <translation type="obsolete">Заполнение пустых кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1277"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1322"/>
         <source>Show Cursor Size Outlines</source>
         <translation>Показать форму кисти</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1300"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1345"/>
         <source>Expand Function Editor Header to Match Quick Toolbar Height*</source>
         <translation>Развернуть заголовок редактора функций, чтобы соответствовать высоте панели инструментов Xsheet*</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1330"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1376"/>
         <source>Open Flipbook after Rendering</source>
         <translation>Открыть Flipbook после рендеринга</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1193"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1238"/>
         <source>Enable Actual Pixel View on Scene Editing Mode</source>
         <translation>Включить реальный пиксельный просмотр в режиме редактирования сцены</translation>
     </message>
@@ -10739,17 +11470,16 @@ Is it OK to release these shortcuts?</source>
         <translation type="obsolete">Показать растровые изображения Darken Blended in Camstand View</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1314"/>
         <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation>Показывать «ABC» суффикс к номеру кадра в ячейке Xsheet</translation>
+        <translation type="vanished">Показывать «ABC» суффикс к номеру кадра в ячейке Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1541"/>
         <source>Visualization</source>
         <translation>Визуализация</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1212"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1257"/>
         <source>Show Lines with Thickness 0</source>
         <translation>Показать линии с нулевой толщиной</translation>
     </message>
@@ -10758,7 +11488,7 @@ Is it OK to release these shortcuts?</source>
         <translation type="obsolete">Сглаженные границы областей</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Loading</source>
         <translation>Загрузка</translation>
     </message>
@@ -10771,17 +11501,17 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">Создавать подпапки при импорте Sub-Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1223"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1268"/>
         <source>Use Camera DPI for All Imported Images</source>
         <translation>Применять разрешение камеры ко всем импортированным изображениям</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1222"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1267"/>
         <source>Automatically Remove Scene Number from Loaded Level Name</source>
         <translation>Автоматически удалять номер сцены из имени загруженного уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1759"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1827"/>
         <source>Edit</source>
         <translation>Правка</translation>
     </message>
@@ -10790,93 +11520,94 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">Импорт/Экспорт</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Drawing</source>
         <translation>Рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1250"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1295"/>
         <source>DPI:</source>
         <translation>DPI:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1247"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1292"/>
         <source>New Levels Default to the Current Camera Size</source>
         <translation>Новые уровни по умолчанию текущего разрешения камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1259"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1304"/>
         <source>Keep Original Cleaned Up Drawings As Backup</source>
         <translation>Сохранять оригинальные очищенные рисунки в качестве резервной копии</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1274"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1319"/>
         <source>Multi Layer Style Picker: Switch Levels by Picking</source>
         <translation>Многослойная пипетка: Переключение уровней путем выбора</translation>
     </message>
     <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1317"/>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">Используйте команду «Сохранить в TLV» для ограничения заливки</translation>
+        <translation>Используйте команду «Сохранить в TLV» для ограничения заливки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1260"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1305"/>
         <source>Minimize Savebox after Editing</source>
         <translation>Минимизировать Savebox после правки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Saving</source>
         <translation>Сохранение</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1262"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1307"/>
         <source>Use Numpad and Tab keys for Switching Styles</source>
         <translation>Использовать клавиши Numpad и Tab для переключения стилей</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1266"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1311"/>
         <source>Keep fill when using &quot;Replace Vectors&quot; command</source>
         <translation>Сохранять заливку при использовании команды  &quot;Заменить векторы &quot;</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1268"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1313"/>
         <source>Use higher DPI for calculations - Slower but more accurate</source>
         <translation>Режим высокого разрешения - медленнее, но точнее</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1488"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1542"/>
         <source>Tools</source>
         <translation>Инструменты</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1427"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1473"/>
         <source>Small</source>
         <translation>Маленький</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1428"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1474"/>
         <source>Large</source>
         <translation>Большой</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1429"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1475"/>
         <source>Crosshair</source>
         <translation>прицел</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1431"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1435"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1442"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1485"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1496"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1432"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1486"/>
         <source>Left-Handed</source>
         <translation>Левша</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1433"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1487"/>
         <source>Simple</source>
         <translation>Простой</translation>
     </message>
@@ -10889,22 +11620,22 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">Автозапуск Xsheet во время воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1289"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1334"/>
         <source>Ignore Alpha Channel on Levels in Column 1</source>
         <translation>Игнорировать альфа-канал на уровнях в столбце 1</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1290"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1335"/>
         <source>Show Keyframes on Cell Area</source>
         <translation>Показывать ключи в областях ячеек</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1293"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1338"/>
         <source>Use Arrow Key to Shift Cell Selection</source>
         <translation>Использовать клавиши-стрелки для добавления ячеек к выбору</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1295"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1340"/>
         <source>Enable to Input Cells without Double Clicking</source>
         <translation>Редактировать ввод ячеек одним кликом</translation>
     </message>
@@ -10917,26 +11648,25 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">Показывать панель инструментов в Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1301"/>
         <source>Show Column Numbers in Column Headers</source>
-        <translation>Отображать номера столбцов в их заголовках</translation>
+        <translation type="vanished">Отображать номера столбцов в их заголовках</translation>
     </message>
     <message>
         <source>Sync Level Strip Drawing Number Changes with the Xsheet</source>
         <translation type="vanished">Синхронно менять номер наброска в Level Strip с Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1420"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1466"/>
         <source>Incremental</source>
         <translation>Дополнительный</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1436"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
         <source>Enable Tools For Level Only</source>
         <translation>Включить инструменты только уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1437"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1491"/>
         <source>Show Tools For Level Only</source>
         <translation>Показать инструменты только для уровня</translation>
     </message>
@@ -10949,62 +11679,62 @@ Is it OK to release these shortcuts?</source>
         <translation type="vanished">Классический-пересмотренный</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1439"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1493"/>
         <source>Compact</source>
         <translation>Компактный</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1307"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1353"/>
         <source>Show Current Time Indicator (Timeline Mode only)</source>
         <translation>Показывать индикатор текущего времени (только на таймлайне)</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1543"/>
         <source>Animation</source>
         <translation>Анимация</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1543"/>
         <source>Preview</source>
         <translation>Предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1326"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1372"/>
         <source>Rewind after Playback</source>
         <translation>Возврат к началу по окончанию воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1328"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1374"/>
         <source>Display in a New Flipbook Window</source>
         <translation>Отображение в новом окне Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1329"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1375"/>
         <source>Fit to Flipbook</source>
         <translation>По размеру Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1544"/>
         <source>Onion Skin</source>
         <translation>Калька</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1333"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1379"/>
         <source>Onion Skin ON</source>
         <translation>Включить кальку</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1338"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1384"/>
         <source>Show Onion Skin During Playback</source>
         <translation>Показывать кальку во время воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1340"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1386"/>
         <source>Use Onion Skin Colors for Reference Drawings of Shift and Trace</source>
         <translation>Использовать цвета кальки для референсных рисунков Shift and Trace</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1337"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1383"/>
         <source>Display Lines Only</source>
         <translation>Отображать только линии</translation>
     </message>
@@ -11017,53 +11747,53 @@ Is it OK to release these shortcuts?</source>
         <translation type="obsolete">Настройки планшета</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1365"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1411"/>
         <source>Enable Windows Ink Support* (EXPERIMENTAL)</source>
         <translation>Включить Windows Ink Support* (ЭКСПЕРИМЕНТАЛЬНО)</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1600"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1656"/>
         <source>Choosing this option will set initial location of all file browsers to $scenefolder.
 Also the initial output destination for new scenes will be set to $scenefolder as well.</source>
         <translation>Выберите этот параметр, чтобы задать начальный путь для всех обозревателей файлов для $scenefolder. Кроме того, папка назначения визуализации на момент создания новой сцены также имеет значение $scenefolder.</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1396"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1442"/>
         <source>Graph Editor Opens in Popup</source>
         <translation>Редактор графиков открывается во всплывающем окне</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1398"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1444"/>
         <source>Spreadsheet Opens in Popup</source>
         <translation>Электронная таблица откроется во всплывающем окне</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1400"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1446"/>
         <source>Toggle Between Graph Editor and Spreadsheet</source>
         <translation>Переключение между редактором графиков и электронной таблицей</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1449"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1503"/>
         <source>Constant</source>
         <translation>Постоянная</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1454"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1508"/>
         <source>Exponential</source>
         <translation>Экспоненциальная</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1455"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1509"/>
         <source>Expression </source>
         <translation>Выражение</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1456"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1510"/>
         <source>File</source>
         <translation>Из файла</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1187"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1232"/>
         <source>Function Editor*:</source>
         <translation>Редактор функций*:</translation>
     </message>
@@ -11088,94 +11818,94 @@ Also the initial output destination for new scenes will be set to $scenefolder a
 </translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1962"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2035"/>
         <source>Cursor Options</source>
         <translation>Настройки курсора</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1275"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1320"/>
         <source>Basic Cursor Type:</source>
         <translation>Базовый тип курсора:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1276"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1321"/>
         <source>Cursor Style:</source>
         <translation>Стиль курсора:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1284"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1329"/>
         <source>Column Header Layout*:</source>
         <translation>Макет заголовка столбца*:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2128"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2206"/>
         <source>Transparency Check</source>
         <translation>Проверка прозрачности</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1491"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1545"/>
         <source>Version Control</source>
         <translation>Управление версиями</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1356"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1402"/>
         <source>Enable Version Control*</source>
         <translation>Включить систему управления версиями*</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1358"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1404"/>
         <source>Automatically Refresh Folder Contents</source>
         <translation>Автоматически обновлять содержимое папки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1383"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1429"/>
         <source>Project Folder Aliases (+drawings, +scenes, etc.)</source>
         <translation>Псевдонимы папок проекта (+drawings, +scenes, и т.д.)</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1385"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1431"/>
         <source>Scene Folder Alias ($scenefolder)</source>
         <translation>Псевдоним папки сцены ($scenefolder)</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1387"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1433"/>
         <source>Use Project Folder Aliases Only</source>
         <translation>Использовать только псевдонимы папок проекта</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1596"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1652"/>
         <source>This option defines which alias to be used
 if both are possible on coding file path.</source>
         <translation>Этот параметр используется для замены пути к файлу псевдонимом.
 Задайте предпочитаемый псевдоним.</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1404"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1450"/>
         <source>Always ask before loading or importing</source>
         <translation>Всегда спрашивать перед загрузкой или импортом</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1405"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1451"/>
         <source>Always import the file to the current project</source>
         <translation>Всегда импортировать файл в текущий проект</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1406"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1452"/>
         <source>Always load the file from the current location</source>
         <translation>Всегда загружать файл из текущего местоположения</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1422"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1468"/>
         <source>Strokes</source>
         <translation>Штрихи</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1422"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1468"/>
         <source>Guides</source>
         <translation>Руководства</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1422"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1468"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
@@ -11188,132 +11918,142 @@ if both are possible on coding file path.</source>
         <translation type="vanished">Циклический выбор параметров</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1447"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1501"/>
         <source>Cells Only</source>
         <translation>Только ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1447"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1501"/>
         <source>Cells and Column Data</source>
         <translation>Ячейки и данные столбцов</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1179"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1224"/>
         <source>Theme:</source>
         <translation>Тема:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1201"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1221"/>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1225"/>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1246"/>
         <source>Font*:</source>
         <translation>Шрифт*:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1202"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1247"/>
         <source>Style*:</source>
         <translation>Начертание*:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1216"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1261"/>
         <source>Default File Import Behavior:</source>
         <translation>Импорт файлов по умолчанию:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1224"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1269"/>
         <source>Default TLV Caching Behavior:</source>
         <translation>Кэшировать TLV изображения:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1225"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1270"/>
         <source>Column Icon:</source>
         <translation>Значок столбца:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1327"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1373"/>
         <source>Number of Frames to Play 
 for Short Play:</source>
         <translation>Количество кадров воспроизведения
 для короткого воспроизведения:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1348"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1394"/>
         <source>Level Editor Canvas Color:</source>
         <translation>Цвет холста редактора уровней:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1390"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1436"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1391"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1437"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1392"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1438"/>
         <source>inch</source>
         <translation>дюйм</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1393"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1439"/>
         <source>field</source>
         <translation>поле</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="556"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="557"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="558"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="559"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1394"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="594"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="595"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="596"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="597"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1440"/>
         <source>pixel</source>
         <translation>пиксель</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1402"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1448"/>
         <source>Mouse Cursor</source>
         <translatorcomment>да, всё верно</translatorcomment>
         <translation>курсора</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1402"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1448"/>
         <source>Viewer Center</source>
         <translation>центра</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1408"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1413"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1454"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1459"/>
         <source>On Demand</source>
         <translation>По требованию</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1409"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1455"/>
         <source>All Icons</source>
         <translation>Все иконки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1410"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1456"/>
         <source>All Icons &amp; Images</source>
         <translation>Все иконки и изображения</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1412"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1458"/>
         <source>At Once</source>
         <translation>Сразу</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="837"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="881"/>
         <source>Life is too short for Comic Sans</source>
         <translatorcomment>это пасхалка, похоже</translatorcomment>
         <translation>Жизнь слишком коротка для Comic Sans</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="839"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="883"/>
         <source>Good luck.  You&apos;re on your own from here.</source>
         <translatorcomment>и это, видимо, тоже</translatorcomment>
         <translation>Удачи. Вы сами отсюда.</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1544"/>
         <source>Colors</source>
         <translation>Цвета</translation>
     </message>
@@ -11334,7 +12074,7 @@ for Short Play:</source>
         <translation type="vanished">Растровый уровень Toonz</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1419"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1465"/>
         <source>Raster Level</source>
         <translation>Растровый уровень</translation>
     </message>
@@ -11351,37 +12091,37 @@ for Short Play:</source>
         <translation type="vanished">Использовать Xsheet как лист анимации</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1450"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1504"/>
         <source>Linear</source>
         <translation>Линейный</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1451"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1505"/>
         <source>Speed In / Speed Out</source>
         <translation>Ускор. в начале/в конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1452"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1506"/>
         <source>Ease In / Ease Out</source>
         <translation>Замедл. в начале/в конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1453"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1507"/>
         <source>Ease In / Ease Out %</source>
         <translation>Замедл. в начале/в конце %</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1458"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1512"/>
         <source>Arrow Markers</source>
         <translation>Стрелки-маркеры направления</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1458"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1512"/>
         <source>Animated Guide</source>
         <translation>Анимированные стрелки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1491"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1545"/>
         <source>Touch/Tablet Settings</source>
         <translation>Настройки сенсорного экрана/планшета</translation>
     </message>
@@ -11390,17 +12130,17 @@ for Short Play:</source>
         <translation type="vanished">Категория</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1161"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1205"/>
         <source>Interval (Minutes):</source>
         <translation>Интервал (в минутах):</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1165"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1209"/>
         <source>Undo Memory Size (MB):</source>
         <translation>Емкость памяти отмен (МБ):</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1166"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1210"/>
         <source>Render Task Chunk Size:</source>
         <translation>Размер блока рендерных задач:</translation>
     </message>
@@ -11409,7 +12149,7 @@ for Short Play:</source>
         <translation type="vanished">Дополнительные местоположения корневой папки проектов</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1176"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1220"/>
         <source>Path Alias Priority:</source>
         <translation>Приоритет псевдонимов, используемых для путей к файлам:</translation>
     </message>
@@ -11418,21 +12158,22 @@ for Short Play:</source>
         <translation type="obsolete">Стиль:</translation>
     </message>
     <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1738"/>
         <source>Pixels Only:</source>
-        <translation type="vanished">Только пиксели:</translation>
+        <translation>Только пиксели:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1184"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1229"/>
         <source>Unit:</source>
         <translation>Единицы:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1185"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1230"/>
         <source>Camera Unit:</source>
         <translation>Единицы камеры:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1186"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1231"/>
         <source>Rooms*:</source>
         <translation>Закладки Rooms*:</translation>
     </message>
@@ -11445,56 +12186,56 @@ for Short Play:</source>
         <translation type="vanished">x</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1197"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1242"/>
         <source>Viewer Shrink:</source>
         <translatorcomment>?</translatorcomment>
         <translation>Viewer Shrink:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1198"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1243"/>
         <source>Step:</source>
         <translation>Шаг:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1835"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1904"/>
         <source>Matte color is used for background when overwriting raster levels with transparent pixels
 in non alpha-enabled image format.</source>
         <translation>Матовый цвет используется для фона при перезаписи растровых уровней прозрачными пикселями
 в формате изображения без альфа.</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1229"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1274"/>
         <source>Matte color:</source>
         <translation>Матовый цвет:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1344"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1390"/>
         <source>Viewer BG Color:</source>
         <translation>Цвет фона просмотра:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1345"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1391"/>
         <source>Preview BG Color:</source>
         <translation>Цвет фона предпросмотра:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1349"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1395"/>
         <source>Chessboard Color 1:</source>
         <translation>Цвет клетки 1:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1350"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1396"/>
         <source>Chessboard Color 2:</source>
         <translation>Цвет клетки 2:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1199"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1244"/>
         <source>Viewer Zoom Center:</source>
         <translatorcomment>дальше будет понятно из контекста</translatorcomment>
         <translation>Зуммировать относительно:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1200"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1245"/>
         <source>Language*:</source>
         <translation>Язык*:</translation>
     </message>
@@ -11507,7 +12248,7 @@ in non alpha-enabled image format.</source>
         <translation type="obsolete">Иконка столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1784"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1853"/>
         <source>Level Settings by File Format:</source>
         <translation>Настройки уровня по формату файла:</translation>
     </message>
@@ -11564,17 +12305,17 @@ in non alpha-enabled image format.</source>
         <translation type="vanished">Формат файла сканирования:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1245"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1290"/>
         <source>Default Level Type:</source>
         <translation>Тип уровня по умолчанию:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1248"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1293"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1249"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1294"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
@@ -11583,12 +12324,12 @@ in non alpha-enabled image format.</source>
         <translation type="obsolete">Автосоздание:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1257"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1302"/>
         <source>Vector Snapping:</source>
         <translation>Векторная привязка:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1924"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1995"/>
         <source>Replace Vectors with Simplified Vectors Command</source>
         <translation>Заменить векторы упрощенными векторами</translation>
     </message>
@@ -11597,38 +12338,38 @@ in non alpha-enabled image format.</source>
         <translation type="vanished">Хоткеи выпадающего списка:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="502"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="510"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="540"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="548"/>
         <source>Please restart to reload the icons.</source>
         <translation>Пожалуйста, перезапустите, чтобы перезагрузить иконки.</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1147"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1191"/>
         <source>* Changes will take effect the next time you run Tahoma2D</source>
         <translation>* Изменения вступят в силу при следующем запуске Tahoma2D</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1164"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1208"/>
         <source>Show Startup Window when Tahoma2D Starts</source>
         <translation>Показывать стартовое окно при запуске Tahoma2D</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1168"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1212"/>
         <source>Replace Vector and Smart Level after SaveLevelAs command</source>
         <translation>Заменить векторный и Smart уровни после команды SaveLevelAs</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1169"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1213"/>
         <source>Backup Scene and Animation Levels when Saving</source>
         <translation>Резервное копирование сцены и уровней анимации при сохранении</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1170"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1214"/>
         <source># of backups to keep:</source>
         <translation>Количество резервных копий для сохранения:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1189"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1234"/>
         <source>Move Current Frame by Clicking on Layer Header / Numerical Columns Cell Area</source>
         <translation>Переместить текущий кадр, щелкнув область заголовка слоя / числовых столбцов</translation>
     </message>
@@ -11637,223 +12378,238 @@ in non alpha-enabled image format.</source>
         <translation type="vanished">Показать приложение &quot;ABC&quot; к номеру кадра в ячейке</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1196"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1241"/>
         <source>Level Strip Thumbnail Size*:</source>
         <translation>Размер иконок Level Strip*:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1203"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1248"/>
         <source>Color Calibration using 3D Look-up Table</source>
         <translation>Калибровка цвета с использованием справочной таблицы 3D</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1205"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1250"/>
         <source>3DLUT File for [%1]:</source>
         <translation>3DLUT Файл дляr [%1]:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1207"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1252"/>
         <source>30bit Display*</source>
         <translation>30-битный дисплей*</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1208"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1253"/>
         <source>Show Icons In Menu*</source>
         <translation>Показать значки в меню*</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1209"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1254"/>
         <source>Show Viewer Indicators</source>
         <translation>Показать индикаторы просмотра</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1217"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1262"/>
         <source>Expose Loaded Levels in the Scene</source>
         <translation>Отображение загруженных уровней в сцене</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1219"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1264"/>
         <source>Automatically Remove Unused Levels From Scene Cast</source>
         <translation>Автоматически удалять неиспользуемые уровни из состава сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1220"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1265"/>
         <source>Create Sub-folder when Importing Sub-Scene</source>
         <translation>Создать подпапку при импорте суб-сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1230"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1275"/>
         <source>Clear Undo History when Saving Levels</source>
         <translation>Очистить историю отмен при сохранении уровней</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1231"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1276"/>
         <source>Do not show Save Scene popup warning</source>
         <translation>Не показывать всплывающее предупреждение о сохранении сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1232"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1277"/>
         <source>Default Project Path:</source>
         <translation>Путь к проекту по умолчанию:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1235"/>
-        <location filename="../../toonz/preferencespopup.cpp" line="1239"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1280"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1284"/>
         <source>Executable Directory:</source>
         <translation>Исполняемый каталог:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1236"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1281"/>
         <source>Import/Export Timeout (seconds):</source>
         <translation>Тайм-аут импорта / экспорта (секунды):</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1237"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1282"/>
         <source>Fast Render Output Directory:</source>
         <translation>Каталог вывода быстрого рендеринга:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1238"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1283"/>
         <source>Allow Multi-Thread in FFMPEG Rendering (UNSTABLE)</source>
         <translation>Разрешить многопоточность в рендеринге FFMPEG (НЕСТАБИЛЬНО)</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1240"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1285"/>
         <source>Analyze Audio Timeout (seconds):</source>
         <translation>Анализ тайм-аута аудио (секунды):</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1243"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1288"/>
         <source>Default Raster Level Format:</source>
         <translation>Формат уровня растра по умолчанию:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1251"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1296"/>
         <source>Enable Autocreation</source>
         <translation>Включить автоматическое создание</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1252"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1297"/>
         <source>Numbering System:</source>
         <translation>Система нумерации:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1253"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1298"/>
         <source>Enable Auto-stretch Frame</source>
         <translation>Включить автоматическое растяжение</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1254"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1299"/>
         <source>Enable Creation in Hold Cells</source>
         <translation>Создавать новый кадр при рисовании на стоп-кадре</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1255"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1300"/>
         <source>Enable Autorenumber</source>
         <translation>Включить автонумерацию</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1256"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1301"/>
         <source>Enable Implicit Hold</source>
         <translation>Включить неявное удержание</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1278"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1323"/>
         <source>Toolbar Display Behaviour:</source>
         <translation>Поведение панели инструментов:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1279"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1324"/>
         <source>Use Ctrl+Alt to Resize Brush</source>
         <translation>Используйте Ctrl + Alt, чтобы изменить размер кисти</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1281"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1326"/>
         <source>Temporary Tool Switch Shortcut Hold Time (ms):</source>
         <translation>Время удержания кнопки для переключения инструмента (мс):</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1285"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1330"/>
         <source>Next/Previous Step Frames:</source>
         <translation>Шаг следующего/предыдущего кадра:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1286"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1331"/>
         <source>Autopan during Playback</source>
         <translation>Автопанорамирование во время воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1287"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1332"/>
         <source>Cell-dragging Behaviour:</source>
         <translation>Поведение при перетаскивании ячейки:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1291"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1336"/>
         <source>Show Camera Column</source>
         <translation>Показать столбец камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1297"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1342"/>
         <source>Enable Tahoma2D Commands&apos; Shortcut Keys While Renaming Cell</source>
         <translation>Включение горячих клавиш команд Tahoma2D при переименовании ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1298"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1343"/>
         <source>Show Quick Toolbar</source>
         <translation>Показать панель быстрого доступа</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1303"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1346"/>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1348"/>
         <source>Show Column Parent&apos;s Color in the Xsheet</source>
         <translation>Показать цвет родительского столбца в Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1305"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1349"/>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1351"/>
         <source>Sync Level Strip Drawing Number Changes with the Scene</source>
         <translation>Синхронизация замены номера рисунка Level Strip со сценой</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1308"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1354"/>
         <source>Current Column Color:</source>
         <translation>Текущий цвет столбца:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1309"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1355"/>
         <source>Current Cell Color:</source>
         <translation>Текущий цвет ячейки:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1312"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1358"/>
         <source>Level Name Display:</source>
         <translation>Отображение названия уровня:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1317"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1360"/>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1363"/>
         <source>Default Interpolation:</source>
         <translation>Интерполяция по умолчанию:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1318"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1364"/>
         <source>Animation Step:</source>
         <translation>Шаг анимации:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1320"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1366"/>
         <source>[Experimental Feature] </source>
         <translation>[Экспериментальная функция] </translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1321"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1367"/>
         <source>Automatically Modify Expression On Moving Referenced Objects</source>
         <translation>Автоматически изменять выражение при перемещении ссылочных объектов</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1324"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1370"/>
         <source>Blank Frames:</source>
         <translation>Пустые кадры:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1325"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1371"/>
         <source>Blank Frames Color:</source>
         <translation>Цвет пустых кадров:</translation>
     </message>
@@ -11862,27 +12618,27 @@ in non alpha-enabled image format.</source>
         <translation type="vanished">Количество кадров для краткого воспроизведения:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1334"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1380"/>
         <source>Paper Thickness:</source>
         <translation>Толщина бумаги:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1335"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1381"/>
         <source>Previous Frames Correction:</source>
         <translation>Коррекция предыдущих кадров:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1336"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1382"/>
         <source>Following Frames Correction:</source>
         <translation>Коррекция последующих кадров:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1341"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1387"/>
         <source>Vector Guided Style:</source>
         <translation>Вид векторного гида:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1347"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1393"/>
         <source>Use the Curent Theme&apos;s Viewer Background Colors</source>
         <translation>Использовать цвета фона средства просмотра текущих тем</translation>
     </message>
@@ -11891,27 +12647,27 @@ in non alpha-enabled image format.</source>
         <translation type="vanished">Цвет рамки редактора уровней:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1351"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1397"/>
         <source>Ink Color on White BG:</source>
         <translation>Цвет штриха на белом фоне:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1352"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1398"/>
         <source>Ink Color on Black BG:</source>
         <translation>Цвет штриха на черном фоне:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1353"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1399"/>
         <source>Paint Color:</source>
         <translation>Цвет краски:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1360"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1406"/>
         <source>Check for the Latest Version of Tahoma2D on Launch</source>
         <translation>Проверяйте наличие последней версии Tahoma2D при запуске</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1367"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1413"/>
         <source>Use Qt&apos;s Native Windows Ink Support*
 (CAUTION: This options is for maintenance purpose. 
  Do not activate this option or the tablet won&apos;t work properly.)</source>
@@ -11920,161 +12676,201 @@ in non alpha-enabled image format.</source>
   Не активируйте эту опцию, иначе планшет не будет работать должным образом.)</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1417"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1463"/>
         <source>Vector Level</source>
         <translation>Векторный уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1418"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1464"/>
         <source>Smart Raster Level</source>
         <translation>Уровень Smart Raster</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1420"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1466"/>
         <source>Animation Sheet</source>
         <translation>Лист анимации</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1439"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1476"/>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1477"/>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1478"/>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1479"/>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1480"/>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1481"/>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1482"/>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1483"/>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/preferencespopup.cpp" line="1493"/>
         <source>Roomy</source>
         <translation>Roomy</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1440"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1494"/>
         <source>Minimum</source>
         <translation>Минимум</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1443"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1497"/>
         <source>Display on Each Marker</source>
         <translation>Отображение на каждом маркере</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1444"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1498"/>
         <source>Display on Column Header</source>
         <translation>Отображать в заголовке столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1489"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1543"/>
         <source>Scene</source>
         <translation>Сцена</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1490"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1544"/>
         <source>3rd Party Apps</source>
         <translation>Сторонние приложения</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1656"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1716"/>
         <source>Check Availability</source>
         <translation>Проверять наличие</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1659"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1719"/>
         <source>Edit Additional Style Sheet..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1861"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1930"/>
         <source>External applications used by Tahoma2D.
 These come bundled with Tahoma2D, but you can set path to a different version.</source>
         <translation>Внешние приложения, используемые Tahoma2D.
 Они идут в комплекте с Tahoma2D, но вы можете указать путь к другой версии.</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1865"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1934"/>
         <source>FFmpeg</source>
         <translation>FFmpeg</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1871"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1940"/>
         <source>Enabling multi-thread rendering will render significantly faster 
 but a random crash might occur, use at your own risk:</source>
         <translation>Включение многопоточного рендеринга значительно ускорит рендеринг.
 но может произойти случайный сбой, используйте на свой страх и риск:</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1877"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1946"/>
         <source>Rhubarb Lip Sync</source>
         <translation>Rhubarb липсинк</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1895"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1964"/>
         <source>Default Frame Filename Format</source>
         <translation>Формат имени файла кадра по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="1907"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="1977"/>
         <source>Frame Creation Options</source>
         <translation>Параметры создания кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2194"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2272"/>
         <source>Enable Touch Gesture Controls</source>
         <translation>Включить сенсорные жесты</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2230"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2308"/>
         <source>Select the Tahoma2D application that you want to import preferences from</source>
         <translation>Выберите приложение Tahoma2D, из которого вы хотите импортировать настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2234"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2312"/>
         <source>Select the folder of the Tahoma2D application that you want to import preferences from</source>
         <translation>Выберите папку приложения Tahoma2D, из которой вы хотите импортировать настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2243"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2321"/>
         <source>Import Options</source>
         <translation>Параметры импорта</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2245"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2323"/>
         <source>Preferences and Settings</source>
         <translation>Предпочтения и настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2249"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2327"/>
         <source>Favorites</source>
         <translation>Избранное</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2253"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2331"/>
         <source>Room Layouts</source>
         <translation>Планировки комнат</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2257"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2335"/>
         <source>Sandbox and Projects</source>
         <translation>Sandbox и проекты</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2261"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2339"/>
         <source>Fx and Plugins</source>
         <translation>FX и плагины</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2265"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2343"/>
         <source>Studio Palettes</source>
         <translation>Палитра Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2269"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2347"/>
         <source>Library</source>
         <translation>Библиотека</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2273"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2351"/>
         <source>Toonzfarm</source>
         <translation>Toonzfarm</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2278"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2356"/>
         <source>Import</source>
         <translation>Импорт</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="2627"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="2705"/>
         <source>Import complete. Please restart to complete applying the changes.</source>
         <translation>Импорт завершен. Пожалуйста, перезапустите, чтобы завершить применение изменений.</translation>
     </message>
@@ -12082,22 +12878,22 @@ but a random crash might occur, use at your own risk:</source>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="365"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="383"/>
         <source>Additional Style Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="369"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="387"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="370"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="388"/>
         <source>Apply</source>
         <translation type="unfinished">Применить</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="371"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="389"/>
         <source>Close</source>
         <translation type="unfinished">Закрыть</translation>
     </message>
@@ -12105,17 +12901,17 @@ but a random crash might occur, use at your own risk:</source>
 <context>
     <name>PreferencesPopup::Display30bitChecker</name>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="323"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="341"/>
         <source>Check 30bit display availability</source>
         <translation>Проверить доступность 30-битного дисплея</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="334"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="352"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../../toonz/preferencespopup.cpp" line="335"/>
+        <location filename="../../toonz/preferencespopup.cpp" line="353"/>
         <source>If the lower gradient looks smooth and has no banding compared to the upper gradient,
 30bit display is available in the current configuration.</source>
         <translation>Если нижний градиент выглядит гладким и не имеет полос по сравнению с верхним градиентом,
@@ -12279,6 +13075,11 @@ Do you want to overwrite it?</source>
         <location filename="../../toonz/projectpopup.cpp" line="77"/>
         <source>Create Project In:</source>
         <translation>Создать проект в:</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/projectpopup.cpp" line="100"/>
+        <source>*Separate assets into scene sub-folders</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/projectpopup.cpp" line="104"/>
@@ -12545,7 +13346,7 @@ What would you like to do?</source>
         <translation>Загрузить сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1373"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1415"/>
         <source>Quit</source>
         <translation>Выйти</translation>
     </message>
@@ -12553,35 +13354,41 @@ What would you like to do?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1839"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="583"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1087"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1098"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1824"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="588"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1146"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1119"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="144"/>
         <location filename="../../toonz/menubar.cpp" line="233"/>
         <location filename="../../toonz/menubar.cpp" line="249"/>
         <location filename="../../toonz/menubar.cpp" line="271"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1693"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="594"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="668"/>
-        <location filename="../../toonz/startuppopup.cpp" line="616"/>
+        <location filename="../../toonz/startuppopup.cpp" line="642"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="497"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1651"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2091"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1839"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1824"/>
         <location filename="../../toonz/iocommand.cpp" line="2503"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="583"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="1087"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1098"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="588"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1146"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1119"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="144"/>
         <location filename="../../toonz/menubar.cpp" line="233"/>
         <location filename="../../toonz/menubar.cpp" line="249"/>
         <location filename="../../toonz/menubar.cpp" line="271"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1693"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="594"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="668"/>
-        <location filename="../../toonz/startuppopup.cpp" line="616"/>
+        <location filename="../../toonz/startuppopup.cpp" line="642"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="497"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1651"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2091"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
@@ -12597,18 +13404,22 @@ What would you like to do?</source>
     <message>
         <location filename="../../toonz/autoinputcellnumberpopup.cpp" line="59"/>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="100"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2587"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2657"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="156"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2598"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2668"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="514"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="1922"/>
-        <location filename="../../toonz/flipbook.cpp" line="688"/>
+        <location filename="../../toonz/flipbook.cpp" line="690"/>
         <location filename="../../toonz/iocommand.cpp" line="1499"/>
         <location filename="../../toonz/iocommand.cpp" line="1716"/>
         <location filename="../../toonz/iocommand.cpp" line="1845"/>
         <location filename="../../toonz/iocommand.cpp" line="2897"/>
         <location filename="../../toonz/iocommand.cpp" line="3196"/>
         <location filename="../../toonz/iocommand.cpp" line="3291"/>
-        <location filename="../../toonz/previewer.cpp" line="895"/>
+        <location filename="../../toonz/previewer.cpp" line="913"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1591"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1625"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2849"/>
         <source>Overwrite</source>
         <translation>Перезаписать</translation>
     </message>
@@ -12623,8 +13434,8 @@ What would you like to do?</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2154"/>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1502"/>
+        <location filename="../../toonz/cellselection.cpp" line="2146"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1513"/>
         <location filename="../../toonz/cleanuppaletteviewer.cpp" line="216"/>
         <location filename="../../toonz/cleanuppopup.cpp" line="703"/>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="563"/>
@@ -12633,20 +13444,20 @@ What would you like to do?</source>
         <location filename="../../toonz/drawingdata.cpp" line="244"/>
         <location filename="../../toonz/exportlevelcommand.cpp" line="80"/>
         <location filename="../../toonz/exportlevelpopup.cpp" line="90"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2587"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2597"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2657"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2667"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2599"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2609"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2669"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2679"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="630"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="771"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="1028"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="515"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="1923"/>
         <location filename="../../toonz/fileselection.cpp" line="289"/>
-        <location filename="../../toonz/fileselection.cpp" line="438"/>
+        <location filename="../../toonz/fileselection.cpp" line="439"/>
         <location filename="../../toonz/flipbook.cpp" line="319"/>
-        <location filename="../../toonz/flipbook.cpp" line="620"/>
-        <location filename="../../toonz/flipbook.cpp" line="689"/>
+        <location filename="../../toonz/flipbook.cpp" line="622"/>
+        <location filename="../../toonz/flipbook.cpp" line="691"/>
         <location filename="../../toonz/iocommand.cpp" line="159"/>
         <location filename="../../toonz/iocommand.cpp" line="1298"/>
         <location filename="../../toonz/iocommand.cpp" line="1340"/>
@@ -12661,19 +13472,24 @@ What would you like to do?</source>
         <location filename="../../toonz/iocommand.cpp" line="3192"/>
         <location filename="../../toonz/loadfoldercommand.cpp" line="556"/>
         <location filename="../../toonz/loadfolderpopup.cpp" line="30"/>
-        <location filename="../../toonz/mainwindow.cpp" line="1338"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1359"/>
         <location filename="../../toonz/matchlinecommand.cpp" line="145"/>
-        <location filename="../../toonz/previewer.cpp" line="779"/>
-        <location filename="../../toonz/previewer.cpp" line="896"/>
-        <location filename="../../toonz/rendercommand.cpp" line="358"/>
-        <location filename="../../toonz/rendercommand.cpp" line="631"/>
+        <location filename="../../toonz/previewer.cpp" line="797"/>
+        <location filename="../../toonz/previewer.cpp" line="914"/>
+        <location filename="../../toonz/rendercommand.cpp" line="357"/>
+        <location filename="../../toonz/rendercommand.cpp" line="630"/>
         <location filename="../../toonz/separatecolorspopup.cpp" line="1941"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="532"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="581"/>
-        <location filename="../../toonz/startuppopup.cpp" line="601"/>
-        <location filename="../../toonz/startuppopup.cpp" line="872"/>
+        <location filename="../../toonz/startuppopup.cpp" line="627"/>
+        <location filename="../../toonz/startuppopup.cpp" line="898"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="423"/>
         <location filename="../../toonz/xsheetcmd.cpp" line="1444"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1592"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1626"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2850"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4747"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4998"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -12741,137 +13557,137 @@ What would you like to do?</source>
     </message>
     <message>
         <location filename="../../toonz/exportpanel.cpp" line="378"/>
-        <location filename="../../toonz/rendercommand.cpp" line="101"/>
+        <location filename="../../toonz/rendercommand.cpp" line="100"/>
         <source>It is not possible to display the file %1: no player associated with its format</source>
         <translation>Невозможно отобразить файл %1: нет плеера, связанный с его форматом</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="218"/>
+        <location filename="../../toonz/rendercommand.cpp" line="217"/>
         <source>The command cannot be executed because the scene is empty.</source>
         <translation>Команда не может быть выполнена, потому что сцена пуста.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="253"/>
+        <location filename="../../toonz/rendercommand.cpp" line="252"/>
         <source>The scene is not yet saved and the output destination is set to $scenefolder.
 Save the scene first.</source>
         <translation>Сцена еще не сохранена, а для выходных данных установлено значение $scenefolder.
 Сначала сохраните сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="274"/>
+        <location filename="../../toonz/rendercommand.cpp" line="273"/>
         <source>It is not possible to create folder : %1</source>
         <translation>Невозможно создать папку: %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="278"/>
+        <location filename="../../toonz/rendercommand.cpp" line="277"/>
         <source>It is not possible to create a folder.</source>
         <translation>Невозможно создать папку.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="343"/>
+        <location filename="../../toonz/rendercommand.cpp" line="342"/>
         <source>Rendering frame %1 / %2</source>
         <comment>RenderListener</comment>
         <translation>Рендер кадров %1 / %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="355"/>
+        <location filename="../../toonz/rendercommand.cpp" line="354"/>
         <source>Precomputing %1 Frames</source>
         <comment>RenderListener</comment>
         <translation>Предварительный расчет %1 кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="356"/>
-        <location filename="../../toonz/rendercommand.cpp" line="374"/>
+        <location filename="../../toonz/rendercommand.cpp" line="355"/>
+        <location filename="../../toonz/rendercommand.cpp" line="373"/>
         <source> of %1</source>
         <comment>RenderListener</comment>
         <translation> из %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="334"/>
+        <location filename="../../toonz/rendercommand.cpp" line="333"/>
         <source>Finalizing render, please wait.</source>
         <comment>RenderListener</comment>
         <translation>Рендер завершается, подождите пожалуйста.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="402"/>
+        <location filename="../../toonz/rendercommand.cpp" line="401"/>
         <source>Aborting render...</source>
         <comment>RenderListener</comment>
         <translation>Прервать рендер...</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="631"/>
-        <location filename="../../toonz/rendercommand.cpp" line="433"/>
-        <location filename="../../toonz/rendercommand.cpp" line="707"/>
+        <location filename="../../toonz/flipbook.cpp" line="633"/>
+        <location filename="../../toonz/rendercommand.cpp" line="432"/>
+        <location filename="../../toonz/rendercommand.cpp" line="706"/>
         <source>The resolution of the output camera does not fit with the options chosen for the output file format.</source>
         <translation>Разрешение выходной камеры не соответствует параметрам, выбранным для формата выходного файла.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="519"/>
+        <location filename="../../toonz/rendercommand.cpp" line="518"/>
         <source>Building Schematic...</source>
         <comment>RenderCommand</comment>
         <translation>Построение Schematic...</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="608"/>
+        <location filename="../../toonz/rendercommand.cpp" line="607"/>
         <source>column </source>
         <comment>MultimediaProgressBar label (mode name)</comment>
         <translation>столбец </translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="610"/>
+        <location filename="../../toonz/rendercommand.cpp" line="609"/>
         <source>layer </source>
         <comment>MultimediaProgressBar label (mode name)</comment>
         <translation>слой </translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="612"/>
+        <location filename="../../toonz/rendercommand.cpp" line="611"/>
         <source>Rendering %1%2, frame %3 / %4</source>
         <comment>MultimediaProgressBar label</comment>
         <translation>Рендер %1%2, кадр %3 / %4</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="628"/>
+        <location filename="../../toonz/rendercommand.cpp" line="627"/>
         <source>Rendering %1 frames of %2</source>
         <comment>MultimediaProgressBar</comment>
         <translation>Рендер %1 кадров из %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="646"/>
+        <location filename="../../toonz/rendercommand.cpp" line="645"/>
         <source>%1 of %2</source>
         <comment>MultimediaProgressBar - [totalframe] of [path]</comment>
         <translation>%1 из %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="683"/>
+        <location filename="../../toonz/rendercommand.cpp" line="682"/>
         <source>Aborting render...</source>
         <comment>MultimediaProgressBar</comment>
         <translation>Прервать рендер...</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="795"/>
+        <location filename="../../toonz/rendercommand.cpp" line="794"/>
         <source>FFmpeg not found, please set the location in the Preferences and restart.</source>
         <translation>FFmpeg не найден, укажите местоположение в настройках и перезапустите.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="847"/>
+        <location filename="../../toonz/rendercommand.cpp" line="846"/>
         <source>It is not possible to write the output:  the file</source>
         <comment>RenderCommand</comment>
         <translation>Не удалось записать на выходе:  файл</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="849"/>
+        <location filename="../../toonz/rendercommand.cpp" line="848"/>
         <source>s are read only.</source>
         <comment>RenderCommand</comment>
         <translation>(ы) только для чтения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="850"/>
+        <location filename="../../toonz/rendercommand.cpp" line="849"/>
         <source> is read only.</source>
         <comment>RenderCommand</comment>
         <translation>только для чтения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/rendercommand.cpp" line="869"/>
+        <location filename="../../toonz/rendercommand.cpp" line="868"/>
         <source>It is not possible to complete the rendering.</source>
         <translation>Выполнение рендеринга невозможно.</translation>
     </message>
@@ -12911,7 +13727,7 @@ Save the scene first.</source>
     </message>
     <message>
         <location filename="../../toonz/cleanupsettingspopup.cpp" line="872"/>
-        <location filename="../../toonz/tpanels.cpp" line="1495"/>
+        <location filename="../../toonz/tpanels.cpp" line="1513"/>
         <source>Cleanup Settings</source>
         <translation>Настройки очистки</translation>
     </message>
@@ -12929,6 +13745,7 @@ Save the scene first.</source>
     </message>
     <message>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="100"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="156"/>
         <location filename="../../toonz/iocommand.cpp" line="2898"/>
         <location filename="../../toonz/iocommand.cpp" line="3197"/>
         <location filename="../../toonz/iocommand.cpp" line="3292"/>
@@ -12963,12 +13780,13 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="85"/>
         <location filename="../../toonz/cleanupsettingsmodel.cpp" line="562"/>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="141"/>
         <location filename="../../toonz/curveio.cpp" line="79"/>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="1028"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="390"/>
-        <location filename="../../toonz/flipbook.cpp" line="620"/>
+        <location filename="../../toonz/flipbook.cpp" line="622"/>
         <location filename="../../toonz/iocommand.cpp" line="3023"/>
-        <location filename="../../toonz/previewer.cpp" line="819"/>
+        <location filename="../../toonz/previewer.cpp" line="837"/>
         <location filename="../../toonz/studiopaletteviewer.cpp" line="422"/>
         <source>Save</source>
         <translation>Сохранить</translation>
@@ -13008,7 +13826,7 @@ Are you sure ?</source>
         <location filename="../../toonz/cleanuppaletteviewer.cpp" line="216"/>
         <location filename="../../toonz/cleanuppopup.cpp" line="702"/>
         <location filename="../../toonz/fileselection.cpp" line="289"/>
-        <location filename="../../toonz/startuppopup.cpp" line="872"/>
+        <location filename="../../toonz/startuppopup.cpp" line="898"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -13054,114 +13872,114 @@ Are you sure ?</source>
     </message>
     <message>
         <location filename="../../toonz/flipbook.cpp" line="319"/>
-        <location filename="../../toonz/previewer.cpp" line="779"/>
+        <location filename="../../toonz/previewer.cpp" line="797"/>
         <source>Saving previewed frames....</source>
         <translation>Сохранение кадров предпросмотра ....</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="2248"/>
+        <location filename="../../toonz/flipbook.cpp" line="2277"/>
         <source>%1  has an invalid extension format.</source>
         <translation>%1 имеет недопустимый формат расширения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="209"/>
-        <location filename="../../toonz/dvitemview.cpp" line="242"/>
+        <location filename="../../toonz/dvitemview.cpp" line="218"/>
+        <location filename="../../toonz/dvitemview.cpp" line="251"/>
         <source>None</source>
         <translation>Ничего</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="212"/>
+        <location filename="../../toonz/dvitemview.cpp" line="221"/>
         <source>Edited</source>
         <translation>Отредактированный</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="215"/>
+        <location filename="../../toonz/dvitemview.cpp" line="224"/>
         <source>Normal</source>
         <translation>Нормальный</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="218"/>
+        <location filename="../../toonz/dvitemview.cpp" line="227"/>
         <source>To Update</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="221"/>
+        <location filename="../../toonz/dvitemview.cpp" line="230"/>
         <source>Modified</source>
         <translation>Модифицированный</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="224"/>
+        <location filename="../../toonz/dvitemview.cpp" line="233"/>
         <source>Locked</source>
         <translation>Заблокированный</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="227"/>
+        <location filename="../../toonz/dvitemview.cpp" line="236"/>
         <source>Unversioned</source>
         <translation>Без версии</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="230"/>
+        <location filename="../../toonz/dvitemview.cpp" line="239"/>
         <source>Missing</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="233"/>
+        <location filename="../../toonz/dvitemview.cpp" line="242"/>
         <source>Partially Edited</source>
         <translation>Частично отредактирован</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="236"/>
+        <location filename="../../toonz/dvitemview.cpp" line="245"/>
         <source>Partially Locked</source>
         <translation>Частично заблокирован</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="239"/>
+        <location filename="../../toonz/dvitemview.cpp" line="248"/>
         <source>Partially Modified</source>
         <translation>Частично модифицирован</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="256"/>
+        <location filename="../../toonz/dvitemview.cpp" line="265"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="260"/>
+        <location filename="../../toonz/dvitemview.cpp" line="269"/>
         <source>Path</source>
         <translation>Путь</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="266"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1697"/>
+        <location filename="../../toonz/dvitemview.cpp" line="275"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1706"/>
         <source>Date Created</source>
         <translation>Дата создания</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="268"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1701"/>
+        <location filename="../../toonz/dvitemview.cpp" line="277"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1710"/>
         <source>Date Modified</source>
         <translation>Дата изменения</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="270"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1689"/>
+        <location filename="../../toonz/dvitemview.cpp" line="279"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1698"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="272"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1693"/>
+        <location filename="../../toonz/dvitemview.cpp" line="281"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1702"/>
         <source>Frames</source>
         <translation>Кадры</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="274"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1709"/>
+        <location filename="../../toonz/dvitemview.cpp" line="283"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1718"/>
         <source>Version Control</source>
         <translation>Контроль версий</translation>
     </message>
     <message>
-        <location filename="../../toonz/dvitemview.cpp" line="276"/>
-        <location filename="../../toonz/dvitemview.cpp" line="1705"/>
+        <location filename="../../toonz/dvitemview.cpp" line="285"/>
+        <location filename="../../toonz/dvitemview.cpp" line="1714"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
@@ -13257,66 +14075,66 @@ Do you want to continue?</source>
         <translation type="vanished">Выбрать ячейку sub-xsheet.</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1056"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1057"/>
         <source>Close Sub-Scene</source>
         <translation>Закрыть суб-сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1150"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1151"/>
         <source>Select a sub-scene cell.</source>
         <translation>Выберите ячейку суб-сцены.</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1689"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1723"/>
         <source>Collapse</source>
         <translation>Коллапс</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="1780"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="1814"/>
         <source>Collapse (Fx)</source>
         <translation>Коллапс (Fx)</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2291"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2401"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2325"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2435"/>
         <source>Maintain parenting relationships in the sub-scene as well.</source>
         <translation>Поддерживать родительские связи и в суб-сцене.</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2293"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2327"/>
         <source>Include only selected columns in the sub-scene.</source>
         <translation>Включите в суб-сцену только выбранные столбцы.</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2404"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2438"/>
         <source>Include the selected columns in the sub-scene without parenting info.</source>
         <translation>Включите выбранные столбцы в суб-сцену без информации о родительских элементах.</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2478"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2512"/>
         <source>Exploding Sub-Scene: what you want to do?</source>
         <translation>Разбивка суб-сцены: чтовы хотите сделать?</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2481"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2515"/>
         <source>Maintain parenting relationships in the main scene.</source>
         <translation>Поддерживать родительские связи в основной сцене.</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2483"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2517"/>
         <source>Bring columns in the main scene without parenting.</source>
         <translation>Внесите столбцы в основную сцену без родительских связей.</translation>
     </message>
     <message>
         <location filename="../../toonz/expressionreferencemanager.cpp" line="770"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2069"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2250"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2103"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2284"/>
         <source>Explode</source>
         <translation>Разбить</translation>
     </message>
     <message>
-        <location filename="../../toonz/subscenecommand.cpp" line="2288"/>
-        <location filename="../../toonz/subscenecommand.cpp" line="2399"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2322"/>
+        <location filename="../../toonz/subscenecommand.cpp" line="2433"/>
         <source>Collapsing columns: what you want to do?</source>
         <translation>Коллапс столбцов: что вы хотите сделать?</translation>
     </message>
@@ -13544,181 +14362,225 @@ Do you want to overwrite it?</source>
 Вы хотите перезаписать его?</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="647"/>
-        <location filename="../../toonz/xdtsio.cpp" line="737"/>
+        <location filename="../../toonz/ocaio.cpp" line="378"/>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="459"/>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/ocaio.cpp" line="506"/>
+        <location filename="../../toonz/xdtsio.cpp" line="651"/>
+        <location filename="../../toonz/xdtsio.cpp" line="743"/>
         <source>No columns can be exported.</source>
         <translation>Столбцы нельзя экспортировать.</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsio.cpp" line="709"/>
+        <location filename="../../toonz/ocaio.cpp" line="520"/>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="691"/>
+        <source>All columns</source>
+        <translation type="unfinished">Все столбцы</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="692"/>
+        <source>Only active columns</source>
+        <translation type="unfinished">Только активные столбцы</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="700"/>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="704"/>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="707"/>
+        <source>Target column</source>
+        <translation type="unfinished">Целевой столбец</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xdtsio.cpp" line="715"/>
         <source>Export Exchange Digital Time Sheet (XDTS)</source>
         <translation>Экспорт Exchange Digital Time Sheet (XDTS)</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="174"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="176"/>
         <source>+</source>
         <comment>XSheetPDF</comment>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="175"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="177"/>
         <source>&apos;</source>
         <comment>XSheetPDF:second</comment>
         <translation>&apos;</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="176"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="178"/>
         <source>&quot;</source>
         <comment>XSheetPDF:frame</comment>
         <translation>&quot;</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="218"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="220"/>
         <source>TOT</source>
         <comment>XSheetPDF</comment>
         <translation>TOT</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="219"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="221"/>
         <source>th</source>
         <comment>XSheetPDF</comment>
         <translation>th</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="316"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="318"/>
         <source>None</source>
         <comment>XSheetPDF CellMark</comment>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="368"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="370"/>
         <source>Dot</source>
         <comment>XSheetPDF CellMark</comment>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="370"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="372"/>
         <source>Circle</source>
         <comment>XSheetPDF CellMark</comment>
         <translation>Круг</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="372"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="374"/>
         <source>Filled circle</source>
         <comment>XSheetPDF CellMark</comment>
         <translation>Заполненный круг</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="375"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="377"/>
         <source>Asterisk</source>
         <comment>XSheetPDF CellMark</comment>
         <translation>Звездочка</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="620"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="622"/>
         <source>ACTION</source>
         <comment>XSheetPDF</comment>
         <translation>ДЕЙСТВИЕ</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="712"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="714"/>
         <source>S</source>
         <comment>XSheetPDF</comment>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="802"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="804"/>
         <source>CELL</source>
         <comment>XSheetPDF</comment>
         <translation>ЯЧЕЙКА</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="839"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="841"/>
         <source>CAMERA</source>
         <comment>XSheetPDF</comment>
         <translation>КАМЕРА</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1653"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2204"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1656"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2214"/>
         <source>EPISODE</source>
         <comment>XSheetPDF</comment>
         <translation>ЭПИЗОД</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1654"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2205"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1657"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2215"/>
         <source>SEQ.</source>
         <comment>XSheetPDF</comment>
         <translation>СЕКВ.</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1655"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2206"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1658"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2216"/>
         <source>SCENE</source>
         <comment>XSheetPDF</comment>
         <translation>СЦЕНА</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1656"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2207"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1659"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2217"/>
         <source>TIME</source>
         <comment>XSheetPDF</comment>
         <translation>ВРЕМЯ</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1657"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2208"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1660"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2218"/>
         <source>NAME</source>
         <comment>XSheetPDF</comment>
         <translation>ИМЯ</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1658"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2209"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1661"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2219"/>
         <source>SHEET</source>
         <comment>XSheetPDF</comment>
         <translation>ЛИСТ</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2210"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2220"/>
         <source>TITLE</source>
         <comment>XSheetPDF</comment>
         <translation>НАЗВАНИЕ</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2211"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2221"/>
         <source>CAMERAMAN</source>
         <comment>XSheetPDF</comment>
         <translation>ОПЕРАТОР</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2596"/>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2666"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2608"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2678"/>
         <source>Create folder</source>
         <translation>Создать папку</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2708"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2720"/>
         <location filename="../../toonz/tvpjson_io.cpp" line="503"/>
-        <location filename="../../toonz/xdtsio.cpp" line="748"/>
+        <location filename="../../toonz/xdtsio.cpp" line="754"/>
         <source>The file %1 has been exported successfully.</source>
         <translation>Файл %1 успешно экспортирован.</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2711"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2723"/>
         <location filename="../../toonz/iocommand.cpp" line="3192"/>
+        <location filename="../../toonz/ocaio.cpp" line="523"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="532"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="581"/>
         <location filename="../../toonz/tvpjson_io.cpp" line="506"/>
-        <location filename="../../toonz/xdtsio.cpp" line="751"/>
+        <location filename="../../toonz/xdtsio.cpp" line="757"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4998"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="2712"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="2724"/>
+        <location filename="../../toonz/ocaio.cpp" line="524"/>
         <location filename="../../toonz/tvpjson_io.cpp" line="507"/>
-        <location filename="../../toonz/xdtsio.cpp" line="752"/>
+        <location filename="../../toonz/xdtsio.cpp" line="758"/>
         <source>Open containing folder</source>
         <translation>Открыть содержащую папку</translation>
     </message>
@@ -13735,8 +14597,8 @@ Do you want to overwrite it?</source>
     <message>
         <location filename="../../toonz/iocommand.cpp" line="385"/>
         <location filename="../../toonz/levelcommand.cpp" line="553"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="601"/>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="975"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="606"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="1034"/>
         <source>Removed unused level %1 from the scene cast. (This behavior can be disabled in Preferences.)</source>
         <translation>Удален неиспользуемый уровень %1 из состава сцены. (Это поведение можно отключить в настройках.)</translation>
     </message>
@@ -13821,7 +14683,7 @@ Do you wish to continue loading the last good save or stop and try to salvage th
     </message>
     <message>
         <location filename="../../toonz/iocommand.cpp" line="1943"/>
-        <location filename="../../toonz/main.cpp" line="709"/>
+        <location filename="../../toonz/main.cpp" line="717"/>
         <source>It is not possible to load the scene %1 because it does not belong to any project.</source>
         <translation>Невозможно загрузить сцену %1, потому что она не принадлежит ни одному проекту.</translation>
     </message>
@@ -13837,13 +14699,13 @@ What do you want to do?</source>
     </message>
     <message>
         <location filename="../../toonz/projectpopup.cpp" line="443"/>
-        <location filename="../../toonz/startuppopup.cpp" line="709"/>
+        <location filename="../../toonz/startuppopup.cpp" line="735"/>
         <source>Change Project</source>
         <translation>Сменить проект</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="288"/>
-        <location filename="../../toonz/exportpanel.cpp" line="296"/>
+        <location filename="../../toonz/exportpanel.cpp" line="287"/>
+        <location filename="../../toonz/exportpanel.cpp" line="295"/>
         <location filename="../../toonz/iocommand.cpp" line="2029"/>
         <source>There were problems loading the scene %1.
  Some files may be missing.</source>
@@ -14006,7 +14868,7 @@ Are you sure you want to revert to previous version?</source>
         <translation>Возвратиться</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2102"/>
+        <location filename="../../toonz/cellselection.cpp" line="2094"/>
         <location filename="../../toonz/filmstripcommand.cpp" line="221"/>
         <source>The copied selection cannot be pasted in the current drawing.</source>
         <translation>Скопированный выбор не может быть вставлен в текущий рисунок.</translation>
@@ -14174,139 +15036,139 @@ Are you sure you want to revert to previous version?</source>
         <translation>Перекадрировать в %1 с помощью %2 заготовок</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1292"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1303"/>
         <source>Roll Up</source>
         <translation>Первый вниз</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1321"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1332"/>
         <source>Roll Down</source>
         <translation>Последний наверх</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1422"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1433"/>
         <source>Clone  Level : %1 &gt; %2</source>
         <translation>Клонировать  уровень : %1 &gt; %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1428"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1439"/>
         <source>Clone  Levels : </source>
         <translation>Клонировать  уровни : </translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1486"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1497"/>
         <source>Clone Level</source>
         <comment>CloneLevelUndo::LevelNamePopup</comment>
         <translation>Клонировать уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1491"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1502"/>
         <source>Level Name:</source>
         <comment>CloneLevelUndo::LevelNamePopup</comment>
         <translation>Имя уровня:</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselectioncommand.cpp" line="1501"/>
+        <location filename="../../toonz/cellselectioncommand.cpp" line="1512"/>
         <location filename="../../toonz/loadfolderpopup.cpp" line="26"/>
         <source>Ok</source>
         <translation>Ок</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1186"/>
+        <location filename="../../toonz/tpanels.cpp" line="1187"/>
         <location filename="../../toonz/viewerpopup.cpp" line="78"/>
         <source>FlipBook</source>
         <translation>Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="754"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="750"/>
         <source>It is not possible to track the level:
 allocation error.</source>
         <translation>Невозможно отслеживать уровень:
 Ошибка распределения.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="758"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="754"/>
         <source>It is not possible to track the level:
 no region defined.</source>
         <translation>Невозможно отслеживать уровень:
 Ни один регион не определен.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="762"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="758"/>
         <source>It is not possible to track specified regions:
 more than 30 regions defined.</source>
         <translation>Невозможно отслеживать указанные регионы:
 Определено более 30 регионов.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="767"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="763"/>
         <source>It is not possible to track specified regions:
 defined regions are not valid.</source>
         <translation>Невозможно отслеживать указанные регионы:
 Определенные регионы недействительны.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="772"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="768"/>
         <source>It is not possible to track specified regions:
 some regions are too wide.</source>
         <translation>Невозможно отслеживать указанные регионы:
 Некоторые регионы слишком широкие.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="777"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="773"/>
         <source>It is not possible to track specified regions:
 some regions are too high.</source>
         <translation>Невозможно отслеживать указанные регионы:
 Некоторые регионы слишком высоки.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="782"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="778"/>
         <source>Frame Start Error</source>
         <translation>Ошибка начального кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="785"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="781"/>
         <source>Frame End Error</source>
         <translation>Ошибка конечного кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="788"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="784"/>
         <source>Threshold Distance Error</source>
         <translation>Ошибка порогового расстояния</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="791"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="787"/>
         <source>Sensitivity Error</source>
         <translation>Ошибка чувствительности</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="794"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="790"/>
         <source>No Frame Found</source>
         <translation>Не найдены кадры</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="797"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="793"/>
         <source>It is not possible to track specified regions:
 the selected level is not valid.</source>
         <translation>Невозможно отслеживать указанные регионы:
 Выбранный уровень недействителен.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="802"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="798"/>
         <source>It is not possible to track the level:
 no level selected.</source>
         <translation>Невозможно отслеживать уровень:
 Не выбран ни один уровень.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="806"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="802"/>
         <source>It is not possible to track specified regions:
 the level has to be saved first.</source>
         <translation>Невозможно отслеживать указанные регионы:
 Сначала необходимо сохранить уровень.</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="812"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="808"/>
         <source>It is not possible to track the level:
 undefined error.</source>
         <translation>Невозможно отслеживать уровень:
@@ -14324,7 +15186,7 @@ undefined error.</source>
     </message>
     <message>
         <location filename="../../toonz/separatecolorspopup.cpp" line="1937"/>
-        <location filename="../../toonz/startuppopup.cpp" line="597"/>
+        <location filename="../../toonz/startuppopup.cpp" line="623"/>
         <source>The chosen folder path does not exist.
 Do you want to create it?</source>
         <translation>Путь к выбранной папке не существует.
@@ -14332,32 +15194,32 @@ Do you want to create it?</source>
     </message>
     <message>
         <location filename="../../toonz/separatecolorspopup.cpp" line="1940"/>
-        <location filename="../../toonz/startuppopup.cpp" line="600"/>
+        <location filename="../../toonz/startuppopup.cpp" line="626"/>
         <source>Create</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="613"/>
+        <location filename="../../toonz/startuppopup.cpp" line="639"/>
         <source>The file name already exists.
 Do you want to overwrite it?</source>
         <translation>Имя файла уже существует.
 Вы хотите переписать его?</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="870"/>
+        <location filename="../../toonz/startuppopup.cpp" line="896"/>
         <source>Deleting &quot;%1&quot;.
 Are you sure?</source>
         <translation>Удаление «%1».
 Вы уверены?</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="1068"/>
+        <location filename="../../toonz/startuppopup.cpp" line="1094"/>
         <source>The selected scene could not be found.</source>
         <translation>Не удалось найти выбранную сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/scriptconsolepanel.cpp" line="135"/>
-        <location filename="../../toonz/tpanels.cpp" line="1381"/>
+        <location filename="../../toonz/scriptconsolepanel.cpp" line="130"/>
+        <location filename="../../toonz/tpanels.cpp" line="1399"/>
         <source>Script Console</source>
         <translation>Консоль скриптов</translation>
     </message>
@@ -14486,8 +15348,8 @@ Are you sure?</source>
         <translation>Палитра заблокирована.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3811"/>
-        <location filename="../../toonz/levelcreatepopup.cpp" line="148"/>
+        <location filename="../../toonz/cellselection.cpp" line="3803"/>
+        <location filename="../../toonz/levelcreatepopup.cpp" line="153"/>
         <source>Create Level %1  at Column %2</source>
         <translation>Создать уровень %1 в столбце %2</translation>
     </message>
@@ -14501,7 +15363,7 @@ Are you sure?</source>
     <message>
         <location filename="../../toonz/filebrowserpopup.cpp" line="511"/>
         <location filename="../../toonz/iocommand.cpp" line="2893"/>
-        <location filename="../../toonz/previewer.cpp" line="893"/>
+        <location filename="../../toonz/previewer.cpp" line="911"/>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
         <translation>Файл «%1» уже существует.
@@ -14569,15 +15431,16 @@ What do you want to do? </source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="2436"/>
+        <location filename="../../toonz/filebrowser.cpp" line="2421"/>
         <location filename="../../toonz/filebrowserpopup.cpp" line="2294"/>
-        <location filename="../../toonz/tpanels.cpp" line="1227"/>
+        <location filename="../../toonz/tpanels.cpp" line="1228"/>
         <source>File Browser</source>
         <translation>Браузер файлов</translation>
     </message>
     <message>
         <location filename="../../toonz/duplicatepopup.cpp" line="47"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1572"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1562"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1489"/>
         <source>Duplicate</source>
         <translation>Дублировать</translation>
     </message>
@@ -14646,87 +15509,87 @@ What do you want to do? </source>
         <translation type="vanished">Выполняется задача конвертации! Подождать, пока она закончится, или отменить?</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="423"/>
+        <location filename="../../toonz/fileselection.cpp" line="424"/>
         <source>A conversion task is in progress! wait until it stops or cancel it</source>
         <translation>Выполняется задание по конвертации! подождите пока он остановится или отмените его</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="434"/>
+        <location filename="../../toonz/fileselection.cpp" line="435"/>
         <source>You are going to premultiply selected files.
 The operation cannot be undone: are you sure?</source>
         <translation>Вы собираетесь сделать premultiply выбранных файлов.
 Операция не может быть отменена: вы уверены?</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="437"/>
+        <location filename="../../toonz/fileselection.cpp" line="438"/>
         <source>Premultiply</source>
         <translation>Premultiply</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="495"/>
+        <location filename="../../toonz/fileselection.cpp" line="496"/>
         <source>Collecting assets...</source>
         <translation>Сбор материала...</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="496"/>
-        <location filename="../../toonz/fileselection.cpp" line="586"/>
+        <location filename="../../toonz/fileselection.cpp" line="497"/>
+        <location filename="../../toonz/fileselection.cpp" line="587"/>
         <source>Abort</source>
         <translation>Прервать</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="510"/>
+        <location filename="../../toonz/fileselection.cpp" line="511"/>
         <source>There are no assets to collect</source>
         <translation>Нет активов для сбора</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="512"/>
+        <location filename="../../toonz/fileselection.cpp" line="513"/>
         <source>One asset imported</source>
         <translation>Один импортированный актив</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="514"/>
+        <location filename="../../toonz/fileselection.cpp" line="515"/>
         <source>%1 assets imported</source>
         <translation>Импортировано %1 активов</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="528"/>
+        <location filename="../../toonz/fileselection.cpp" line="529"/>
         <source>A separation task is in progress! wait until it stops or cancel it</source>
         <translation>Выполняется задача разделения! Дождитесь остановки или отмените</translation>
     </message>
     <message>
         <location filename="../../toonz/exportscenepopup.cpp" line="52"/>
-        <location filename="../../toonz/fileselection.cpp" line="547"/>
+        <location filename="../../toonz/fileselection.cpp" line="548"/>
         <source>Error loading scene %1 :%2</source>
         <translation>Ошибка загрузки сцены %1 :%2</translation>
     </message>
     <message>
         <location filename="../../toonz/exportscenepopup.cpp" line="59"/>
-        <location filename="../../toonz/fileselection.cpp" line="554"/>
+        <location filename="../../toonz/fileselection.cpp" line="555"/>
         <source>Error loading scene %1</source>
         <translation>Ошибка загрузки сцены %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="561"/>
+        <location filename="../../toonz/fileselection.cpp" line="562"/>
         <source>There was an error saving the %1 scene.</source>
         <translation>Ошибка с сохранением сцены %1.</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="585"/>
+        <location filename="../../toonz/fileselection.cpp" line="586"/>
         <source>Importing scenes...</source>
         <translation>Импорт сцен...</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="602"/>
+        <location filename="../../toonz/fileselection.cpp" line="603"/>
         <source>No scene imported</source>
         <translation>Нет импортированной сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="604"/>
+        <location filename="../../toonz/fileselection.cpp" line="605"/>
         <source>One scene imported</source>
         <translation>Одна сцена импортирована</translation>
     </message>
     <message>
-        <location filename="../../toonz/fileselection.cpp" line="607"/>
+        <location filename="../../toonz/fileselection.cpp" line="608"/>
         <source>%1 scenes imported</source>
         <translation>%1 импортированных сцен</translation>
     </message>
@@ -14762,64 +15625,64 @@ The operation cannot be undone: are you sure?</source>
         <translation>Автопересчёт</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="504"/>
+        <location filename="../../toonz/cellselection.cpp" line="501"/>
         <source>It is not possible to paste vectors in the current cell.</source>
         <translation>Невозможно вставить векторы в текущую ячейку.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="622"/>
+        <location filename="../../toonz/cellselection.cpp" line="619"/>
         <source>Paste (Strokes)</source>
         <translation>Вставить (штрихи)</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="705"/>
+        <location filename="../../toonz/cellselection.cpp" line="702"/>
         <source>It is not possible to paste image on the current cell.</source>
         <translation>Невозможно вставить изображение в текущую ячейку.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="819"/>
-        <location filename="../../toonz/cellselection.cpp" line="913"/>
+        <location filename="../../toonz/cellselection.cpp" line="816"/>
+        <location filename="../../toonz/cellselection.cpp" line="910"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="858"/>
+        <location filename="../../toonz/cellselection.cpp" line="855"/>
         <source>Paste (Raster)</source>
         <translation>Вставить (Растр)</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1038"/>
+        <location filename="../../toonz/cellselection.cpp" line="1035"/>
         <source>Overwrite Paste Cells</source>
         <translation>Заменить вставленные ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1151"/>
+        <location filename="../../toonz/cellselection.cpp" line="1148"/>
         <source>Paste Numbers</source>
         <translation>Вставлять номер видео</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1242"/>
+        <location filename="../../toonz/cellselection.cpp" line="1239"/>
         <location filename="../../toonz/xshcellviewer.cpp" line="519"/>
         <source>Rename Cell  at Column %1  Frame %2</source>
         <translation>Переименовать ячейку в столбце %1 Кадр %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1281"/>
+        <location filename="../../toonz/cellselection.cpp" line="1278"/>
         <source>Create Blank Drawing</source>
         <translation>Создать пустой рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1322"/>
+        <location filename="../../toonz/cellselection.cpp" line="1319"/>
         <source>Set Stop Frame Hold</source>
         <translation>Установить стоп-кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1361"/>
+        <location filename="../../toonz/cellselection.cpp" line="1358"/>
         <source>Duplicate Drawing</source>
         <translation>Продублировать рисунок</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1403"/>
+        <location filename="../../toonz/cellselection.cpp" line="1400"/>
         <source>Fill In Empty Cells</source>
         <translation>Заполнить пустые ячейки</translation>
     </message>
@@ -14828,164 +15691,164 @@ The operation cannot be undone: are you sure?</source>
         <translation type="vanished">Дублировать кадр в Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1833"/>
-        <location filename="../../toonz/cellselection.cpp" line="2283"/>
-        <location filename="../../toonz/cellselection.cpp" line="3521"/>
-        <location filename="../../toonz/cellselection.cpp" line="3620"/>
+        <location filename="../../toonz/cellselection.cpp" line="1825"/>
+        <location filename="../../toonz/cellselection.cpp" line="2275"/>
+        <location filename="../../toonz/cellselection.cpp" line="3513"/>
+        <location filename="../../toonz/cellselection.cpp" line="3612"/>
         <source>No data to paste.</source>
         <translation>Нет данных для вставки.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1854"/>
-        <location filename="../../toonz/cellselection.cpp" line="3545"/>
-        <location filename="../../toonz/cellselection.cpp" line="3649"/>
+        <location filename="../../toonz/cellselection.cpp" line="1846"/>
+        <location filename="../../toonz/cellselection.cpp" line="3537"/>
+        <location filename="../../toonz/cellselection.cpp" line="3641"/>
         <source>It is not possible to paste the cells: there is a circular reference.</source>
         <translation>Невозможно вставить ячейки: имеется круговой референс.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1923"/>
-        <location filename="../../toonz/cellselection.cpp" line="2248"/>
-        <location filename="../../toonz/cellselection.cpp" line="2531"/>
+        <location filename="../../toonz/cellselection.cpp" line="1915"/>
+        <location filename="../../toonz/cellselection.cpp" line="2240"/>
+        <location filename="../../toonz/cellselection.cpp" line="2523"/>
         <source>It is not possible to paste data: there is nothing to paste.</source>
         <translation>Невозможно вставить данные: нечего вставлять.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2151"/>
+        <location filename="../../toonz/cellselection.cpp" line="2143"/>
         <source>Paste in place or create a new level?</source>
         <translation>Вставить на место или создать новый уровень?</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2152"/>
+        <location filename="../../toonz/cellselection.cpp" line="2144"/>
         <source>Paste in place</source>
         <translation>Вставить на место</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2153"/>
+        <location filename="../../toonz/cellselection.cpp" line="2145"/>
         <source>Create a new level</source>
         <translation>Создать новый уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2275"/>
-        <location filename="../../toonz/cellselection.cpp" line="2576"/>
+        <location filename="../../toonz/cellselection.cpp" line="2267"/>
+        <location filename="../../toonz/cellselection.cpp" line="2568"/>
         <source>There are no copied cells to duplicate.</source>
         <translation>Нет скопированных ячеек для дублирования.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2302"/>
+        <location filename="../../toonz/cellselection.cpp" line="2294"/>
         <source>Cannot paste cells on locked layers.</source>
         <translation>Невозможно вставить ячейки в заблокированные слои.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2309"/>
+        <location filename="../../toonz/cellselection.cpp" line="2301"/>
         <source>Can&apos;t place drawings on the camera column.</source>
         <translation>Невозможно разместить рисунки на колонне камеры.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2362"/>
+        <location filename="../../toonz/cellselection.cpp" line="2354"/>
         <source>Cannot duplicate frames in read only levels</source>
         <translation>Невозможно дублировать кадры на уровнях только для чтения</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2366"/>
+        <location filename="../../toonz/cellselection.cpp" line="2358"/>
         <source>Can only duplicate frames in image sequence levels.</source>
         <translation>Можно дублировать кадры только на уровнях последовательности изображений.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2740"/>
+        <location filename="../../toonz/cellselection.cpp" line="2732"/>
         <source>Unable to create a blank drawing on the camera column</source>
         <translation>Нельзя создать пустой рисунок в столбце камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2746"/>
-        <location filename="../../toonz/cellselection.cpp" line="2920"/>
-        <location filename="../../toonz/cellselection.cpp" line="3011"/>
+        <location filename="../../toonz/cellselection.cpp" line="2738"/>
+        <location filename="../../toonz/cellselection.cpp" line="2912"/>
+        <location filename="../../toonz/cellselection.cpp" line="3003"/>
         <source>The current column is locked</source>
         <translation>Текущий столбец заблокирован</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2773"/>
+        <location filename="../../toonz/cellselection.cpp" line="2765"/>
         <source>Cannot create a blank drawing on the current column</source>
         <translation>Нельзя создать пустой рисунок в текущем столбце</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2778"/>
-        <location filename="../../toonz/cellselection.cpp" line="3043"/>
+        <location filename="../../toonz/cellselection.cpp" line="2770"/>
+        <location filename="../../toonz/cellselection.cpp" line="3035"/>
         <source>The current level is not editable</source>
         <translation>Текущий столбец не редактируем</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2789"/>
+        <location filename="../../toonz/cellselection.cpp" line="2781"/>
         <source>Unable to create a blank drawing on a Single Frame level</source>
         <translation>Невозможно создать пустой рисунок на уровне одного кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2826"/>
+        <location filename="../../toonz/cellselection.cpp" line="2818"/>
         <source>Unable to create a blank drawing on the current column</source>
         <translation>Нельзя создать пустой рисунок в столбце камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2841"/>
+        <location filename="../../toonz/cellselection.cpp" line="2833"/>
         <source>Unable to replace a Stop Frame Hold with a blank drawing</source>
         <translation>Невозможно заменить стоп-кадр  пустым рисунком</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2844"/>
+        <location filename="../../toonz/cellselection.cpp" line="2836"/>
         <source>Unable to replace the current drawing with a blank drawing</source>
         <translation>Вы не можете заменить текущий рисунок пустым</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2913"/>
+        <location filename="../../toonz/cellselection.cpp" line="2905"/>
         <source>Unable to create a stop frame hold on the camera column</source>
         <translation>Невозможно создать стоп-кадр для столбца камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2943"/>
+        <location filename="../../toonz/cellselection.cpp" line="2935"/>
         <source>Cannot create a stop frame hold on the current column</source>
         <translation>Не удается создать стоп-кадр для текущего столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2949"/>
+        <location filename="../../toonz/cellselection.cpp" line="2941"/>
         <source>Cannot create a stop from hold on a column without a level</source>
         <translation>Невозможно создать стоп-кадр в столбце без уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2961"/>
+        <location filename="../../toonz/cellselection.cpp" line="2953"/>
         <source>Unable to create a stop frame hold on the current column</source>
         <translation>Невозможно создать стоп-кадр для текущего столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3004"/>
+        <location filename="../../toonz/cellselection.cpp" line="2996"/>
         <source>There are no drawings in the camera column to duplicate</source>
         <translation>В колонке камеры нет продублированных рисунков</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="2357"/>
-        <location filename="../../toonz/cellselection.cpp" line="3038"/>
+        <location filename="../../toonz/cellselection.cpp" line="2349"/>
+        <location filename="../../toonz/cellselection.cpp" line="3030"/>
         <source>Cannot duplicate a drawing in the current column</source>
         <translation>Не удается скопировать рисунок в текущем столбце</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="1459"/>
+        <location filename="../../toonz/cellselection.cpp" line="1456"/>
         <source>Duplicate Frame in Scene</source>
         <translation>Дублировать кадр в сцене</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3062"/>
+        <location filename="../../toonz/cellselection.cpp" line="3054"/>
         <source>Cannot duplicate a Stop Frame Hold</source>
         <translation>Не удается дублировать стоп-кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3078"/>
+        <location filename="../../toonz/cellselection.cpp" line="3070"/>
         <source>Unable to duplicate a drawing on a Single Frame level</source>
         <translation>Невозможно дублировать рисунок на уровне одного кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3110"/>
+        <location filename="../../toonz/cellselection.cpp" line="3102"/>
         <source>Unable to duplicate a drawing on the current column</source>
         <translation>Не удается скопировать рисунок в текущем столбце</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3125"/>
+        <location filename="../../toonz/cellselection.cpp" line="3117"/>
         <source>Unable to replace the current or next drawing with a duplicate drawing</source>
         <translation>Вы не можете заменить текущий рисунок или следующий копией</translation>
     </message>
@@ -15004,36 +15867,36 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation type="obsolete">Выберите только один кадр для дублирования.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3599"/>
-        <location filename="../../toonz/cellselection.cpp" line="3676"/>
+        <location filename="../../toonz/cellselection.cpp" line="3591"/>
+        <location filename="../../toonz/cellselection.cpp" line="3668"/>
         <source>Cannot paste data 
  Nothing to paste</source>
         <translation>Не удается вставить данные
   Нечего вставлять</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3639"/>
+        <location filename="../../toonz/cellselection.cpp" line="3631"/>
         <source>It is not possible to paste the cells: Some column is locked or column type is not match.</source>
         <translation>Вставить в ячейку невозможно. Столбец заблокирован или его формат не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3830"/>
-        <location filename="../../toonz/cellselection.cpp" line="3836"/>
+        <location filename="../../toonz/cellselection.cpp" line="3822"/>
+        <location filename="../../toonz/cellselection.cpp" line="3828"/>
         <source>This command only works on vector cells.</source>
         <translation>Эта команда работает только с векторными ячейками.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3842"/>
+        <location filename="../../toonz/cellselection.cpp" line="3834"/>
         <source>Please select only one column for this command.</source>
         <translation>Пожалуйста, выберите только один столбец для этой команды.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3850"/>
+        <location filename="../../toonz/cellselection.cpp" line="3842"/>
         <source>All selected cells must belong to the same level.</source>
         <translation>Все выбранные ячейки должны принадлежать к одному и тому же уровню.</translation>
     </message>
     <message>
-        <location filename="../../toonz/cellselection.cpp" line="3942"/>
+        <location filename="../../toonz/cellselection.cpp" line="3934"/>
         <source>Simplify Vectors : Level %1</source>
         <translation>Упрощение векторов : уровень %1</translation>
     </message>
@@ -15109,85 +15972,85 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation>Установить метку ячейки в столбце %1 кадра %2 на %3</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3368"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3309"/>
         <source>Toggle cycle of  %1</source>
         <translation>Переключить цикл %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellmover.cpp" line="461"/>
+        <location filename="../../toonz/xshcellmover.cpp" line="464"/>
         <source>Move Level</source>
         <translation>Переместить уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="184"/>
-        <location filename="../../toonz/tpanels.cpp" line="381"/>
+        <location filename="../../toonz/tpanels.cpp" line="185"/>
+        <location filename="../../toonz/tpanels.cpp" line="382"/>
         <source>Schematic</source>
         <translation>Схема</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="312"/>
+        <location filename="../../toonz/tpanels.cpp" line="313"/>
         <source>Stage Schematic</source>
         <translation>Схема сцены</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="314"/>
+        <location filename="../../toonz/tpanels.cpp" line="315"/>
         <source>Fx Schematic</source>
         <translation>Fx Схема</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="719"/>
+        <location filename="../../toonz/tpanels.cpp" line="720"/>
         <source>Palette</source>
         <translation>Палитра</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="782"/>
-        <location filename="../../toonz/tpanels.cpp" line="796"/>
+        <location filename="../../toonz/tpanels.cpp" line="783"/>
+        <location filename="../../toonz/tpanels.cpp" line="797"/>
         <source>Studio Palette</source>
         <translation>Палитра Studio</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="996"/>
-        <location filename="../../toonz/tpanels.cpp" line="1009"/>
+        <location filename="../../toonz/tpanels.cpp" line="997"/>
+        <location filename="../../toonz/tpanels.cpp" line="1010"/>
         <source>Style Editor</source>
         <translation>Редактор стилей</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1463"/>
-        <location filename="../../toonz/tpanels.cpp" line="1472"/>
+        <location filename="../../toonz/tpanels.cpp" line="1481"/>
+        <location filename="../../toonz/tpanels.cpp" line="1490"/>
         <source>Viewer</source>
         <translation>Просмотрщик</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1672"/>
-        <location filename="../../toonz/tpanels.cpp" line="1686"/>
+        <location filename="../../toonz/tpanels.cpp" line="1690"/>
+        <location filename="../../toonz/tpanels.cpp" line="1704"/>
         <source>Vector Guided Tweening Controls</source>
         <translation>Контроллер векторного гид-твининга</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1058"/>
+        <location filename="../../toonz/tpanels.cpp" line="1059"/>
         <source>Command Bar</source>
         <translation>Панель команд</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1099"/>
+        <location filename="../../toonz/tpanels.cpp" line="1100"/>
         <source>Tool Options</source>
         <translation>Настройки инструмента</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1013"/>
-        <location filename="../../toonz/tpanels.cpp" line="1201"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="996"/>
+        <location filename="../../toonz/tpanels.cpp" line="1202"/>
         <source>Tasks</source>
         <translation>Задания</translation>
     </message>
     <message>
-        <location filename="../../toonz/batchserversviewer.cpp" line="383"/>
-        <location filename="../../toonz/tpanels.cpp" line="1213"/>
+        <location filename="../../toonz/batchserversviewer.cpp" line="379"/>
+        <location filename="../../toonz/tpanels.cpp" line="1214"/>
         <source>Batch Servers</source>
         <translation>Пакетные серверы</translation>
     </message>
     <message>
-        <location filename="../../toonz/castviewer.cpp" line="929"/>
-        <location filename="../../toonz/tpanels.cpp" line="1247"/>
+        <location filename="../../toonz/castviewer.cpp" line="926"/>
+        <location filename="../../toonz/tpanels.cpp" line="1265"/>
         <source>Scene Cast</source>
         <translation>Состав сцены</translation>
     </message>
@@ -15201,20 +16064,20 @@ to use the duplicate command in the xsheet / timeline.</source>
     </message>
     <message>
         <location filename="../../toonz/curveio.cpp" line="159"/>
-        <location filename="../../toonz/tpanels.cpp" line="1281"/>
-        <location filename="../../toonz/tpanels.cpp" line="1292"/>
+        <location filename="../../toonz/tpanels.cpp" line="1299"/>
+        <location filename="../../toonz/tpanels.cpp" line="1310"/>
         <source>Export</source>
         <translation>Экспортировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1321"/>
-        <location filename="../../toonz/tpanels.cpp" line="1334"/>
+        <location filename="../../toonz/tpanels.cpp" line="1339"/>
+        <location filename="../../toonz/tpanels.cpp" line="1352"/>
         <source>Function Editor</source>
         <translation>Редактор функций</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1344"/>
-        <location filename="../../toonz/tpanels.cpp" line="1354"/>
+        <location filename="../../toonz/tpanels.cpp" line="1362"/>
+        <location filename="../../toonz/tpanels.cpp" line="1372"/>
         <source>Message Center</source>
         <translation>Центр сообщений</translation>
     </message>
@@ -15227,32 +16090,32 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation type="vanished">LineTest захват</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1418"/>
-        <location filename="../../toonz/tpanels.cpp" line="1427"/>
+        <location filename="../../toonz/tpanels.cpp" line="1436"/>
+        <location filename="../../toonz/tpanels.cpp" line="1445"/>
         <source>Combo Viewer</source>
         <translation>ComboViewer</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1510"/>
-        <location filename="../../toonz/tpanels.cpp" line="1519"/>
+        <location filename="../../toonz/tpanels.cpp" line="1528"/>
+        <location filename="../../toonz/tpanels.cpp" line="1537"/>
         <source>History</source>
         <translation>История</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1536"/>
-        <location filename="../../toonz/tpanels.cpp" line="1547"/>
+        <location filename="../../toonz/tpanels.cpp" line="1554"/>
+        <location filename="../../toonz/tpanels.cpp" line="1565"/>
         <source>Stop Motion Controller</source>
         <translation>Панель управления стоп-моушн</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1564"/>
-        <location filename="../../toonz/tpanels.cpp" line="1575"/>
+        <location filename="../../toonz/tpanels.cpp" line="1582"/>
+        <location filename="../../toonz/tpanels.cpp" line="1593"/>
         <source>Motion Paths</source>
         <translation>Пути движения</translation>
     </message>
     <message>
-        <location filename="../../toonz/tpanels.cpp" line="1633"/>
-        <location filename="../../toonz/tpanels.cpp" line="1648"/>
+        <location filename="../../toonz/tpanels.cpp" line="1651"/>
+        <location filename="../../toonz/tpanels.cpp" line="1666"/>
         <source>Fx Settings</source>
         <translation>Настройки эффектов</translation>
     </message>
@@ -15305,39 +16168,39 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation>Уровень, который вы используете, не имеет допустимой палитры.</translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="452"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="451"/>
         <source>It is not possible to merge tlv columns because no column was selected.</source>
         <translation>Столбцы TLV не могут быть объединены, поскольку столбцы не были выбраны.</translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="461"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="460"/>
         <source>It is not possible to merge tlv columns because at least two columns have to be selected.</source>
         <translation>Столбцы TLV не могут быть объединены, поскольку необходимо выбрать как минимум два столбца.</translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="491"/>
-        <location filename="../../toonz/matchlinecommand.cpp" line="495"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="490"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="494"/>
         <source>Merging Tlv Levels...</source>
         <translation>Слияние уровней Tlv ...</translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="554"/>
-        <location filename="../../toonz/matchlinecommand.cpp" line="584"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="553"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="583"/>
         <source>It is not possible to delete lines because no column, cell or level strip frame was selected.</source>
         <translation>Невозможно удалить строки, потому что не выбран ни один столбец, ячейка или кадр Level Strip.</translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="562"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="561"/>
         <source>The selected column is empty.</source>
         <translation>Выбранный столбец пуст.</translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="572"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="571"/>
         <source>Selected cells must be in the same column.</source>
         <translation>Выбранные ячейки должны находиться в одном столбце.</translation>
     </message>
     <message>
-        <location filename="../../toonz/matchlinecommand.cpp" line="589"/>
+        <location filename="../../toonz/matchlinecommand.cpp" line="588"/>
         <source>Match lines can be deleted from Smart Raster levels only</source>
         <translation>Разделительные линии можно удалить только с уровней Smart растра</translation>
     </message>
@@ -15346,37 +16209,42 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation type="vanished">Разделительные линии могут быть удалены только из растровых уровней Toonz</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstrip.cpp" line="2035"/>
+        <location filename="../../toonz/filmstrip.cpp" line="2023"/>
         <source>Level: </source>
         <translation>Уровень: </translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="623"/>
+        <location filename="../../toonz/filebrowser.cpp" line="613"/>
         <source>Skipping frame.</source>
         <translation>Пропуск кадра.</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1573"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1563"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1490"/>
         <source>Don&apos;t Duplicate</source>
         <translation>Не дублировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1796"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1781"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1650"/>
         <source>The specified name is already assigned to the %1 file.</source>
         <translation>Указанное имя уже присвоено файлу %1.</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1837"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1822"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1691"/>
         <source>Warning: level %1 already exists; overwrite?</source>
         <translation>Предупреждение: уровень %1 уже существует; перезаписать?</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1855"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1840"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1709"/>
         <source>It is not possible to rename the %1 file.</source>
         <translation>Невозможно переименовать файл %1.</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1861"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1846"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1715"/>
         <source>It is not possible to copy the %1 file.</source>
         <translation>Невозможно скопировать файл %1.</translation>
     </message>
@@ -15452,6 +16320,7 @@ to use the duplicate command in the xsheet / timeline.</source>
     <message>
         <location filename="../../toonz/commandbarpopup.cpp" line="53"/>
         <location filename="../../toonz/commandbarpopup.cpp" line="69"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="278"/>
         <source>[Drag] to move position</source>
         <translation>[Перетаскивание] для перемещения позиции</translation>
     </message>
@@ -15461,12 +16330,12 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation>----Разделитель----</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="333"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="336"/>
         <source>[Drag&amp;Drop] to copy separator to toolbar</source>
         <translation>[Drag&amp;Drop], чтобы скопировать разделитель на панель инструментов</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="357"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="360"/>
         <source>[Drag&amp;Drop] to copy command to toolbar</source>
         <translation>[Drag&amp;Drop], чтобы скопировать команду на панель инструментов</translation>
     </message>
@@ -15475,8 +16344,8 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation type="vanished">[Перетащить], чтобы переместить позицию, [Двойной щелчок], чтобы изменить название</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbar.cpp" line="93"/>
-        <location filename="../../toonz/commandbarpopup.cpp" line="136"/>
+        <location filename="../../toonz/commandbar.cpp" line="130"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="139"/>
         <source>Incorrect file</source>
         <translation>Неверный файл</translation>
     </message>
@@ -15541,27 +16410,27 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation type="vanished">Не удается открыть файл шаблонов настроек меню. Повторная установка Toonz решит эту проблему.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1011"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1032"/>
         <source>No more Undo operations available.</source>
         <translation>Больше нет операций Undo.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1018"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1039"/>
         <source>No more Redo operations available.</source>
         <translation>Больше нет операций Redo.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1080"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1101"/>
         <source>Report a Bug</source>
         <translation>Сообщить об ошибке</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1081"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1102"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1351"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1372"/>
         <source>https://github.com/tahoma2d/tahoma2d/releases/latest</source>
         <translation>https://github.com/tahoma2d/tahoma2d/releases/latest</translation>
     </message>
@@ -15570,19 +16439,19 @@ to use the duplicate command in the xsheet / timeline.</source>
         <translation type="vanished">Вкладки будут восстановлены при следующем запуске OpenToonz.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1337"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1358"/>
         <source>Visit Web Site</source>
         <translation>Посетить сайт</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1341"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1362"/>
         <source>An update is available for this software.
 Visit the Web site for more information.</source>
         <translation>Доступно обновление программного обеспечения.
 Подробную информацию можно найти на веб-сайте.</translation>
     </message>
     <message>
-        <location filename="../../toonz/mainwindow.cpp" line="1343"/>
+        <location filename="../../toonz/mainwindow.cpp" line="1364"/>
         <source>Check for the latest version on launch.</source>
         <translation>Проверять наличие обновлений при запуске.</translation>
     </message>
@@ -15591,19 +16460,79 @@ Visit the Web site for more information.</source>
         <translation type="vanished">https://opentoonz.readthedocs.io/ru/latest/</translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="120"/>
+        <location filename="../../toonz/main.cpp" line="122"/>
         <source>Installing %1 again could fix the problem.</source>
         <translation>Установка %1 снова может устранить проблему.</translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="165"/>
+        <location filename="../../toonz/main.cpp" line="167"/>
         <source>The qualifier %1 is not a valid key name. Skipping.</source>
         <translation>Квалификатор%1 не является допустимым именем ключа. Пропуск.</translation>
     </message>
     <message>
-        <location filename="../../toonz/main.cpp" line="733"/>
+        <location filename="../../toonz/main.cpp" line="559"/>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="571"/>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="658"/>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="672"/>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="678"/>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="685"/>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="698"/>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="741"/>
         <source>Script file %1 does not exists.</source>
         <translation>Файл скрипта %1 не существует.</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="768"/>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="777"/>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="787"/>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="790"/>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/main.cpp" line="833"/>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../toonz/loadfoldercommand.cpp" line="459"/>
@@ -15639,7 +16568,7 @@ Do you want to import them or load from their original location?</source>
 Вы хотите импортировать их или загрузить из своего исходного местоположения?</translation>
     </message>
     <message>
-        <location filename="../../toonz/lipsyncpopup.cpp" line="76"/>
+        <location filename="../../toonz/lipsyncpopup.cpp" line="77"/>
         <source>Apply Lip Sync Data</source>
         <translation>Применить данные липсинга</translation>
     </message>
@@ -15648,7 +16577,7 @@ Do you want to import them or load from their original location?</source>
         <translation type="vanished">Имя слоя</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbar.cpp" line="95"/>
+        <location filename="../../toonz/commandbar.cpp" line="132"/>
         <source>Cannot Read XML File</source>
         <translation>Не удается загрузить XML-файл</translation>
     </message>
@@ -15665,67 +16594,68 @@ Do you want to import them or load from their original location?</source>
         <translation>Произошла ошибка при копировании %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="818"/>
+        <location filename="../../toonz/previewer.cpp" line="836"/>
         <source>Save Previewed Images</source>
         <translation>Сохранить просмотренные изображения</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="856"/>
+        <location filename="../../toonz/previewer.cpp" line="874"/>
         <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? &quot;  |</source>
         <translation>Имя файла не может быть пустым или содержать любой из следующих символов: (новая строка) \ /: *? &quot;|</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="863"/>
+        <location filename="../../toonz/previewer.cpp" line="881"/>
         <source>Unsopporter raster format, cannot save</source>
         <translation>Неподдерживаемый растровый формат, невозможно сохранить</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="879"/>
+        <location filename="../../toonz/previewer.cpp" line="897"/>
         <source>Cannot create %1 : %2</source>
         <comment>Previewer warning %1:path %2:message</comment>
         <translation>Не удается создать %1 : %2</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="885"/>
+        <location filename="../../toonz/previewer.cpp" line="903"/>
         <source>Cannot create %1</source>
         <comment>Previewer warning %1:path</comment>
         <translation>Не удается создать %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="962"/>
+        <location filename="../../toonz/previewer.cpp" line="980"/>
         <source>Saved %1 frames out of %2 in %3</source>
         <comment>Previewer %1:savedframes %2:framecount %3:filepath</comment>
         <translation>Сохранено %1 кадр из %2 в %3</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="968"/>
+        <location filename="../../toonz/previewer.cpp" line="986"/>
         <source>Canceled! </source>
         <comment>Previewer</comment>
         <translation>Отменено! </translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="1103"/>
+        <location filename="../../toonz/previewer.cpp" line="1184"/>
         <source>No frame to save!</source>
         <translation>Нет кадра для сохранения!</translation>
     </message>
     <message>
-        <location filename="../../toonz/previewer.cpp" line="1107"/>
+        <location filename="../../toonz/previewer.cpp" line="1188"/>
         <source>Already saving!</source>
         <translation>Уже сохранено!</translation>
     </message>
     <message>
-        <location filename="../../toonz/levelsettingspopup.cpp" line="302"/>
+        <location filename="../../toonz/levelsettingspopup.cpp" line="320"/>
         <source>Edit Level Settings : %1</source>
         <translation>Изменить опции уровня : %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.h" line="206"/>
+        <location filename="../../toonz/xshcolumnviewer.h" line="201"/>
         <source>Camera Column Switch :  </source>
         <translation>Переключить столбец камеры :  </translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowsermodel.cpp" line="695"/>
-        <location filename="../../toonz/filebrowsermodel.cpp" line="787"/>
+        <location filename="../../toonz/filebrowsermodel.cpp" line="702"/>
+        <location filename="../../toonz/filebrowsermodel.cpp" line="794"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="2096"/>
         <source>Change project</source>
         <translation>Изменить проект</translation>
     </message>
@@ -15740,7 +16670,7 @@ Do you want to import them or load from their original location?</source>
         <translation>Не сохранять</translation>
     </message>
     <message>
-        <location filename="../../toonz/filmstripselection.cpp" line="277"/>
+        <location filename="../../toonz/filmstripselection.cpp" line="279"/>
         <source>Can&apos;t delete the last drawing in a level.</source>
         <translation>Невозможно удалить последний рисунок на уровне.</translation>
     </message>
@@ -15777,6 +16707,33 @@ Do you want to import them or load from their original location?</source>
         <location filename="../../toonz/tvpjson_io.cpp" line="478"/>
         <source>Export TVPaint JSON File</source>
         <translation>Экспорт файла TVPaint JSON</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="138"/>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="153"/>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="305"/>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="2200"/>
+        <location filename="../../toonz/tpanels.cpp" line="1248"/>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4747"/>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -15832,38 +16789,38 @@ Do you want to import them or load from their original location?</source>
 <context>
     <name>RenameAsToonzPopup</name>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1640"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1629"/>
         <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? &quot;  |</source>
         <translation>Имя файла не может быть пустым или содержать любой из следующих символов: (новая строка) \ /: *? &quot;|</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1650"/>
-        <location filename="../../toonz/filebrowser.cpp" line="1687"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1639"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1676"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1656"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1645"/>
         <source>Renaming File </source>
         <translation>Переименование файла </translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1659"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1648"/>
         <source>Creating an animation level of %1 frames</source>
         <translation>Создание анимационного уровня из %1 кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1668"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1657"/>
         <source>Delete Original Files</source>
         <translation>Удалить исходные файлы</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1680"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1669"/>
         <source>Level Name:</source>
         <translation>Имя уровня:</translation>
     </message>
     <message>
-        <location filename="../../toonz/filebrowser.cpp" line="1689"/>
+        <location filename="../../toonz/filebrowser.cpp" line="1678"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -15871,57 +16828,57 @@ Do you want to import them or load from their original location?</source>
 <context>
     <name>RenderController</name>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="232"/>
+        <location filename="../../toonz/exportpanel.cpp" line="231"/>
         <source>Please specify an file name.</source>
         <translation>Укажите имя файла.</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="236"/>
-        <location filename="../../toonz/exportpanel.cpp" line="250"/>
+        <location filename="../../toonz/exportpanel.cpp" line="235"/>
+        <location filename="../../toonz/exportpanel.cpp" line="249"/>
         <source>Drag a scene into the box to export a scene.</source>
         <translation>Перетащите сцену в поле, чтобы экспортировать сцену.</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="275"/>
+        <location filename="../../toonz/exportpanel.cpp" line="274"/>
         <source>The %1  scene has a different resolution from the %2 scene.
                            The output result may differ from what you expect. What do you want to do?</source>
         <translation>Разрешение сцены %1 отличается от сцены %2.
 Результат может стать неожиданным. Что вы хотите сделать?</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="279"/>
+        <location filename="../../toonz/exportpanel.cpp" line="278"/>
         <source>Continue</source>
         <translation>Продолжить</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="279"/>
+        <location filename="../../toonz/exportpanel.cpp" line="278"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="306"/>
+        <location filename="../../toonz/exportpanel.cpp" line="305"/>
         <source>Exporting ...</source>
         <translation>Экспорт ...</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="306"/>
+        <location filename="../../toonz/exportpanel.cpp" line="305"/>
         <source>Abort</source>
         <translation>Прервать</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="309"/>
+        <location filename="../../toonz/exportpanel.cpp" line="308"/>
         <source>Exporting</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="343"/>
+        <location filename="../../toonz/exportpanel.cpp" line="342"/>
         <source>The %1 scene contains an audio file with different characteristics from the one used in the first exported scene.
 The audio file will not be included in the rendered clip.</source>
         <translation>Сцена %1 содержит звуковой файл с другими характеристиками,  чем тот который используется в первой экспортируемой сцене.
 Аудиофайл не будет включен в отрендеренное видео.</translation>
     </message>
     <message>
-        <location filename="../../toonz/exportpanel.cpp" line="361"/>
+        <location filename="../../toonz/exportpanel.cpp" line="360"/>
         <source>The %1 scene contains a plastic deformed level.
 These levels can&apos;t be exported with this tool.</source>
         <translation>Сцена %1 содержит пластически деформированный уровень.
@@ -16001,6 +16958,44 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="231"/>
+        <source>2D</source>
+        <translation type="unfinished">2D</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="233"/>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="235"/>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="237"/>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="239"/>
+        <source>Browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="241"/>
+        <source>History</source>
+        <translation type="unfinished">История</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/mainwindow.cpp" line="243"/>
+        <source>New Room</source>
+        <translation type="unfinished">Новая вкладка</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <location filename="../../toonz/menubar.cpp" line="167"/>
@@ -16014,6 +17009,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <location filename="../../toonz/menubar.cpp" line="191"/>
+        <location filename="../../toonz/menubar.cpp" line="222"/>
         <source>New Room</source>
         <translation>Новая вкладка</translation>
     </message>
@@ -16042,9 +17038,8 @@ These levels can&apos;t be exported with this tool.</source>
         <translation type="vanished">Настроить панель вкладок «%1»</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="222"/>
         <source>Room</source>
-        <translation>Вкладка</translation>
+        <translation type="vanished">Вкладка</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -17170,12 +18165,12 @@ Please commit or revert changes first.</source>
 <context>
     <name>SaveImagesPopup</name>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="530"/>
+        <location filename="../../toonz/flipbook.cpp" line="532"/>
         <source>Save Flipbook Images</source>
         <translation>Сохранить изображения Flipbook</translation>
     </message>
     <message>
-        <location filename="../../toonz/flipbook.cpp" line="531"/>
+        <location filename="../../toonz/flipbook.cpp" line="533"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
@@ -17191,6 +18186,14 @@ Please commit or revert changes first.</source>
         <location filename="../../toonz/filebrowserpopup.cpp" line="1570"/>
         <source>Save</source>
         <translation>Сохранить</translation>
+    </message>
+</context>
+<context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <location filename="../../toonz/convertfolderpopup.cpp" line="166"/>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -17354,6 +18357,229 @@ Please commit or revert changes first.</source>
     </message>
 </context>
 <context>
+    <name>SceneBrowser</name>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="142"/>
+        <source>Folder: </source>
+        <translation type="unfinished">Папка: </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="281"/>
+        <source>Open folder failed</source>
+        <translation type="unfinished">Не удалось открыть папку</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="282"/>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished">Недопустимый путь к папке ввода.</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="976"/>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">Не удалось расширение файла</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="982"/>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">Не удалось установить номер рисунка</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="997"/>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">Не удалось переименовать. Файл уже существует: </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1019"/>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">Не удалось переименовать </translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1085"/>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">Загрузить как Sub-xsheet</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1087"/>
+        <source>Load</source>
+        <translation type="unfinished">Загрузить</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1137"/>
+        <source>Rename</source>
+        <translation type="unfinished">Переименовать</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1151"/>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">Конвертировать в окрашенный TLV</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1157"/>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">Конвертировать в неокрашенный TLV</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1184"/>
+        <source>Version Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1190"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1202"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1197"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1293"/>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">Изменить диапазон кадров...</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1209"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1255"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1322"/>
+        <source>Put...</source>
+        <translation type="unfinished">Поместить...</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1213"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1326"/>
+        <source>Revert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1220"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1271"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1289"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1303"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1317"/>
+        <source>Get</source>
+        <translation type="unfinished">Получить</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1225"/>
+        <source>Delete</source>
+        <translation type="unfinished">Удалить</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1233"/>
+        <source>Get Revision...</source>
+        <translation type="unfinished">Пересмотреть...</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1249"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1261"/>
+        <source>Unlock</source>
+        <translation type="unfinished">Разблокировать</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1265"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1297"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1312"/>
+        <source>Edit Info</source>
+        <translation type="unfinished">Изменить инфо</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1277"/>
+        <source>Revision History...</source>
+        <translation type="unfinished">Пересмотреть историю...</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1308"/>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">Разблокировать диапазон кадров</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1469"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="2065"/>
+        <source>Save Scene</source>
+        <translation type="unfinished">Сохранить сцену</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1469"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="2065"/>
+        <source>Scene name:</source>
+        <translation type="unfinished">Название сцены:</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1522"/>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished">Произошла ошибка при копировании %1 в %2</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1755"/>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">Конвертировать в неокрашенный TLV</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1769"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1863"/>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1771"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1865"/>
+        <source>Yes</source>
+        <translation type="unfinished">Да</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1771"/>
+        <location filename="../../toonz/scenebrowser.cpp" line="1865"/>
+        <source>No</source>
+        <translation type="unfinished">Нет</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1831"/>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">Выполнено: все уровни конвертированы в формат TLV</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1851"/>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">Конвертировать в окрашенный TLV</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="1909"/>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">Выполнено: 2 уровня, конвертированы в формат TLV</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="2103"/>
+        <source>New Folder</source>
+        <translation type="unfinished">Новая папка</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="2114"/>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">Не удалось создать папку %1.</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowserversioncontrol.cpp" line="185"/>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">Некоторые файлы, которые вы хотите редактировать, в настоящее время открыты. Закройте их сначала.</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowserversioncontrol.cpp" line="409"/>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">Некоторые файлы, которые вы хотите разблокировать, в настоящее время открыты. Закройте их сначала.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="120"/>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/scenebrowser.cpp" line="121"/>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SceneSettingsPopup</name>
     <message>
         <location filename="../../toonz/scenesettingspopup.cpp" line="244"/>
@@ -17376,42 +18602,42 @@ Please commit or revert changes first.</source>
         <translation>Частота кадров:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="299"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="300"/>
         <source>Camera BG Color:</source>
         <translation>Цвет фона камеры:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="303"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="304"/>
         <source>Field Guide Size:</source>
         <translation>Размер направляющей сетки:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="306"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="307"/>
         <source>A/R:</source>
         <translation>A/R:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="310"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="312"/>
         <source>Image Subsampling:</source>
         <translation>Субсемплинг изображения:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="314"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="316"/>
         <source>TLV Subsampling:</source>
         <translation>СубсемплингTLV:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="319"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="321"/>
         <source>Marker Interval:</source>
         <translation>Интервал маркеров:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="322"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="324"/>
         <source>  Start Frame:</source>
         <translation>  Начальный кадр:</translation>
     </message>
     <message>
-        <location filename="../../toonz/scenesettingspopup.cpp" line="330"/>
+        <location filename="../../toonz/scenesettingspopup.cpp" line="332"/>
         <source>Cell Marks:</source>
         <translation>Метки ячеек:</translation>
     </message>
@@ -17419,52 +18645,52 @@ Please commit or revert changes first.</source>
 <context>
     <name>SceneViewer</name>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1877"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1932"/>
         <source>FROZEN</source>
         <translation>ЗАМОРОЖЕН</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1885"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1940"/>
         <source>Motion Path Selected</source>
         <translation>Выбран путь движения</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1892"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1947"/>
         <source>Transparency Check</source>
         <translation>Проверка прозрачности</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1893"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1948"/>
         <source>Ink Check</source>
         <translation>Проверка штриха</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1894"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1949"/>
         <source>Ink#1 Check</source>
         <translation>Проверка штриха#1</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1895"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1950"/>
         <source>Paint Check</source>
         <translation>Проверка цвета</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1896"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1951"/>
         <source>Inks Only Check</source>
         <translation>Проверить только чернила</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1897"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1952"/>
         <source>Black BG Check</source>
         <translation>На чёрном фоне</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1898"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1953"/>
         <source>Fill Check</source>
         <translation>Проверка заполнения</translation>
     </message>
     <message>
-        <location filename="../../toonz/sceneviewer.cpp" line="1899"/>
+        <location filename="../../toonz/sceneviewer.cpp" line="1954"/>
         <source>Gap Check</source>
         <translation>Проверка замкнутости</translation>
     </message>
@@ -17628,80 +18854,66 @@ Please commit or revert changes first.</source>
 <context>
     <name>SceneViewerPanel</name>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="439"/>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>Безопасная зона (Щелкните правой кнопкой мыши, чтобы выбрать)</translation>
+        <translation type="vanished">Безопасная зона (Щелкните правой кнопкой мыши, чтобы выбрать)</translation>
     </message>
     <message>
         <source>Field Guide</source>
         <translation type="vanished">Направляющая сетка</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="231"/>
         <source>GUI Show / Hide</source>
-        <translation>Показать / скрыть GUI</translation>
+        <translation type="vanished">Показать / скрыть GUI</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="234"/>
         <source>Playback Toolbar</source>
-        <translation>Панель инструментов воспроизведения</translation>
+        <translation type="vanished">Панель инструментов воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="235"/>
         <source>Frame Slider</source>
-        <translation>Бегунок кадра</translation>
+        <translation type="vanished">Бегунок кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="453"/>
         <source>Grids and Overlays
 Right click to adjust.</source>
-        <translation>Сетки и наложения
+        <translation type="vanished">Сетки и наложения
 Щелкните правой кнопкой мыши, чтобы настроить.</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="468"/>
         <source>Grids and Overlays Settings</source>
-        <translation>Настройки сеток и наложений</translation>
+        <translation type="vanished">Настройки сеток и наложений</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="477"/>
         <source>Camera Stand View</source>
-        <translation>Стандартный вид с камеры</translation>
+        <translation type="vanished">Стандартный вид с камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="485"/>
         <source>3D View</source>
-        <translation>3D-просмотр</translation>
+        <translation type="vanished">3D-просмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="492"/>
         <source>Camera View</source>
-        <translation>Вид с  камеры</translation>
+        <translation type="vanished">Вид с  камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="500"/>
         <source>Change camera view transparency.</source>
-        <translation>Изменить прозрачность обзора камеры.</translation>
+        <translation type="vanished">Изменить прозрачность обзора камеры.</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="515"/>
         <source>Freeze</source>
-        <translation>Заморозить</translation>
+        <translation type="vanished">Заморозить</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="525"/>
         <source>Preview</source>
-        <translation>Предпросмотр</translation>
+        <translation type="vanished">Предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="534"/>
         <source>Sub-camera Preview</source>
-        <translation>Предпросмотр суб-камеры</translation>
+        <translation type="vanished">Предпросмотр суб-камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="638"/>
         <source>Untitled</source>
-        <translation>Безымянный</translation>
+        <translation type="vanished">Безымянный</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -17712,36 +18924,28 @@ Right click to adjust.</source>
         <translation type="vanished">[УРОВЕНЬ]: </translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="640"/>
         <source>Scene: </source>
-        <translation>Сцена: </translation>
+        <translation type="vanished">Сцена: </translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="643"/>
         <source>   ::   Frame: </source>
-        <translation>   ::   Кадр: </translation>
+        <translation type="vanished">   ::   Кадр: </translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="660"/>
-        <location filename="../../toonz/viewerpane.cpp" line="688"/>
         <source>  ::  Zoom : </source>
-        <translation>  ::  Зум : </translation>
+        <translation type="vanished">  ::  Зум : </translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="663"/>
-        <location filename="../../toonz/viewerpane.cpp" line="691"/>
         <source> (Flipped)</source>
-        <translation> (Перевёрнутый)</translation>
+        <translation type="vanished"> (Перевёрнутый)</translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="673"/>
         <source>   ::   Level: </source>
-        <translation>   ::   Уровень: </translation>
+        <translation type="vanished">   ::   Уровень: </translation>
     </message>
     <message>
-        <location filename="../../toonz/viewerpane.cpp" line="680"/>
         <source>Level: </source>
-        <translation>Уровень: </translation>
+        <translation type="vanished">Уровень: </translation>
     </message>
 </context>
 <context>
@@ -17947,27 +19151,27 @@ Right click to adjust.</source>
 <context>
     <name>SeparateSwatch</name>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="299"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="303"/>
         <source>Sub Color 3</source>
         <translation>Подцвет 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="305"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="309"/>
         <source>Original</source>
         <translation>Оригинал</translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="306"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="310"/>
         <source>Main Color</source>
         <translation>Основной цвет</translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="311"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="315"/>
         <source>Sub Color 1</source>
         <translation>Подцвет 1</translation>
     </message>
     <message>
-        <location filename="../../toonz/separatecolorsswatch.cpp" line="312"/>
+        <location filename="../../toonz/separatecolorsswatch.cpp" line="316"/>
         <source>Sub Color 2</source>
         <translation>Подцвет 2</translation>
     </message>
@@ -18118,133 +19322,151 @@ Right click to adjust.</source>
 <context>
     <name>ShortcutTree</name>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="300"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="303"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="325"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="236"/>
         <source>Menu Commands</source>
         <translation>Команды меню</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="321"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="324"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="346"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="239"/>
         <source>Fill</source>
         <translation>Заливка</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="304"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="307"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="329"/>
         <location filename="../../toonz/menubar.cpp" line="309"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="240"/>
         <source>File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="305"/>
-        <location filename="../../toonz/menubar.cpp" line="370"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="308"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="330"/>
+        <location filename="../../toonz/menubar.cpp" line="371"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="241"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="306"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="309"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="331"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="242"/>
         <source>Scan &amp; Cleanup</source>
         <translation>Сканирование и очистка</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="308"/>
-        <location filename="../../toonz/menubar.cpp" line="443"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="311"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="333"/>
+        <location filename="../../toonz/menubar.cpp" line="444"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="244"/>
         <source>Level</source>
         <translation>Уровень</translation>
     </message>
     <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="334"/>
         <source>Xsheet</source>
-        <translation type="vanished">Xsheet</translation>
+        <translation>Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="311"/>
-        <location filename="../../toonz/menubar.cpp" line="499"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="314"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="336"/>
+        <location filename="../../toonz/menubar.cpp" line="500"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="246"/>
         <source>Cells</source>
         <translation>Ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="312"/>
-        <location filename="../../toonz/menubar.cpp" line="552"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="315"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="337"/>
+        <location filename="../../toonz/menubar.cpp" line="553"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="247"/>
         <source>Play</source>
         <translation>Воспроизведение</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="313"/>
-        <location filename="../../toonz/menubar.cpp" line="572"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="316"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="338"/>
+        <location filename="../../toonz/menubar.cpp" line="573"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="248"/>
         <source>Render</source>
         <translation>Рендер</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="315"/>
-        <location filename="../../toonz/menubar.cpp" line="592"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="318"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="340"/>
+        <location filename="../../toonz/menubar.cpp" line="593"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="249"/>
         <source>View</source>
         <translation>Вид</translation>
     </message>
     <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="341"/>
         <source>Windows</source>
-        <translation type="vanished">Окна</translation>
+        <translation>Окна</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="318"/>
-        <location filename="../../toonz/menubar.cpp" line="676"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="321"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="343"/>
+        <location filename="../../toonz/menubar.cpp" line="679"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="251"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="322"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="325"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="347"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="253"/>
         <source>Right-click Menu Commands</source>
         <translation>Меню команд правого клика</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="320"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="323"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="345"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="257"/>
         <source>Tools</source>
         <translation>Инструменты</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="309"/>
-        <location filename="../../toonz/menubar.cpp" line="405"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="312"/>
+        <location filename="../../toonz/menubar.cpp" line="406"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="245"/>
         <source>Scene</source>
         <translation>Сцена</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="316"/>
-        <location filename="../../toonz/menubar.cpp" line="628"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="319"/>
+        <location filename="../../toonz/menubar.cpp" line="629"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="250"/>
         <source>Panels</source>
         <translation>Панели</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="324"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="327"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="352"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="258"/>
         <source>Tool Modifiers</source>
         <translation>Модификаторы инструментов</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="325"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="328"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="353"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="260"/>
         <source>Visualization</source>
         <translation>Визуализация</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="326"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="329"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="354"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="261"/>
         <source>Misc</source>
         <translation>Прочее</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="328"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="331"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="259"/>
         <source>Stop Motion</source>
         <translation>Стоп-моушн</translation>
@@ -18254,7 +19476,8 @@ Right click to adjust.</source>
         <translation type="obsolete">Управление воспроизведением</translation>
     </message>
     <message>
-        <location filename="../../toonz/commandbarpopup.cpp" line="327"/>
+        <location filename="../../toonz/commandbarpopup.cpp" line="330"/>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="355"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="262"/>
         <source>RGBA Channels</source>
         <translation>Каналы RGBA</translation>
@@ -18264,11 +19487,12 @@ Right click to adjust.</source>
         <translation type="obsolete">Воспроизведение</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="585"/>
+        <location filename="../../toonz/menubar.cpp" line="586"/>
         <source>Cleanup</source>
         <translation>Очистка</translation>
     </message>
     <message>
+        <location filename="../../toonz/custompaneleditorpopup.cpp" line="351"/>
         <location filename="../../toonz/shortcutpopup.cpp" line="255"/>
         <source>Cell Mark</source>
         <translation>Метка ячейки</translation>
@@ -18530,8 +19754,9 @@ Assign shortcut sequence anyway?</source>
         <translation>Высота:</translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="118"/>
         <source>DPI:</source>
-        <translation type="vanished">DPI:</translation>
+        <translation>DPI:</translation>
     </message>
     <message>
         <location filename="../../toonz/startuppopup.cpp" line="98"/>
@@ -18554,69 +19779,74 @@ Assign shortcut sequence anyway?</source>
         <translation>Частота кадров:</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="129"/>
+        <location filename="../../toonz/startuppopup.cpp" line="130"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="130"/>
+        <location filename="../../toonz/startuppopup.cpp" line="131"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="131"/>
+        <location filename="../../toonz/startuppopup.cpp" line="132"/>
         <source>Show this at startup</source>
         <translation>Показывать это окно при запуске</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="132"/>
+        <location filename="../../toonz/startuppopup.cpp" line="133"/>
         <source>Automatically Save Every </source>
         <translation>Автоматически сохранять каждые </translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="134"/>
+        <location filename="../../toonz/startuppopup.cpp" line="135"/>
         <source>Create Scene</source>
         <translation>Создать сцену</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="135"/>
+        <location filename="../../toonz/startuppopup.cpp" line="136"/>
         <source>New Project...</source>
         <translation>Новый проект...</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="138"/>
+        <location filename="../../toonz/startuppopup.cpp" line="139"/>
         <source>Open Another Scene...</source>
         <translation>Открыть другую сцену...</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="222"/>
+        <location filename="../../toonz/startuppopup.cpp" line="226"/>
         <source>Preset:</source>
         <translation>Предустановка:</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="245"/>
+        <location filename="../../toonz/startuppopup.cpp" line="249"/>
         <source>fps</source>
         <translation>кадр/сек</translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
         <source>pixel</source>
-        <translation type="vanished">пиксель</translation>
+        <translation>пиксель</translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
         <source>cm</source>
-        <translation type="vanished">см</translation>
+        <translation>см</translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
         <source>mm</source>
-        <translation type="vanished">мм</translation>
+        <translation>мм</translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
         <source>inch</source>
-        <translation type="vanished">дюйм</translation>
+        <translation>дюйм</translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="141"/>
         <source>field</source>
-        <translation type="vanished">поле</translation>
+        <translation>поле</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -18627,31 +19857,32 @@ Assign shortcut sequence anyway?</source>
         <translation type="vanished">Размер камеры:</translation>
     </message>
     <message>
+        <location filename="../../toonz/startuppopup.cpp" line="128"/>
         <source>Units:</source>
-        <translation type="vanished">Единицы:</translation>
+        <translation>Единицы:</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="278"/>
+        <location filename="../../toonz/startuppopup.cpp" line="289"/>
         <source>Minutes</source>
         <translation>Минут(ы)</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="415"/>
+        <location filename="../../toonz/startuppopup.cpp" line="441"/>
         <source>No Recent Scenes</source>
         <translation>Нет недавних сцен</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="477"/>
+        <location filename="../../toonz/startuppopup.cpp" line="503"/>
         <source>Browse...</source>
         <translation>Просмотр...</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="478"/>
+        <location filename="../../toonz/startuppopup.cpp" line="504"/>
         <source>Open a different project.</source>
         <translation>Откройте другой проект.</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="571"/>
+        <location filename="../../toonz/startuppopup.cpp" line="597"/>
         <source>The name cannot be empty.</source>
         <translation>Имя не может быть пустым.</translation>
     </message>
@@ -18660,85 +19891,85 @@ Assign shortcut sequence anyway?</source>
         <translation type="obsolete">Выбранный путь к файлу недействителен.</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="576"/>
+        <location filename="../../toonz/startuppopup.cpp" line="602"/>
         <source>The width must be greater than zero.</source>
         <translation>Ширина должна быть больше нуля.</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="581"/>
+        <location filename="../../toonz/startuppopup.cpp" line="607"/>
         <source>The height must be greater than zero.</source>
         <translation>Высота должна быть больше нуля.</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="586"/>
+        <location filename="../../toonz/startuppopup.cpp" line="612"/>
         <source>The frame rate must be 1 or more.</source>
         <translation>Частота кадров должна быть 1 или более.</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="607"/>
+        <location filename="../../toonz/startuppopup.cpp" line="633"/>
         <source>Failed to create the folder.</source>
         <translation>Создать папку не удалось.</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="658"/>
+        <location filename="../../toonz/startuppopup.cpp" line="684"/>
         <source>This is not a valid folder.  Please choose an existing location.</source>
         <translation>Это недопустимая папка. Пожалуйста, выберите существующее местоположение.</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="674"/>
+        <location filename="../../toonz/startuppopup.cpp" line="700"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="675"/>
+        <location filename="../../toonz/startuppopup.cpp" line="701"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="676"/>
+        <location filename="../../toonz/startuppopup.cpp" line="702"/>
         <source>No project found at this location 
 What would you like to do?</source>
         <translation>В этом месте не найдено ни одного проекта
 Что будем делать?</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="678"/>
+        <location filename="../../toonz/startuppopup.cpp" line="704"/>
         <source>Make a new project</source>
         <translation>Создайте новый проект</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="678"/>
+        <location filename="../../toonz/startuppopup.cpp" line="704"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="841"/>
+        <location filename="../../toonz/startuppopup.cpp" line="867"/>
         <source>Preset name</source>
         <translation>Имя предустановки</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="842"/>
+        <location filename="../../toonz/startuppopup.cpp" line="868"/>
         <source>Enter the name for %1</source>
         <translation>Введите имя для %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="847"/>
+        <location filename="../../toonz/startuppopup.cpp" line="873"/>
         <source>Error : Preset Name is Invalid</source>
         <translation>Ошибка: недопустимое имя предустановки</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="848"/>
+        <location filename="../../toonz/startuppopup.cpp" line="874"/>
         <source>The preset name must not use &apos;,&apos;(comma).</source>
         <translation>Имя файла предустановки не должно содержать &quot;,&quot; (запятую).</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="911"/>
+        <location filename="../../toonz/startuppopup.cpp" line="937"/>
         <source>Bad camera preset</source>
         <translatorcomment>савсэм плахой предустановк, слюшай</translatorcomment>
         <translation>Плохая предустановка камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/startuppopup.cpp" line="912"/>
+        <location filename="../../toonz/startuppopup.cpp" line="938"/>
         <source>&apos;%1&apos; doesn&apos;t seem to be a well formed camera preset. 
 Possibly the preset file has been corrupted</source>
         <translation>«%1», похоже, не является предустановленной камерой.
@@ -19052,6 +20283,7 @@ Possibly the preset file has been corrupted</source>
     </message>
     <message>
         <location filename="../../toonz/statusbar.cpp" line="353"/>
+        <location filename="../../toonz/statusbar.cpp" line="371"/>
         <source>%1%2Move entire object</source>
         <translation>%1%2Переместить весь объект</translation>
     </message>
@@ -19071,12 +20303,22 @@ Possibly the preset file has been corrupted</source>
         <translation>%1%2Переместить объект вдоль горизонта</translation>
     </message>
     <message>
-        <location filename="../../toonz/statusbar.cpp" line="369"/>
+        <location filename="../../toonz/statusbar.cpp" line="370"/>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/statusbar.cpp" line="375"/>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/statusbar.cpp" line="377"/>
         <source>Finger Tool: Smudges small areas to cover with line</source>
         <translation>Инструмент &quot;Палец&apos;&apos;: размазывает небольшие участки, чтобы покрыть линией</translation>
     </message>
     <message>
-        <location filename="../../toonz/statusbar.cpp" line="370"/>
+        <location filename="../../toonz/statusbar.cpp" line="378"/>
         <source>This tool doesn&apos;t work on this layer type.</source>
         <translation>Этот инструмент не работает с этим типом слоя.</translation>
     </message>
@@ -19084,264 +20326,570 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>StopMotion</name>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="143"/>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="vanished">Нет</translation>
+        <translation>Нет</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="649"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="678"/>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1520"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2067"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2746"/>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="vanished">Имя уровня не указано: пожалуйста, укажите правильное имя уровня</translation>
+        <translation>Имя уровня не указано: пожалуйста, укажите правильное имя уровня</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1566"/>
         <source>The level name specified is already used: please choose a different level name.</source>
-        <translation type="vanished">Имя уровня уже используется: выберите другое имя.</translation>
+        <translation>Имя уровня уже используется: выберите другое имя.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1575"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2786"/>
         <source>The save in path specified does not match with the existing level.</source>
-        <translation type="vanished">Указанный путь сохранения не соответствует существующему уровню.</translation>
+        <translation>Указанный путь сохранения не соответствует существующему уровню.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1581"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1614"/>
         <source>The captured image size does not match with the existing level.</source>
-        <translation type="vanished">Размер захваченного изображения не соответствует существующему уровню.</translation>
+        <translation>Размер захваченного изображения не соответствует существующему уровню.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1589"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1623"/>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
-        <translation type="vanished">Файл «%1» уже существует.
+        <translation>Файл «%1» уже существует.
 Хотите перезаписать его?</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1604"/>
         <source>Failed to load %1.</source>
-        <translation type="vanished">Не удалось загрузить %1.</translation>
+        <translation>Не удалось загрузить %1.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1649"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2089"/>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="vanished">Папки %1 не существует.
+        <translation>Папки %1 не существует.
 Вы хотите создать ее?</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1657"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1667"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1676"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2097"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2107"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2116"/>
         <source>Unable to create</source>
-        <translation type="vanished">Не удалось создать</translation>
+        <translation>Не удалось создать</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1859"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2022"/>
         <source>Please start live view before capturing an image.</source>
-        <translation type="vanished">Пожалуйста, начните просмотр в реальном времени, прежде чем сделать снимок.</translation>
+        <translation>Пожалуйста, начните просмотр в реальном времени, прежде чем сделать снимок.</translation>
     </message>
     <message>
         <source>Cannot capture webcam image unless live view is active.</source>
         <translation type="vanished">Невозможно захватить изображение с веб-камеры, если не активен просмотр в реальном времени.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1921"/>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2769"/>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2775"/>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2779"/>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2807"/>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2819"/>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2841"/>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2848"/>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2859"/>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2863"/>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2864"/>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2960"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2965"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2972"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2977"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2996"/>
         <source>UNDEFINED WARNING</source>
-        <translation type="vanished">НЕОПРЕДЕЛЕННОЕ ПРЕДУПРЕЖДЕНИЕ</translation>
+        <translation>НЕОПРЕДЕЛЕННОЕ ПРЕДУПРЕЖДЕНИЕ</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="2987"/>
         <source>The level is not registered in the scene, but exists in the file system.</source>
-        <translation type="vanished">Уровень не загружен в текущую сцену, но файл существует.</translation>
+        <translation>Уровень не загружен в текущую сцену, но файл существует.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3003"/>
         <source>
 WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 Предупреждение: несоответствие размера изображения. Размер сохраненного изображения%1 x %2.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3007"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3057"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3067"/>
         <source>WARNING </source>
-        <translation type="vanished">ВНИМАНИЕ </translation>
+        <translation>ВНИМАНИЕ </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3013"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3074"/>
         <source>
 Frame %1 exists.</source>
-        <translation type="vanished">
+        <translation>
 Кадр %1 существует.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3016"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3077"/>
         <source>
 Frames %1 exist.</source>
-        <translation type="vanished">
+        <translation>
 Кадры %1 существуют.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3020"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3089"/>
         <source>OVERWRITE 1 of</source>
-        <translation type="vanished">ПЕРЕЗАПИСАТЬ 1 из</translation>
+        <translation>ПЕРЕЗАПИСАТЬ 1 из</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3023"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3094"/>
         <source>ADD to</source>
-        <translation type="vanished">ДОБАВИТЬ</translation>
+        <translation>ДОБАВИТЬ</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3027"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3098"/>
         <source> %1 frame</source>
-        <translation type="vanished"> %1 кадр</translation>
+        <translation> %1 кадр</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3029"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3100"/>
         <source> %1 frames</source>
-        <translation type="vanished"> %1 кадров</translation>
+        <translation> %1 кадров</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3035"/>
         <source>The level will be newly created.</source>
-        <translation type="vanished">Уровень будет вновь создан.</translation>
+        <translation>Уровень будет вновь создан.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3036"/>
         <source>NEW</source>
-        <translation type="vanished">НОВЫЙ</translation>
+        <translation>НОВЫЙ</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3044"/>
         <source>The level is already registered in the scene.</source>
-        <translation type="vanished">Этот уровень уже загружен в сцену.</translation>
+        <translation>Этот уровень уже загружен в сцену.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3045"/>
         <source>
 NOTE : The level is not saved.</source>
-        <translation type="vanished">
+        <translation>
 ПРИМЕЧАНИЕ : уровень не сохранен.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3055"/>
         <source>
 WARNING : Failed to get image size of the existing level %1.</source>
-        <translation type="vanished">
+        <translation>
 ВНИМАНИЕ : получить размер изображения уровня %1 не удалось.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3063"/>
         <source>
 WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 ВНИМАНИЕ: несоответствие размера изображения. Существующий размер уровня %1 x %2.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3110"/>
         <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
           %2.</source>
-        <translation type="vanished">ВНИМАНИЕ: конфликт имен уровней. Уровень %1 уже присутствует в сцене с путем                        
+        <translation>ВНИМАНИЕ: конфликт имен уровней. Уровень %1 уже присутствует в сцене с путем                        
 %2.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3118"/>
         <source>
 WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 ВНИМАНИЕ: несоответствие размера изображения. Размер уровня с тем же именем — %1 x %2.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3128"/>
         <source>WARNING : Level path conflicts. There already is a level with the path %1                        
           in the scene with the name %2.</source>
-        <translation type="vanished">ВНИМАНИЕ : повторяющийся путь к файлу. В сцене уже есть уровень из %1                        под именем %2.</translation>
+        <translation>ВНИМАНИЕ : повторяющийся путь к файлу. В сцене уже есть уровень из %1                        под именем %2.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3136"/>
         <source>
 WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 ВНИМАНИЕ: несоответствие размера изображения. Размер уровня с тем же путем %1 x %2.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3142"/>
         <source>WARNING</source>
-        <translation type="vanished">Предупреждение</translation>
+        <translation>Предупреждение</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3448"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3456"/>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotion.cpp" line="1828"/>
+        <location filename="../../stopmotion/stopmotion.cpp" line="3437"/>
         <source>No camera selected.</source>
-        <translation type="vanished">Камера не выбрана.</translation>
+        <translation>Камера не выбрана.</translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="821"/>
         <source>Controls</source>
         <translatorcomment>так и хочется написать &quot;Рульки&quot;</translatorcomment>
-        <translation type="vanished">Контроль</translation>
+        <translation>Контроль</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="822"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2225"/>
         <source>Settings</source>
-        <translation type="vanished">Настройки</translation>
+        <translation>Настройки</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="823"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="883"/>
         <source>Options</source>
-        <translation type="vanished">Опции</translation>
+        <translation>Опции</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="824"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="825"/>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="826"/>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="845"/>
         <source>Resolution: </source>
-        <translation type="vanished">Разрешение: </translation>
+        <translation>Разрешение: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="846"/>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="847"/>
         <source>Refresh</source>
-        <translation type="vanished">Обновить</translation>
+        <translation>Обновить</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="850"/>
         <source>File</source>
-        <translation type="vanished">Файл</translation>
+        <translation>Файл</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="952"/>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="960"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="964"/>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="966"/>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="970"/>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1090"/>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1093"/>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1124"/>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1157"/>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1205"/>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1248"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1676"/>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1253"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1284"/>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1266"/>
         <source>Image adjust</source>
-        <translation type="obsolete">Настройка изображения</translation>
+        <translation type="unfinished">Настройка изображения</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1274"/>
         <source>Color</source>
-        <translation type="obsolete">Цвет</translation>
+        <translation type="unfinished">Цвет</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1274"/>
         <source>Grayscale</source>
-        <translation type="obsolete">Оттенки серого</translation>
+        <translation type="unfinished">Оттенки серого</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1274"/>
         <source>Black &amp; White</source>
-        <translation type="obsolete">Черно-белый</translation>
+        <translation type="unfinished">Черно-белый</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1292"/>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1321"/>
         <source>Brightness: </source>
-        <translation type="obsolete">Яркость: </translation>
+        <translation type="unfinished">Яркость: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1331"/>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1341"/>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1351"/>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1363"/>
         <source>More</source>
-        <translation type="obsolete">Больше</translation>
+        <translation type="unfinished">Больше</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1365"/>
         <source>Webcam Settings...</source>
-        <translation type="vanished">Настройки веб-камеры...</translation>
+        <translation>Настройки веб-камеры...</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4420"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4438"/>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4428"/>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4735"/>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4745"/>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4848"/>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4926"/>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4992"/>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished">Не удалось загрузить%1</translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4997"/>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="5034"/>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished">Не удалось сохранить %1</translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="938"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1401"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4422"/>
         <source>Capture</source>
-        <translation type="vanished">Захват</translation>
+        <translation>Захват</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="895"/>
         <source>Next Level</source>
-        <translation type="vanished">Следующий уровень</translation>
+        <translation>Следующий уровень</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="896"/>
         <source>Next New</source>
-        <translation type="vanished">Новый следующий</translation>
+        <translation>Новый следующий</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="903"/>
         <source>Previous Level</source>
-        <translation type="vanished">Предыдущий уровень</translation>
+        <translation>Предыдущий уровень</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="906"/>
         <source>Next Frame</source>
-        <translation type="vanished">Следующий кадр</translation>
+        <translation>Следующий кадр</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="907"/>
         <source>Last Frame</source>
-        <translation type="vanished">Последний кадр</translation>
+        <translation>Последний кадр</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="913"/>
         <source>Previous Frame</source>
-        <translation type="vanished">Предыдущий кадр</translation>
+        <translation>Предыдущий кадр</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="918"/>
         <source>Next XSheet Frame</source>
-        <translation type="vanished">Следующий кадр в XSheet</translation>
+        <translation>Следующий кадр в XSheet</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="921"/>
         <source>Previous XSheet Frame</source>
-        <translation type="vanished">Предшествующий кадр в XSheet</translation>
+        <translation>Предшествующий кадр в XSheet</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="924"/>
         <source>Current Frame</source>
-        <translation type="vanished">Текущий кадр</translation>
+        <translation>Текущий кадр</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="930"/>
         <source>Set to the Current Playhead Location</source>
-        <translation type="vanished">Установить текущую позицию указателя воспроизведения</translation>
+        <translation>Установить текущую позицию указателя воспроизведения</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="935"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2618"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4337"/>
         <source>Start Live View</source>
-        <translation type="vanished">Реалтайм</translation>
+        <translation>Реалтайм</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -19352,40 +20900,49 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
         <translation type="vanished">Выбрать увеличение</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="972"/>
         <source>&lt;</source>
-        <translation type="vanished">&lt;</translation>
+        <translation>&lt;</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="974"/>
         <source>&gt;</source>
-        <translation type="vanished">&gt;</translation>
+        <translation>&gt;</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="976"/>
         <source>&lt;&lt;</source>
-        <translation type="vanished">&lt;&lt;</translation>
+        <translation>&lt;&lt;</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="978"/>
         <source>&gt;&gt;</source>
-        <translation type="vanished">&gt;&gt;</translation>
+        <translation>&gt;&gt;</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="980"/>
         <source>&lt;&lt;&lt;</source>
-        <translation type="vanished">&lt;&lt;&lt;</translation>
+        <translation>&lt;&lt;&lt;</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="982"/>
         <source>&gt;&gt;&gt;</source>
-        <translation type="vanished">&gt;&gt;&gt;</translation>
+        <translation>&gt;&gt;&gt;</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="999"/>
         <source>Camera:</source>
-        <translation type="vanished">Камера:</translation>
+        <translation>Камера:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1026"/>
         <source>Name:</source>
-        <translation type="vanished">Имя:</translation>
+        <translation>Имя:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1039"/>
         <source>Frame:</source>
-        <translation type="vanished">Кадр:</translation>
+        <translation>Кадр:</translation>
     </message>
     <message>
         <source>File Type:</source>
@@ -19400,68 +20957,233 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
         <translation type="vanished">Кадр xsheet:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1154"/>
         <source>Camera Model</source>
-        <translation type="vanished">Модель камеры</translation>
+        <translation>Модель камеры</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1155"/>
         <source>Camera Mode</source>
-        <translation type="vanished">Режим камеры</translation>
+        <translation>Режим камеры</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1144"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3064"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3855"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3885"/>
         <source>Temperature: </source>
-        <translation type="vanished">Температура: </translation>
+        <translation>Температура: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1375"/>
         <source>Color type:</source>
-        <translation type="obsolete">Тип цвета:</translation>
+        <translation type="unfinished">Тип цвета:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1400"/>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1402"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1403"/>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1404"/>
+        <source>Load</source>
+        <translation type="unfinished">Загрузить</translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1405"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1410"/>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1414"/>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1458"/>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1475"/>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1481"/>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1496"/>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1499"/>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1500"/>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1529"/>
         <source>Interval(sec):</source>
-        <translation type="obsolete">Интервал(сек):</translation>
+        <translation type="unfinished">Интервал(сек):</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1565"/>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1567"/>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1584"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1585"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1586"/>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1587"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1588"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1589"/>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1596"/>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1607"/>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1618"/>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1644"/>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1646"/>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2765"/>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2816"/>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2821"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3646"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3681"/>
         <source>Shutter Speed: </source>
-        <translation type="vanished">Выдержка: </translation>
+        <translation>Выдержка: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2868"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2873"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3714"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3744"/>
         <source>Iso: </source>
-        <translation type="vanished">ISO: </translation>
+        <translation>ISO: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2770"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3579"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3609"/>
         <source>Aperture: </source>
-        <translation type="vanished">Диафрагма: </translation>
+        <translation>Диафрагма: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1208"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1311"/>
         <source>Exposure: </source>
-        <translation type="vanished">Экспозиция: </translation>
+        <translation>Экспозиция: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1202"/>
         <source>Image Quality: </source>
-        <translation type="vanished">Качество изображения: </translation>
+        <translation>Качество изображения: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1199"/>
         <source>Picture Style: </source>
-        <translation type="vanished">Стиль изображения: </translation>
+        <translation>Стиль изображения: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1190"/>
         <source>White Balance: </source>
-        <translation type="vanished">Баланс белого: </translation>
+        <translation>Баланс белого: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1456"/>
         <source>Webcam Options</source>
-        <translation type="vanished">Параметры веб-камеры</translation>
+        <translation>Параметры веб-камеры</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1457"/>
         <source>DSLR Options</source>
-        <translation type="vanished">Параметры DSLR</translation>
+        <translation>Параметры DSLR</translation>
     </message>
     <message>
         <source>Place the frame in the XSheet</source>
         <translation type="vanished">Поместить кадр в Xsheet</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1477"/>
         <source>Use Direct Show Webcam Drivers</source>
-        <translation type="vanished">Использовать драйверы DirectShow для веб-камеры</translation>
+        <translation>Использовать драйверы DirectShow для веб-камеры</translation>
     </message>
     <message>
         <source>Black Screen for Capture</source>
@@ -19472,169 +21194,225 @@ WARNING : Image size mismatch. The size of level with the same path is %1 x %2.<
         <translation type="vanished">Использовать изображения с уменьшенным разрешением</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1478"/>
         <source>Use MJPG with Webcam</source>
-        <translation type="vanished">Использовать MJPG с веб-камерой</translation>
+        <translation>Использовать MJPG с веб-камерой</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1474"/>
         <source>Place on XSheet</source>
-        <translation type="vanished">Поместить в Xsheet</translation>
+        <translation>Поместить в Xsheet</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1479"/>
         <source>Use Numpad Shortcuts When Active</source>
-        <translation type="vanished">Использовать клавиши цифрового блока, когда они включены</translation>
+        <translation>Использовать клавиши цифрового блока, когда они включены</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1498"/>
         <source>Show Live View on All Frames</source>
-        <translation type="vanished">Показывать в реальном времени все изображения</translation>
+        <translation>Показывать в реальном времени все изображения</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1551"/>
         <source>Capture Review Time: </source>
-        <translation type="vanished">Время захвата: </translation>
+        <translation>Время захвата: </translation>
     </message>
     <message>
         <source>Level Subsampling: </source>
         <translation type="vanished">Уровень понижающей дискретизации: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="1727"/>
         <source>Opacity:</source>
-        <translation type="vanished">Непрозрачность:</translation>
+        <translation>Непрозрачность:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2612"/>
         <source>No camera detected.</source>
-        <translation type="vanished">Камера не обнаружена.</translation>
+        <translation>Камера не обнаружена.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2613"/>
         <source>No camera detected</source>
-        <translation type="vanished">Камера не обнаружена</translation>
+        <translation>Камера не обнаружена</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2621"/>
         <source>- Select camera -</source>
-        <translation type="vanished">- Выбрать камеру -</translation>
+        <translation>- Выбрать камеру -</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2733"/>
         <source>Mode: </source>
-        <translation type="vanished">Режим: </translation>
+        <translation>Режим: </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2868"/>
         <source>Auto</source>
-        <translation type="vanished">Автоматически</translation>
+        <translation>Автоматически</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2917"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="2964"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3105"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3152"/>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="3199"/>
         <source>Disabled</source>
-        <translation type="vanished">Отключено</translation>
+        <translation>Отключено</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4027"/>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="4334"/>
         <source>Stop Live View</source>
-        <translation type="vanished">Остановить просмотр в реальном времени</translation>
+        <translation>Остановить просмотр в реальном времени</translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="278"/>
         <source>Create the Destination Subfolder to Save</source>
-        <translation type="obsolete">Создать папку назначения для сохранения</translation>
+        <translation type="unfinished">Создать папку назначения для сохранения</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="282"/>
         <source>Set As Default</source>
-        <translation type="obsolete">Установить по умолчанию</translation>
+        <translation type="unfinished">Установить по умолчанию</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="284"/>
         <source>Set the current &quot;Save In&quot; path as the default.</source>
-        <translation type="obsolete">Сделать текущий путь расположения по умолчанию.</translation>
+        <translation type="unfinished">Сделать текущий путь расположения по умолчанию.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="286"/>
         <source>Create Subfolder</source>
-        <translation type="obsolete">Создать подпапку</translation>
+        <translation type="unfinished">Создать подпапку</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="290"/>
         <source>Infomation</source>
-        <translation type="obsolete">Информация</translation>
+        <translation type="unfinished">Информация</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="291"/>
         <source>Subfolder Name</source>
-        <translation type="obsolete">Имя подпапки</translation>
+        <translation type="unfinished">Имя подпапки</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="298"/>
         <source>Auto Format:</source>
-        <translation type="obsolete">Автоформат:</translation>
+        <translation type="unfinished">Автоформат:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="303"/>
         <source>Show This on Launch of the Camera Capture</source>
-        <translation type="obsolete">Показывать это окно при запуске захвата камеры</translation>
+        <translation type="unfinished">Показывать это окно при запуске захвата камеры</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="304"/>
         <source>Save Scene in Subfolder</source>
-        <translation type="obsolete">Сохранить сцену в подпапке</translation>
+        <translation type="unfinished">Сохранить сцену в подпапке</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="306"/>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="307"/>
         <source>Cancel</source>
-        <translation type="obsolete">Отмена</translation>
+        <translation type="unfinished">Отмена</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="334"/>
         <source>C- + Sequence + Scene</source>
-        <translation type="obsolete">C- + Секвенция + Сцена</translation>
+        <translation type="unfinished">C- + Секвенция + Сцена</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="334"/>
         <source>Sequence + Scene</source>
-        <translation type="obsolete">Секвенция + Сцена</translation>
+        <translation type="unfinished">Секвенция + Сцена</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="335"/>
         <source>Episode + Sequence + Scene</source>
-        <translation type="obsolete">Эпизод + Секвенция + Сцена</translation>
+        <translation type="unfinished">Эпизод + Секвенция + Сцена</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="336"/>
         <source>Project + Episode + Sequence + Scene</source>
-        <translation type="obsolete">Проект + Эпизод + Секвенция + Сцена</translation>
+        <translation type="unfinished">Проект + Эпизод + Секвенция + Сцена</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="344"/>
         <source>Save the current scene in the subfolder.
 Set the output folder path to the subfolder as well.</source>
-        <translation type="obsolete">Сохранить текущую сцену во вложенной папке.
+        <translation type="unfinished">Сохранить текущую сцену во вложенной папке.
 Также задайте путь к папке вывода на вложенную папку.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="358"/>
         <source>Save In:</source>
-        <translation type="obsolete">Сохранить в:</translation>
+        <translation type="unfinished">Сохранить в:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="378"/>
         <source>Project:</source>
-        <translation type="obsolete">Проект:</translation>
+        <translation type="unfinished">Проект:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="381"/>
         <source>Episode:</source>
-        <translation type="obsolete">Эпизод:</translation>
+        <translation type="unfinished">Эпизод:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="384"/>
         <source>Sequence:</source>
-        <translation type="obsolete">Секвенция:</translation>
+        <translation type="unfinished">Секвенция:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="387"/>
         <source>Scene:</source>
-        <translation type="obsolete">Сцена:</translation>
+        <translation type="unfinished">Сцена:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="403"/>
         <source>Subfolder Name:</source>
-        <translation type="obsolete">Имя подпапки:</translation>
+        <translation type="unfinished">Имя подпапки:</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="575"/>
         <source>Subfolder name should not be empty.</source>
-        <translation type="obsolete">Имя подпапки не должно быть пустым.</translation>
+        <translation type="unfinished">Имя подпапки не должно быть пустым.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="582"/>
         <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
-        <translation type="obsolete">Имя подпапки не должно содержать следующих символов: *. &quot;/ \ []:; | =, </translation>
+        <translation type="unfinished">Имя подпапки не должно содержать следующих символов: *. &quot;/ \ []:; | =, </translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="594"/>
         <source>Folder %1 already exists.</source>
-        <translation type="obsolete">Папка %1 уже существует.</translation>
+        <translation type="unfinished">Папка %1 уже существует.</translation>
     </message>
     <message>
+        <location filename="../../stopmotion/stopmotioncontroller.cpp" line="613"/>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">Не удалось создать папку %1.</translation>
+        <translation type="unfinished">Не удалось создать папку %1.</translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <location filename="../../stopmotion/stopmotionserial.cpp" line="16"/>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -19787,7 +21565,7 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>TPanelTitleBarButtonForCameraView</name>
     <message>
-        <location filename="../../toonz/pane.cpp" line="388"/>
+        <location filename="../../toonz/pane.cpp" line="393"/>
         <source>Opacity: </source>
         <translation>Непрозрачность: </translation>
     </message>
@@ -19795,24 +21573,29 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>TPanelTitleBarButtonForGrids</name>
     <message>
-        <location filename="../../toonz/pane.cpp" line="420"/>
+        <location filename="../../toonz/pane.cpp" line="425"/>
         <source>Rule of Thirds</source>
         <translation>Правило третей</translation>
     </message>
     <message>
-        <location filename="../../toonz/pane.cpp" line="426"/>
+        <location filename="../../toonz/pane.cpp" line="431"/>
         <source>Golden Ratio</source>
         <translation>Золотое сечение</translation>
     </message>
     <message>
-        <location filename="../../toonz/pane.cpp" line="433"/>
+        <location filename="../../toonz/pane.cpp" line="438"/>
         <source>Field Guide</source>
         <translation>Направляющая сетка</translation>
     </message>
     <message>
-        <location filename="../../toonz/pane.cpp" line="440"/>
+        <location filename="../../toonz/pane.cpp" line="445"/>
         <source>Perspective Grids</source>
         <translation>Перспективные сетки</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="452"/>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Vanishing Point Rays</source>
@@ -19872,232 +21655,250 @@ Set the output folder path to the subfolder as well.</source>
     </message>
 </context>
 <context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="499"/>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="500"/>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/pane.cpp" line="501"/>
+        <source>Selected cells - Auto play</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TaskSheet</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="207"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="190"/>
         <source>Suspended</source>
         <translation>Приостановлено</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="209"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="192"/>
         <source>Waiting</source>
         <translation>В ожидании</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="211"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="194"/>
         <source>Running</source>
         <translation>Запущено</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="213"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="196"/>
         <source>Completed</source>
         <translation>Завершено</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="215"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="198"/>
         <source>Failed</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="217"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="200"/>
         <source>TaskUnknown</source>
         <translation>Неизвестная задача</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="825"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="808"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="826"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="809"/>
         <source>Status:</source>
         <translation>Статус:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="827"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="810"/>
         <source>Command Line:</source>
         <translation>Командная строка:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="828"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="811"/>
         <source>Server:</source>
         <translation>Сервер:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="829"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="812"/>
         <source>Submitted By:</source>
         <translation>Представленный:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="830"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="813"/>
         <source>Submitted On:</source>
         <translation>Представлены на:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="831"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="814"/>
         <source>Submission Date:</source>
         <translation>Дата представления:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="832"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="815"/>
         <source>Start Date:</source>
         <translation>Дата начала:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="833"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="816"/>
         <source>Completion Date:</source>
         <translation>Дата завершения:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="834"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="817"/>
         <source>Duration:</source>
         <translation>Продолжительность:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="836"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="819"/>
         <source>Step Count:</source>
         <translation>Количество шагов:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="838"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="821"/>
         <source>Failed Steps:</source>
         <translation>Неудачные шаги:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="840"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="823"/>
         <source>Successful Steps:</source>
         <translation>Успешные шаги:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="842"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="825"/>
         <source>Priority:</source>
         <translation>Приоритет:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="860"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="843"/>
         <source>Output:</source>
         <translation>Вывод:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="862"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="845"/>
         <source>Frames per Chunk:</source>
         <translatorcomment>???</translatorcomment>
         <translation>Кадров в чанке:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="846"/>
         <source>Multimedia:</source>
         <translation>Мультимедиа:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="865"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="848"/>
         <source>From:</source>
         <translation>От:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="865"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="848"/>
         <source>To:</source>
         <translation>До:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="851"/>
         <source>Step:</source>
         <translation>Шаг:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="851"/>
         <source>Shrink:</source>
         <translation>Сокращение:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="874"/>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="857"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="874"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="857"/>
         <source>Fx Schematic Flows</source>
         <translation>Схемы Fx</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="875"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="858"/>
         <source>Fx Schematic Terminal Nodes</source>
         <translation>Fx Схематические терминальные узлы</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="878"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="861"/>
         <source>Dedicated CPUs:</source>
         <translation>Выделенные процессоры:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="880"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
         <source>Single</source>
         <translation>Один</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="880"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
         <source>Half</source>
         <translation>Половина</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="880"/>
-        <location filename="../../toonz/tasksviewer.cpp" line="910"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="863"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="893"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="883"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="866"/>
         <source>Render Tile:</source>
         <translation>Render Tile:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>Large</source>
         <translation>Большой</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>Medium</source>
         <translation>Средний</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="885"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="868"/>
         <source>Small</source>
         <translation>Маленький</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="906"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="889"/>
         <source>Visible Only</source>
         <translation>Только видимые</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="907"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="890"/>
         <source>Overwrite</source>
         <translation>Перезаписать</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="910"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="893"/>
         <source>NoPaint</source>
         <translation>Без краски</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="910"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="893"/>
         <source>Off</source>
         <translation>Выкл</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="920"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="903"/>
         <source>Dependencies:</source>
         <translation>Зависимости:</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="937"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="920"/>
         <source>Remove &gt;&gt;</source>
         <translation>Удалить &gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="940"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="923"/>
         <source>&lt;&lt; Add</source>
         <translation>&lt;&lt; Добавить</translation>
     </message>
@@ -20105,17 +21906,17 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>TaskTreeModel</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1292"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1275"/>
         <source>Are you sure you want to remove ALL tasks?</source>
         <translation>Вы действительно хотите удалить ВСЕ задачи?</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1293"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1276"/>
         <source>Remove All</source>
         <translation>Удалить все</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1293"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1276"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -20123,17 +21924,17 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>TaskTreeView</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1078"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1061"/>
         <source>Start</source>
         <translation>Старт</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1082"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1065"/>
         <source>Stop</source>
         <translation>Стоп</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="1086"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="1069"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
@@ -20141,82 +21942,82 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>TasksViewer</name>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="86"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="73"/>
         <source>&amp;Start</source>
         <translation>&amp;Старт</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="86"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="73"/>
         <source>Start</source>
         <translation>Старт</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="87"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="74"/>
         <source>&amp;Stop</source>
         <translation>&amp;Стоп</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="87"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="74"/>
         <source>Stop</source>
         <translation>Стоп</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="89"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="76"/>
         <source>&amp;Add Render Task</source>
         <translation>&amp;Добавить задачу рендеринга</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="90"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="77"/>
         <source>Add Render</source>
         <translation>Добавить рендер</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="91"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="78"/>
         <source>&amp;Add Cleanup Task</source>
         <translation>&amp;Добавить задачу очистки</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="92"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="79"/>
         <source>Add Cleanup</source>
         <translation>Добавить очистку</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="98"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="85"/>
         <source>&amp;Save Task List</source>
         <translation>&amp;Сохранить список задач</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="98"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="85"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="99"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="86"/>
         <source>&amp;Save Task List As</source>
         <translation>&amp;Сохранить список задач как</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="100"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="87"/>
         <source>Save As</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="101"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="88"/>
         <source>&amp;Load Task List</source>
         <translation>&amp;Загрузить список задач</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="101"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="88"/>
         <source>Load</source>
         <translation>Загрузить</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="103"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="90"/>
         <source>&amp;Remove</source>
         <translation>&amp;Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonz/tasksviewer.cpp" line="103"/>
+        <location filename="../../toonz/tasksviewer.cpp" line="90"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
@@ -20224,12 +22025,12 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>TestPanel</name>
     <message>
-        <location filename="../../toonz/testpanel.cpp" line="53"/>
+        <location filename="../../toonz/testpanel.cpp" line="48"/>
         <source>Left:</source>
         <translation>Слева:</translation>
     </message>
     <message>
-        <location filename="../../toonz/testpanel.cpp" line="54"/>
+        <location filename="../../toonz/testpanel.cpp" line="49"/>
         <source>Right:</source>
         <translation>Справа:</translation>
     </message>
@@ -20302,14 +22103,19 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>Toolbar</name>
     <message>
-        <location filename="../../toonz/toolbar.cpp" line="191"/>
+        <location filename="../../toonz/toolbar.cpp" line="187"/>
         <source>Collapse toolbar</source>
         <translation>Свернуть панель инструментов</translation>
     </message>
     <message>
-        <location filename="../../toonz/toolbar.cpp" line="195"/>
+        <location filename="../../toonz/toolbar.cpp" line="191"/>
         <source>Expand toolbar</source>
         <translation>Развернуть панель инструментов</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/toolbar.cpp" line="273"/>
+        <source>Toggle Orientation</source>
+        <translation type="unfinished">Переключить ориентацию</translation>
     </message>
 </context>
 <context>
@@ -20339,72 +22145,72 @@ Set the output folder path to the subfolder as well.</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="356"/>
+        <location filename="../../toonz/menubar.cpp" line="357"/>
         <source>Script</source>
         <translation>Скрипт</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="388"/>
+        <location filename="../../toonz/menubar.cpp" line="389"/>
         <source>Group</source>
         <translation>Группа</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="396"/>
+        <location filename="../../toonz/menubar.cpp" line="397"/>
         <source>Arrange</source>
         <translation>Расположить</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="444"/>
+        <location filename="../../toonz/menubar.cpp" line="445"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="468"/>
+        <location filename="../../toonz/menubar.cpp" line="469"/>
         <source>Adjust</source>
         <translation>Отрегулировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="477"/>
+        <location filename="../../toonz/menubar.cpp" line="478"/>
         <source>Optimize</source>
         <translation>Оптимизировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="482"/>
+        <location filename="../../toonz/menubar.cpp" line="483"/>
         <source>Convert</source>
         <translation>Конвертировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="506"/>
+        <location filename="../../toonz/menubar.cpp" line="507"/>
         <source>Reframe</source>
         <translation>Перестроить</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="514"/>
+        <location filename="../../toonz/menubar.cpp" line="515"/>
         <source>Step</source>
         <translation>Шаг</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="523"/>
+        <location filename="../../toonz/menubar.cpp" line="524"/>
         <source>Each</source>
         <translation>Каждый</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="534"/>
+        <location filename="../../toonz/menubar.cpp" line="535"/>
         <source>Drawing Substitution</source>
         <translation>Замена рисунка</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="729"/>
+        <location filename="../../toonz/menubar.cpp" line="732"/>
         <source>Lock Rooms</source>
         <translation>Блокировка комнат</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="732"/>
+        <location filename="../../toonz/menubar.cpp" line="735"/>
         <source>Unlocking this enables creating new rooms and rearranging the workspace.</source>
         <translation>Разблокировка позволяет создавать новые комнаты и переставлять рабочее пространство.</translation>
     </message>
     <message>
-        <location filename="../../toonz/menubar.cpp" line="735"/>
+        <location filename="../../toonz/menubar.cpp" line="738"/>
         <source>Locking this prevents the workspace from being changed and prevents new rooms from being created.  Unlock this to change the workspace or create new rooms.</source>
         <translation>Блокировка предотвращает изменение рабочего пространства и предотвращает создание новых комнат. Разблокируйте это, чтобы изменить рабочее пространство или создать новые комнаты.</translation>
     </message>
@@ -20412,42 +22218,42 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>TrackerPopup</name>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="158"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="154"/>
         <source>Tracking Settings</source>
         <translation>Настройки трекинга</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="167"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="163"/>
         <source>Threshold:</source>
         <translation>Предел:</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="173"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="169"/>
         <source>Sensitivity:</source>
         <translation>Чувствительность:</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="175"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="171"/>
         <source>Variable Region Size</source>
         <translation>Размер изменяемого региона</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="179"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="175"/>
         <source>Include Background</source>
         <translation>Включить фон</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="186"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="182"/>
         <source>Track</source>
         <translation>Старт</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="240"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="236"/>
         <source>Processing...</source>
         <translation>Обработка...</translation>
     </message>
     <message>
-        <location filename="../../toonz/trackerpopup.cpp" line="240"/>
+        <location filename="../../toonz/trackerpopup.cpp" line="236"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -20455,99 +22261,99 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>VectorGuidedDrawingPane</name>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>Off</source>
         <translation>Отключен</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>Closest</source>
         <translation>В ближайшем кадре кальки</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>Farthest</source>
         <translation>В дальнем кадре кальки</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="29"/>
         <source>All</source>
         <translation>Во всех кадрах кальки</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="41"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="35"/>
         <source>Auto Inbetween</source>
         <translation>Автофазовка</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>Linear</source>
         <translation>Линейная</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>Ease In</source>
         <translation>Замедл. в начале</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>Ease Out</source>
         <translation>Замедл. в конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="49"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="43"/>
         <source>EaseIn/Out</source>
         <translation>Замедл. в нач./ конце</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="61"/>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="105"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="55"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="99"/>
         <source>Previous</source>
         <translation>Предыдущий</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="66"/>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="100"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="60"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="94"/>
         <source>Next</source>
         <translation>Следующий</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="71"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="65"/>
         <source>Both</source>
         <translation>Оба</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="76"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="70"/>
         <source>Reset</source>
         <translation>Сброс</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="82"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="76"/>
         <source>Tween Selected Guide Strokes</source>
         <translation>Автофазовка: между выбранными гидами</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="88"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="82"/>
         <source>Tween Guide Strokes to Selected</source>
         <translation>Автофазовка: от гида до выбранного штриха</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="95"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="89"/>
         <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
         <translation>Выбрать первый, затем второй гид &amp; автофазовка</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="115"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="109"/>
         <source>Use Onion Skin Frames:</source>
         <translation>Использовать кадры кальки:</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="120"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="114"/>
         <source>Select Stroke:</source>
         <translation>Выбрать штрих:</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="134"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="128"/>
         <source>Flip Stroke Direction:</source>
         <translation>Перевернуть направление штриха:</translation>
     </message>
@@ -20564,7 +22370,7 @@ Set the output folder path to the subfolder as well.</source>
         <translation type="vanished">Перевернуть направление штриха:</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="150"/>
+        <location filename="../../toonz/vectorguideddrawingpane.cpp" line="144"/>
         <source>Interpolation:</source>
         <translation>Интерполяция:</translation>
     </message>
@@ -20572,225 +22378,225 @@ Set the output folder path to the subfolder as well.</source>
 <context>
     <name>VectorizerPopup</name>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="457"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="453"/>
         <source>Convert-to-Vector Settings</source>
         <translation>Настройки конвертации в вектор</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="522"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="518"/>
         <source>Centerline</source>
         <translation>Сплошная линия</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="522"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="518"/>
         <source>Outline</source>
         <translation>Контурная обводка</translation>
     </message>
     <message>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="529"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="532"/>
         <location filename="../../toonz/vectorizerpopup.cpp" line="533"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="536"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="537"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="544"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="550"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="540"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="546"/>
         <source>Threshold</source>
         <translation>Предел</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="553"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="559"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="662"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="668"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="549"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="555"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="658"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="664"/>
         <source>Accuracy</source>
         <translation>Точность</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="562"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="568"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="671"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="677"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="558"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="564"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="667"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="673"/>
         <source>Despeckling</source>
         <translation>Удаление соринок</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="571"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="578"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="567"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="574"/>
         <source>Max Thickness</source>
         <translation>Максимальная толщина</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="581"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="609"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="577"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="605"/>
         <source>Thickness Calibration</source>
         <translation>Калибровка толщины</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="591"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="587"/>
         <source>Start:</source>
         <translation>Начало:</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="598"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="594"/>
         <source>End:</source>
         <translation>Конец:</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="613"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="681"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="609"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="677"/>
         <source>Preserve Painted Areas</source>
         <translation>Сохранять окрашенные области</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="622"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="690"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="618"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="686"/>
         <source>Align Boundary Strokes Direction</source>
         <translation>Выровнять направление граничных штрихов</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="628"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="696"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="624"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="692"/>
         <source>Align boundary strokes direction to be the same.
 (clockwise, i.e. left to right as viewed from inside of the shape)</source>
         <translation>Выровнить направление граничных штрихов так, чтобы оно было одинаковым.
 (по часовой стрелке, т.е. слева направо, если смотреть изнутри фигуры)</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="634"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="630"/>
         <source>Add Border</source>
         <translation>Добавить кайму</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="644"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="640"/>
         <source>Full color non-AA images</source>
         <translation>Полноцветные изображения без сглаживания</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="648"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="644"/>
         <source>Enhanced ink recognition</source>
         <translation>Улучшенное распознавание контура</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="702"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="698"/>
         <source>Corners</source>
         <translation>Углы</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="706"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="712"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="702"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="708"/>
         <source>Adherence</source>
         <translation>Смачивание</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="715"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="721"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="711"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="717"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="724"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="730"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="720"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="726"/>
         <source>Curve Radius</source>
         <translation>Радиус кривой</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="734"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="730"/>
         <source>Raster Levels</source>
         <translation>Уровни растра</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="738"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="744"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="734"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="740"/>
         <source>Max Colors</source>
         <translation>Макс. цвета</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="747"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="752"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="743"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="748"/>
         <source>Transparent Color</source>
         <translation>Прозрачный цвет</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="756"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="752"/>
         <source>TLV Levels</source>
         <translation>Уровни TLV</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="760"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="766"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="756"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="762"/>
         <source>Tone Threshold</source>
         <translation>Порог тона</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="782"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="778"/>
         <source>Toggle Swatch Preview</source>
         <translation>Переключить просмотр образцов</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="787"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="783"/>
         <source>Toggle Centerlines Check</source>
         <translation>Переключить проверку сплошной линии</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="793"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="789"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="803"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="799"/>
         <source>Save Settings</source>
         <translation>Сохранить настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="806"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="802"/>
         <source>Load Settings</source>
         <translation>Загрузить изменения</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="811"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="807"/>
         <source>Reset Settings</source>
         <translation>Сбросить настройки</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="827"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="823"/>
         <source>Convert</source>
         <translation>Конвертировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="942"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="938"/>
         <source>The current selection is invalid.</source>
         <translation>Текущий выбор недействителен.</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="994"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="990"/>
         <source>Cannot convert to vector the current selection.</source>
         <translation>Невозможно преобразовать текущий выделенный фрагмент в вектор.</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1087"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1083"/>
         <source>Conversion in progress: </source>
         <translation>Выполняется конвертация: </translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1476"/>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1538"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1472"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1534"/>
         <source>File could not be opened for read</source>
         <translation>Файл не может быть открыт для чтения</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1492"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1488"/>
         <source>File could not be opened for write</source>
         <translation>Файл не может быть открыт для записи</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1510"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1506"/>
         <source>Save Vectorizer Parameters</source>
         <translation>Сохранить параметры векторизации</translation>
     </message>
     <message>
-        <location filename="../../toonz/vectorizerpopup.cpp" line="1565"/>
+        <location filename="../../toonz/vectorizerpopup.cpp" line="1561"/>
         <source>Load Vectorizer Parameters</source>
         <translation>Загрузить параметры векторизации</translation>
     </message>
@@ -20834,7 +22640,7 @@ Please refer to the user guide for details.</source>
 <context>
     <name>ViewerHistogramPopup</name>
     <message>
-        <location filename="../../toonz/histogrampopup.cpp" line="119"/>
+        <location filename="../../toonz/histogrampopup.cpp" line="163"/>
         <source>Viewer Histogram</source>
         <translation>Просмотр гистограммы</translation>
     </message>
@@ -20877,105 +22683,113 @@ Please refer to the user guide for details.</source>
         <translation>Путь уровня</translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsimportpopup.cpp" line="104"/>
-        <source>Inbetween symbol mark</source>
-        <translation>Промежуточная метка</translation>
+        <location filename="../../toonz/xdtsimportpopup.cpp" line="105"/>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xdtsimportpopup.cpp" line="108"/>
+        <location filename="../../toonz/xdtsimportpopup.cpp" line="110"/>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween symbol mark</source>
+        <translation type="vanished">Промежуточная метка</translation>
+    </message>
+    <message>
         <source>Reverse sheet symbol mark</source>
-        <translation>Знак обратного листа</translation>
+        <translation type="vanished">Знак обратного листа</translation>
     </message>
 </context>
 <context>
     <name>XsheetGUI::CellArea</name>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3731"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3672"/>
         <source>Click to select keyframe, drag to move it</source>
         <translation>Кликнуть для выделения кадра, потянуть для перемещения</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3740"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3681"/>
         <source>Click and drag to set the acceleration range</source>
         <translation>Нажмите и перетащите, чтобы установить диапазон ускорения</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3742"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3683"/>
         <source>Click and drag to set the deceleration range</source>
         <translation>Нажмите и перетащите, чтобы установить диапазон замедления</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3751"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3692"/>
         <source>Set the cycle of previous keyframes</source>
         <translation>Установите цикл предыдущих ключевых кадров</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3756"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3697"/>
         <source>Click and drag to move the selection</source>
         <translation>Кликнуть и потянуть для перемещения выделенного</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3792"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3733"/>
         <source>Click and drag to play</source>
         <translation>Кликнуть и потянуть для воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="3794"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="3735"/>
         <source>Click and drag to repeat selected cells</source>
         <translation>Нажмите и перетащите, чтобы повторить выбранные ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4095"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4036"/>
         <source>Reframe</source>
         <translation>Перестроить</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4106"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4047"/>
         <source>Step</source>
         <translation>Шаг</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4116"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4057"/>
         <source>Each</source>
         <translation>Каждый</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4125"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4066"/>
         <source>Edit Cell Numbers</source>
         <translation>Ввести номер кадра</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4150"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4091"/>
         <source>Replace Level</source>
         <translation>Заменить уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4167"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4108"/>
         <source>Replace with</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4212"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4153"/>
         <source>Paste Special</source>
         <translation>Специальная вставка</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4247"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4188"/>
         <source>Edit Image</source>
         <translation>Редактирование изображений</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4261"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4202"/>
         <source>Lip Sync</source>
         <translation>Синхронизация губ</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4294"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4235"/>
         <source>Cell Mark</source>
         <translation>Метка ячейки</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4296"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4237"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
@@ -20984,12 +22798,12 @@ Please refer to the user guide for details.</source>
         <translation type="obsolete">Заменить</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4475"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4416"/>
         <source>Open Memo</source>
         <translation>Открыть мемо</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcellviewer.cpp" line="4476"/>
+        <location filename="../../toonz/xshcellviewer.cpp" line="4417"/>
         <source>Delete Memo</source>
         <translation>Удалить мемо</translation>
     </message>
@@ -20997,7 +22811,7 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::ChangeObjectParent</name>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="516"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="512"/>
         <source>Table</source>
         <translation>Таблица</translation>
     </message>
@@ -21005,175 +22819,175 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::ColumnArea</name>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1474"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1464"/>
         <source>&amp;Subsampling 1</source>
         <translation>&amp;Субсемплинг 1</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1475"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1465"/>
         <source>&amp;Subsampling 2</source>
         <translation>&amp;Субсемплинг 2</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1476"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1466"/>
         <source>&amp;Subsampling 3</source>
         <translation>&amp;Субсемплинг 3</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1477"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1467"/>
         <source>&amp;Subsampling 4</source>
         <translation>&amp;Субсемплинг 4</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2277"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2267"/>
         <source>Unlock</source>
         <translation>Разблокировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2277"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2267"/>
         <source>Lock</source>
         <translation>Заблокировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2606"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2596"/>
         <source>Click to select camera</source>
         <translation>Нажмите, чтобы выбрать камеру</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2608"/>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2611"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2598"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2601"/>
         <source>Click to select column, drag to move it</source>
         <translation>Нажмите, чтобы выбрать столбец, перетащите, чтобы переместить его</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2613"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2603"/>
         <source>Click to select column</source>
         <translation>Щелкните для выбора столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2617"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2607"/>
         <source>Click to select column, drag to move it, double-click to edit</source>
         <translation>Нажмите, чтобы выбрать столбец, перетащите, чтобы переместить его, двойной клик чтобы редактировать</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2626"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2616"/>
         <source>Click to select column, double-click to edit</source>
         <translation>Щелкните для выбора столбца, двойной клик для редактирования</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2628"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2618"/>
         <source>Lock Toggle</source>
         <translation>Блокировка переключения</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2630"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2620"/>
         <source>Additional column settings</source>
         <translation>Дополнительные настройки столбцов</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2632"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2622"/>
         <source>Preview Visibility Toggle</source>
         <translation>Переключение видимости</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2635"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2625"/>
         <source>Camera Stand Visibility Toggle</source>
         <translation>Переключатель видимости камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2936"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2926"/>
         <source>Hide Camera Column</source>
         <translation>Скрыть столбец камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2938"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2928"/>
         <source>Show Camera Column</source>
         <translation>Показать столбец камеры</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2944"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2934"/>
         <source>Toggle Orientation</source>
         <translation>Переключить ориентацию</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2946"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2936"/>
         <source>Toggle Between Timeline and Xsheet View</source>
         <translation>Переключение между таймлайном и Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3010"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3000"/>
         <source>Show Column Parent Colors</source>
         <translation>Показать цвет родительского столбца</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3015"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3005"/>
         <source>Show the column parent&apos;s color in the Xsheet</source>
         <translation>Показать цвет родительского столбца в Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3034"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3024"/>
         <source>&amp;Insert Before</source>
         <translation>&amp;Вставить пробел сзади</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3033"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3023"/>
         <source>&amp;Insert After</source>
         <translation>&amp;Вставить пробел cпереди</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3036"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3026"/>
         <source>&amp;Paste Insert Before</source>
         <translation>&amp;Вставить копию сзади</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3035"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3025"/>
         <source>&amp;Paste Insert After</source>
         <translation>&amp;Вставить копию спереди</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3039"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3029"/>
         <source>&amp;Insert Below</source>
         <translation>&amp;Вставить пробел сзади</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3038"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3028"/>
         <source>&amp;Insert Above</source>
         <translation>&amp;Вставить пробел cпереди</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3041"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3031"/>
         <source>&amp;Paste Insert Below</source>
         <translation>&amp;Вставить копию сзади</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="3040"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="3030"/>
         <source>&amp;Paste Insert Above</source>
         <translation>&amp;Вставить копию спереди</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2621"/>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2640"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2611"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2630"/>
         <source>Click to play the soundtrack back</source>
         <translation>Нажмите, чтобы воспроизвести зв. дорожку</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2624"/>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2643"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2614"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2633"/>
         <source>Set the volume of the soundtrack</source>
         <translation>Установите громкость зв. дорожки</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2646"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2636"/>
         <source>Alt + Click to Toggle Thumbnail</source>
         <translation>Alt + Click для переключения иконок</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2961"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2951"/>
         <source>Reframe</source>
         <translation>Перестроить</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2976"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2966"/>
         <source>Subsampling</source>
         <translation>Субсемплинг</translation>
     </message>
@@ -21214,67 +23028,83 @@ Please refer to the user guide for details.</source>
         <translation type="obsolete">Фильтр не влияет на уровни вектора</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1964"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1954"/>
         <source>Lock Column</source>
         <translation>Заблокировать столбец</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1999"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1989"/>
         <source>Filter:</source>
         <translation>Фильтр:</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="1987"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="1977"/>
         <source>Opacity:</source>
         <translation>Непрозрачность:</translation>
     </message>
 </context>
 <context>
-    <name>XsheetGUI::NoteArea</name>
+    <name>XsheetGUI::FooterNoteArea</name>
     <message>
-        <source>Toggle Xsheet/Timeline</source>
-        <translation type="vanished">Переключить Xsheet/таймлайн</translation>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="784"/>
+        <source>Add New Memo</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="499"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="793"/>
+        <source>Previous Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="802"/>
+        <source>Next Memo</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::NoteArea</name>
+    <message>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="488"/>
+        <source>Toggle Xsheet/Timeline</source>
+        <translation>Переключить Xsheet/таймлайн</translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="494"/>
         <source>Add New Level</source>
         <translation>Добавить новый уровень</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="510"/>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="788"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="505"/>
         <source>Add New Memo</source>
         <translation>Добавить новый мемо</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="516"/>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="797"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="511"/>
         <source>Previous Memo</source>
         <translation>Предыдущий мемо</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="522"/>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="806"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="517"/>
         <source>Next Memo</source>
         <translation>Следующий мемо</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="525"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="520"/>
         <source>Frame</source>
         <translation>Кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="525"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="520"/>
         <source>Sec Frame</source>
         <translation>Сек Кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="525"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="520"/>
         <source>6sec Sheet</source>
         <translation>6сек Лист</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshnoteviewer.cpp" line="526"/>
+        <location filename="../../toonz/xshnoteviewer.cpp" line="521"/>
         <source>3sec Sheet</source>
         <translation>3сек Лист</translation>
     </message>
@@ -21300,7 +23130,7 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::QuickToolbar</name>
     <message>
-        <location filename="../../toonz/quicktoolbar.cpp" line="69"/>
+        <location filename="../../toonz/quicktoolbar.cpp" line="65"/>
         <source>Customize Quick Toolbar</source>
         <translation>Настроить панель инструментов Xsheet</translation>
     </message>
@@ -21308,22 +23138,22 @@ Please refer to the user guide for details.</source>
 <context>
     <name>XsheetGUI::RowArea</name>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1229"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1296"/>
         <source>Playback Start Marker</source>
         <translation>Маркер начала воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1231"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1298"/>
         <source>Playback End Marker</source>
         <translation>Маркер окончания воспроизведения</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1233"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1300"/>
         <source>Pinned Center : Col%1%2</source>
         <translation>Фиксированный центр : Кол%1%2</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1248"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1315"/>
         <source>Double Click to Toggle Onion Skin</source>
         <translation>Двойной клик для переключения Onion Skin</translation>
     </message>
@@ -21332,58 +23162,65 @@ Please refer to the user guide for details.</source>
         <translation type="obsolete">Текущий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1156"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1214"/>
         <source>Click to Reset Shift &amp; Trace Markers to Neighbor Frames
 Hold F2 Key on the Viewer to Show This Frame Only</source>
         <translation>Нажмите, чтобы сбросить маркеры Shift &amp; Trace для соседних кадров
 Удерживайте клавишу F2 чтобы видеть только этот кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1160"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1218"/>
         <source>Click to Hide This Frame from Shift &amp; Trace
 Hold F1 Key on the Viewer to Show This Frame Only</source>
         <translation>Нажмите, чтобы скрыть этот кадр из Shift &amp; Trace
 Удерживайте клавишу F1 чтобы видеть только этот кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1164"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1222"/>
         <source>Click to Hide This Frame from Shift &amp; Trace
 Hold F3 Key on the Viewer to Show This Frame Only</source>
         <translation>Нажмите, чтобы скрыть этот кадр из Shift &amp; Trace
 Удерживайте клавишу F3 чтобы видеть только этот кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1167"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1225"/>
         <source>Click to Move Shift &amp; Trace Marker</source>
         <translation>Нажмите, чтобы переместить маркер Shift &amp; Trace</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1242"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1309"/>
         <source>Tag: %1</source>
         <translation>Тег: %1</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1250"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1317"/>
         <source>Current Frame</source>
         <translation>Текущий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1252"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1319"/>
         <source>Fixed Onion Skin Toggle</source>
         <translation>Переключение фиксированной кальки</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1254"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1321"/>
         <source>Relative Onion Skin Toggle</source>
         <translation>Переключение относительной кальки</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1333"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1323"/>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1411"/>
         <source>Tags</source>
         <translation>Теги</translation>
     </message>
     <message>
-        <location filename="../../toonz/xshrowviewer.cpp" line="1343"/>
+        <location filename="../../toonz/xshrowviewer.cpp" line="1421"/>
         <source>Frame %1</source>
         <translation>Кадр %1</translation>
     </message>
@@ -21411,7 +23248,7 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
 <context>
     <name>XsheetGUI::SoundColumnPopup</name>
     <message>
-        <location filename="../../toonz/xshcolumnviewer.cpp" line="2133"/>
+        <location filename="../../toonz/xshcolumnviewer.cpp" line="2123"/>
         <source>Volume:</source>
         <translation>Громкость:</translation>
     </message>
@@ -21419,7 +23256,7 @@ Hold F3 Key on the Viewer to Show This Frame Only</source>
 <context>
     <name>XsheetPdfPreviewArea</name>
     <message>
-        <location filename="../../toonz/exportxsheetpdf.cpp" line="1828"/>
+        <location filename="../../toonz/exportxsheetpdf.cpp" line="1831"/>
         <source>Fit To Window</source>
         <translation>По размеру окна</translation>
     </message>

--- a/toonz/sources/translations/russian/toonzlib.ts
+++ b/toonz/sources/translations/russian/toonzlib.ts
@@ -157,27 +157,27 @@
         <translation>Запись исключений %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="268"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="264"/>
         <source>frame index (%1) must be a number</source>
         <translation>Индекс кадра (%1) должен быть числом</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="272"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="268"/>
         <source>frame index (%1) is out of range (0-%2)</source>
         <translation>Индекс кадра (%1) вне диапазона (0-%2)</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="295"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="291"/>
         <source>second argument (%1) is not an image</source>
         <translation>Второй аргумент (%1) не является изображением</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="308"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="304"/>
         <source>can not insert a %1 image into a level</source>
         <translation>Невозможно вставить изображение %1 в уровень</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="329"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="325"/>
         <source>can not insert a %1 image to a %2 level</source>
         <translation>Невозможно  вставить изображение %1 в уровень %2</translation>
     </message>
@@ -213,17 +213,17 @@
 <context>
     <name>Preferences</name>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="101"/>
+        <location filename="../../toonzlib/preferences.cpp" line="102"/>
         <source>Retas Level Format</source>
         <translation>Формат уровней Retas</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="107"/>
+        <location filename="../../toonzlib/preferences.cpp" line="108"/>
         <source>Adobe Photoshop</source>
         <translation>Adobe Photoshop</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/preferences.cpp" line="204"/>
+        <location filename="../../toonzlib/preferences.cpp" line="208"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
@@ -428,98 +428,98 @@
         <translation>Обновление цветов с использованием выбранных расположений в палитре %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="908"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="917"/>
         <source>Add Fx  : </source>
         <translation>Добавить эффект  : </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="909"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="918"/>
         <source>Insert Fx  : </source>
         <translation>Вставить Fx  : </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1073"/>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1076"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1082"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1085"/>
         <source>Create Linked Fx  : %1</source>
         <translation>Создать связанный Fx : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1298"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1307"/>
         <source>Replace Fx  : </source>
         <translation>Заменить Fx  : </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1364"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1373"/>
         <source>Unlink Fx  : %1 - - %2</source>
         <translation>Разъединить Fx  : %1 - - %2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1405"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1414"/>
         <source>Make Macro Fx  : %1</source>
         <translation>Сделать Makro Fx  : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1548"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1557"/>
         <source>Explode Macro Fx  : %1</source>
         <translation>Разбить Macro Fx  : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1611"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1620"/>
         <source>Create Output Fx</source>
         <translation>Создать выход Fx</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1702"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1711"/>
         <source>Connect to Xsheet  : </source>
         <translation>Подключить к Xsheet  : </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="1762"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="1771"/>
         <source>Disconnect from Xsheet  : </source>
         <translation>Отключить от Xsheet  : </translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2035"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2044"/>
         <source>Delete Link</source>
         <translation>Удалить связь</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2322"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2331"/>
         <source>Delete Fx Node : %1</source>
         <translation>Удалить Fx-узел : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="2747"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="2756"/>
         <source>Paste Fx  :  </source>
         <translation>Вставить Fx :</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3116"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3125"/>
         <source>Disconnect Fx</source>
         <translation>Отключить Fx</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3368"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3377"/>
         <source>Connect Fx : %1 - %2</source>
         <translation>Подключить Fx : %1 - %2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3550"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3559"/>
         <source>Rename Fx : %1 &gt; %2</source>
         <translation>Переименовать Fx : %1 - %2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3602"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3611"/>
         <source>Group Fx</source>
         <translation>Сгруппировать Fx</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3706"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3715"/>
         <source>Ungroup Fx</source>
         <translation>Разгруппировать Fx</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/fxcommand.cpp" line="3808"/>
+        <location filename="../../toonzlib/fxcommand.cpp" line="3817"/>
         <source>Rename Group  : %1 &gt; %2</source>
         <translation>Переименовать группу  : %1 &gt; %2</translation>
     </message>
@@ -529,12 +529,12 @@
         <translation>Установить ключевой кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/doubleparamcmd.cpp" line="816"/>
+        <location filename="../../toonzlib/doubleparamcmd.cpp" line="817"/>
         <source>Remove Keyframe</source>
         <translation>Удалить ключевой кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/doubleparamcmd.cpp" line="856"/>
+        <location filename="../../toonzlib/doubleparamcmd.cpp" line="857"/>
         <source>Cycle</source>
         <translation>Цикл</translation>
     </message>
@@ -634,7 +634,7 @@
         <translation>Векторизация не выполнена</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/scriptbinding_level.cpp" line="235"/>
+        <location filename="../../toonzlib/scriptbinding_level.cpp" line="231"/>
         <source>Argument &apos;%1&apos; does not look like a FrameId</source>
         <translation>Аргумент %1  не похож на FrameId</translation>
     </message>
@@ -703,14 +703,14 @@
         <translation>Переключить автопокраску палитры : %1  Стиль#%2</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="742"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="770"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="760"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="788"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="28"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="744"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="762"/>
         <source>Red</source>
         <translation>Красный</translation>
     </message>
@@ -731,7 +731,7 @@
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="32"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="746"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="764"/>
         <source>Green</source>
         <translation>Зеленый</translation>
     </message>
@@ -742,7 +742,7 @@
     </message>
     <message>
         <location filename="../../toonzlib/sceneproperties.cpp" line="34"/>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="748"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="766"/>
         <source>Blue</source>
         <translation>Синий</translation>
     </message>
@@ -772,17 +772,17 @@
         <translation>Белый</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="750"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="768"/>
         <source>DarkYellow</source>
         <translation>Темно-желтый</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="752"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="770"/>
         <source>DarkCyan</source>
         <translation>Темный циан</translation>
     </message>
     <message>
-        <location filename="../../toonzlib/txshcolumn.cpp" line="754"/>
+        <location filename="../../toonzlib/txshcolumn.cpp" line="772"/>
         <source>DarkMagenta</source>
         <translation>Темно-пурпурный</translation>
     </message>
@@ -793,6 +793,7 @@
     </message>
     <message>
         <location filename="../../toonzlib/cleanupcolorstyles.cpp" line="95"/>
+        <location filename="../../toonzlib/imagestyles.cpp" line="554"/>
         <source>Contrast</source>
         <translation>Контраст</translation>
     </message>
@@ -825,6 +826,41 @@
         <location filename="../../toonzlib/orientation.cpp" line="155"/>
         <source>Timeline</source>
         <translation>Таймлайн</translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="540"/>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="542"/>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="544"/>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="546"/>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="548"/>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="550"/>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzlib/imagestyles.cpp" line="552"/>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/russian/toonzqt.ts
+++ b/toonz/sources/translations/russian/toonzqt.ts
@@ -19,17 +19,27 @@
         <translation>Заменить FX</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="248"/>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="484"/>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="620"/>
         <source>Insert </source>
         <translation>Вставить </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="623"/>
         <source>Add </source>
         <translation>Добавить </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="629"/>
+        <location filename="../../toonzqt/addfxcontextmenu.cpp" line="626"/>
         <source>Replace </source>
         <translation>Заменить </translation>
     </message>
@@ -91,12 +101,12 @@
 <context>
     <name>CameraPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="506"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="518"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Сброс центра</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="509"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="521"/>
         <source>&amp;Activate</source>
         <translation>&amp;Активировать</translation>
     </message>
@@ -104,85 +114,113 @@
 <context>
     <name>CameraSettingsWidget</name>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="198"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="214"/>
         <source>DPI</source>
         <translation>DPI</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="406"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="210"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="215"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="432"/>
         <source>Pixels</source>
         <translation>Пиксели</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="200"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="216"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="195"/>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="199"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="210"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="215"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="204"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="221"/>
         <source>Use Current Level Settings</source>
         <translation>Использовать настройки текущего уровня</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="207"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="224"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="208"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="225"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="245"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="262"/>
         <source>Force Squared Pixel</source>
         <translation>Force Squared Pixel</translation>
     </message>
     <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="217"/>
         <source>A/R</source>
-        <translation type="vanished">A/R</translation>
+        <translation>A/R</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="414"/>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="846"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="186"/>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="187"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="188"/>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="189"/>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="190"/>
+        <source>pixel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="441"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="873"/>
         <source>&lt;custom&gt;</source>
         <translation>&lt;пользовательский&gt;</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="892"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="919"/>
         <source>Bad camera preset</source>
         <translation>Плохой пресет камеры</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="893"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="920"/>
         <source>&apos;%1&apos; doesn&apos;t seem a well formed camera preset. 
 Possibly the preset file has been corrupted</source>
         <translation>&quot;%1&quot; не кажется правильно сформированным пресетом камеры.
 Возможно предустановка повреждена</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="926"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="953"/>
         <source>Preset name</source>
         <translation>Имя предустановки</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="927"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="954"/>
         <source>Enter the name for %1</source>
         <translation>Введите имя для %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="932"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="959"/>
         <source>Error : Preset Name is Invalid</source>
         <translation>Ошибка: имя предустановки недействительно</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="933"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="960"/>
         <source>The preset name must not use &apos;,&apos;(comma).</source>
         <translation>Имя предустановки не должно содержать &quot;,&quot; (запятую).</translation>
     </message>
@@ -190,27 +228,27 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>ChannelHisto</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="262"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="282"/>
         <source>Red</source>
         <translation>Красный (R)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="266"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="286"/>
         <source>Green</source>
         <translation>Зеленый (G)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="270"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="290"/>
         <source>Blue</source>
         <translation>Голубой (B)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="274"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="294"/>
         <source>Alpha</source>
         <translation>Альфа</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="278"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="298"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
@@ -243,46 +281,37 @@ Possibly the preset file has been corrupted</source>
 <context>
     <name>ColorChannelControl</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>R</source>
-        <translation>R</translation>
+        <translation type="vanished">R</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>G</source>
-        <translation>G</translation>
+        <translation type="vanished">G</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>B</source>
-        <translation>B</translation>
+        <translation type="vanished">B</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>A</source>
-        <translation>A</translation>
+        <translation type="vanished">A</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>H</source>
-        <translation>H</translation>
+        <translation type="vanished">H</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
         <source>S</source>
-        <translation>S</translation>
+        <translation type="vanished">S</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
         <source>V</source>
-        <translation>V</translation>
+        <translation type="vanished">V</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1379"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="1381"/>
         <source>Alpha controls the transparency. 
 Zero is fully transparent.</source>
-        <translation>Альфа контролирует прозрачность.
+        <translation type="vanished">Альфа контролирует прозрачность.
 Ноль полностью прозрачен.</translation>
     </message>
 </context>
@@ -327,7 +356,7 @@ Zero is fully transparent.</source>
 <context>
     <name>ColumnPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="208"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="220"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Сброс центра</translation>
     </message>
@@ -339,47 +368,59 @@ Zero is fully transparent.</source>
 <context>
     <name>ComboHistoRGBLabel</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="393"/>
-        <location filename="../../toonzqt/combohistogram.cpp" line="401"/>
-        <location filename="../../toonzqt/combohistogram.cpp" line="408"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="418"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="427"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="436"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="442"/>
         <source>R:%1 G:%2 B:%3</source>
         <translation>R:%1 G:%2 B:%3</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/combohistogram.cpp" line="422"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="431"/>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/combohistogram.cpp" line="446"/>
+        <source>A:%1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ComboHistogram</name>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="445"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="496"/>
         <source>8bit (0-255)</source>
         <translation>8 бит (0-255)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="447"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="498"/>
         <source>16bit (0-65535)</source>
         <translation>16 бит (0-65535)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="450"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="501"/>
         <source>0.0-1.0</source>
         <translation>0.0-1.0</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="463"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="522"/>
         <source>Picked Color</source>
         <translation>Выбранный цвет</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="471"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="530"/>
         <source>Average Color (Ctrl + Drag)</source>
         <translation>Средний цвет (потянуть при нажатом Ctrl)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="479"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="538"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/combohistogram.cpp" line="483"/>
+        <location filename="../../toonzqt/combohistogram.cpp" line="541"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
@@ -646,172 +687,177 @@ Zero is fully transparent.</source>
 <context>
     <name>FlipConsole</name>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="805"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="924"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1651"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1714"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="816"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="941"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1698"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1763"/>
         <source> FPS </source>
         <translation> FPS </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1197"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1223"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1201"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1227"/>
         <source>Snapshot</source>
         <translation>Snapshot</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1204"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1230"/>
         <source>Define Sub-camera</source>
         <translation>Определить подкамеру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1206"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1232"/>
         <source>Define Loading Box</source>
         <translation>Определить Loading Box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1208"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1234"/>
         <source>Use Loading Box</source>
         <translation>Использовать Loading Box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1213"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1239"/>
         <source>Background Colors</source>
         <translation>Фоновые цвета</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1243"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1269"/>
         <source>Framerate</source>
         <translation>Частота кадров</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1215"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1241"/>
         <source>Playback Controls</source>
         <translation>Управление воспроизведением</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1219"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1245"/>
         <source>Color Channels</source>
         <translation>Цветовые каналы</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1230"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1256"/>
         <source>Set Key</source>
         <translation>Установить ключ</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1225"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1251"/>
         <source>Histogram</source>
         <translation>Гистограмма</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="829"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="842"/>
         <source>This value is different than the scene framerate.
 Control click to reset.</source>
         <translation>Это значение отличается от частоты кадров сцены.
 Нажмите Control, чтобы сбросить.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="908"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="925"/>
         <source>Cannot set the scene fps to a negative value.</source>
         <translation>Невозможно установить отрицательное значение частоты кадров в секунду.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1222"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1248"/>
         <source>Sound</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1228"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1254"/>
         <source>Locator</source>
         <translation>Локатор</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1233"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1259"/>
         <source>Display Areas as Filled</source>
         <translation>Отобразить область заполненной</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1240"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1266"/>
         <source>Viewer Controls</source>
         <translation>Управление просмотрщиком</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1269"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1272"/>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1298"/>
         <source>&amp;Save Images</source>
         <translation>&amp;Сохранить изображения</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1276"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1305"/>
         <source>&amp;Snapshot</source>
         <translation>&amp;Snapshot</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1280"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1309"/>
         <source>&amp;Compare to Snapshot</source>
         <translation>&amp;Сравнить с Snapshot</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1289"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1318"/>
         <source>&amp;Define Sub-camera</source>
         <translation>&amp;Определить подкамеру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1294"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1323"/>
         <source>&amp;Define Loading Box</source>
         <translation>&amp;Определить Loading Box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1298"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1327"/>
         <source>&amp;Use Loading Box</source>
         <translation>&amp;Использовать Loading Box</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1307"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1336"/>
         <source>&amp;White Background</source>
         <translation>&amp;Белый фон</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1310"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1339"/>
         <source>&amp;Black Background</source>
         <translation>&amp;Черный фон</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1314"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1343"/>
         <source>&amp;Checkered Background</source>
         <translation>&amp;Клетчатый фон</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1321"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1350"/>
         <source>&amp;First Frame</source>
         <translation>&amp;Первый кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1323"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1352"/>
         <source>&amp;Previous Frame</source>
         <translation>&amp;Предыдущий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1325"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1354"/>
         <source>Pause</source>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1328"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1357"/>
         <source>Play</source>
         <translation>Play</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1331"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1360"/>
         <source>Loop</source>
         <translation>Loop</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1335"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1364"/>
         <source>&amp;Next Frame</source>
         <translation>&amp;Следующий кадр</translation>
     </message>
@@ -820,123 +866,145 @@ Control click to reset.</source>
         <translation type="vanished">&amp;Следующий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1337"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1366"/>
         <source>&amp;Last Frame</source>
         <translation>&amp;Последний кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1346"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1349"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1375"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1378"/>
         <source>Red Channel</source>
         <translation>Красный канал</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1350"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1379"/>
         <source>Red Channel in Grayscale</source>
         <translation>Красный канал в оттенках серого</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1353"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1357"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1382"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1386"/>
         <source>Green Channel</source>
         <translation>Зеленый канал</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1358"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1387"/>
         <source>Green Channel in Grayscale</source>
         <translation>Зеленый канал в оттенках серого</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1361"/>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1364"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1390"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1393"/>
         <source>Blue Channel</source>
         <translation>Синий канал</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1365"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1394"/>
         <source>Blue Channel in Grayscale</source>
         <translation>Синий канал в оттенках серого</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1371"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1400"/>
         <source>Alpha Channel</source>
         <translation>Альфа-канал</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1381"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1410"/>
         <source>&amp;Soundtrack </source>
         <translation>&amp;Звуковая дорожка </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1385"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1414"/>
         <source>&amp;Histogram</source>
         <translation>&amp;Гистограмма</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1387"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1416"/>
         <source>&amp;Locator</source>
         <translation>&amp;Локатор</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1394"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1423"/>
         <source>&amp;Display Areas as Filled</source>
         <translation>&amp;Отобразить область заливкой</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1408"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1437"/>
         <source>&amp;Zoom In</source>
         <translation>&amp;Приближение</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1410"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1439"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Отдаление</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1412"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1441"/>
         <source>&amp;Flip Horizontally</source>
         <translation>&amp;Отразить по горизонтали</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1414"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1443"/>
         <source>&amp;Flip Vertically</source>
         <translation>&amp;Отразить по вертикали</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1416"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1445"/>
         <source>&amp;Reset View</source>
         <translation>&amp;Восстановить вид по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1657"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1451"/>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1457"/>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1462"/>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1704"/>
         <source> FPS	</source>
         <translation> FPS	</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1842"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1905"/>
         <source>Set the current frame</source>
         <translation>Установите текущий кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1846"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1909"/>
         <source>Drag to play the animation</source>
         <translation>Перетащите, чтобы воспроизвести анимацию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/flipconsole.cpp" line="1906"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="1976"/>
         <source>Set the playback frame rate</source>
         <translation>Установите частоту кадров воспроизведения</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/flipconsole.cpp" line="2238"/>
+        <location filename="../../toonzqt/flipconsole.cpp" line="2254"/>
+        <source> (gain %1)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FontParamField</name>
     <message>
-        <location filename="../../toonzqt/paramfield.cpp" line="1678"/>
+        <location filename="../../toonzqt/paramfield.cpp" line="1681"/>
         <source>Style:</source>
         <translation>Начертания:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paramfield.cpp" line="1682"/>
+        <location filename="../../toonzqt/paramfield.cpp" line="1685"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
@@ -976,132 +1044,132 @@ Control click to reset.</source>
 <context>
     <name>FunctionPanel</name>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="255"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="256"/>
         <source>Function Curves</source>
         <translation>Кривые функции</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1548"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1579"/>
         <source>Link Handles</source>
         <translation>Связать Handles</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1549"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1580"/>
         <source>Unlink Handles</source>
         <translation>Разъединить Handles</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1550"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1581"/>
         <source>Reset Handles</source>
         <translation>Сбросить Handles</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1551"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1582"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1552"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1583"/>
         <source>Set Key</source>
         <translation>Установить ключ</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1553"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1584"/>
         <source>Activate Cycle</source>
         <translation>Активировать цикл</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1554"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1585"/>
         <source>Deactivate Cycle</source>
         <translation>Деактивировать цикл</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1555"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1586"/>
         <source>Linear Interpolation</source>
         <translation>Линейная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1556"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1587"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation>Интерполяция Замедл. в начале/в конце</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1557"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1588"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation>Ease In / Ease Out Интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1558"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1589"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation>Ease In / Ease Out (%) Интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1559"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1590"/>
         <source>Exponential Interpolation</source>
         <translation>Экспоненциальная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1560"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1591"/>
         <source>Expression Interpolation</source>
         <translation>Интерполяция выражений</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1561"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1592"/>
         <source>File Interpolation</source>
         <translation>Интерполяция из файла</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1562"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1593"/>
         <source>Constant Interpolation</source>
         <translation>Равномерная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1563"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1594"/>
         <source>Similar Shape Interpolation</source>
         <translation>Интерполяция аналогичной формы</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1564"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1595"/>
         <source>Fit Selection</source>
         <translation>Подогнать выделенное</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1565"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1596"/>
         <source>Fit</source>
         <translation>Подогнать</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1566"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1597"/>
         <source>Step 1</source>
         <translation>Шаг 1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1567"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1598"/>
         <source>Step 2</source>
         <translation>Шаг 2</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1568"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1599"/>
         <source>Step 3</source>
         <translation>Шаг 3</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1569"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1600"/>
         <source>Step 4</source>
         <translation>Шаг 4</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1641"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1672"/>
         <source>Smooth</source>
         <translation>Плавно</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1642"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1673"/>
         <source>Frame Based</source>
         <translation>Frame Based</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionpanel.cpp" line="1643"/>
+        <location filename="../../toonzqt/functionpanel.cpp" line="1674"/>
         <source>Curve Shape</source>
         <translation>Форма кривой</translation>
     </message>
@@ -1250,7 +1318,7 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheet</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1196"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1206"/>
         <source>Function Editor</source>
         <translation>Редактор функций</translation>
     </message>
@@ -1266,57 +1334,57 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheetCellViewer</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1038"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1048"/>
         <source>Delete Key</source>
         <translation>Удалить ключ</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1039"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1049"/>
         <source>Set Key</source>
         <translation>Установить ключ</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1042"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
         <source>Linear Interpolation</source>
         <translation>Линейная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1043"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1053"/>
         <source>Speed In / Speed Out Interpolation</source>
         <translation>Интерполяция ускорения в начале/в конце</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1044"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1054"/>
         <source>Ease In / Ease Out Interpolation</source>
         <translation>Интерполяция замедления в нач./в конце</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1045"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1055"/>
         <source>Ease In / Ease Out (%) Interpolation</source>
         <translation>Замедление в начале/в конце (%) Интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1046"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1056"/>
         <source>Exponential Interpolation</source>
         <translation>Экспоненциальная интерполяция</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1047"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1057"/>
         <source>Expression Interpolation</source>
         <translation>Интерполяция выражений</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1047"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1057"/>
         <source>File Interpolation</source>
         <translation>Интерполяция из файла</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1048"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1058"/>
         <source>Similar Shape Interpolation</source>
         <translation>Интерполяция аналогичной формы</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1042"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
         <source>Constant Interpolation</source>
         <translation>Равномерная интерполяция</translation>
     </message>
@@ -1337,32 +1405,32 @@ Control click to reset.</source>
         <translation type="obsolete">Шаг 4</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1049"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1059"/>
         <source>Activate Cycle</source>
         <translation>Включить цикл</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1050"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1060"/>
         <source>Deactivate Cycle</source>
         <translation>Выключить цикл</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1051"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1061"/>
         <source>Show Inbetween Values</source>
         <translation>Показать промежуточные значения кадра</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1052"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1062"/>
         <source>Hide Inbetween Values</source>
         <translation>Скрыть промежуточные значения кадра</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1102"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1112"/>
         <source>Change Interpolation</source>
         <translation>Изменить интерполяцию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="1117"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="1127"/>
         <source>Change Step</source>
         <translation>Изменить шаг</translation>
     </message>
@@ -1370,7 +1438,7 @@ Control click to reset.</source>
 <context>
     <name>FunctionSheetColumnHeadViewer</name>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="456"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="465"/>
         <source>Some key(s) in this parameter loses original reference in expression.
 Manually changing any keyframe will clear the warning.</source>
         <translation>Некоторые ключи в этом параметре теряют исходную ссылку в выражении.
@@ -1403,17 +1471,17 @@ Manually changing any keyframe will clear the warning.</source>
 Если вручную изменить любой ключевой кадр, предупреждение будет снято.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="895"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="859"/>
         <source>Stage</source>
         <translation>Сцена</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="896"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="860"/>
         <source>FX</source>
         <translation>FX</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1060"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1024"/>
         <source>Plastic Skeleton</source>
         <translation>Plastic Skeleton</translation>
     </message>
@@ -1421,7 +1489,7 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FunctionTreeModel::Channel</name>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="668"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="632"/>
         <source>Some key(s) in this parameter loses original reference in expression.
 Manually changing any keyframe will clear the warning.</source>
         <translation>Некоторые ключи в этом параметре теряют исходную ссылку в выражении.
@@ -1436,34 +1504,34 @@ Manually changing any keyframe will clear the warning.</source>
         <translation>Стол</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1649"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1609"/>
         <source>Save Curve</source>
         <translation>Сохранить кривую</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1650"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1610"/>
         <source>Load Curve</source>
         <translation>Загрузить кривую</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1651"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1611"/>
         <source>Export Data</source>
         <translation>Экспорт данных</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="581"/>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1677"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="590"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1637"/>
         <source>Show Animated Only</source>
         <translation>Показать только анимированные</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="582"/>
-        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1678"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="591"/>
+        <location filename="../../toonzqt/functiontreeviewer.cpp" line="1638"/>
         <source>Show All</source>
         <translation>Показать все</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/functionsheet.cpp" line="583"/>
+        <location filename="../../toonzqt/functionsheet.cpp" line="592"/>
         <source>Hide Selected</source>
         <translation>Скрыть выбранное</translation>
     </message>
@@ -1479,32 +1547,32 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Присоединить к Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="267"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="280"/>
         <source>&amp;Disconnect from Scene</source>
         <translation>&amp;Отключить от сцены</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="271"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="286"/>
         <source>&amp;Connect to Scene</source>
         <translation>&amp;Подключить к сцене</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="278"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="294"/>
         <source>&amp;Paste Add</source>
         <translation>&amp;Вставить Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="281"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="298"/>
         <source>&amp;Preview</source>
         <translation>&amp;Предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="288"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="305"/>
         <source>&amp;Uncache Fx</source>
         <translation>&amp;Очистить кэш Fx</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="288"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="305"/>
         <source>&amp;Cache FX</source>
         <translation>&amp;Кэшировать FX</translation>
     </message>
@@ -1516,17 +1584,17 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxOutputPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1055"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1117"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1073"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1136"/>
         <source>&amp;Delete</source>
         <translation>&amp;Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1076"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1139"/>
         <source>&amp;Activate</source>
         <translation>&amp;Активировать</translation>
     </message>
@@ -1534,22 +1602,22 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="703"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="747"/>
         <source>&amp;Open Group</source>
         <translation>&amp;Открыть группу</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="706"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="751"/>
         <source>&amp;Paste Replace</source>
         <translation>&amp;Вставить Заменить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="709"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="755"/>
         <source>&amp;Paste Add</source>
         <translation>&amp;Вставить Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="715"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="762"/>
         <source>&amp;Delete</source>
         <translation>&amp;Удалить</translation>
     </message>
@@ -1562,57 +1630,57 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Присоединить к Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="719"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="767"/>
         <source>&amp;Disconnect from Scene</source>
         <translation>&amp;Отключить от сцены</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="723"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="773"/>
         <source>&amp;Connect to Scene</source>
         <translation>&amp;Подключить к сцене</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="727"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="778"/>
         <source>&amp;Create Linked FX</source>
         <translation>&amp;Создать связанный FX</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="730"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="782"/>
         <source>&amp;Unlink</source>
         <translation>&amp;Разъединить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="733"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="786"/>
         <source>&amp;Make Macro FX</source>
         <translation>&amp;Сделать Macro FX</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="736"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="790"/>
         <source>&amp;Explode Macro FX</source>
         <translation>&amp;Разбить Makro FX</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="740"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="795"/>
         <source>&amp;Open Macro FX</source>
         <translation>&amp;Открыть Makro FX</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="743"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="799"/>
         <source>&amp;Save As Preset...</source>
         <translation>&amp;Сохранить как пресет...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="746"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="803"/>
         <source>&amp;Preview</source>
         <translation>&amp;Предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="752"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="811"/>
         <source>&amp;Uncache FX</source>
         <translation>&amp;Очистить кэш Fx</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="752"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="811"/>
         <source>&amp;Cache FX</source>
         <translation>&amp;Кэшировать FX</translation>
     </message>
@@ -1628,17 +1696,17 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Присоединить к Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="483"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="512"/>
         <source>&amp;Disconnect from Scene</source>
         <translation>&amp;Отключить от сцены</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="487"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="518"/>
         <source>&amp;Connect to Scene</source>
         <translation>&amp;Подключить к сцене</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="491"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="523"/>
         <source>&amp;Preview</source>
         <translation>&amp;Предпросмотр</translation>
     </message>
@@ -1646,12 +1714,12 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxPassThroughPainter</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3842"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3913"/>
         <source>&amp;Paste Add</source>
         <translation>&amp;Вставить Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3845"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3917"/>
         <source>&amp;Preview</source>
         <translation>&amp;Предпросмотр</translation>
     </message>
@@ -1659,12 +1727,12 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicLink</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1121"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1185"/>
         <source>&amp;Delete</source>
         <translation>&amp;Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1124"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1189"/>
         <source>&amp;Paste Insert</source>
         <translation>&amp;Вставить</translation>
     </message>
@@ -1672,7 +1740,7 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicOutputNode</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="2248"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="2316"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
@@ -1680,8 +1748,8 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicPassThroughNode</name>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="3896"/>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="4007"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="3968"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="4079"/>
         <source> (Pass Through)</source>
         <translation> (Пройти сквозь)</translation>
     </message>
@@ -1697,12 +1765,12 @@ Manually changing any keyframe will clear the warning.</source>
         <translation type="vanished">&amp;Присоединить к Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1590"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1656"/>
         <source>&amp;Disconnect from Scene</source>
         <translation>&amp;Отключить от сцены</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="1594"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1662"/>
         <source>&amp;Connect to Scene</source>
         <translation>&amp;Подключить к сцене</translation>
     </message>
@@ -1710,21 +1778,21 @@ Manually changing any keyframe will clear the warning.</source>
 <context>
     <name>FxSchematicScene</name>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1787"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1776"/>
         <source>Cannot Paste Insert a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation>Невозможно вставить выбранные неподключенные узлы FX.
 Выберите FX-узлы и связи перед копированием или сокращением выбора, который вы хотите вставить.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1797"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1786"/>
         <source>Cannot Paste Add a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation>Невозможно вставить (добавить) выбранные неподключенные узлы FX.
 Выберите FX-узлы и связи перед копированием или сокращением выбора, который вы хотите вставить.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicscene.cpp" line="1807"/>
+        <location filename="../../toonzqt/fxschematicscene.cpp" line="1796"/>
         <source>Cannot Paste Replace a selection of unconnected FX nodes.
 Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
         <translation>Невозможно вставить (заменить) выбранные неподключенные узлы FX.
@@ -1738,7 +1806,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
         <translation type="vanished">Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="2325"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="2393"/>
         <source>Scene</source>
         <translation>Сцена</translation>
     </message>
@@ -1746,37 +1814,37 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>FxSettings</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1318"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1351"/>
         <source>&amp;Camera Preview</source>
         <translation>&amp;Предпросмотр камеры</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1324"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1357"/>
         <source>&amp;Preview</source>
         <translation>&amp;Предпросмотр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1337"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1370"/>
         <source>&amp;White Background</source>
         <translation>&amp;Белый фон</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1345"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1378"/>
         <source>&amp;Black Background</source>
         <translation>&amp;Черный фон</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1352"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1385"/>
         <source>&amp;Checkered Background</source>
         <translation>&amp;Клетчатый фон</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1424"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1470"/>
         <source>Fx Settings</source>
         <translation>Настройки эффектов</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1426"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1472"/>
         <source> : </source>
         <translation> : </translation>
     </message>
@@ -1788,17 +1856,17 @@ Select FX nodes and related links before copying or cutting the selection you wa
         <translation type="vanished">Xsheet</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="951"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1011"/>
         <source>Scene</source>
         <translation>Сцена</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="985"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1046"/>
         <source>&amp;Paste Add</source>
         <translation>&amp;Вставить Добавить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxschematicnode.cpp" line="988"/>
+        <location filename="../../toonzqt/fxschematicnode.cpp" line="1050"/>
         <source>&amp;Preview</source>
         <translation>&amp;Предпросмотр</translation>
     </message>
@@ -1806,7 +1874,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>GroupPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="349"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="361"/>
         <source>&amp;Open Group</source>
         <translation>&amp;Открыть группу</translation>
     </message>
@@ -1874,42 +1942,42 @@ Select FX nodes and related links before copying or cutting the selection you wa
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="890"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="894"/>
         <source>Open Color Names</source>
         <translation>Открыть имена цветов</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="891"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
         <source>Text or XML (*.txt *.xml);;Text files (*.txt);;XML files (*.xml)</source>
         <translation>Текст или XML (*.txt *.xml);;Текстовые файлы (*.txt);;XML-файлы (*.xml)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="899"/>
         <source>Hex Color Names Import</source>
         <translation>Hex Color Импорт имён</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="895"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="899"/>
         <source>Do you want to merge with existing entries?</source>
         <translation>Хотите объединиться с существующими записями?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="901"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="905"/>
         <source>Error importing color names XML</source>
         <translation>Ошибка при импорте названий цветов XML</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="917"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="921"/>
         <source>Save Color Names</source>
         <translation>Сохранить имена цветов</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="918"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="922"/>
         <source>XML files (*.xml);;Text files (*.txt)</source>
         <translation>XML-файлы (*.xml);;Текстовые файлы (*.txt)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/hexcolornames.cpp" line="927"/>
+        <location filename="../../toonzqt/hexcolornames.cpp" line="931"/>
         <source>Error exporting color names XML</source>
         <translation>Ошибка экспорта названий цветов XML</translation>
     </message>
@@ -1955,7 +2023,7 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>InfoViewer</name>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="117"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="118"/>
         <source>File Info</source>
         <translation>Информация о файле</translation>
     </message>
@@ -1998,32 +2066,32 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>NewStyleSetPopup</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6960"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7190"/>
         <source>New Style Set</source>
         <translation>Новый набор стилей</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6963"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7193"/>
         <source>Style Set Name:</source>
         <translation>Название набора стилей:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6965"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7195"/>
         <source>Create as Favorite</source>
         <translation>Создать как Избранное</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6968"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7198"/>
         <source>Style Set Type:</source>
         <translation>Тип набора стилей:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6994"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7224"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6995"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7225"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -2049,34 +2117,31 @@ Select FX nodes and related links before copying or cutting the selection you wa
 <context>
     <name>PageViewer</name>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="609"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="613"/>
         <source>- No Styles -</source>
         <translation>- Нет стилей -</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="686"/>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="942"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="690"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="955"/>
         <source> + </source>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1179"/>
         <source>Name Editor</source>
-        <translation>Редактор имен</translation>
+        <translation type="vanished">Редактор имен</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1233"/>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1417"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1436"/>
         <source>New Style</source>
         <translation>Новый стиль</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1235"/>
         <source>New Page</source>
-        <translation>Новая страница</translation>
+        <translation type="vanished">Новая страница</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1403"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1422"/>
         <source>Style 0 is set to full transparent. 
 It can&apos;t be changed.  Ever.</source>
         <translation>Стиль 0 установлен на полную прозрачность.
@@ -2086,53 +2151,61 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>PaletteViewer</name>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="320"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="624"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="666"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="354"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="659"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="754"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="796"/>
         <source>&amp;Save Palette As</source>
         <translation>&amp;Сохранить палитру как</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="321"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="512"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="625"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="667"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="355"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="640"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="653"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="755"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="797"/>
         <source>&amp;Save Palette</source>
         <translation>&amp;Сохранить палитру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="376"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="401"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="442"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="478"/>
         <source>Lock Palette</source>
         <translation>Блокировать палитру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="405"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="482"/>
         <source>&amp;Lock Palette</source>
         <translation>&amp;Блокировать палитру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="463"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="499"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="618"/>
+        <source>Name Editor</source>
+        <translation type="unfinished">Редактор имен</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="555"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="484"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="576"/>
         <source>&amp;Small Thumbnails View</source>
         <translation>&amp;Маленькие иконки</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="485"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="577"/>
         <source>&amp;Medium Thumbnails View</source>
         <translation>&amp;Средние иконки</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="486"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="578"/>
         <source>&amp;Large Thumbnails View</source>
         <translation>&amp;Большие иконки</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="487"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="579"/>
         <source>&amp;List View</source>
         <translation>&amp;Посмотреть список</translation>
     </message>
@@ -2149,66 +2222,81 @@ It can&apos;t be changed.  Ever.</source>
         <translation type="vanished">Оба имени</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="152"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="154"/>
         <source>&amp;New Page</source>
         <translation>&amp;Новая страница</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="592"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="602"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="604"/>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="606"/>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="614"/>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="722"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="732"/>
         <source>&amp;New Style</source>
         <translation>&amp;Новый стиль</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="457"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="925"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="549"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1057"/>
         <source>&amp;Move Palette</source>
         <translation>&amp;Переместить палитру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="322"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="628"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="670"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="722"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="356"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="758"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="800"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="852"/>
         <source>&amp;Save As Default Vector Palette</source>
         <translation>&amp;Сохранить как векторную палитру по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="323"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="629"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="671"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="725"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="357"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="759"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="801"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="855"/>
         <source>&amp;Save As Default Smart Raster Palette</source>
         <translation>&amp;Сохранить как палитру Smart- растра по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="324"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="630"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="672"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="728"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="358"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="760"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="802"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="858"/>
         <source>&amp;Save As Default Raster Palette</source>
         <translation>&amp;Сохранить как палитру растра по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="325"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="631"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="673"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="731"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="359"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="761"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="803"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="861"/>
         <source>&amp;Save As Default Palette</source>
         <translation>&amp;Сохранить как палитру по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="389"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="455"/>
         <source>Stay on Current Palette</source>
         <translation>Оставаться на текущей палитре</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="453"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="545"/>
         <source>Drag this icon to a Studio or Project palette to add it.</source>
         <translation>Перетащите этот значок на палитру Studio или Project, чтобы добавить его.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="490"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="582"/>
         <source>Show Style Index</source>
         <translation>Показать индекс  стиля</translation>
     </message>
@@ -2217,7 +2305,7 @@ It can&apos;t be changed.  Ever.</source>
         <translation type="vanished">Сохраните палитру под другим именем.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="513"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="641"/>
         <source>Save the palette.</source>
         <translation>Сохраните палитру.</translation>
     </message>
@@ -2226,73 +2314,73 @@ It can&apos;t be changed.  Ever.</source>
         <translation type="vanished">Сохраните палитру по умолчанию для новых уровней текущего типа уровня.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="626"/>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="668"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="756"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="798"/>
         <source>&amp;Palette Gizmo</source>
         <translation>&amp;Палитра Gizmo</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="743"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="874"/>
         <source>New Page</source>
         <translation>Новая страница</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="755"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="887"/>
         <source>Delete Page</source>
         <translation>Удалить страницу</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1137"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1269"/>
         <source>Overwrite</source>
         <translation>Перезаписать</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1137"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1269"/>
         <source>Don&apos;t Overwrite</source>
         <translation>Не перезаписывать</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1146"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1278"/>
         <source>Failed to save palette.</source>
         <translation>Не удалось сохранить палитру.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1284"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1416"/>
         <source>Palette</source>
         <translation>Палитра</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1288"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1420"/>
         <source>Level Palette: </source>
         <translation>Палитра уровней: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1295"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1427"/>
         <source>Cleanup Palette</source>
         <translation>Палитра очистки</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1306"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1438"/>
         <source>Studio Palette</source>
         <translation>Studio Палитра</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1313"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1445"/>
         <source>     (Color Model: </source>
         <translation>     (Цветовая модель: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1315"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1447"/>
         <source>)</source>
         <translation>)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1354"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1486"/>
         <source>Hide New Style Button</source>
         <translation>Скрыть кнопку нового стиля</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1355"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1487"/>
         <source>Show New Style Button</source>
         <translation>Показать кнопку нового стиля</translation>
     </message>
@@ -2357,7 +2445,7 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>ParamViewer</name>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="1058"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1082"/>
         <source>Swatch Viewer</source>
         <translation>Просмотрщик образцов</translation>
     </message>
@@ -2369,15 +2457,22 @@ It can&apos;t be changed.  Ever.</source>
         <translation type="vanished">FX Помощь</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/fxsettings.cpp" line="746"/>
+        <location filename="../../toonzqt/fxsettings.cpp" line="723"/>
         <source>View help page</source>
         <translation>Просмотреть страницу справки</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/fxsettings.cpp" line="1062"/>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PegbarPainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="416"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="428"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Сброс центра</translation>
     </message>
@@ -2385,12 +2480,12 @@ It can&apos;t be changed.  Ever.</source>
 <context>
     <name>PlaneViewer</name>
     <message>
-        <location filename="../../toonzqt/planeviewer.cpp" line="303"/>
+        <location filename="../../toonzqt/planeviewer.cpp" line="309"/>
         <source>Reset View</source>
         <translation>Восстановить вид по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/planeviewer.cpp" line="308"/>
+        <location filename="../../toonzqt/planeviewer.cpp" line="314"/>
         <source>Fit To Window</source>
         <translation>Подогнать к окну</translation>
     </message>
@@ -2427,75 +2522,75 @@ It can&apos;t be changed.  Ever.</source>
         <translation type="obsolete">&lt;пользовательский&gt;</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="953"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="980"/>
         <source>Deleting &quot;%1&quot;.
 Are you sure?</source>
         <translation>Удаление «%1».
 Вы уверены?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="955"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="982"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/camerasettingswidget.cpp" line="955"/>
+        <location filename="../../toonzqt/camerasettingswidget.cpp" line="982"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="856"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1350"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1436"/>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2026"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2045"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2153"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6423"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="773"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="1076"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="775"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1078"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="186"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="187"/>
         <source>It is not possible to delete the style #</source>
         <translation>Невозможно удалить стиль #</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="321"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="323"/>
         <source>Paste Style  in Palette : %1</source>
         <translation>Всавить стиль в палитру: %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="397"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="399"/>
         <source>Delete Style  from Palette : %1</source>
         <translation>Удалить стиль из палитры : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="466"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="468"/>
         <source>Cut Style  from Palette : %1</source>
         <translation>Вырезать стиль из палитры : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="587"/>
-        <location filename="../../toonzqt/styleselection.cpp" line="659"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="589"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="661"/>
         <source>It is not possible to delete styles #0 and #1.</source>
         <translation>Невозможно удалить стили # 0 и # 1.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="638"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="640"/>
         <source>Can&apos;t paste styles there</source>
         <translation>Здесь невозможно вставлять стили</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="759"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="761"/>
         <source>There are no unused styles.</source>
         <translation>Нет неиспользованных стилей.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="766"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="768"/>
         <source>and %1 more styles.</source>
         <translation>и еще%1 стилей.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="769"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="771"/>
         <source>Erasing unused styles with following indices. Are you sure?
 
 %1</source>
@@ -2504,67 +2599,67 @@ Are you sure?</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="773"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="775"/>
         <source>Erase</source>
         <translation>Стереть</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1037"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1039"/>
         <source>  to Palette : %1</source>
         <translation>  к палитре : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1040"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1042"/>
         <source>Paste Color &amp;&amp; Name%1</source>
         <translation>Вставить цвет &amp;&amp; Имя%1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1042"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1044"/>
         <source>Paste Name%1</source>
         <translation>Вставить имя%1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1044"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1046"/>
         <source>Paste Color%1</source>
         <translation>Вставить цвет%1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1046"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1048"/>
         <source>Paste%1</source>
         <translation>Вставить%1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1062"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1064"/>
         <source>Can&apos;t modify color #0</source>
         <translation>Не удается изменить цвет # 0</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1072"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1074"/>
         <source>There are more cut/copied styles than selected. Paste anyway (adding styles)?</source>
         <translation>Есть больше вырезанных / скопированных стилей, чем выбрано. Вставить в любом случае (добавление стилей)?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1076"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1078"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1317"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1319"/>
         <source>Blend Colors  in Palette : %1</source>
         <translation>Цвета смешивания в палитре : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1447"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1449"/>
         <source>Toggle Link  in Palette : %1</source>
         <translation>Переключить связь в палитре : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1637"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1639"/>
         <source>Remove Reference  in Palette : %1</source>
         <translation>Удалить референс в палитре : %1</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleselection.cpp" line="1754"/>
+        <location filename="../../toonzqt/styleselection.cpp" line="1756"/>
         <source>Get Color from Studio Palette</source>
         <translation>Взять цвет из палитры Studio</translation>
     </message>
@@ -2594,38 +2689,38 @@ Are you sure?</source>
         <translation>Переместить ключевой кадр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1007"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="999"/>
         <source>Save Motion Path</source>
         <translation>Сохранить траекторию движения</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1009"/>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1059"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1001"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1051"/>
         <source>Motion Path files (*.mpath)</source>
         <translation>Файлы траектории движения (* .mpath)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1047"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1039"/>
         <source>It is not possible to save the motion path.</source>
         <translation>Невозможно сохранить траекторию движения.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1057"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1049"/>
         <source>Load Motion Path</source>
         <translation>Загрузить траекторию движения</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1087"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1079"/>
         <source>It is not possible to load the motion path.</source>
         <translation>Невозможно загрузить траекторию движения.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1124"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1219"/>
         <source>Stage Schematic</source>
         <translation>Stage Schematic</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1146"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1241"/>
         <source>FX Schematic</source>
         <translation>FX Schematic</translation>
     </message>
@@ -2635,64 +2730,212 @@ Are you sure?</source>
         <translation>Изменить стиль   Палитра : %1  Стиль#%2  [R%3 G%4 B%5] -&gt; [R%6 G%7 B%8]</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2023"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>R</source>
+        <translation type="unfinished">R</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1361"/>
+        <source>B</source>
+        <translation type="unfinished">B</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>H</source>
+        <translation type="unfinished">H</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1362"/>
+        <source>S</source>
+        <translation type="unfinished">S</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1363"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1380"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="1382"/>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished">Альфа контролирует прозрачность.
+Ноль полностью прозрачен.</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2032"/>
         <source>Removing a Style will permanently delete the style file. This cannot be undone!
 Are you sure?</source>
         <translation>При удалении стиля навсегда удаляется файл стиля. Это не может быть отменено!
 Уверены ли вы?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2041"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2050"/>
         <source>Emptying Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation>При очистке набора &quot;%1&quot; все файлы стилей для этого набора будут безвозвратно удалены. Это не может быть отменено!
 Уверены ли вы?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2149"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2162"/>
         <source>Removing Style Set &quot;%1&quot; will permanently delete all style files for this set. This cannot be undone!
 Are you sure?</source>
         <translation>Удаление набора стилей &quot;%1&quot; приведет к безвозвратному удалению всех файлов стилей для этого набора. Это не может быть отменено!
 Уверены ли вы?</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2607"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2251"/>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished">Диспетчер наборов стилей:              %1+клик - Добавить стиль в палитру               %2+клик - Выбор нескольких стилей</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2307"/>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished">Добавить выбранные в палитру</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2314"/>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished">Удалить выбранное из избранного</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2318"/>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished">Добавить выбранное в избранное</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2326"/>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished">Копировать выбранное в набор стилей...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2341"/>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished">Переместить выбранное в набор стилей...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2358"/>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished">Удалить выбранное из наборов</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2380"/>
+        <source>Add to Palette</source>
+        <translation type="unfinished">Добавить в палитру</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2388"/>
+        <source>Add to Favorites</source>
+        <translation type="unfinished">Добавить в избранное</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2396"/>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished">Копировать в набор стилей...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2413"/>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished">Перейти к набору стилей...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2431"/>
+        <source>Remove from Set</source>
+        <translation type="unfinished">Удалить из набора</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2442"/>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished">Добавить набор в палитру</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2448"/>
+        <source>Empty Set</source>
+        <translation type="unfinished">Пустой набор</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2460"/>
+        <source>New Style Set...</source>
+        <translation type="unfinished">Набор нового стиля...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2465"/>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished">Переименовать набор стилей...</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2472"/>
+        <source>Reload Style Set</source>
+        <translation type="unfinished">Перезагрузить набор стилей</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2480"/>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished">Сканировать изменения набора стилей</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2488"/>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished">Удалить набор стилей &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2639"/>
         <source>Plain color</source>
         <comment>CustomStyleChooserPage</comment>
         <translation>Простой цвет</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2822"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2856"/>
         <source>Plain color</source>
         <comment>VectorBrushStyleChooserPage</comment>
         <translation>Простой цвет</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3075"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3115"/>
         <source>Plain color</source>
         <comment>TextureStyleChooserPage</comment>
         <translation>Простой цвет</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3087"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3127"/>
         <source>Custom Texture</source>
         <comment>TextureStyleChooserPage</comment>
         <translation>Пользовательская текстура</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3253"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3300"/>
         <source>Plain color</source>
         <comment>MyPaintBrushStyleChooserPage</comment>
         <translation>Простой цвет</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3447"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3551"/>
         <source>Plain color</source>
         <comment>SpecialStyleChooserPage</comment>
         <translation>Простой цвет</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6420"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3725"/>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">Автозаливка линий</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="3883"/>
+        <source>Reset to default</source>
+        <translation type="unfinished">Сбросить по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6639"/>
         <source>Removing the selected Styles will permanently delete style files from their sets. This cannot be undone!
 Are you sure?</source>
         <translation>Удаление выбранных стилей навсегда удалит файлы стилей из их наборов. Это не может быть отменено!
@@ -2784,197 +3027,202 @@ Are you sure?</source>
         <translation type="vanished">Палитра</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1114"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1246"/>
         <source>Overwrite</source>
         <translation>Перезаписать</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewer.cpp" line="1115"/>
+        <location filename="../../toonzqt/paletteviewer.cpp" line="1247"/>
         <source>Don&apos;t Overwrite</source>
         <translation>Не перезаписывать</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/menubarcommand.cpp" line="292"/>
+        <location filename="../../toonzqt/menubarcommand.cpp" line="293"/>
         <source>It is not possible to assign a shortcut with modifiers to the visualization commands.</source>
         <translation>Невозможно назначить ярлык с модификаторами для команд визуализации.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="174"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="175"/>
         <source>Current Frame: </source>
         <translation>Текущий кадр: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="177"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="178"/>
         <source>File History</source>
         <translation>История файла</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="185"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="186"/>
         <source>Fullpath:     </source>
         <translation>Полный путь:     </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="186"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="187"/>
         <source>File Type:    </source>
         <translation>Тип файла:    </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="187"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="188"/>
         <source>Frames:       </source>
         <translation>Кадры:       </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="188"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="189"/>
         <source>Owner:        </source>
         <translation>Owner:        </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="189"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="190"/>
         <source>Size:         </source>
         <translation>Размер:         </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="191"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="192"/>
         <source>Created:      </source>
         <translation>Создан:      </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="192"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="193"/>
         <source>Modified:     </source>
         <translation>Изменен:     </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="193"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="194"/>
         <source>Last Access:  </source>
         <translation>Последний доступ:  </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="197"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="198"/>
         <source>Image Size:   </source>
         <translation>Размер изображения:   </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="198"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="199"/>
         <source>SaveBox:      </source>
         <translation>SaveBox:      </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="199"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="200"/>
         <source>Bits/Sample:  </source>
         <translation>Глубина цвета:  </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="200"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="201"/>
         <source>Sample/Pixel: </source>
         <translation>Количество каналов: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="201"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="202"/>
         <source>Dpi:          </source>
         <translation>Dpi:          </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="202"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="203"/>
         <source>Orientation:  </source>
         <translation>Ориентация:  </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="203"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="204"/>
         <source>Compression:  </source>
         <translation>Сжатие:  </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="204"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="205"/>
         <source>Quality:      </source>
         <translation>Качество:      </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="205"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="206"/>
         <source>Smoothing:    </source>
         <translation>Сглаживание:    </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="206"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="207"/>
         <source>Codec:        </source>
         <translation>Кодек:        </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="207"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="208"/>
         <source>Alpha Channel:</source>
         <translation>Альфа-канал:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="208"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="209"/>
         <source>Byte Ordering:</source>
         <translation>Байт:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="209"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="210"/>
         <source>H Pos:</source>
         <translation>H Pos:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="210"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="211"/>
         <source>Palette Pages:</source>
         <translation>Страницы палитры:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="211"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="212"/>
         <source>Palette Styles:</source>
         <translation>Стили палитры:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="213"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="214"/>
         <source>Camera Size:      </source>
         <translation>Размер камеры:      </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="214"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="215"/>
         <source>Camera Dpi:       </source>
         <translation> DPI Камеры:       </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="215"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="216"/>
         <source>Number of Frames: </source>
         <translation>Количество кадров: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="216"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="217"/>
         <source>Number of Levels: </source>
         <translation>Количество уровней: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="217"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="218"/>
         <source>Output Path:      </source>
         <translation>Выходной путь:      </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="218"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="219"/>
         <source>Endianess:      </source>
         <translation>Порядок байтов:      </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="221"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="222"/>
         <source>Length:       </source>
         <translation>Длина:       </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="222"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="223"/>
         <source>Channels: </source>
         <translation>Каналы: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="223"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="224"/>
         <source>Sample Rate: </source>
         <translation>Частота дискретизации: </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="224"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="225"/>
         <source>Sample Size:      </source>
         <translation>Размер образца:      </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/infoviewer.cpp" line="549"/>
+        <location filename="../../toonzqt/infoviewer.cpp" line="226"/>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/infoviewer.cpp" line="579"/>
         <source>The file %1 does not exist.</source>
         <translation>Файл %1 не существует.</translation>
     </message>
@@ -3024,12 +3272,12 @@ Are you sure?</source>
         <translation>Исходное изображение кажется непригодным для такой конверсии</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/gutil.cpp" line="608"/>
+        <location filename="../../toonzqt/gutil.cpp" line="676"/>
         <source>The file name cannot be empty or contain any of the following characters: (new line) \ / : * ? &quot; |</source>
         <translation>Имя файла не может быть пустым или содержать любой из следующих символов: (новая строка) \ /: *? &quot;|</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/gutil.cpp" line="635"/>
+        <location filename="../../toonzqt/gutil.cpp" line="703"/>
         <source>That is a reserved file name and cannot be used.</source>
         <translation>Это зарезервированное имя файла, его нельзя использовать.</translation>
     </message>
@@ -3099,10 +3347,10 @@ Are you sure?</source>
     </message>
     <message>
         <location filename="../../toonzqt/dvdialog.cpp" line="1443"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2026"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2045"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2153"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6423"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2035"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2054"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="2166"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6642"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -3186,13 +3434,28 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 Вторая строка должна быть &quot;Mesh [глубина цвета на входе] [глубина цвета на выходе]&quot;</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/lutcalibrator.cpp" line="520"/>
-        <location filename="../../toonzqt/lutcalibrator.cpp" line="537"/>
+        <location filename="../../toonzqt/lutcalibrator.cpp" line="524"/>
+        <location filename="../../toonzqt/lutcalibrator.cpp" line="545"/>
         <source>Failed to Load 3DLUT File.</source>
         <translation>Не удалось загрузить файл 3DLUT.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/paletteviewergui.cpp" line="1705"/>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1196"/>
+        <source>Name Editor</source>
+        <translation type="unfinished">Редактор имен</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1252"/>
+        <source>New Style</source>
+        <translation type="unfinished">Новый стиль</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1255"/>
+        <source>New Page</source>
+        <translation type="unfinished">Новая страница</translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/paletteviewergui.cpp" line="1720"/>
         <source>Click &amp; Drag Palette into Studio Palette</source>
         <translation>Нажмите и перетащите палитру в палитру Studio</translation>
     </message>
@@ -3220,9 +3483,9 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 <context>
     <name>RenameStyleSet</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7152"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7167"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="7179"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7385"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7400"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7412"/>
         <source> (Favorites)</source>
         <translation> (Избранное)</translation>
     </message>
@@ -3271,71 +3534,71 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 <context>
     <name>SchematicViewer</name>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="971"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1066"/>
         <source>&amp;Fit to Window</source>
         <translation>&amp;По размеру окна</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="977"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1072"/>
         <source>&amp;Focus on Current</source>
         <translation>&amp;Фокус на текущем</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="982"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1077"/>
         <source>&amp;Reorder Nodes</source>
         <translation>&amp;Изменение порядка узлов</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="988"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1083"/>
         <source>&amp;Reset Size</source>
         <translation>&amp;Сбросить размер</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="995"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1171"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1227"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1090"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1266"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1322"/>
         <source>&amp;Minimize Nodes</source>
         <translation>&amp;Минимизировать узлы</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="995"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1172"/>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1228"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1090"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1267"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1323"/>
         <source>&amp;Maximize Nodes</source>
         <translation>&amp;Максимизировать узлы</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1001"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1096"/>
         <source>&amp;Selection Mode</source>
         <translation>&amp;Режим выделения</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1006"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1101"/>
         <source>&amp;Zoom Mode</source>
         <translation>&amp;Режим приближения</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1011"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1106"/>
         <source>&amp;Hand Mode</source>
         <translation>&amp;Ручной режим</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1019"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1114"/>
         <source>&amp;New Pegbar</source>
         <translation>&amp;Новый Pegbar</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1026"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1121"/>
         <source>&amp;New Camera</source>
         <translation>&amp;Новая камера</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1033"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1128"/>
         <source>&amp;New Motion Path</source>
         <translation>&amp;Новая траектория движения</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1041"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1136"/>
         <source>&amp;Switch output port display mode</source>
         <translation>&amp;Переключить режим отображения выходного порта</translation>
     </message>
@@ -3344,7 +3607,7 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
         <translation type="vanished">&amp;Переключение отображения выходного порта</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/schematicviewer.cpp" line="1056"/>
+        <location filename="../../toonzqt/schematicviewer.cpp" line="1151"/>
         <source>&amp;Toggle node icons</source>
         <translation>&amp;Переключить иконки узлов</translation>
     </message>
@@ -3352,7 +3615,7 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 <context>
     <name>SchematicWindowEditor</name>
     <message>
-        <location filename="../../toonzqt/schematicgroupeditor.cpp" line="170"/>
+        <location filename="../../toonzqt/schematicgroupeditor.cpp" line="164"/>
         <source>&amp;Close Editor</source>
         <translation>&amp;Закрыть редактор</translation>
     </message>
@@ -3360,14 +3623,12 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3621"/>
         <source>Autopaint for Lines</source>
-        <translation>Автозаливка линий</translation>
+        <translation type="vanished">Автозаливка линий</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="3779"/>
         <source>Reset to default</source>
-        <translation>Сбросить по умолчанию</translation>
+        <translation type="vanished">Сбросить по умолчанию</translation>
     </message>
 </context>
 <context>
@@ -3438,17 +3699,17 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 <context>
     <name>SplinePainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="680"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="692"/>
         <source>&amp;Delete</source>
         <translation>&amp;Удалить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="683"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="695"/>
         <source>&amp;Save Motion Path...</source>
         <translation>&amp;Сохранить траекторию движения...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="685"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="697"/>
         <source>&amp;Load Motion Path...</source>
         <translation>&amp;Загрузить траекторию движения...</translation>
     </message>
@@ -3469,17 +3730,17 @@ The second line should be &quot;Mesh [Input bit depth] [Output bit depth]&quot;<
 <context>
     <name>StageSchematicScene</name>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1179"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1171"/>
         <source>&amp;New Pegbar</source>
         <translation>&amp;Новый Pegbar</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1183"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1175"/>
         <source>&amp;New Motion Path</source>
         <translation>&amp;Новая траектория движения</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicscene.cpp" line="1187"/>
+        <location filename="../../toonzqt/stageschematicscene.cpp" line="1179"/>
         <source>&amp;New Camera</source>
         <translation>&amp;Новая камера</translation>
     </message>
@@ -3644,106 +3905,87 @@ Are you sure ?</source>
 <context>
     <name>StyleChooserPage</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2238"/>
         <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation>Диспетчер наборов стилей:              %1+клик - Добавить стиль в палитру               %2+клик - Выбор нескольких стилей</translation>
+        <translation type="vanished">Диспетчер наборов стилей:              %1+клик - Добавить стиль в палитру               %2+клик - Выбор нескольких стилей</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2283"/>
         <source>Add Selected to Palette</source>
-        <translation>Добавить выбранные в палитру</translation>
+        <translation type="vanished">Добавить выбранные в палитру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2290"/>
         <source>Remove Selected from Favorites</source>
-        <translation>Удалить выбранное из избранного</translation>
+        <translation type="vanished">Удалить выбранное из избранного</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2294"/>
         <source>Add Selected to Favorites</source>
-        <translation>Добавить выбранное в избранное</translation>
+        <translation type="vanished">Добавить выбранное в избранное</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2302"/>
         <source>Copy Selected to Style Set...</source>
-        <translation>Копировать выбранное в набор стилей...</translation>
+        <translation type="vanished">Копировать выбранное в набор стилей...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2317"/>
         <source>Move Selected to Style Set...</source>
-        <translation>Переместить выбранное в набор стилей...</translation>
+        <translation type="vanished">Переместить выбранное в набор стилей...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2334"/>
         <source>Remove Selected from Sets</source>
-        <translation>Удалить выбранное из наборов</translation>
+        <translation type="vanished">Удалить выбранное из наборов</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2356"/>
         <source>Add to Palette</source>
-        <translation>Добавить в палитру</translation>
+        <translation type="vanished">Добавить в палитру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2364"/>
         <source>Add to Favorites</source>
-        <translation>Добавить в избранное</translation>
+        <translation type="vanished">Добавить в избранное</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2372"/>
         <source>Copy to Style Set...</source>
-        <translation>Копировать в набор стилей...</translation>
+        <translation type="vanished">Копировать в набор стилей...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2389"/>
         <source>Move to Style Set...</source>
-        <translation>Перейти к набору стилей...</translation>
+        <translation type="vanished">Перейти к набору стилей...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2407"/>
         <source>Remove from Set</source>
-        <translation>Удалить из набора</translation>
+        <translation type="vanished">Удалить из набора</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2418"/>
         <source>Add Set to Palette</source>
-        <translation>Добавить набор в палитру</translation>
+        <translation type="vanished">Добавить набор в палитру</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2424"/>
         <source>Empty Set</source>
-        <translation>Пустой набор</translation>
+        <translation type="vanished">Пустой набор</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2436"/>
         <source>New Style Set...</source>
-        <translation>Набор нового стиля...</translation>
+        <translation type="vanished">Набор нового стиля...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2441"/>
         <source>Rename Style Set...</source>
-        <translation>Переименовать набор стилей...</translation>
+        <translation type="vanished">Переименовать набор стилей...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2448"/>
         <source>Reload Style Set</source>
-        <translation>Перезагрузить набор стилей</translation>
+        <translation type="vanished">Перезагрузить набор стилей</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2456"/>
         <source>Scan for Style Set Changes</source>
-        <translation>Сканировать изменения набора стилей</translation>
+        <translation type="vanished">Сканировать изменения набора стилей</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="2464"/>
         <source>Remove &apos;%1&apos; Style Set</source>
-        <translation>Удалить набор стилей &quot;%1&quot;</translation>
+        <translation type="vanished">Удалить набор стилей &quot;%1&quot;</translation>
     </message>
 </context>
 <context>
     <name>StyleEditor</name>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5622"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6943"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7173"/>
         <source>Generated</source>
         <translation>Сформирован</translation>
     </message>
@@ -3758,7 +4000,7 @@ Apply</source>
 применение</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4255"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4373"/>
         <source>Show or hide parts of the Color Page.</source>
         <translation>Показать или скрыть части цветовой страницы.</translation>
     </message>
@@ -3767,138 +4009,161 @@ Apply</source>
         <translation type="vanished">Переключить ориентацию цветовой страницы.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4176"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4286"/>
         <source>Auto</source>
         <translation>Автоматически</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4179"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4289"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4186"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4295"/>
         <source>Apply changes to current style</source>
         <translation>Применить изменения к текущему стилю</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4191"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4300"/>
         <source>Automatically update style changes</source>
         <translation>Автообновление изменений стиля</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4195"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4304"/>
         <source>Return To Previous Style</source>
         <translation>Вернуться в предыдущий стиль</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4200"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4309"/>
         <source>Current Style</source>
         <translation>Текущий стиль</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4219"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4328"/>
         <source>Hex</source>
         <translation>Hex</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4244"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4329"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4357"/>
         <source>Toggle Orientation</source>
         <translation>Переключить ориентацию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4247"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4361"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5562"/>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4365"/>
         <source>Hex Color Names...</source>
         <translation>Hex Color Имена...</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4261"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4379"/>
         <source>Show or hide style sets.</source>
         <translation>Показать или скрыть наборы стилей.</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4768"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4488"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4560"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4633"/>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5033"/>
         <source>No Style Selected</source>
         <translation>Стиль не выбран</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4785"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5050"/>
         <source>Cleanup </source>
         <translation>Очистка </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4787"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5052"/>
         <source>Studio </source>
         <translation>Studio </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4789"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5054"/>
         <source>Level </source>
         <translation>Уровень </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4792"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5057"/>
         <source>Palette</source>
         <translation>Палитра</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4806"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5071"/>
         <source>Style Editor - No Valid Style Selected</source>
         <translation>Редактор стилей - не выбран правильный стиль</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5623"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5563"/>
+        <source>Show Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5793"/>
         <source>My Favorites</source>
         <translation>Мои избранные</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5626"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6862"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5796"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7090"/>
         <source> (Favorites)</source>
         <translation> (Избранное)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5629"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="5799"/>
         <source> (External)</source>
         <translation> (Внешний)</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5892"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5915"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5938"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6074"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6097"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6120"/>
         <source>Show All</source>
         <translation>Показать все</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5897"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5920"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5943"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6079"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6102"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6125"/>
         <source>Hide All</source>
         <translation>Скрыть всё</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5902"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5925"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5948"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6084"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6107"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6130"/>
         <source>Collapse All</source>
         <translation>Свернуть всё</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5907"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5930"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="5953"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6089"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6112"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="6135"/>
         <source>Expand All</source>
         <translation>Развернуть всё</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6900"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7128"/>
         <source>Style Set Name cannot be empty or contain any of the following characters:
  \ / : * ? &quot; &lt; &gt; |</source>
         <translation>Имя набора стилей не может быть пустым или содержать любой из следующих символов:
   \ / : * ? &quot; &lt; &gt; |</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="6945"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="7175"/>
         <source>Style Set Name already exists. Please try another name.</source>
         <translation>Имя набора стилей уже существует. Пожалуйста, попробуйте другое имя.</translation>
     </message>
@@ -3907,22 +4172,22 @@ Apply</source>
         <translation type="vanished">[ОЧИСТКА]  </translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4215"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4324"/>
         <source>Wheel</source>
         <translation>Круг</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4216"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4325"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4217"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4326"/>
         <source>Alpha</source>
         <translation>Альфа</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4218"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4327"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
@@ -3939,7 +4204,7 @@ Apply</source>
         <translation type="obsolete">Простой</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4501"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4756"/>
         <source>Texture</source>
         <translation>Текстура</translation>
     </message>
@@ -3956,25 +4221,25 @@ Apply</source>
         <translation type="vanished">Векторная кисть</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4499"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4505"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4507"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4754"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4760"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4762"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4502"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4757"/>
         <source>Vector</source>
         <translation>Вектор</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4500"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4755"/>
         <source>Raster</source>
         <translation>Растр</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4503"/>
-        <location filename="../../toonzqt/styleeditor.cpp" line="4508"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4758"/>
+        <location filename="../../toonzqt/styleeditor.cpp" line="4763"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
@@ -4053,8 +4318,9 @@ Zero is fully transparent.</source>
 <context>
     <name>StyleIndexLineEdit</name>
     <message>
-        <location filename="../../toonzqt/styleindexlineedit.cpp" line="19"/>
-        <location filename="../../toonzqt/styleindexlineedit.cpp" line="37"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="20"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="23"/>
+        <location filename="../../toonzqt/styleindexlineedit.cpp" line="42"/>
         <source>current</source>
         <translation>текущий</translation>
     </message>
@@ -4100,12 +4366,12 @@ Zero is fully transparent.</source>
 <context>
     <name>SwatchViewer</name>
     <message>
-        <location filename="../../toonzqt/swatchviewer.cpp" line="845"/>
+        <location filename="../../toonzqt/swatchviewer.cpp" line="846"/>
         <source>Reset View</source>
         <translation>Восстановить вид по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/swatchviewer.cpp" line="850"/>
+        <location filename="../../toonzqt/swatchviewer.cpp" line="851"/>
         <source>Fit To Window</source>
         <translation>Подогнать к окну</translation>
     </message>
@@ -4145,12 +4411,12 @@ Zero is fully transparent.</source>
 <context>
     <name>TablePainter</name>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="586"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="598"/>
         <source>Table</source>
         <translation>Стол</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/stageschematicnode.cpp" line="596"/>
+        <location filename="../../toonzqt/stageschematicnode.cpp" line="608"/>
         <source>&amp;Reset Center</source>
         <translation>&amp;Сброс центра</translation>
     </message>
@@ -4158,22 +4424,22 @@ Zero is fully transparent.</source>
 <context>
     <name>ToneCurveField</name>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="902"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="906"/>
         <source>Channel:</source>
         <translation>Канал:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="905"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="909"/>
         <source>Range:</source>
         <translation>Диапазон:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="923"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="927"/>
         <source>Output:</source>
         <translation>Вывод:</translation>
     </message>
     <message>
-        <location filename="../../toonzqt/tonecurvefield.cpp" line="926"/>
+        <location filename="../../toonzqt/tonecurvefield.cpp" line="930"/>
         <source>Input:</source>
         <translation>Ввод:</translation>
     </message>

--- a/toonz/sources/translations/spanish/colorfx.ts
+++ b/toonz/sources/translations/spanish/colorfx.ts
@@ -21,6 +21,29 @@
     </message>
 </context>
 <context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation type="unfinished">Densidad</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MovingSolidColor</name>
     <message>
         <source>Offset</source>

--- a/toonz/sources/translations/spanish/image.ts
+++ b/toonz/sources/translations/spanish/image.ts
@@ -2,6 +2,24 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="es_UY">
 <context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225"/>
+        <source>Scale</source>
+        <translation type="unfinished">Escala</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226"/>
+        <source>Looping</source>
+        <translation type="unfinished">Ciclo</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227"/>
+        <source>Write as .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AviWriterProperties</name>
     <message>
         <location filename="../../image/avi/tiio_avi.cpp" line="1182"/>
@@ -12,6 +30,97 @@
         <location filename="../../image/avi/tiio_avi.cpp" line="1183"/>
         <source>Uncompressed</source>
         <translation>Sin compresión</translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290"/>
+        <source>Bits Per Pixel</source>
+        <translation type="unfinished">Bits por píxel</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292"/>
+        <source>48(RGB Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293"/>
+        <source>64(RGBA Half Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294"/>
+        <source>96(RGB Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295"/>
+        <source>128(RGBA Float)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299"/>
+        <source>Compression Type</source>
+        <translation type="unfinished">Tipo de compresión</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301"/>
+        <source>No compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304"/>
+        <source>Run Length Encoding (RLE)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307"/>
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310"/>
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313"/>
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315"/>
+        <source>Storage Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316"/>
+        <source>Scan-line based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317"/>
+        <source>Tile based</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319"/>
+        <source>Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234"/>
+        <source>Quality</source>
+        <translation type="unfinished">Calidad</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235"/>
+        <source>Scale</source>
+        <translation type="unfinished">Escala</translation>
     </message>
 </context>
 <context>
@@ -110,14 +219,12 @@
 <context>
     <name>MovWriterProperties</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="238"/>
         <source>Quality</source>
-        <translation type="unfinished">Calidad</translation>
+        <translation type="obsolete">Calidad</translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_mov.cpp" line="239"/>
         <source>Scale</source>
-        <translation type="unfinished">Escala</translation>
+        <translation type="obsolete">Escala</translation>
     </message>
 </context>
 <context>
@@ -144,12 +251,13 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="272"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="193"/>
         <source>FFmpeg returned error-code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="181"/>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="197"/>
         <source>FFmpeg timed out.
 Please check the file for errors.
 If the file doesn&apos;t play or is incomplete, 

--- a/toonz/sources/translations/spanish/tnztools.ts
+++ b/toonz/sources/translations/spanish/tnztools.ts
@@ -663,6 +663,10 @@
         <source>Ignore Gaps</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FingerTool</name>
@@ -777,6 +781,30 @@
     </message>
     <message>
         <source>Refer Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation type="unfinished">Distancia:</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation type="unfinished">Índice del estilo:</translation>
+    </message>
+    <message>
+        <source>Gaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close and Fill</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1820,6 +1848,96 @@ Do you want to proceed?</source>
 moved to the end of the first page of the palette.</source>
         <translation>Con esta opción activa, el estilo escogido será
 movido hacia el final de la primera página de la paleta.</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryTool</name>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished">Opacidad</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line Symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">Ajustes:</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation type="unfinished">&lt;personalizado&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>SymmetryToolOptionBox</name>
+    <message>
+        <source>Rotation:</source>
+        <translation type="unfinished">Rotación:</translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate Perspective Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation type="unfinished">Restablecer posición</translation>
+    </message>
+    <message>
+        <source>Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation type="unfinished">Opacidad:</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation type="unfinished">Ajustes:</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/spanish/toonz.ts
+++ b/toonz/sources/translations/spanish/toonz.ts
@@ -174,7 +174,7 @@ Special thanks to:</source>
     <message>
         <source>The microphone is not available: 
 Please select a different device or check the microphone.</source>
-        <translation>El micrófono no está disponible: 
+        <translation type="vanished">El micrófono no está disponible: 
 Por favor seleccionar un dispositivo diferente o comprobar el micrófono.</translation>
     </message>
     <message>
@@ -272,6 +272,26 @@ Make sure you have write permissions in folder.</source>
 Nearest format will be internally used.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoInputCellNumberPopup</name>
@@ -365,6 +385,90 @@ todos los fotogramas del nivel seleccionado.</translation>
     <message>
         <source>Field Guide:</source>
         <translation type="vanished">Guía de campos:</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation type="unfinished">Mostrar en interfaz</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation type="unfinished">Áreas de seguridad (clic derecho para seleccionar)</translation>
+    </message>
+    <message>
+        <source>Grids and Overlays
+Right click to adjust.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grids and Overlays Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation type="unfinished">Vista de mesa de trabajo</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation type="unfinished">Vista 3D</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation type="unfinished">Vista de cámara</translation>
+    </message>
+    <message>
+        <source>Change camera view transparency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation type="unfinished">Congelar</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation type="unfinished">Previsualizar región</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation type="unfinished">Sin título</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation type="unfinished">Escena: </translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation type="unfinished">   ::   Fotograma: </translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation type="unfinished">  ::  Zoom : </translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation type="unfinished"> (Invertido)</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation type="unfinished">   ::   Nivel: </translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -672,6 +776,21 @@ Detenerla o esperar a su finalización antes de eliminarla.</translation>
     </message>
 </context>
 <context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CanvasSizePopup</name>
     <message>
         <source>Canvas Size</source>
@@ -695,7 +814,7 @@ Detenerla o esperar a su finalización antes de eliminarla.</translation>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="vanished">Unidades:</translation>
+        <translation>Unidades:</translation>
     </message>
     <message>
         <source>Relative</source>
@@ -725,23 +844,23 @@ Do you want to crop the canvas?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">píxeles</translation>
+        <translation>píxeles</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">cm</translation>
+        <translation>cm</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">campos</translation>
+        <translation>campos</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">pulgadas</translation>
+        <translation>pulgadas</translation>
     </message>
 </context>
 <context>
@@ -1309,7 +1428,7 @@ What do you want to do? </source>
     <name>ComboViewerPanel</name>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>Áreas de seguridad (clic derecho para seleccionar)</translation>
+        <translation type="vanished">Áreas de seguridad (clic derecho para seleccionar)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -1317,19 +1436,19 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>Vista de mesa de trabajo</translation>
+        <translation type="vanished">Vista de mesa de trabajo</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>Vista 3D</translation>
+        <translation type="vanished">Vista 3D</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>Vista de cámara</translation>
+        <translation type="vanished">Vista de cámara</translation>
     </message>
     <message>
         <source>Freeze</source>
-        <translation>Congelar</translation>
+        <translation type="vanished">Congelar</translation>
     </message>
     <message>
         <source>GUI Show / Hide</source>
@@ -1349,35 +1468,35 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Preview</source>
-        <translation>Previsualizar</translation>
+        <translation type="vanished">Previsualizar</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Previsualizar región</translation>
+        <translation type="vanished">Previsualizar región</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Sin título</translation>
+        <translation type="vanished">Sin título</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Escena: </translation>
+        <translation type="vanished">Escena: </translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>   ::   Fotograma: </translation>
+        <translation type="vanished">   ::   Fotograma: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>   ::   Nivel: </translation>
+        <translation type="vanished">   ::   Nivel: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Nivel: </translation>
+        <translation type="vanished">Nivel: </translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (Invertido)</translation>
+        <translation type="vanished"> (Invertido)</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -1393,19 +1512,6 @@ What do you want to do? </source>
     </message>
     <message>
         <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1469,6 +1575,10 @@ Right click to adjust.</source>
         <source>Search:</source>
         <translation type="unfinished">Buscar:</translation>
     </message>
+    <message>
+        <source>Save as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CommandBarTree</name>
@@ -1493,6 +1603,131 @@ Right click to adjust.</source>
     <message>
         <source>Theirs</source>
         <translation>De otros</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation type="unfinished">El nivel %1 no contiene fotogramas; omitido.</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation type="unfinished">Omitir archivos existentes</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1769,6 +2004,99 @@ contuviera información de PPP, entonces se usarán los de la cámara actual.
     </message>
 </context>
 <context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Cerrar</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation type="unfinished">Sobrescribir</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DVGui::ProgressDialog</name>
     <message>
         <source>Loading &quot;%1&quot;...</source>
@@ -2042,6 +2370,13 @@ contuviera información de PPP, entonces se usarán los de la cámara actual.
     </message>
 </context>
 <context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportCurrentSceneCommandHandler</name>
     <message>
         <source>You must save the current scene first.</source>
@@ -2170,6 +2505,47 @@ contuviera información de PPP, entonces se usarán los de la cámara actual.
     </message>
 </context>
 <context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportPanel</name>
     <message>
         <source>Export</source>
@@ -2259,26 +2635,6 @@ contuviera información de PPP, entonces se usarán los de la cámara actual.
     <name>ExportXDTSCommand</name>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>All columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Only active columns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inbetween symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet symbol mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Target column</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2401,14 +2757,6 @@ contuviera información de PPP, entonces se usarán los de la cámara actual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse sheet mark:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Keyframe mark:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2476,6 +2824,18 @@ Do you want to create it?</source>
     </message>
     <message>
         <source>Failed to create folder %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2923,6 +3283,10 @@ Do you want to overwrite it?</source>
         <source>It is not possible to take or compare snapshots for Toonz vector levels.</source>
         <translation>No es posible tomar o comparar capturas en niveles vectoriales de OpenToonz.</translation>
     </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlipbookPanel</name>
@@ -2994,6 +3358,13 @@ Do you want to overwrite it?</source>
     <message>
         <source>Fx Settings</source>
         <translation>Opciones de efectos</translation>
+    </message>
+</context>
+<context>
+    <name>GPhotoCam</name>
+    <message>
+        <source>An error occurred.  Please try again.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3170,6 +3541,10 @@ Do you want to overwrite it?</source>
     <message>
         <source>Search:</source>
         <translation type="unfinished">Buscar:</translation>
+    </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3568,6 +3943,10 @@ Do you want to create it?</source>
 Please choose a different file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LineTestCapturePane</name>
@@ -3873,6 +4252,13 @@ Please choose a valid lip sync data file to continue.</source>
     </message>
 </context>
 <context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadColorModelPopup</name>
     <message>
         <source>Load Color Model</source>
@@ -4173,6 +4559,10 @@ Please choose a valid lip sync data file to continue.</source>
     <message>
         <source>Locator</source>
         <translation>Localizador</translation>
+    </message>
+    <message>
+        <source>  Zoom : </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7441,6 +7831,78 @@ or you may delete necessary files for it.</source>
         <source>Set Cell Mark </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Markers to Selected Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatchlinesDialog</name>
@@ -7711,6 +8173,22 @@ What do you want to do?</source>
     </message>
     <message>
         <source>Polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Color</translation>
+    </message>
+    <message>
+        <source>Steps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8168,7 +8646,7 @@ The parameters to be saved are:
 - File options
 - Resample Balance
 - Channel width</source>
-        <translation>Guardar las opciones actuales de salida.
+        <translation type="vanished">Guardar las opciones actuales de salida.
 Los parámetros que serán guardados son:
 - Opciones de cámara
 - Carpeta de proyecto donde se guardará
@@ -8215,6 +8693,93 @@ Los parámetros que serán guardados son:
     </message>
     <message>
         <source>(linked to Scene Settings)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished">Color</translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the &quot;Linear Color Space&quot; option is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t apply field rendering in a time stretched scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t stretch time in a field rendered scene
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file %1 does already exist.
+Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting &quot;%1&quot;.
+Are you sure?</source>
+        <translation type="unfinished">A punto de borrar &quot;%1&quot;.
+¿Seguro?</translation>
+    </message>
+    <message>
+        <source>The preset file %1.txt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to open the preset file %1.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bad file format: %1.txt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9067,7 +9632,7 @@ También establecer la ruta de salida a esa carpeta.</translation>
     </message>
     <message>
         <source>Use the TLV Savebox to Limit Filling Operations</source>
-        <translation type="vanished">Al usar Rellenar en niveles TLV, usar su marco delimitador como límite</translation>
+        <translation>Al usar Rellenar en niveles TLV, usar su marco delimitador como límite</translation>
     </message>
     <message>
         <source>Paper Thickness:</source>
@@ -9163,7 +9728,7 @@ También establecer la ruta de salida a esa carpeta.</translation>
     </message>
     <message>
         <source>Show &quot;ABC&quot; Appendix to the Frame Number in Xsheet Cell</source>
-        <translation>Mostrar el sufijo &quot;ABC&quot; detrás del número de fotograma en los acetatos de la planilla</translation>
+        <translation type="vanished">Mostrar el sufijo &quot;ABC&quot; detrás del número de fotograma en los acetatos de la planilla</translation>
     </message>
     <message>
         <source>Automatically Remove Scene Number from Loaded Level Name</source>
@@ -9363,7 +9928,7 @@ También establecer la ruta de salida a esa carpeta.</translation>
     </message>
     <message>
         <source>Pixels Only:</source>
-        <translation type="vanished">Sólo píxeles:</translation>
+        <translation>Sólo píxeles:</translation>
     </message>
     <message>
         <source>Rooms *:</source>
@@ -9469,7 +10034,7 @@ Is it OK to release these shortcuts?</source>
     </message>
     <message>
         <source>Show Column Numbers in Column Headers</source>
-        <translation>Mostrar número de columna en encabezado de columnas</translation>
+        <translation type="vanished">Mostrar número de columna en encabezado de columnas</translation>
     </message>
     <message>
         <source>Always ask before loading or importing</source>
@@ -10146,6 +10711,58 @@ but a random crash might occur, use at your own risk:</source>
         <source>Edit Additional Style Sheet..</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Advanced Preferences and Options*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Column Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show &quot;ABC&quot; Appendix to the Frame Number in Scene Cell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -10381,6 +10998,10 @@ Note that this mode uses regular expression for file name validation and may slo
     </message>
     <message>
         <source>File Path Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*Separate assets into scene sub-folders</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13031,6 +13652,107 @@ Do you want to continue?</source>
         <source>Explicit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Save log text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to set command to control in the custom panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing QGLFormat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing environment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading styles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading shaders...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initializing Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Plugins...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creating main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading style sheet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading Perspective Grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting Tahoma2D...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting main window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading file &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReframePopup</name>
@@ -13208,6 +13930,37 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
 </context>
 <context>
+    <name>Room</name>
+    <message>
+        <source>2D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StopMotion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">Explorador</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished">Historia</translation>
+    </message>
+    <message>
+        <source>New Room</source>
+        <translation type="unfinished">Nuevo espacio de trabajo</translation>
+    </message>
+</context>
+<context>
     <name>RoomTabWidget</name>
     <message>
         <source>New Room</source>
@@ -13219,7 +13972,7 @@ These levels can&apos;t be exported with this tool.</source>
     </message>
     <message>
         <source>Room</source>
-        <translation>Espacio de trabajo</translation>
+        <translation type="vanished">Espacio de trabajo</translation>
     </message>
     <message>
         <source>Are you sure you want to remove room %1</source>
@@ -14106,6 +14859,13 @@ Por favor enviar o revertir los cambios antes.</translation>
     </message>
 </context>
 <context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SavePaletteAsPopup</name>
     <message>
         <source>Save Palette</source>
@@ -14247,6 +15007,172 @@ Por favor enviar o revertir los cambios antes.</translation>
     <message>
         <source>Threshold: </source>
         <translation type="vanished">Umbral: </translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation type="unfinished">Carpeta: </translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation type="unfinished">Fallo al abrir la carpeta</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation type="unfinished">La ruta a la carpeta de origen es inválida.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t change file extension</source>
+        <translation type="unfinished">No es posible cambiar la extensión del archivo</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set a drawing number</source>
+        <translation type="unfinished">No es posible definir un número para el dibujo</translation>
+    </message>
+    <message>
+        <source>Can&apos;t rename. File already exists: </source>
+        <translation type="unfinished">No es posible renombrar. El archivo ya existe: </translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t rename </source>
+        <translation type="unfinished">No fue posible renombrar </translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation type="unfinished">Cargar como sub-planilla</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">Cargar</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">Renombrar</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation type="unfinished">Convertir a TLV pintado</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation type="unfinished">Convertir a TLV no pintado</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation type="unfinished">Control de versiones</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">Editar</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation type="unfinished">Editar rango de fotogramas...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation type="unfinished">Revertir</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation type="unfinished">Obtener</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Borrar</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation type="unfinished">Obtener revisión...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="unfinished">Desbloquear</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation type="unfinished">Información de edición</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation type="unfinished">Historial de revisiones...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation type="unfinished">Desbloquear rango de fotogramas</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation type="unfinished">Guardar escena</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation type="unfinished">Nombre de la escena:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation type="unfinished">Se produjo un error al copiar %1 a %2</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation type="unfinished">Convertir a TLV no pintado</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation type="unfinished">Advertencia: el nivel %1 ya existe; ¿sobrescribirlo?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Sí</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">No</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation type="unfinished">Hecho: Todos los niveles convertidos a formato TLV</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation type="unfinished">Convertir a TLV pintado</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation type="unfinished">Hecho: 2 niveles convertidos a formato TLV</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished">Nueva carpeta</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation type="unfinished">No es posible crear la carpeta %1.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation type="unfinished">Algunos archivos que se desea editar se encuentran abiertos actualmente. Cerrarlos primero.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation type="unfinished">Algunos archivos que se desea desbloquear se encuentran abiertos actualmente. Cerrarlos primero.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14518,55 +15444,55 @@ Por favor enviar o revertir los cambios antes.</translation>
     <name>SceneViewerPanel</name>
     <message>
         <source>Freeze</source>
-        <translation>Congelar</translation>
+        <translation type="vanished">Congelar</translation>
     </message>
     <message>
         <source>Camera Stand View</source>
-        <translation>Vista de mesa de trabajo</translation>
+        <translation type="vanished">Vista de mesa de trabajo</translation>
     </message>
     <message>
         <source>3D View</source>
-        <translation>Vista 3D</translation>
+        <translation type="vanished">Vista 3D</translation>
     </message>
     <message>
         <source>Camera View</source>
-        <translation>Vista de cámara</translation>
+        <translation type="vanished">Vista de cámara</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>Previsualizar</translation>
+        <translation type="vanished">Previsualizar</translation>
     </message>
     <message>
         <source>Sub-camera Preview</source>
-        <translation>Previsualizar región</translation>
+        <translation type="vanished">Previsualizar región</translation>
     </message>
     <message>
         <source>Untitled</source>
-        <translation>Sin título</translation>
+        <translation type="vanished">Sin título</translation>
     </message>
     <message>
         <source>Scene: </source>
-        <translation>Escena: </translation>
+        <translation type="vanished">Escena: </translation>
     </message>
     <message>
         <source>   ::   Frame: </source>
-        <translation>   ::   Fotograma: </translation>
+        <translation type="vanished">   ::   Fotograma: </translation>
     </message>
     <message>
         <source>   ::   Level: </source>
-        <translation>   ::   Nivel: </translation>
+        <translation type="vanished">   ::   Nivel: </translation>
     </message>
     <message>
         <source>Level: </source>
-        <translation>Nivel: </translation>
+        <translation type="vanished">Nivel: </translation>
     </message>
     <message>
         <source>  ::  Zoom : </source>
-        <translation>  ::  Zoom : </translation>
+        <translation type="vanished">  ::  Zoom : </translation>
     </message>
     <message>
         <source>Safe Area (Right Click to Select)</source>
-        <translation>Áreas de seguridad (clic derecho para seleccionar)</translation>
+        <translation type="vanished">Áreas de seguridad (clic derecho para seleccionar)</translation>
     </message>
     <message>
         <source>Field Guide</source>
@@ -14574,7 +15500,7 @@ Por favor enviar o revertir los cambios antes.</translation>
     </message>
     <message>
         <source> (Flipped)</source>
-        <translation> (Invertido)</translation>
+        <translation type="vanished"> (Invertido)</translation>
     </message>
     <message>
         <source>[SCENE]: </source>
@@ -14586,28 +15512,7 @@ Por favor enviar o revertir los cambios antes.</translation>
     </message>
     <message>
         <source>GUI Show / Hide</source>
-        <translation type="unfinished">Mostrar en interfaz</translation>
-    </message>
-    <message>
-        <source>Playback Toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Frame Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays
-Right click to adjust.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Grids and Overlays Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change camera view transparency.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Mostrar en interfaz</translation>
     </message>
 </context>
 <context>
@@ -14935,7 +15840,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Xsheet</source>
-        <translation type="vanished">Planilla</translation>
+        <translation>Planilla</translation>
     </message>
     <message>
         <source>Cells</source>
@@ -14947,7 +15852,7 @@ Right click to adjust.</source>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="vanished">Ventanas</translation>
+        <translation>Ventanas</translation>
     </message>
     <message>
         <source>Right-click Menu Commands</source>
@@ -15248,7 +16153,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>DPI:</source>
-        <translation type="vanished">PPP:</translation>
+        <translation>PPP:</translation>
     </message>
     <message>
         <source>X</source>
@@ -15288,23 +16193,23 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>pixel</source>
-        <translation type="vanished">píxeles</translation>
+        <translation>píxeles</translation>
     </message>
     <message>
         <source>cm</source>
-        <translation type="vanished">cm</translation>
+        <translation>cm</translation>
     </message>
     <message>
         <source>mm</source>
-        <translation type="vanished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
         <source>inch</source>
-        <translation type="vanished">pulgadas</translation>
+        <translation>pulgadas</translation>
     </message>
     <message>
         <source>field</source>
-        <translation type="vanished">campos</translation>
+        <translation>campos</translation>
     </message>
     <message>
         <source>Save In:</source>
@@ -15316,7 +16221,7 @@ Assign shortcut sequence anyway?</source>
     </message>
     <message>
         <source>Units:</source>
-        <translation type="vanished">Unidades:</translation>
+        <translation>Unidades:</translation>
     </message>
     <message>
         <source>No Recent Scenes</source>
@@ -15677,244 +16582,305 @@ What would you like to do?</source>
         <source>%1%2Move object along horizon</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Symmetry Tool: Set up symmetrical guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1%2Snap rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StopMotion</name>
     <message>
         <source>No</source>
         <comment>frame id</comment>
-        <translation type="vanished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <source>No level name specified: please choose a valid level name</source>
-        <translation type="vanished">No se ha especificado un nombre de nivel: por favor escoger un nombre válido</translation>
+        <translation>No se ha especificado un nombre de nivel: por favor escoger un nombre válido</translation>
     </message>
     <message>
         <source>The level name specified is already used: please choose a different level name.</source>
-        <translation type="vanished">El nombre de nivel especificado ya está en uso: por favor escoger un nombre diferente.</translation>
+        <translation>El nombre de nivel especificado ya está en uso: por favor escoger un nombre diferente.</translation>
     </message>
     <message>
         <source>The save in path specified does not match with the existing level.</source>
-        <translation type="vanished">La ruta especificada para guardar no coincide con la del nivel existente.</translation>
+        <translation>La ruta especificada para guardar no coincide con la del nivel existente.</translation>
     </message>
     <message>
         <source>The captured image size does not match with the existing level.</source>
-        <translation type="vanished">El tamaño de la imagen capturada no coincide con el del nivel existente.</translation>
+        <translation>El tamaño de la imagen capturada no coincide con el del nivel existente.</translation>
     </message>
     <message>
         <source>File %1 already exists.
 Do you want to overwrite it?</source>
-        <translation type="vanished">El archivo %1 ya existe.
+        <translation>El archivo %1 ya existe.
 ¿Sobrescribirlo?</translation>
     </message>
     <message>
         <source>Failed to load %1.</source>
-        <translation type="vanished">Falla al cargar %1.</translation>
+        <translation>Falla al cargar %1.</translation>
     </message>
     <message>
         <source>Folder %1 doesn&apos;t exist.
 Do you want to create it?</source>
-        <translation type="vanished">La carpeta %1 no existe.
+        <translation>La carpeta %1 no existe.
 ¿Crearla?</translation>
     </message>
     <message>
         <source>Unable to create</source>
-        <translation type="vanished">No es posible crearlo</translation>
+        <translation>No es posible crearlo</translation>
     </message>
     <message>
         <source>UNDEFINED WARNING</source>
-        <translation type="vanished">ADVERTENCIA NO DEFINIDA</translation>
+        <translation>ADVERTENCIA NO DEFINIDA</translation>
     </message>
     <message>
         <source>The level is not registered in the scene, but exists in the file system.</source>
-        <translation type="vanished">El nivel no se encuentra registrado en la escena, pero existe en el sistema de archivos.</translation>
+        <translation>El nivel no se encuentra registrado en la escena, pero existe en el sistema de archivos.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño de la imagen guardada es de %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING </source>
-        <translation type="vanished">ADVERTENCIA </translation>
+        <translation>ADVERTENCIA </translation>
     </message>
     <message>
         <source>
 Frame %1 exists.</source>
-        <translation type="vanished">
+        <translation>
 El fotograma %1 ya existe.</translation>
     </message>
     <message>
         <source>
 Frames %1 exist.</source>
-        <translation type="vanished">
+        <translation>
 Los fotogramas %1 ya existen.</translation>
     </message>
     <message>
         <source>OVERWRITE 1 of</source>
-        <translation type="vanished">SOBRESCRIBIR 1 de</translation>
+        <translation>SOBRESCRIBIR 1 de</translation>
     </message>
     <message>
         <source>ADD to</source>
-        <translation type="vanished">AGREGAR a</translation>
+        <translation>AGREGAR a</translation>
     </message>
     <message>
         <source> %1 frame</source>
-        <translation type="vanished"> %1 fotograma</translation>
+        <translation> %1 fotograma</translation>
     </message>
     <message>
         <source> %1 frames</source>
-        <translation type="vanished"> %1 fotogramas</translation>
+        <translation> %1 fotogramas</translation>
     </message>
     <message>
         <source>The level will be newly created.</source>
-        <translation type="vanished">El nivel se creará desde cero.</translation>
+        <translation>El nivel se creará desde cero.</translation>
     </message>
     <message>
         <source>NEW</source>
-        <translation type="vanished">NUEVO</translation>
+        <translation>NUEVO</translation>
     </message>
     <message>
         <source>The level is already registered in the scene.</source>
-        <translation type="vanished">El nivel ya se encuentra registrado en la escena.</translation>
+        <translation>El nivel ya se encuentra registrado en la escena.</translation>
     </message>
     <message>
         <source>
 NOTE : The level is not saved.</source>
-        <translation type="vanished">
+        <translation>
 NOTA : El nivel no está guardado.</translation>
     </message>
     <message>
         <source>
 WARNING : Failed to get image size of the existing level %1.</source>
-        <translation type="vanished">
+        <translation>
 ADVERTENCIA : No se pudo obtener el tamaño de imagen del nivel %1 ya existente.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel ya existente es %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
           %2.</source>
-        <translation type="vanished">ADVERTENCIA : Conflicto en el nombre del nivel. Ya existe un nivel %1 en la escena con la ruta                        
+        <translation>ADVERTENCIA : Conflicto en el nombre del nivel. Ya existe un nivel %1 en la escena con la ruta                        
           %2.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel con ese nombre es %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING : Level path conflicts. There already is a level with the path %1                        
           in the scene with the name %2.</source>
-        <translation type="vanished">ADVERTENCIA : Conflicto en la ruta del nivel. Ya existe un nivel con la ruta %1                        
+        <translation>ADVERTENCIA : Conflicto en la ruta del nivel. Ya existe un nivel con la ruta %1                        
           en la escena llamada %2.</translation>
     </message>
     <message>
         <source>
 WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
-        <translation type="vanished">
+        <translation>
 ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel con esa ruta es %1 x %2.</translation>
     </message>
     <message>
         <source>WARNING</source>
-        <translation type="vanished">ADVERTENCIA</translation>
+        <translation>ADVERTENCIA</translation>
     </message>
     <message>
         <source>No camera selected.</source>
-        <translation type="vanished">No se seleccionó una cámara.</translation>
+        <translation>No se seleccionó una cámara.</translation>
     </message>
     <message>
         <source>Please start live view before capturing an image.</source>
-        <translation type="vanished">Por favor iniciar Ver en vivo antes de capturar una imagen.</translation>
+        <translation>Por favor iniciar Ver en vivo antes de capturar una imagen.</translation>
     </message>
     <message>
         <source>Cannot capture webcam image unless live view is active.</source>
         <translation type="vanished">No es posible capturar imágenes con una cámara web a menos que Ver en vivo se encuentre activo.</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t capture an image with focus check on.
+Please click the Check button in the Settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully exported </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start Live View.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StopMotionController</name>
     <message>
         <source>Controls</source>
-        <translation type="vanished">Controles</translation>
+        <translation>Controles</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Opciones</translation>
+        <translation>Opciones</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">Preferencias</translation>
+        <translation>Preferencias</translation>
     </message>
     <message>
         <source>Resolution: </source>
-        <translation type="vanished">Resolución: </translation>
+        <translation>Resolución: </translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="vanished">Actualizar</translation>
+        <translation>Actualizar</translation>
     </message>
     <message>
         <source>File</source>
-        <translation type="vanished">Archivo</translation>
+        <translation>Archivo</translation>
     </message>
     <message>
         <source>Webcam Settings...</source>
-        <translation type="vanished">Opciones de cámara...</translation>
+        <translation>Opciones de cámara...</translation>
     </message>
     <message>
         <source>Capture</source>
-        <translation type="vanished">Capturar</translation>
+        <translation>Capturar</translation>
     </message>
     <message>
         <source>Next Level</source>
-        <translation type="vanished">Nivel siguiente</translation>
+        <translation>Nivel siguiente</translation>
     </message>
     <message>
         <source>Next New</source>
-        <translation type="vanished">Nuevo siguiente</translation>
+        <translation>Nuevo siguiente</translation>
     </message>
     <message>
         <source>Previous Level</source>
-        <translation type="vanished">Nivel anterior</translation>
+        <translation>Nivel anterior</translation>
     </message>
     <message>
         <source>Next Frame</source>
-        <translation type="vanished">Fotograma siguiente</translation>
+        <translation>Fotograma siguiente</translation>
     </message>
     <message>
         <source>Last Frame</source>
-        <translation type="vanished">Fotograma final</translation>
+        <translation>Fotograma final</translation>
     </message>
     <message>
         <source>Previous Frame</source>
-        <translation type="vanished">Fotograma anterior</translation>
+        <translation>Fotograma anterior</translation>
     </message>
     <message>
         <source>Next XSheet Frame</source>
-        <translation type="vanished">Fotograma siguiente en planilla</translation>
+        <translation>Fotograma siguiente en planilla</translation>
     </message>
     <message>
         <source>Previous XSheet Frame</source>
-        <translation type="vanished">Fotograma anterior en planilla</translation>
+        <translation>Fotograma anterior en planilla</translation>
     </message>
     <message>
         <source>Current Frame</source>
-        <translation type="vanished">Fotograma actual</translation>
+        <translation>Fotograma actual</translation>
     </message>
     <message>
         <source>Set to the Current Playhead Location</source>
-        <translation type="vanished">Llevar hasta cursor de tiempo actual</translation>
+        <translation>Llevar hasta cursor de tiempo actual</translation>
     </message>
     <message>
         <source>Start Live View</source>
-        <translation type="vanished">Ver en vivo</translation>
+        <translation>Ver en vivo</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -15926,39 +16892,39 @@ ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel con esa rut
     </message>
     <message>
         <source>&lt;</source>
-        <translation type="vanished">&lt;</translation>
+        <translation>&lt;</translation>
     </message>
     <message>
         <source>&gt;</source>
-        <translation type="vanished">&gt;</translation>
+        <translation>&gt;</translation>
     </message>
     <message>
         <source>&lt;&lt;</source>
-        <translation type="vanished">&lt;&lt;</translation>
+        <translation>&lt;&lt;</translation>
     </message>
     <message>
         <source>&gt;&gt;</source>
-        <translation type="vanished">&gt;&gt;</translation>
+        <translation>&gt;&gt;</translation>
     </message>
     <message>
         <source>&lt;&lt;&lt;</source>
-        <translation type="vanished">&lt;&lt;&lt;</translation>
+        <translation>&lt;&lt;&lt;</translation>
     </message>
     <message>
         <source>&gt;&gt;&gt;</source>
-        <translation type="vanished">&gt;&gt;&gt;</translation>
+        <translation>&gt;&gt;&gt;</translation>
     </message>
     <message>
         <source>Camera:</source>
-        <translation type="vanished">Cámara:</translation>
+        <translation>Cámara:</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="vanished">Nombre:</translation>
+        <translation>Nombre:</translation>
     </message>
     <message>
         <source>Frame:</source>
-        <translation type="vanished">Fotograma:</translation>
+        <translation>Fotograma:</translation>
     </message>
     <message>
         <source>File Type:</source>
@@ -15974,51 +16940,51 @@ ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel con esa rut
     </message>
     <message>
         <source>Camera Model</source>
-        <translation type="vanished">Modelo de cámara</translation>
+        <translation>Modelo de cámara</translation>
     </message>
     <message>
         <source>Camera Mode</source>
-        <translation type="vanished">Modo de cámara</translation>
+        <translation>Modo de cámara</translation>
     </message>
     <message>
         <source>Temperature: </source>
-        <translation type="vanished">Temperatura: </translation>
+        <translation>Temperatura: </translation>
     </message>
     <message>
         <source>Shutter Speed: </source>
-        <translation type="vanished">Velocidad de obturación: </translation>
+        <translation>Velocidad de obturación: </translation>
     </message>
     <message>
         <source>Iso: </source>
-        <translation type="vanished">ISO: </translation>
+        <translation>ISO: </translation>
     </message>
     <message>
         <source>Aperture: </source>
-        <translation type="vanished">Apertura: </translation>
+        <translation>Apertura: </translation>
     </message>
     <message>
         <source>Exposure: </source>
-        <translation type="vanished">Exposición: </translation>
+        <translation>Exposición: </translation>
     </message>
     <message>
         <source>Image Quality: </source>
-        <translation type="vanished">Calidad de imagen: </translation>
+        <translation>Calidad de imagen: </translation>
     </message>
     <message>
         <source>Picture Style: </source>
-        <translation type="vanished">Estilo de imagen: </translation>
+        <translation>Estilo de imagen: </translation>
     </message>
     <message>
         <source>White Balance: </source>
-        <translation type="vanished">Balance de blancos: </translation>
+        <translation>Balance de blancos: </translation>
     </message>
     <message>
         <source>Webcam Options</source>
-        <translation type="vanished">Cámaras web</translation>
+        <translation>Cámaras web</translation>
     </message>
     <message>
         <source>DSLR Options</source>
-        <translation type="vanished">Cámaras DSLR</translation>
+        <translation>Cámaras DSLR</translation>
     </message>
     <message>
         <source>Place the frame in the XSheet</source>
@@ -16026,7 +16992,7 @@ ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel con esa rut
     </message>
     <message>
         <source>Use Direct Show Webcam Drivers</source>
-        <translation type="vanished">Usar controladores de cámara web Direct Show</translation>
+        <translation>Usar controladores de cámara web Direct Show</translation>
     </message>
     <message>
         <source>Black Screen for Capture</source>
@@ -16038,23 +17004,23 @@ ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel con esa rut
     </message>
     <message>
         <source>Use MJPG with Webcam</source>
-        <translation type="vanished">Usar MJPG con cámaras web</translation>
+        <translation>Usar MJPG con cámaras web</translation>
     </message>
     <message>
         <source>Place on XSheet</source>
-        <translation type="vanished">Colocar en planilla</translation>
+        <translation>Colocar en planilla</translation>
     </message>
     <message>
         <source>Use Numpad Shortcuts When Active</source>
-        <translation type="vanished">Usar atajos del teclado numérico</translation>
+        <translation>Usar atajos del teclado numérico</translation>
     </message>
     <message>
         <source>Show Live View on All Frames</source>
-        <translation type="vanished">Mostrar la vista en vivo en todos los fotogramas</translation>
+        <translation>Mostrar la vista en vivo en todos los fotogramas</translation>
     </message>
     <message>
         <source>Capture Review Time: </source>
-        <translation type="vanished">Tiempo de revisión al capturar: </translation>
+        <translation>Tiempo de revisión al capturar: </translation>
     </message>
     <message>
         <source>Level Subsampling: </source>
@@ -16062,168 +17028,416 @@ ADVERTENCIA : Tamaño de imagen no coincidente. El tamaño del nivel con esa rut
     </message>
     <message>
         <source>Opacity:</source>
-        <translation type="vanished">Opacidad:</translation>
+        <translation>Opacidad:</translation>
     </message>
     <message>
         <source>No camera detected.</source>
-        <translation type="vanished">Ninguna cámara detectada.</translation>
+        <translation>Ninguna cámara detectada.</translation>
     </message>
     <message>
         <source>No camera detected</source>
-        <translation type="vanished">Ninguna cámara detectada</translation>
+        <translation>Ninguna cámara detectada</translation>
     </message>
     <message>
         <source>- Select camera -</source>
-        <translation type="vanished">- seleccionar -</translation>
+        <translation>- seleccionar -</translation>
     </message>
     <message>
         <source>Mode: </source>
-        <translation type="vanished">Modo: </translation>
+        <translation>Modo: </translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="vanished">Auto</translation>
+        <translation>Auto</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="vanished">Deshabilitada</translation>
+        <translation>Deshabilitada</translation>
     </message>
     <message>
         <source>Stop Live View</source>
-        <translation type="vanished">Detener en vivo</translation>
+        <translation>Detener en vivo</translation>
     </message>
     <message>
         <source>Image adjust</source>
-        <translation type="obsolete">Ajustes de imagen</translation>
+        <translation type="unfinished">Ajustes de imagen</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Color</translation>
+        <translation type="unfinished">Color</translation>
     </message>
     <message>
         <source>Grayscale</source>
-        <translation type="obsolete">Escala de grises</translation>
+        <translation type="unfinished">Escala de grises</translation>
     </message>
     <message>
         <source>Black &amp; White</source>
-        <translation type="obsolete">Blanco y negro</translation>
+        <translation type="unfinished">Blanco y negro</translation>
     </message>
     <message>
         <source>Brightness: </source>
-        <translation type="obsolete">Brillo: </translation>
+        <translation type="unfinished">Brillo: </translation>
     </message>
     <message>
         <source>Color type:</source>
-        <translation type="obsolete">Tipo de color:</translation>
+        <translation type="unfinished">Tipo de color:</translation>
     </message>
     <message>
         <source>Interval(sec):</source>
-        <translation type="obsolete">Intervalo(seg):</translation>
+        <translation type="unfinished">Intervalo(seg):</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expose as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scene Frame:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image Size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Shot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation type="unfinished">Cargar</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Exportar</translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Camera Calibration.
+Right-click for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Place the frame in the Scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use current frame as overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the current scene frame as an overlay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Live View Offset: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to find complete checkerboard pattern. Check pattern position and camera settings.
+
+Print and use %1 to calibrate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load %1</source>
+        <translation type="unfinished">No fue posible cargar %1</translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t save %1</source>
+        <translation type="unfinished">No fue posible guardar %1</translation>
     </message>
 </context>
 <context>
     <name>StopMotionSaveInFolderPopup</name>
     <message>
         <source>Create the Destination Subfolder to Save</source>
-        <translation type="obsolete">Crear la subcarpeta de destino donde guardar</translation>
+        <translation type="unfinished">Crear la subcarpeta de destino donde guardar</translation>
     </message>
     <message>
         <source>Set As Default</source>
-        <translation type="obsolete">Establecer como predefinida</translation>
+        <translation type="unfinished">Establecer como predefinida</translation>
     </message>
     <message>
         <source>Set the current &quot;Save In&quot; path as the default.</source>
-        <translation type="obsolete">Establecer la ruta actual de &quot;Guardar en&quot; como ruta predefinida.</translation>
+        <translation type="unfinished">Establecer la ruta actual de &quot;Guardar en&quot; como ruta predefinida.</translation>
     </message>
     <message>
         <source>Create Subfolder</source>
-        <translation type="obsolete">Crear subcarpeta</translation>
+        <translation type="unfinished">Crear subcarpeta</translation>
     </message>
     <message>
         <source>Infomation</source>
-        <translation type="obsolete">Información</translation>
+        <translation type="unfinished">Información</translation>
     </message>
     <message>
         <source>Subfolder Name</source>
-        <translation type="obsolete">Nombre de la subcarpeta</translation>
+        <translation type="unfinished">Nombre de la subcarpeta</translation>
     </message>
     <message>
         <source>Auto Format:</source>
-        <translation type="obsolete">Formato autom:</translation>
+        <translation type="unfinished">Formato autom:</translation>
     </message>
     <message>
         <source>Show This on Launch of the Camera Capture</source>
-        <translation type="obsolete">Mostrar esto al iniciar Capturar con cámara</translation>
+        <translation type="unfinished">Mostrar esto al iniciar Capturar con cámara</translation>
     </message>
     <message>
         <source>Save Scene in Subfolder</source>
-        <translation type="obsolete">Guardar escena en subcarpeta</translation>
+        <translation type="unfinished">Guardar escena en subcarpeta</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">Aceptar</translation>
+        <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
         <source>C- + Sequence + Scene</source>
-        <translation type="obsolete">C- + secuencia + escena</translation>
+        <translation type="unfinished">C- + secuencia + escena</translation>
     </message>
     <message>
         <source>Sequence + Scene</source>
-        <translation type="obsolete">secuencia + escena</translation>
+        <translation type="unfinished">secuencia + escena</translation>
     </message>
     <message>
         <source>Episode + Sequence + Scene</source>
-        <translation type="obsolete">episodio + secuencia + escena</translation>
+        <translation type="unfinished">episodio + secuencia + escena</translation>
     </message>
     <message>
         <source>Project + Episode + Sequence + Scene</source>
-        <translation type="obsolete">proyecto + episodio + secuencia + escena</translation>
+        <translation type="unfinished">proyecto + episodio + secuencia + escena</translation>
     </message>
     <message>
         <source>Save the current scene in the subfolder.
 Set the output folder path to the subfolder as well.</source>
-        <translation type="obsolete">Guardar la escena actual en la subcarpeta.
+        <translation type="unfinished">Guardar la escena actual en la subcarpeta.
 También establecer la ruta de salida a esa carpeta.</translation>
     </message>
     <message>
         <source>Save In:</source>
-        <translation type="obsolete">Guardar en:</translation>
+        <translation type="unfinished">Guardar en:</translation>
     </message>
     <message>
         <source>Project:</source>
-        <translation type="obsolete">Proyecto:</translation>
+        <translation type="unfinished">Proyecto:</translation>
     </message>
     <message>
         <source>Episode:</source>
-        <translation type="obsolete">Episodio:</translation>
+        <translation type="unfinished">Episodio:</translation>
     </message>
     <message>
         <source>Sequence:</source>
-        <translation type="obsolete">Secuencia:</translation>
+        <translation type="unfinished">Secuencia:</translation>
     </message>
     <message>
         <source>Scene:</source>
-        <translation type="obsolete">Escena:</translation>
+        <translation type="unfinished">Escena:</translation>
     </message>
     <message>
         <source>Subfolder Name:</source>
-        <translation type="obsolete">Nombre de subcarpeta:</translation>
+        <translation type="unfinished">Nombre de subcarpeta:</translation>
     </message>
     <message>
         <source>Subfolder name should not be empty.</source>
-        <translation type="obsolete">El nombre de la subcarpeta no puede estar vacío.</translation>
+        <translation type="unfinished">El nombre de la subcarpeta no puede estar vacío.</translation>
     </message>
     <message>
         <source>Subfolder name should not contain following characters:  * . &quot; / \ [ ] : ; | = , </source>
-        <translation type="obsolete">El nombre de la subcarpeta no puede contener los siguientes caracteres:  * . &quot; / \ [ ] : ; | = , </translation>
+        <translation type="unfinished">El nombre de la subcarpeta no puede contener los siguientes caracteres:  * . &quot; / \ [ ] : ; | = , </translation>
     </message>
     <message>
         <source>Folder %1 already exists.</source>
-        <translation type="obsolete">La carpeta %1 ya existe.</translation>
+        <translation type="unfinished">La carpeta %1 ya existe.</translation>
     </message>
     <message>
         <source>It is not possible to create the %1 folder.</source>
-        <translation type="obsolete">No es posible crear la carpeta %1.</translation>
+        <translation type="unfinished">No es posible crear la carpeta %1.</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -16414,6 +17628,25 @@ Clic en el botón con la flecha para crear una nueva sub-planilla</translation>
     </message>
     <message>
         <source>Perspective Grids</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Symmetry Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16783,6 +18016,10 @@ Clic en el botón con la flecha para crear una nueva sub-planilla</translation>
     <message>
         <source>Expand toolbar</source>
         <translation>Expandir barra de herramientas</translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -17227,11 +18464,11 @@ Por favor ver la guía de usuario para obtener más detalles.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbetween symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reverse sheet symbol mark</source>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17540,6 +18777,21 @@ Por favor ver la guía de usuario para obtener más detalles.</translation>
     </message>
 </context>
 <context>
+    <name>XsheetGUI::FooterNoteArea</name>
+    <message>
+        <source>Add New Memo</source>
+        <translation type="unfinished">Agregar nueva nota</translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation type="unfinished">Nota anterior</translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation type="unfinished">Nota siguiente</translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::NoteArea</name>
     <message>
         <source>Frame</source>
@@ -17559,7 +18811,7 @@ Por favor ver la guía de usuario para obtener más detalles.</translation>
     </message>
     <message>
         <source>Toggle Xsheet/Timeline</source>
-        <translation type="vanished">Alternar planilla / línea de tiempo</translation>
+        <translation>Alternar planilla / línea de tiempo</translation>
     </message>
     <message>
         <source>Add New Memo</source>
@@ -17690,6 +18942,12 @@ Mantener presionada la tecla F3 para ver sólo este fotograma en el visor</trans
     </message>
     <message>
         <source>Frame %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1+Click	- Set Playback Start Marker
+%2+Click 	- Set Playback End Marker
+%3+Click	- Remove Playback Markers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/spanish/toonzlib.ts
+++ b/toonz/sources/translations/spanish/toonzlib.ts
@@ -664,6 +664,34 @@
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Load From File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use As Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation(degrees)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X displ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y displ</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Rasterizer</name>

--- a/toonz/sources/translations/spanish/toonzqt.ts
+++ b/toonz/sources/translations/spanish/toonzqt.ts
@@ -27,6 +27,14 @@
         <source>Replace </source>
         <translation>Reemplazar</translation>
     </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddWordButton</name>
@@ -167,7 +175,7 @@ Es posible que el archivo de dicho ajuste se encuentre corrupto.</translation>
     </message>
     <message>
         <source>A/R</source>
-        <translation type="vanished">Proporción</translation>
+        <translation>Proporción</translation>
     </message>
     <message>
         <source>&lt;custom&gt;</source>
@@ -175,6 +183,26 @@ Es posible que el archivo de dicho ajuste se encuentre corrupto.</translation>
     </message>
     <message>
         <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pixel</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -268,36 +296,31 @@ Es posible que el archivo de dicho ajuste se encuentre corrupto.</translation>
     <name>ColorChannelControl</name>
     <message>
         <source>R</source>
-        <translation type="unfinished">R</translation>
+        <translation type="obsolete">R</translation>
     </message>
     <message>
         <source>G</source>
-        <translation type="unfinished">V</translation>
+        <translation type="obsolete">V</translation>
     </message>
     <message>
         <source>B</source>
-        <translation type="unfinished">A</translation>
+        <translation type="obsolete">A</translation>
     </message>
     <message>
         <source>A</source>
-        <translation type="unfinished">α</translation>
+        <translation type="obsolete">α</translation>
     </message>
     <message>
         <source>H</source>
-        <translation type="unfinished">T</translation>
+        <translation type="obsolete">T</translation>
     </message>
     <message>
         <source>S</source>
-        <translation type="unfinished">S</translation>
+        <translation type="obsolete">S</translation>
     </message>
     <message>
         <source>V</source>
-        <translation type="unfinished">V</translation>
-    </message>
-    <message>
-        <source>Alpha controls the transparency. 
-Zero is fully transparent.</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">V</translation>
     </message>
 </context>
 <context>
@@ -347,6 +370,14 @@ Zero is fully transparent.</source>
     <message>
         <source>R:%1 G:%2 B:%3</source>
         <translation>R:%1 V:%2 A:%3</translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A:%1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -833,6 +864,27 @@ Control click to reset.</source>
     </message>
     <message>
         <source>&amp;Next Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the &quot;neutral&quot; or 1.0 gain f-stop is f/8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1784,7 +1836,7 @@ Seleccionar los nodos de efecto y sus vínculos relacionados antes de copiar o c
     </message>
     <message>
         <source>New Page</source>
-        <translation>Nueva página</translation>
+        <translation type="vanished">Nueva página</translation>
     </message>
     <message>
         <source>- No Styles -</source>
@@ -1792,7 +1844,7 @@ Seleccionar los nodos de efecto y sus vínculos relacionados antes de copiar o c
     </message>
     <message>
         <source>Name Editor</source>
-        <translation type="unfinished">Editor de nombres</translation>
+        <translation type="obsolete">Editor de nombres</translation>
     </message>
     <message>
         <source> + </source>
@@ -1970,6 +2022,22 @@ It can&apos;t be changed.  Ever.</source>
         <source>Show New Style Button</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">Editor de nombres</translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PaletteViewerGUI::PageViewer</name>
@@ -2032,6 +2100,12 @@ It can&apos;t be changed.  Ever.</source>
     </message>
     <message>
         <source>View help page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2701,6 +2775,139 @@ Are you sure?</source>
 Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation type="unfinished">Editor de nombres</translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation type="unfinished">Nuevo estilo</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation type="unfinished">Nueva página</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished">R</translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation type="unfinished">α</translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished">T</translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished">S</translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <source>Alpha controls the transparency. 
+Zero is fully transparent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Selected to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Selected to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Selected from Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Set to Palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Style Set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scan for Style Set Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove &apos;%1&apos; Style Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation type="unfinished">Pintar (líneas) automáticamente al rellenar</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished">Restablecer a predefinido</translation>
+    </message>
 </context>
 <context>
     <name>QPushButton</name>
@@ -2839,11 +3046,11 @@ Are you sure?</source>
     <name>SettingsPage</name>
     <message>
         <source>Autopaint for Lines</source>
-        <translation type="unfinished">Pintar (líneas) automáticamente al rellenar</translation>
+        <translation type="obsolete">Pintar (líneas) automáticamente al rellenar</translation>
     </message>
     <message>
         <source>Reset to default</source>
-        <translation type="unfinished">Restablecer a predefinido</translation>
+        <translation type="obsolete">Restablecer a predefinido</translation>
     </message>
 </context>
 <context>
@@ -3087,85 +3294,6 @@ Are you sure ?</source>
     </message>
 </context>
 <context>
-    <name>StyleChooserPage</name>
-    <message>
-        <source>Style Set Manager:              %1+click - Add Style to Palette              %2+click - Multi-Style Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Selected to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move Selected to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove Selected from Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add to Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move to Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove from Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add Set to Palette</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rename Style Set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Scan for Style Set Changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remove &apos;%1&apos; Style Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>StyleEditor</name>
     <message>
         <source>Apply</source>
@@ -3364,6 +3492,22 @@ Autom</translation>
     </message>
     <message>
         <source>Style Set Name already exists. Please try another name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Auto/Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Auto/Apply</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/toonz/sources/translations/update.sh
+++ b/toonz/sources/translations/update.sh
@@ -15,3 +15,7 @@ lupdate ../../toonzlib/ -ts toonzlib.ts
 lupdate ../../toonzqt/ -ts toonzqt.ts
 lupdate ../../image/ -ts image.ts
 
+if [ "$OSTYPE" = "msys" ]
+then
+   unix2dos *.ts
+fi

--- a/toonz/sources/translations/update.sh
+++ b/toonz/sources/translations/update.sh
@@ -10,7 +10,7 @@ cd "${BASE_DIR}/${TOONZLANG}"
 lupdate ../../colorfx/ -ts colorfx.ts
 lupdate ../../common/ -ts tnzcore.ts
 lupdate ../../tnztools/ -ts tnztools.ts
-lupdate ../../toonz/ -ts toonz.ts
+lupdate ../../toonz/ ../../stopmotion/ -ts toonz.ts
 lupdate ../../toonzlib/ -ts toonzlib.ts
 lupdate ../../toonzqt/ -ts toonzqt.ts
 lupdate ../../image/ -ts image.ts

--- a/toonz/sources/translations/updateAll.sh
+++ b/toonz/sources/translations/updateAll.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Usage: updateAll.sh
+
+BASE_DIR=$(cd `dirname "$0"`; pwd)
+
+for TOONZLANG in `ls`
+do
+
+if [ -d "${BASE_DIR}/${TOONZLANG}" ]
+then
+   echo "./update.sh $TOONZLANG"
+   ./update.sh $TOONZLANG
+fi
+
+done


### PR DESCRIPTION
This PR deals with untranslatable text as follows

- Adds recently added brazilian-portuguese to the build list
- Fixes untranslatable text in the following areas
  - Stop Motion panel
  - Motion Path panel
  - Project Management popup
  - Preview/Output Settings popup
  - Locator window (in level edit mode)
  - Style Editor panel
  - Palette viewer panel
- Enables translation in the following areas
  - Default room names
  - Splash screen
  - FX lists and settings (see note below)
  - Style Editor MyPaint (Raster) settings  (see note below)
  
NOTE:
FX lists/settings and MyPaint settings text are not translatable via Qt Linguist because the text isn't directly accessible in code.  

T2D already provides a method of providing translations for external text via a string lookup table file (`current.txt`) which has been primarily used by FX settings.  I've broadened the use of this system.

In order to provide translations for external text, you need to do the following :
  - Copy `stuff/config/current.txt` to `stuff/config/loc/language/current.txt`
  - Modify the strings in `stuff/config/loc/language/current.txt`

Language specific current.txt is loaded after the original current.txt so if anything is missing in the language specific version, the English translation will still show.

Language specific current.txt will not be automatically maintained when FX are added or updated.  It will be up to the language translators to update the file with missing/modified entries.