### PR TITLE
Stop Function editor folder auto-expansion

### DIFF
--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -1446,10 +1446,10 @@ void FunctionTreeView::onActivated(const QModelIndex &index) {
   // were active
   bool someInactiveChannels = (activeFlag != ACTIVE_CHANNELS);
 
-  if (someInactiveChannels && !isExpanded(index)) {
-    setExpanded(index, true);
-    ftModel->onExpanded(index);
-  }
+//  if (someInactiveChannels && !isExpanded(index)) {
+//    setExpanded(index, true);
+//    ftModel->onExpanded(index);
+//  }
 
   if (item) {
     if (!childChannels.empty()) {


### PR DESCRIPTION
This PR will stop the auto-expansion/collapse of the Function Editor tree folders when clicking on the name.  Must now use the drill icon to expand/collapse a folder.