### PR TITLE
Reset cell selection size on navigation

### DIFF
--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -51,13 +51,10 @@ public:
         return;
 
       int row = TApp::instance()->getCurrentFrame()->getFrame();
+      int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
       TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
           TApp::instance()->getCurrentSelection()->getSelection());
-      if (cellSelection) {
-        int r0, r1, c0, c1;
-        cellSelection->getSelectedCells(r0, c0, r1, c1);
-        cellSelection->selectCells(row, c0, r1 + (row - r0), c1);
-      }
+      if (cellSelection) cellSelection->selectCells(row, col, row, col);
     }
   }
 };
@@ -85,11 +82,7 @@ public:
 
         TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
             TApp::instance()->getCurrentSelection()->getSelection());
-        if (cellSelection) {
-          int r0, r1, c0, c1;
-          cellSelection->getSelectedCells(r0, c0, r1, c1);
-          cellSelection->selectCells(row, c0, r1 + (row - r0), c1);
-        }
+        if (cellSelection) cellSelection->selectCells(row, col, row, col);
         break;
       }
     }
@@ -128,11 +121,7 @@ public:
 
       TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
           TApp::instance()->getCurrentSelection()->getSelection());
-      if (cellSelection) {
-        int r0, r1, c0, c1;
-        cellSelection->getSelectedCells(r0, c0, r1, c1);
-        cellSelection->selectCells(row, c0, r1 + (row - r0), c1);
-      }
+      if (cellSelection) cellSelection->selectCells(row, col, row, col);
     }
   }
 };
@@ -145,17 +134,15 @@ public:
 
   void execute() override {
     int row  = TApp::instance()->getCurrentFrame()->getFrame();
+    int col  = TApp::instance()->getCurrentColumn()->getColumnIndex();
     int step = Preferences::instance()->getXsheetStep();
 
     TApp::instance()->getCurrentFrame()->setFrame(row + step);
 
     TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
         TApp::instance()->getCurrentSelection()->getSelection());
-    if (cellSelection) {
-      int r0, r1, c0, c1;
-      cellSelection->getSelectedCells(r0, c0, r1, c1);
-      cellSelection->selectCells(r0 + step, c0, r1 + step, c1);
-    }
+    if (cellSelection)
+      cellSelection->selectCells(row + step, col, row + step, col);
   }
 };
 
@@ -167,17 +154,15 @@ public:
 
   void execute() override {
     int row  = TApp::instance()->getCurrentFrame()->getFrame();
+    int col  = TApp::instance()->getCurrentColumn()->getColumnIndex();
     int step = Preferences::instance()->getXsheetStep();
 
     TApp::instance()->getCurrentFrame()->setFrame(std::max(row - step, 0));
 
     TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
         TApp::instance()->getCurrentSelection()->getSelection());
-    if (cellSelection) {
-      int r0, r1, c0, c1;
-      cellSelection->getSelectedCells(r0, c0, r1, c1);
-      cellSelection->selectCells(r0 - step, c0, r1 - step, c1);
-    }
+    if (cellSelection)
+      cellSelection->selectCells(row - step, col, row - step, col);
   }
 };
 
@@ -230,13 +215,10 @@ public:
           TApp::instance()->getCurrentFrame()->emitTriggerNextKeyframe(panel);
 
           int row = TApp::instance()->getCurrentFrame()->getFrame();
+          int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
           TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
               TApp::instance()->getCurrentSelection()->getSelection());
-          if (cellSelection) {
-            int r0, r1, c0, c1;
-            cellSelection->getSelectedCells(r0, c0, r1, c1);
-            cellSelection->selectCells(row, c0, r1 + (row - r0), c1);
-          }
+          if (cellSelection) cellSelection->selectCells(row, col, row, col);
           break;
         } else
           panel = TApp::instance()->getActiveViewer()->parentWidget();
@@ -268,13 +250,10 @@ public:
           TApp::instance()->getCurrentFrame()->emitTriggerPrevKeyframe(panel);
 
           int row = TApp::instance()->getCurrentFrame()->getFrame();
+          int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
           TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
               TApp::instance()->getCurrentSelection()->getSelection());
-          if (cellSelection) {
-            int r0, r1, c0, c1;
-            cellSelection->getSelectedCells(r0, c0, r1, c1);
-            cellSelection->selectCells(row, c0, r1 + (row - r0), c1);
-          }
+          if (cellSelection) cellSelection->selectCells(row, col, row, col);
           break;
         } else
           panel = TApp::instance()->getActiveViewer()->parentWidget();

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2801,6 +2801,7 @@ public:
   void execute() override {
     TApp *app = TApp::instance();
     int frame = app->getCurrentFrame()->getFrame();
+    int col   = app->getCurrentColumn()->getColumnIndex();
     assert(frame >= 0);
     TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
 
@@ -2810,11 +2811,8 @@ public:
       app->getCurrentXsheetViewer()->setCurrentRow(nextFrame);
       TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
           TApp::instance()->getCurrentSelection()->getSelection());
-      if (cellSelection) {
-        int r0, r1, c0, c1;
-        cellSelection->getSelectedCells(r0, c0, r1, c1);
-        cellSelection->selectCells(nextFrame, c0, r1 + (nextFrame - r0), c1);
-      }
+      if (cellSelection)
+        cellSelection->selectCells(nextFrame, col, nextFrame, col);
     }
   }
 } NextTaggedFrame;
@@ -2827,6 +2825,7 @@ public:
   void execute() override {
     TApp *app = TApp::instance();
     int frame = app->getCurrentFrame()->getFrame();
+    int col   = app->getCurrentColumn()->getColumnIndex();
     assert(frame >= 0);
     TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
 
@@ -2836,11 +2835,8 @@ public:
       app->getCurrentXsheetViewer()->setCurrentRow(prevFrame);
       TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
           TApp::instance()->getCurrentSelection()->getSelection());
-      if (cellSelection) {
-        int r0, r1, c0, c1;
-        cellSelection->getSelectedCells(r0, c0, r1, c1);
-        cellSelection->selectCells(prevFrame, c0, r1 + (prevFrame - r0), c1);
-      }
+      if (cellSelection)
+        cellSelection->selectCells(prevFrame, col, prevFrame, col);
     }
   }
 } PrevTaggedFrame;


### PR DESCRIPTION
This is a follow up to PR #1116.

When there is a multi-cell selection and you navigate the timeline/xsheet via shortcuts, the cell selection size will reset to 1 cell, the new current cell.