### PR TITLE
Fix Smart Raster Brush Lock Alpha Tone

### DIFF
--- a/toonz/sources/tnztools/bluredbrush.cpp
+++ b/toonz/sources/tnztools/bluredbrush.cpp
@@ -52,10 +52,14 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
           continue;
         }
         bool sameStyleId = styleId == outPix->getInk();
+        // line with lock alpha : use original pixel's tone
         // line with the same style : multiply tones
         // line with different style : pick darker tone
-        int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
-                               : std::min(255 - inPix->m, outPix->getTone());
+        int tone = lockAlpha
+                       ? outPix->getTone()
+                       : sameStyleId
+                             ? outPix->getTone() * (255 - inPix->m) / 255
+                             : std::min(255 - inPix->m, outPix->getTone());
         int ink  = !sameStyleId && outPix->getTone() < 255 - inPix->m
                        ? outPix->getInk()
                        : styleId;

--- a/toonz/sources/tnztools/mypainttoonzbrush.cpp
+++ b/toonz/sources/tnztools/mypainttoonzbrush.cpp
@@ -34,10 +34,13 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         continue;
       }
       bool sameStyleId = styleId == outPix->getInk();
+      // line with lock alpha : use original pixel's tone
       // line with the same style : multiply tones
       // line with different style : pick darker tone
-      int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
-                             : std::min(255 - inPix->m, outPix->getTone());
+      int tone = lockAlpha ? outPix->getTone()
+                           : sameStyleId
+                                 ? outPix->getTone() * (255 - inPix->m) / 255
+                                 : std::min(255 - inPix->m, outPix->getTone());
       int ink = !sameStyleId && outPix->getTone() < 255 - inPix->m
                     ? outPix->getInk()
                     : styleId;

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -234,7 +234,8 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
           }
         }
         if (inTone <= outTone) {
-          *outPix = TPixelCM32(inPix->getInk(), outPix->getPaint(), inTone);
+          *outPix = TPixelCM32(inPix->getInk(), outPix->getPaint(),
+                               m_modifierLockAlpha ? outTone : inTone);
         }
       }
       if (m_task == ERASE) {


### PR DESCRIPTION
This PR fixes Smart Raster Brush Tool's tone when `Lock Alpha` is enabled.

It corrects the brush (aliased, anti-aliased, MyPaint) so it accounts for the original pixel's tone when drawing.  This will make the results of drawing with `Lock Alpha` look the same as if painting lines with the Smart Raster Paint tool .

<img src="https://user-images.githubusercontent.com/19245851/232034217-9bfebbe2-bc7a-40cc-a0fb-47968547aff1.png" width="75%" height="75%" />
