### PR TITLE
Revert "Revert Linux builds to Ubuntu 18.04"

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         compiler: [ gcc, clang ]

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo add-apt-repository --yes ppa:beineri/opt-qt-5.15.2-bionic
+sudo add-apt-repository --yes ppa:beineri/opt-qt-5.15.2-focal
 sudo apt-get update
 sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt515script libsuperlu-dev qt515svg qt515tools qt515multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg-turbo8-dev libturbojpeg0-dev libglib2.0-dev qt515serialport
 # Removed: libopenjpeg-dev 

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,8 +1,5 @@
-﻿if(WIN32 AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25.0") 
-    message("Enabling CMP0141")
-    cmake_policy(SET CMP0141 NEW)
-    set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)
-endif()
+﻿cmake_policy(SET CMP0141 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)
 
 cmake_minimum_required(VERSION 2.8.11)
 


### PR DESCRIPTION
This reverts commit 05797320f4d02e140fa9b0537ec2bcf12763977b.

This will switch Linux builds back to building on Ubuntu 20.04 since Ubuntu 18.04 is no longer supported by Github and linuxdeployqt finally updated to support Ubuntu 20.04.

Will merge once successful so nightly linux versions can be built.