### PR TITLE
Symbolicate macOS and Linux crash logs for debugging

### DIFF
--- a/ci-scripts/linux/tahoma-build.sh
+++ b/ci-scripts/linux/tahoma-build.sh
@@ -15,6 +15,7 @@ source /opt/qt515/bin/qt515-env.sh
 
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 cmake ../sources \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DWITH_GPHOTO2:BOOL=ON \
     -DWITH_SYSTEM_SUPERLU=ON
 

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -78,7 +78,7 @@ then
 fi
 
 export LD_LIBRARY_PATH=appdir/usr/lib/tahoma2d
-./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma2D -bundle-non-qt-libs -verbose=0 -always-overwrite \
+./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma2D -bundle-non-qt-libs -verbose=0 -always-overwrite -no-strip \
    -executable=appdir/usr/bin/lzocompress \
    -executable=appdir/usr/bin/lzodecompress \
    -executable=appdir/usr/bin/tcleanup \
@@ -91,7 +91,7 @@ rm appdir/AppRun
 cp ../sources/scripts/AppRun appdir
 chmod 775 appdir/AppRun
 
-./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma2D -appimage
+./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma2D -appimage -no-strip 
 
 mv Tahoma2D*.AppImage Tahoma2D/Tahoma2D.AppImage
 

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -7,20 +7,13 @@ else
 fi
 export TOONZDIR=toonz/build/toonz
 
-echo ">>> Creating DSYM files"
-for X in `find $TOONZDIR/Tahoma2D.app/Contents/MacOS -type f`
-do
-   dsymutil -o $TOONZDIR/DSYM $X
-   strip -S $X
-done
-
 # If found, use Xcode Release build
 if [ -d $TOONZDIR/Release ]
 then
    export TOONZDIR=$TOONZDIR/Release
 fi
 
-echo ">>> Copying stuff to $TOONZDIR/Tahoma2D.app/tahomastuff"
+echo ">>> Copying stuff to Tahoma2D.app/tahomastuff"
 if [ -d $TOONZDIR/Tahoma2D.app/tahomastuff ]
 then
    # In case of prior builds, replace stuff folder
@@ -33,7 +26,7 @@ find $TOONZDIR/Tahoma2D.app/tahomastuff -name .gitkeep -exec rm -f {} \;
 
 if [ -d thirdparty/apps/ffmpeg/bin ]
 then
-   echo ">>> Copying FFmpeg to $TOONZDIR/Tahoma2D.app/ffmpeg"
+   echo ">>> Copying FFmpeg to Tahoma2D.app/ffmpeg"
    if [ -d $TOONZDIR/Tahoma2D.app/ffmpeg ]
    then
       # In case of prior builds, replace ffmpeg folder
@@ -46,7 +39,7 @@ fi
 
 if [ -d thirdparty/apps/rhubarb ]
 then
-   echo ">>> Copying Rhubarb Lip Sync to $TOONZDIR/Tahoma2D.app/rhubarb"
+   echo ">>> Copying Rhubarb Lip Sync to Tahoma2D.app/rhubarb"
    if [ -d $TOONZDIR/Tahoma2D.app/rhubarb ]
    then
       # In case of prior builds, replace rhubarb folder
@@ -64,17 +57,40 @@ fi
 
 if [ -d thirdparty/canon/Framework ]
 then
-   echo ">>> Copying canon framework to $TOONZDIR/Tahoma2D.app/Contents/Frameworks/EDSDK.Framework"
-   cp -R thirdparty/canon/Framework/ $TOONZDIR/Tahoma2D.app/Contents/Frameworks
-   chmod -R 755 $TOONZDIR/Tahoma2D.app/Contents/Frameworks/EDSDK.framework
+   if [ ! -d $TOONZDIR/Tahoma2D.app/Contents/Frameworks/EDSDK.framework ]
+   then
+      echo ">>> Copying canon framework to Tahoma2D.app/Contents/Frameworks/EDSDK.Framework"
+      cp -R thirdparty/canon/Framework/ $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+      chmod -R 755 $TOONZDIR/Tahoma2D.app/Contents/Frameworks/EDSDK.framework
+   fi
 fi
 
-echo ">>> Copying libghoto2 supporting directories"
-cp -R /usr/local/lib/libgphoto2 $TOONZDIR/Tahoma2D.app/Contents/Frameworks
-cp -R /usr/local/lib/libgphoto2_port $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+if [ ! -d $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2 ]
+then
+   echo ">>> Copying libghoto2 supporting directories to Tahoma2D.app/Contents/Frameworks"
+   cp -R /usr/local/lib/libgphoto2 $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+   cp -R /usr/local/lib/libgphoto2_port $TOONZDIR/Tahoma2D.app/Contents/Frameworks
 
-rm $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2/print-camera-list
-find $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2* -name *.la -exec rm -f {} \;
+   rm $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2/print-camera-list
+   find $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2* -name *.la -exec rm -f {} \;
+fi
+
+echo ">>> Creating DSYM files"
+if [ -d $TOONZDIR/DSYM ]
+then
+   rm -rf $TOONZDIR/DSYM
+fi
+
+for X in `find $TOONZDIR/Tahoma2D.app/Contents/MacOS -type f`
+do
+   dsymutil -o $TOONZDIR/DSYM $X
+   strip -S $X
+done
+
+if [ -d $TOONZDIR/Tahoma2D.app/DSYM ]
+then
+   rm -rf $TOONZDIR/Tahoma2D.app/DSYM
+fi
 
 echo ">>> Configuring Tahoma2D.app for deployment"
 
