### PR TITLE
Fix plastic render crash

### DIFF
--- a/toonz/sources/toonzlib/plasticdeformerfx.cpp
+++ b/toonz/sources/toonzlib/plasticdeformerfx.cpp
@@ -444,8 +444,10 @@ void PlasticDeformerFx::doCompute(TTile &tile, double frame,
 
     // ts->unloadTexture(texId);                                // Auto-released
     // due to display list destruction
-    context->deleteLater();
-    // context->doneCurrent();
+    //context->deleteLater();
+    context->moveToThread(0);
+    context->doneCurrent();
+    delete context;
   }
   assert(glGetError() == GL_NO_ERROR);
 }


### PR DESCRIPTION
I believe this will fix crashes some may be having when rendering scenes with meshes. (fixes #889)

I tested this on a 700+ frame scene with all vector levels and a few meshes.  It would constantly crash during render after 92 frames with the following error:

```
ARB::createContext: wglCreateContextAttribsARB() failed (GL error code: 0x502) for format: QSurfaceFormat(version 2.0, options QFlags<QSurfaceFormat::FormatOption>(), depthBufferSize -1, redBufferSize -1, greenBufferSize -1, blueBufferSize -1, alphaBufferSize -1, stencilBufferSize -1, samples -1, swapBehavior QSurfaceFormat::SwapBehavior(DefaultSwapBehavior), swapInterval 1, profile  QSurfaceFormat::OpenGLContextProfile(NoProfile)), shared context: 0x100cf (The operation completed successfully.)
GDI::createContext: wglCreateContext failed. (Unknown error 0xc00705aa.)
Unable to create a GL Context.
```

It appears that the plasticdeformerfx would constantly create a new context without releasing it when it was done, expecting it to happen later, but never does.  I believe it would eventually run out of memory (or something) to build more contexts and subsequently crashes when trying to use the context.   Where it would crash during render my vary depending on a user's system.

At any rate, I added logic to immediately release and destroy the newly created context as soon as it was done with it.  This allowed my scene to render without issue. 

EDIT:  I think this might also fix render issues with plastic where it appears to get stuck.  Sometimes my scene would crash, other times it would get stuck on a frame and never continue.
 
If anyone has scene with plastic meshes that kept failing to render, I would ask you to try with this PR and let me know the results.