### PR TITLE
Add Clear Frames and Remove Cells commands

### DIFF
--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -21,6 +21,7 @@
 #define MI_ClearFrames "MI_ClearFrames"
 #define MI_SelectAll "MI_SelectAll"
 #define MI_InvertSelection "MI_InvertSelection"
+#define MI_RemoveCells "MI_RemoveCells"
 
 #define MI_BlendColors "MI_BlendColors"
 #define MI_EraseUnusedStyles "MI_EraseUnusedStyles"

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -48,7 +48,10 @@ public:
   void pasteCells();
   void doPaste();  // choose pasting behavior by preference option
   void pasteDuplicateCells();
-  void deleteCells();
+  void deleteCells(bool withShift = false);
+  void clearCells();
+  void removeCells();
+  void clearFrames();
   void cutCells();
   void cutCells(bool withoutCopy);
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1939,6 +1939,7 @@ void MainWindow::defineActions() {
                        tr("Remove everything from the recent project list."));
   // createMenuEditAction(MI_PasteNew, QT_TR_NOOP("&Paste New"),  "");
   createMenuEditAction(MI_ClearFrames, QT_TR_NOOP("&Clear Frames"), "");
+  createMenuEditAction(MI_RemoveCells, QT_TR_NOOP("&Remove Cells"), "", "");
 
   // Menu - Cleanup
 

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -383,6 +383,9 @@ void TopBar::loadMenubar() {
   addMenuItem(editMenu, MI_Insert);
   addMenuItem(editMenu, MI_InsertBelow);
   addMenuItem(editMenu, MI_Clear);
+  addMenuItem(editMenu, MI_RemoveCells);
+  editMenu->addSeparator();
+  addMenuItem(editMenu, MI_ClearFrames);
   editMenu->addSeparator();
   addMenuItem(editMenu, MI_SelectAll);
   addMenuItem(editMenu, MI_InvertSelection);
@@ -460,7 +463,6 @@ void TopBar::loadMenubar() {
   addMenuItem(levelMenu, MI_ExportLevel);
   levelMenu->addSeparator();
   addMenuItem(levelMenu, MI_AddFrames);
-  addMenuItem(levelMenu, MI_ClearFrames);
   addMenuItem(levelMenu, MI_Renumber);
   addMenuItem(levelMenu, MI_ReplaceLevel);
   addMenuItem(levelMenu, MI_RevertToCleanedUp);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -4167,6 +4167,8 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
 
     if (!isImplicitCell) menu.addAction(cmdManager->getAction(MI_Clear));
     menu.addAction(cmdManager->getAction(MI_Insert));
+    menu.addAction(cmdManager->getAction(MI_RemoveCells));
+    if (!isImplicitCell) menu.addAction(cmdManager->getAction(MI_ClearFrames));
     if (!soundTextCellsSelected) {
       menu.addAction(cmdManager->getAction(MI_CreateBlankDrawing));
       menu.addAction(cmdManager->getAction(MI_Duplicate));


### PR DESCRIPTION
This PR adds the following commands to the timeline/xsheet:

- `Clear Frames` - Clears drawing on the selected frames like it does in Level Strip. 
  - Does not work on Implicit Cells, but does work on Explicitly Held cells.
  - Moved command from `Level` menu to `Edit` menu
- `Remove Cells` - Deletes and shift cells up 1, the effective reverse of `Insert Cells`, but without copying to clipboard as `Cut Cells` does.

Some changes to cell selection's delete cell logic from OT PR 4475 "make delete command behavior selectable by Contrail Co.,ltd." was ported over. As such, I have added @shun-iwasawa as a Co-Author since he introduced the changes into OT.