@@ -91,14 +107,14 @@ for FW in `echo "QtDBus QtPdf QtQml QtQmlModels QtQuick QtVirtualKeyboard"`
 do
    if [ ! -d $TOONZDIR/Tahoma2D.app/Contents/Frameworks/$FW.framework ]
    then
-      echo ">>> Copying missing $FW.framework to Contents/Frameworks"
+      echo ">>> Copying missing $FW.framework to Tahoma2D.app/Contents/Frameworks"
       cp -r $QTDIR/Frameworks/$FW.framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
    fi
 done
 
 if [ ! -d $TOONZDIR/Tahoma2D.app/Contents/lib ]
 then
-   echo ">>> Adding Contents/lib symbolic link to Contents/Frameworks"
+   echo ">>> Adding Contents/lib symbolic link to Tahoma2D.app/Contents/Frameworks"
    ln -s Frameworks $TOONZDIR/Tahoma2D.app/Contents/lib
 fi
 
@@ -158,7 +174,8 @@ for FILE in `find $TOONZDIR/Tahoma2D.app/Contents -type f | grep -v -e"\.h" -e"\
 do
    checkLibFile $FILE
 done
-   
+
+echo ">>> Moving DYSM to Tahoma2D.app"
 mv $TOONZDIR/DSYM $TOONZDIR/Tahoma2D.app
 
 echo ">>> Creating Tahoma2D-osx.dmg"

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -7,6 +7,13 @@ else
 fi
 export TOONZDIR=toonz/build/toonz
 
+echo ">>> Creating DSYM files"
+for X in `find $TOONZDIR/Tahoma2D.app/Contents/MacOS -type f`
+do
+   dsymutil -o $TOONZDIR/DSYM $X
+   strip -S $X
+done
+
 # If found, use Xcode Release build
 if [ -d $TOONZDIR/Release ]
 then
@@ -71,7 +78,7 @@ find $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2* -name *.la -exec rm 
 
 echo ">>> Configuring Tahoma2D.app for deployment"
 
-$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -verbose=0 -always-overwrite -no-strip \
+$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -verbose=0 -always-overwrite \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/lzocompress \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/lzodecompress \
    -executable=$TOONZDIR/Tahoma2D.app/Contents/MacOS/tcleanup \
@@ -152,9 +159,11 @@ do
    checkLibFile $FILE
 done
    
+mv $TOONZDIR/DSYM $TOONZDIR/Tahoma2D.app
+
 echo ">>> Creating Tahoma2D-osx.dmg"
 
-$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -dmg -verbose=0 -no-strip
+$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -dmg -verbose=0
 
 mv $TOONZDIR/Tahoma2D.dmg $TOONZDIR/../Tahoma2D-osx.dmg
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -549,7 +549,7 @@ elseif(BUILD_ENV_UNIXLIKE)
         Tahoma2D Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
         Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort Qt5::UiTools
         ${GL_LIB} ${GLUT_LIB} ${GLU_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS}
-        ${EXTRA_LIBS}
+        ${EXTRA_LIBS} dl
     )
 endif()
 

--- a/toonz/sources/toonz/crashhandler.cpp
+++ b/toonz/sources/toonz/crashhandler.cpp
@@ -329,7 +329,7 @@ static bool addr2line(std::string &out, const char *exepath, const char *addr) {
   }
 
   if(!libFound)
-     return true;
+     return false;
 
   if (exe.find("Tahoma2D.app/Contents/MacOS") != std::string::npos) {
     std::string dsym = exe;

--- a/toonz/sources/toonz/crashhandler.cpp
+++ b/toonz/sources/toonz/crashhandler.cpp
@@ -331,6 +331,14 @@ static bool addr2line(std::string &out, const char *exepath, const char *addr) {
   if(!libFound)
      return true;
 
+  if (exe.find("Tahoma2D.app/Contents/MacOS") != std::string::npos) {
+    std::string dsym = exe;
+    int pos = dsym.find("Contents");
+    dsym.replace(pos, 14, "DSYM/Contents/Resources/DWARF");
+    TFilePath file(dsym);
+    if(TFileStatus(file).doesExist()) exe = dsym;
+  }
+
   sprintf(cmd, "atos -o \"%.400s\" -l %p %s 2>&1", exe.c_str(), loadaddr, addr);
 #else
   sprintf(cmd, "addr2line -f -p -e \"%.400s\" %s 2>&1", exepath, addr);


### PR DESCRIPTION
In order to provide filename/line number in backtrace information for macOS and Linux crash logs, this PR does the following:

1. This generates DSYM files for macOS and configures T2D to use them when generating backtrace.

As a result of including the DSYM files as part of the build, the overall footprint will increase by about 570 MB.

2. Compiles Linux builds to include symbol information.

As a result of doing this, the overall footprint will increase by about 200 MB.
