### PR TITLE
Fix macOS Preference UI issues

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -446,14 +446,14 @@ int main(int argc, char *argv[]) {
   }
 #endif
 
+  TEnv::setApplicationFileName(argv[0]);
+
   // Set show icons in menus flag (use iconVisibleInMenu to disable selectively)
   bool dontShowIcon =
       !Preferences::instance()->isShowAdvancedOptionsEnabled() ||
       !Preferences::instance()->getBoolValue(showIconsInMenu);
   QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus,
                                          dontShowIcon);
-
-  TEnv::setApplicationFileName(argv[0]);
 
   // splash screen
   QPixmap splashPixmap =


### PR DESCRIPTION
This PR fixes #1200 as well as corrects the `Interface` -> `Theme` displaying with the wrong control type.

The issue, specific to macOS (maybe Linux?), was caused by a change in #1196 which caused user Preferences to be loaded before setting the application name when trying to determine if icons should be shown in menus or not.

This somehow resulted in messing up the `Theme` control type and would cause T2D to crash when trying to import preferences.  Issue fixed by simply moving the change to after setting the application name.
