### PR TITLE
Range intermediate status bar and tooltip

### DIFF
--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -197,6 +197,10 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                    spacer +
                    tr("%1%2Allow or Disallow Snapping")
                        .arg(trModKey("Ctrl+Shift"))
+                       .arg(cmdTextSeparator) +
+                   spacer +
+                   tr("%1%2Intermediate Stroke in Range")
+                       .arg(trModKey("Ctrl+Alt+Shift"))
                        .arg(cmdTextSeparator)});
   lMap.insert({"T_BrushSmartRaster",
                tr("Brush Tool : Draws in the work area freehand") + spacer +


### PR DESCRIPTION
I have made a change to include a description for the Brush Tool Range option "Intermediate Stroke in Range" on the status bar.

![image](https://github.com/tahoma2d/tahoma2d/assets/44948041/00c120ea-a1eb-48fe-a842-701597482c3f)

The mouseover tooltip will show this:
![image](https://github.com/tahoma2d/tahoma2d/assets/44948041/b08a50fe-51fc-4475-b2be-775b7625b0db)
