### PR TITLE
Fix macos library path reference

### DIFF
--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -93,11 +93,15 @@ function checkLibFile() {
          if [ ! -f $TOONZDIR/Tahoma2D.app/Contents/Frameworks/$Y ]
          then
             local SRC=$DEPFILE	
-            local Z=`echo $DEPFILE | cut -c 1-24`
-            if [ "$Z" = "@loader_path/../../../.." ]
+            local Z=`echo $DEPFILE | cut -c 1-16`
+            local Z2=`echo $DEPFILE | cut -c 1-6`
+            if [ "$Z" = "@loader_path/../" ]
             then
-               local V=`echo $DEPFILE | cut -c 26-`
+               local V=`echo $DEPFILE | sed -e"s/^.*\/\.\.\///"`
                local SRC=/usr/local/$V
+            elif [ "$Z2" = "@rpath" ]
+            then
+                local SRC=/usr/local/lib/$Y
             fi
             echo "Copying $SRC to Frameworks"
             cp $SRC $TOONZDIR/Tahoma2D.app/Contents/Frameworks

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -80,6 +80,17 @@ $QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -verbose=0 -always-overwrite -no-s
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/tfarmcontroller \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/tfarmserver 
 
+echo ">>> Copying missing Qt frameworks"
+cp -r $QTDIR/Frameworks/QtDBus.framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+cp -r $QTDIR/Frameworks/QtPdf.framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+cp -r $QTDIR/Frameworks/QtQml.framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+cp -r $QTDIR/Frameworks/QtQmlModels.framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+cp -r $QTDIR/Frameworks/QtQuick.framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+cp -r $QTDIR/Frameworks/QtVirtualKeyboard.framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+
+echo ">>> Adding Contents/lib symbolic link to Frameworks"
+ln -s Frameworks $TOONZDIR/Tahoma2D.app/Contents/lib
+
 echo ">>> Correcting library paths"
 function checkLibFile() {
    local LIBFILE=$1   


### PR DESCRIPTION
This PR fixes the issue of the macOS builds not fully starting, not even a splash screen, and just stops responding.

This is, in part, due to yet another set of missing frameworks and bad library path references caused by recent updates in Homebrew to webp and qt@5 packages.  Coupled with the crash handler not able to handle the crash at immediate startup causes it to get stuck.

This fix will only address the missing frameworks and library path issue.  Will needed to seprately handle why the crash handler is causing it to get stuck instead of crashing at start up 

Will merge this once I verify the artifact successfully opens.