### PR TITLE
Fix rpath in macOS packaged libraries

### DIFF
--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -81,10 +81,10 @@ $QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -verbose=0 -always-overwrite \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/tfarmserver 
 
 echo ">>> Correcting library paths"
-for X in `find $TOONZDIR/Tahoma2D.app/Contents -type f '(' -name *.dylib -o -name *.so ')' -exec otool -l {} \; | grep -e "^toonz" -e"name \/usr\/local" | sed -e"s/://" -e"s/ (.*$//" -e"s/^ *name //"`
+for X in `find $TOONZDIR/Tahoma2D.app/Contents -type f '(' -name *.dylib -o -name *.so ')' -exec otool -l {} \; | grep -e "^toonz" -e"name \/usr\/local" -e"@rpath" | sed -e"s/://" -e"s/ (.*$//" -e"s/^ *name //"`
 do
    Z=`echo $X | cut -c 1-1`
-   if [ "$Z" != "/" ]
+   if [ "$Z" != "/" -a "$Z" != "@" ]
    then
       LIBFILE=$X
    else


### PR DESCRIPTION
This PR fixes #1154 caused by recent updates to Homebrew's webp libraries.  They have new dependencies defined using `@rpath` which causes T2D not to find them at startup.

Updated the packaging script to scan packaged library files for dependencies defined with `@rpath` and converting them to `@executable_path`.

Assumption: macdeployqt copied the `@rpath` file into the `@executable_path` along with all the other relevant library files.