### PR TITLE
Fix Canvas Size Units showing incorrectly

### DIFF
--- a/toonz/sources/toonz/canvassizepopup.cpp
+++ b/toonz/sources/toonz/canvassizepopup.cpp
@@ -548,7 +548,9 @@ CanvasSizePopup::CanvasSizePopup()
   m_unit->addItem(tr("field"), "field");
   m_unit->addItem(tr("inch"), "inch");
   m_unit->setFixedHeight(DVGui::WidgetHeight);
+  m_unit->hide();
   if (Preferences::instance()->isShowAdvancedOptionsEnabled()) {
+    m_unit->show();
     addWidget(tr("Unit:"), m_unit);
     connect(m_unit, SIGNAL(currentIndexChanged(int)), this,
             SLOT(onUnitChanged(int)));


### PR DESCRIPTION
This fixes the issue where `Units` combo box shows up in the `Canvas Size...` popup even though `Show Advanced Preferences and Options` is not selected.