### PR TITLE
Restore current column indicator

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2086,7 +2086,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
     insertUI(syncLevelRenumberWithXsheet, lay);
     insertUI(currentTimelineEnabled, lay);
   }
-  // insertUI(currentColumnColor, lay);
+  insertUI(currentColumnColor, lay);
   insertUI(currentCellColor, lay);
   if (Preferences::instance()->isShowAdvancedOptionsEnabled())
     insertUI(showFrameNumberWithLetters, lay);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1047,9 +1047,8 @@ void ColumnArea::DrawHeader::drawColumnNumber() const {
   p.setPen(m_viewer->getVerticalLineColor());
   if (o->flag(PredefinedFlag::LAYER_NUMBER_BORDER)) p.drawRect(pos);
 
-  //  p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
-  //                       : m_viewer->getTextColor());
-  p.setPen(m_viewer->getTextColor());
+  p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
+                       : m_viewer->getTextColor());
 
   int valign = o->isVerticalTimeline() ? Qt::AlignVCenter : Qt::AlignBottom;
 
@@ -1121,13 +1120,11 @@ void ColumnArea::DrawHeader::drawColumnName() const {
         leftadj = 24;
     }
 
-    //    p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
-    //                         : nameBacklit ? Qt::black : m_viewer->getTextColor());
-    p.setPen(nameBacklit ? Qt::black : m_viewer->getTextColor());
+    p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
+                         : nameBacklit ? Qt::black : m_viewer->getTextColor());
   } else
-    //    p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
-    //                         : m_viewer->getTextColor());
-    p.setPen(m_viewer->getTextColor());
+    p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
+                         : m_viewer->getTextColor());
 
   if (o->isVerticalTimeline() && col < 0) {
     QString cameraName = QString::fromStdString(name);

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -359,6 +359,7 @@ public:
   void drawSoundColumnHead(QPainter &p, int col);
   void drawPaletteColumnHead(QPainter &p, int col);
   void drawSoundTextColumnHead(QPainter &p, int col);
+  void drawCurrentColumnFocus(QPainter &p, int col);
 
   QPixmap getColumnIcon(int columnIndex);
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1986,7 +1986,7 @@ void XsheetViewer::zoomOnFrame(int frame, int factor) {
   m_rowArea->update();
 }
 
-QColor XsheetViewer::getSelectedColumnTextColor() const {
+QColor XsheetViewer::getColumnFocusColor() const {
   // get colors
   TPixel currentColumnPixel;
   Preferences::instance()->getCurrentColumnData(currentColumnPixel);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -834,7 +834,7 @@ public:
   QColor getEmptyColumnHeadColor() const { return m_emptyColumnHeadColor; }
 
   // specified by preferences
-  QColor getSelectedColumnTextColor() const;
+  QColor getColumnFocusColor() const;
 
   // Cell
   void setEmptyCellColor(const QColor &color) { m_emptyCellColor = color; }

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -593,7 +593,7 @@ void Preferences::definePreferenceItems() {
   define(currentTimelineEnabled, "currentTimelineEnabled", QMetaType::Bool,
          true);
   define(currentColumnColor, "currentColumnColor", QMetaType::QColor,
-         QColor(Qt::yellow));
+         QColor(Qt::cyan));
   define(currentCellColor, "currentCellColor", QMetaType::QColor,
          QColor(Qt::cyan));
   // define(levelNameOnEachMarkerEnabled, "levelNameOnEachMarkerEnabled",


### PR DESCRIPTION
This PR restores the Current Column indicator. The default color has been changed to cyan to match the current cell indicator which can be changed in `Scene` preference.