### PR TITLE
Fix crash rendering with MOV QuickTime properties

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ff_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ff_mov.cpp
@@ -40,7 +40,10 @@ private:
 TLevelWriterFFMov::TLevelWriterFFMov(const TFilePath &path,
                                      TPropertyGroup *winfo)
     : TLevelWriter(path, winfo) {
-  if (!m_properties) m_properties = new Tiio::FFMovWriterProperties();
+  // Older scenes saved with MOV properties from QuickTime have incompatible
+  // properties. Swicth to new ones.
+  if (!m_properties || !m_properties->getProperty("Scale"))
+    m_properties = new Tiio::FFMovWriterProperties();
   if (m_properties->getPropertyCount() == 0) {
     m_scale      = 100;
     m_vidQuality = 100;


### PR DESCRIPTION
This PR fixes a crash when rendering a scene in MOV format that was previously rendered using the QuickTime library instead of Ffmpeg.

The saved MOV properties from QuickTime are completely different from the properties when using Ffmpeg.  This would cause a crash when it couldn't find the expected ffmpeg properties.