### PR TITLE
Fix more implicit issues

### DIFF
--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -593,7 +593,7 @@ in TXsheetImp.
   bool isReferenceManagementIgnored(TDoubleParam *);
 
   void convertToImplicitHolds();
-  void convertToExplicitHolds();
+  void convertToExplicitHolds(int endPlayRange);
 
   NavigationTags *getNavigationTags() const { return m_navigationTags; }
   bool isFrameTagged(int frame) const;

--- a/toonz/sources/toonz/previewfxmanager.cpp
+++ b/toonz/sources/toonz/previewfxmanager.cpp
@@ -558,6 +558,9 @@ void PreviewFxInstance::updateFrameRange() {
   properties->getRange(m_start, m_end, m_step);
   if (m_end < 0) m_end = frameCount - 1;
 
+  if (m_end >= frameCount && Preferences::instance()->isImplicitHoldEnabled())
+    frameCount = m_end;
+
   // Intersect with the fx active frame range
   TRasterFxP rasterFx(m_fx);
   TFxTimeRegion timeRegion(rasterFx->getTimeRegion());

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -1283,39 +1283,6 @@ void removeFx(TXsheet *xsh, TFx *fx) {
 
 //-----------------------------------------------------------------------------
 
-int getChildFrameCount(TXsheet *childXsh) {
-  if (!childXsh) return 0;
-
-  int frameCount = childXsh->getFrameCount();
-
-  // For implicit holds, use last Stop Frame marker or last Key frame marker as
-  // frame count
-  if (Preferences::instance()->isImplicitHoldEnabled()) {
-    for (int c = 0; c < childXsh->getColumnCount(); c++) {
-      int r0, r1;
-
-      r1            = childXsh->getMaxFrame(c);
-      TXshCell cell = childXsh->getCell(r1, c);
-      // If last frame is a stop frame, don't check for keyframe in the same
-      // column in case of overshoot
-      if (cell.getFrameId().isStopFrame()) {
-        frameCount = std::max(frameCount, (r1 + 1));
-        continue;
-      }
-
-      TStageObject *pegbar =
-          childXsh->getStageObject(TStageObjectId::ColumnId(c));
-      if (!pegbar) continue;
-      if (!pegbar->getKeyframeRange(r0, r1)) continue;
-      frameCount = std::max(frameCount, (r1 + 1));
-    }
-  }
-
-  return frameCount;
-}
-
-//-----------------------------------------------------------------------------
-
 void collapseColumns(std::set<int> indices, bool columnsOnly) {
   // return if there is no selected columns
   if (indices.empty()) return;
@@ -1371,7 +1338,7 @@ void collapseColumns(std::set<int> indices, bool columnsOnly) {
   xsh->insertColumn(index);
 
   // set subxsheet cells in the parent xhseet
-  int r, rowCount = getChildFrameCount(childXsh);
+  int r, rowCount = childXsh->getFrameCount();
   for (r = 0; r < rowCount; ++r)
     xsh->setCell(r, index, TXshCell(xl, TFrameId(r + 1)));
 
@@ -1474,7 +1441,7 @@ void collapseColumns(std::set<int> indices,
 
   xsh->insertColumn(index);
 
-  int r, rowCount = getChildFrameCount(childXsh);
+  int r, rowCount = childXsh->getFrameCount();
   for (r = 0; r < rowCount; r++)
     xsh->setCell(r, index, TXshCell(xl, TFrameId(r + 1)));
 
@@ -1548,7 +1515,7 @@ void collapseColumns(std::set<int> indices, const std::set<TFx *> &fxs,
     if (output) xsh->getFxDag()->removeOutputFx(output);
   }
 
-  int rowCount = getChildFrameCount(childXsh);
+  int rowCount = childXsh->getFrameCount();
   int r;
   for (r = 0; r < rowCount; r++)
     xsh->setCell(r, index, TXshCell(xl, TFrameId(r + 1)));

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1451,7 +1451,9 @@ static void convertHoldType(int holdType) {
     xsh->convertToImplicitHolds();
     if (action && !action->isChecked()) action->trigger();
   } else {
-    xsh->convertToExplicitHolds();
+    int r0, r1, step;
+    XsheetGUI::getPlayRange(r0, r1, step);
+    xsh->convertToExplicitHolds(r1);
     if (action && action->isChecked()) action->trigger();
   }
 

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -957,7 +957,8 @@ int TXsheet::reframeCells(int r0, int r1, int col, int type, int withBlank) {
   for (int r = r0; r <= r1; r++) {
     const TXshCell &cell = getCell(CellPosition(r, col));
     if (cells.size() == 0 || cells.last() != cell) {
-      if (cell.isEmpty() && cells.last().getFrameId() == TFrameId::STOP_FRAME)
+      if (cell.isEmpty() && cells.size() &&
+          cells.last().getFrameId() == TFrameId::STOP_FRAME)
         continue;
       cells.push_back(cell);
     }

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -1062,7 +1062,7 @@ void TXsheet::rollupCells(int r0, int c0, int r1, int c1) {
 
   // in cells copio il contenuto delle celle che mi interessano
   int k;
-  for (k = c0; k <= c1; k++) cells[k - c0] = getCell(CellPosition(r0, k));
+  for (k = c0; k <= c1; k++) cells[k - c0] = getCell(CellPosition(r0, k), false);
 
   for (k = c0; k <= c1; k++) removeCells(r0, k, 1);
 
@@ -1085,7 +1085,7 @@ void TXsheet::rolldownCells(int r0, int c0, int r1, int c1) {
 
   // in cells copio il contenuto delle celle che mi interessano
   int k;
-  for (k = c0; k <= c1; k++) cells[k - c0] = getCell(CellPosition(r1, k));
+  for (k = c0; k <= c1; k++) cells[k - c0] = getCell(CellPosition(r1, k), false);
 
   for (k = c0; k <= c1; k++) removeCells(r1, k, 1);
 

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -2043,7 +2043,7 @@ void TXsheet::convertToImplicitHolds() {
 
 //---------------------------------------------------------
 
-void TXsheet::convertToExplicitHolds() {
+void TXsheet::convertToExplicitHolds(int endPlayRange) {
   int cols = getColumnCount();
   if (!cols) return;
 
@@ -2063,6 +2063,10 @@ void TXsheet::convertToExplicitHolds() {
     if (!cc->getRange(r0, r1)) continue;
 
     int frameCount = getFrameCount() - 1;
+    if (endPlayRange > frameCount &&
+        Preferences::instance()->isImplicitHoldEnabled())
+      frameCount = endPlayRange;
+
     TXshCell prevCell;
 
     r1 = std::max(r1, frameCount);


### PR DESCRIPTION
This PR fixes the following Implicit Hold Issues

- Fixes calculating an Implicit Scene frame count
   - The change made in #1060 to calculate the number of frames to show when collapsing subscene has been extended to general scene (timeline/xsheet) frame calculations
   - This change fixes an issue with Preview-Render not rendering past the last real level frame
   - For implicit scenes only, this change moves the auto-stop marker based to last key or last stop frame, whichever is first or last drawing if neither are present. (fixes #1055)
- Fixes Preview-Render ignoring the last Stop Hold
- Fixes implicit to explicit scene conversion to factor in Stop marker when determining where to end a level exposure without a stop hold. 
- Fixes Rollup/Rolldown issue incorrectly creating explicit cells
- Fixes reframe crashes caused by logic checking for stop hold frames (fixes #1143 and fixes #1163 )