### PR TITLE
Fix crashrpt initialization creating bad directories

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -253,12 +253,6 @@ static void script_output(int type, const QString &value) {
 }
 
 //-----------------------------------------------------------------------------
-#ifdef WITH_CRASHRPT
-LPCWSTR convertToLPCWSTR(std::string str) {
-  std::wstring stemp = std::wstring(str.begin(), str.end());
-  return stemp.c_str();
-}
-#endif
 
 int main(int argc, char *argv[]) {
 #ifdef Q_OS_WIN
@@ -513,15 +507,26 @@ int main(int argc, char *argv[]) {
   initToonzEnv(argumentPathValues);
 
 #ifdef WITH_CRASHRPT
+  std::string str;
+
   CR_INSTALL_INFO pInfo;
   memset(&pInfo, 0, sizeof(CR_INSTALL_INFO));
-  pInfo.cb = sizeof(CR_INSTALL_INFO);
-  pInfo.pszAppName = convertToLPCWSTR(TEnv::getApplicationName());
-  pInfo.pszAppVersion = convertToLPCWSTR(TEnv::getApplicationVersion());
+  pInfo.cb                 = sizeof(CR_INSTALL_INFO);
+
+  str                      = TEnv::getApplicationName();
+  std::wstring wAppName    = std::wstring(str.begin(), str.end());
+  pInfo.pszAppName         = wAppName.c_str();
+
+  str                      = TEnv::getApplicationVersion();
+  std::wstring wAppVersion = std::wstring(str.begin(), str.end());
+  pInfo.pszAppVersion      = wAppVersion.c_str();
+
   TFilePath crashrptCache =
-    ToonzFolder::getCacheRootFolder() + TFilePath("crashrpt");
-  pInfo.pszErrorReportSaveDir =
-    convertToLPCWSTR(crashrptCache.getQString().toStdString());
+      ToonzFolder::getCacheRootFolder() + TFilePath("crashrpt");
+  str                         = crashrptCache.getQString().toStdString();
+  std::wstring wRptdir        = std::wstring(str.begin(), str.end());
+  pInfo.pszErrorReportSaveDir = wRptdir.c_str();
+
   // Install all available exception handlers.
   // Don't send reports automaticall, store locally
   pInfo.dwFlags |= CR_INST_ALL_POSSIBLE_HANDLERS | CR_INST_DONT_SEND_REPORT;


### PR DESCRIPTION
This PR fixes an issue with T2D randomly creating garbage directories when starting up.  

It was caused by a memory leak when setting up the configuration for initializing the crashrpt module. The end result caused the path for the crashrpt folder in the user's cache folder to be garbled and create garbage folders usually in the Tahoma2D directory but could also appear on the C: drive or main drive the T2D folder was in.