### PR TITLE
Fix missing icon on different resolutions

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -447,7 +447,11 @@ int main(int argc, char *argv[]) {
 #endif
 
   // Set show icons in menus flag (use iconVisibleInMenu to disable selectively)
-  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, false);
+  bool dontShowIcon =
+      !Preferences::instance()->isShowAdvancedOptionsEnabled() ||
+      !Preferences::instance()->getBoolValue(showIconsInMenu);
+  QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus,
+                                         dontShowIcon);
 
   TEnv::setApplicationFileName(argv[0]);
 

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -568,11 +568,19 @@ QIcon createQIcon(const QString &iconSVGName, bool useFullOpacity,
   // there can be scaling artifacts with high dpi and load these in addition
   if (baseImg.width() == (16 * devPixRatio) &&
       baseImg.height() == (16 * devPixRatio)) {
-    QSize expandSize(20, 20);
-    QImage toolBaseImg(compositeImage(baseImg, expandSize));
-    QImage toolOverImg(compositeImage(overImg, expandSize));
-    QImage toolOnImg(compositeImage(onImg, expandSize));
-    addImagesToIcon(icon, toolBaseImg, toolOverImg, toolOnImg, useFullOpacity);
+    for (auto screen : QApplication::screens()) {
+      QSize expandSize(20, 20);
+      int otherDevPixRatio = screen->devicePixelRatio();
+      if (otherDevPixRatio != devPixRatio) {
+        expandSize.setWidth(16 * otherDevPixRatio);
+        expandSize.setHeight(16 * otherDevPixRatio);
+      }
+      QImage toolBaseImg(compositeImage(baseImg, expandSize));
+      QImage toolOverImg(compositeImage(overImg, expandSize));
+      QImage toolOnImg(compositeImage(onImg, expandSize));
+      addImagesToIcon(icon, toolBaseImg, toolOverImg, toolOnImg,
+                      useFullOpacity);
+    }
   }
 
   return icon;


### PR DESCRIPTION
This PR fixes #1193 

This restores the logic to handle icon creation for different monitor resolutions when multiple monitors are in use.  It was missed in the recently refactored icon logic.

As a result of restoring this logic, I had discovered an issue with icons always showing in menubars when multiple monitors with different resolutions were being used even though `Show Icons In Menu` is disabled.  This was caused by the change to set `Qt::AA_DontShowIconsInMenus` from True to False when `Show Advanced Preferences and Options` was implemented.  The setting is now controlled by `Show Icons In Menu` Preference settings.
