### PR TITLE
Fix SVG sequence file loading

### DIFF
--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -75,7 +75,7 @@ void initImageIo(bool lightVersion) {
   TFileType::declare("pli", TFileType::VECTOR_LEVEL);
 
   TLevelReader::define("svg", 0, TLevelReaderSvg::create);
-  TFileType::declare("svg", TFileType::VECTOR_LEVEL);
+  TFileType::declare("svg", TFileType::VECTOR_IMAGE);
   TLevelWriter::define("svg", TLevelWriterSvg::create, false);
   Tiio::defineWriterProperties("svg", new Tiio::SvgWriterProperties());
 

--- a/toonz/sources/include/tlevel_io.h
+++ b/toonz/sources/include/tlevel_io.h
@@ -293,6 +293,10 @@ inline bool isMultipleFrameType(const TFilePath &fp) {
 
 inline bool doesSupportRandomAccess(const TFilePath &fp,
                                     bool isToonzOutput = false) {
+  const std::string &type = fp.getType();
+
+  if (type == "pli") return false;
+
   return (fp.getDots() == "..");
 }
 

--- a/toonz/sources/toonzlib/levelupdater.cpp
+++ b/toonz/sources/toonzlib/levelupdater.cpp
@@ -25,6 +25,9 @@ namespace {
 
 inline bool supportsRandomAccess(const TFilePath &fp) {
   const std::string &type = fp.getType();
+
+  if (type == "pli") return false;
+
   return type == "tlv" ||  // TLVs do support random access
          fp.getDots() == "..";  // Multi-file levels of course do
 }

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1002,6 +1002,7 @@ static LevelType getLevelType(const TFilePath &fp) {
       ret.m_ltype = OVL_XSHLEVEL;
     break;
 
+  case TFileType::VECTOR_IMAGE:
   case TFileType::VECTOR_LEVEL:
     if (format == "svg") {
       ret.m_vectorNotPli = true;


### PR DESCRIPTION
This PR fixes an issue when trying to load an SVG file sequence.

Modified it so SVG files are treated as Vector **Images** instead of Vector **Levels**, which allows the SVG files to be detected as a single image file or a series of files (filename.####.svg or filename_####.svg format).
