### PR TITLE
Fix Toggle and Edit Tag shortcuts

### DIFF
--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -44,7 +44,9 @@ class RowArea final : public QWidget {
   // panning by middle-drag
   bool m_isPanning;
 
+  QTimer *m_resetMenuTimer;
   int m_contextMenuRow;
+  bool m_editTagEnabled;
 
   // returns true if the frame area can have extra space
   bool checkExpandFrameArea();
@@ -85,6 +87,8 @@ protected:
 
 protected slots:
   void onJumpToTag();
+  void onHideMenu();
+  void resetContextMenu();
 };
 
 }  // namespace XsheetGUI;


### PR DESCRIPTION
The changes made in #1117 caused the `Toggle Navigation Tag` and `Edit Tag` shortcuts to not always work using current frame indicator.  It was using the last frame the frame context menu was opened on.. This fixes the problem.  

Additionally, this fixes an issue where `Edit Tag` context menu option was always on or always off based on he current frame indicator even though you might have selected a different frame with/without a tag.  It now properly enables/disables the option based on the frame the context menu was brought up.