### PR TITLE
Fix missing enabled toggle button icon on hover

### DIFF
--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -510,8 +510,7 @@ void addImagesToIcon(QIcon &icon, const QImage &baseImg, const QImage &overImg,
 
 // Add the same pixmap to all modes and states of a QIcon
 void addPixmapToAllModesAndStates(QIcon &icon, const QPixmap &pixmap) {
-  QIcon::Mode modes[]   = {QIcon::Normal, QIcon::Disabled, QIcon::Active,
-                           QIcon::Selected};
+  QIcon::Mode modes[]   = {QIcon::Normal, QIcon::Disabled, QIcon::Selected};
   QIcon::State states[] = {QIcon::On, QIcon::Off};
 
   for (const auto &mode : modes) {
@@ -519,6 +518,7 @@ void addPixmapToAllModesAndStates(QIcon &icon, const QPixmap &pixmap) {
       icon.addPixmap(pixmap, mode, state);
     }
   }
+  icon.addPixmap(pixmap, QIcon::Active, QIcon::Off);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #1194 

When `Show Icons In Menu` is disabled, the recently refactored icon logic was setting the empty icon for icon mode/status `Active`/`On` causing the icon to disappear when hovering over an active toggle button.

Modified to only set it for `Active`/`Off`. 