### PR TITLE
Fix macOS backtrace error

### DIFF
--- a/ci-scripts/osx/tahoma-build.sh
+++ b/ci-scripts/osx/tahoma-build.sh
@@ -29,6 +29,7 @@ fi
 
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/jpeg-turbo/lib/pkgconfig"
 cmake ../sources  $CANON_FLAG \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DWITH_GPHOTO2=ON \
       -DQT_PATH=$USEQTLIB \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.2.0/libtiff/ \

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -71,7 +71,7 @@ find $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2* -name *.la -exec rm 
 
 echo ">>> Configuring Tahoma2D.app for deployment"
 
-$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -verbose=0 -always-overwrite \
+$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -verbose=0 -always-overwrite -no-strip \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/lzocompress \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/lzodecompress \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/tcleanup \
@@ -128,7 +128,7 @@ done
    
 echo ">>> Creating Tahoma2D-osx.dmg"
 
-$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -dmg -verbose=0
+$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -dmg -verbose=0 -no-strip
 
 mv $TOONZDIR/Tahoma2D.dmg $TOONZDIR/../Tahoma2D-osx.dmg
 

--- a/toonz/sources/toonz/crashhandler.cpp
+++ b/toonz/sources/toonz/crashhandler.cpp
@@ -293,7 +293,7 @@ static bool sh(std::string &out, const char *cmd) {
 
 static bool addr2line(std::string &out, const char *exepath, const char *addr) {
   char cmd[512];
-#ifdef OSX
+#ifdef MACOSX
   sprintf(cmd, "atos -o \"%.400s\" %s 2>&1", exepath, addr);
 #else
   sprintf(cmd, "addr2line -f -p -e \"%.400s\" %s 2>&1", exepath, addr);


### PR DESCRIPTION
This fixes an issue with macOS backtrace reporting on crash.  The backtrace was showing `sh: addr2line: command not found` error.  It should be using `atos` .