### PR TITLE
Control file history information

### DIFF
--- a/toonz/sources/image/pli/pli_io.cpp
+++ b/toonz/sources/image/pli/pli_io.cpp
@@ -12,6 +12,7 @@
 //#include <fstream.h>
 #include "../compatibility/tfile_io.h"
 #include "tenv.h"
+#include "toonz/preferences.h"
 
 /*=====================================================================*/
 
@@ -700,7 +701,11 @@ void ParsedPliImp::loadInfo(bool readPlt, TPalette *&palette,
       m_iChan.seekg(pos, ios::beg);
       TagElem *tagElem = readTag();
       TextTag *textTag = (TextTag *)tagElem->m_tag;
-      history          = new TContentHistory(true);
+      QString altUsername =
+          Preferences::instance()->getStringValue(recordAsUsername);
+      bool recordEdit =
+          Preferences::instance()->getBoolValue(recordFileHistory);
+      history = new TContentHistory(true, altUsername, recordEdit);
       history->deserialize(QString::fromStdString(textTag->m_text));
       delete tagElem;
     }

--- a/toonz/sources/image/tzl/tiio_tzl.cpp
+++ b/toonz/sources/image/tzl/tiio_tzl.cpp
@@ -18,6 +18,7 @@
 #include "tenv.h"
 #include "tconvert.h"
 #include "trasterimage.h"
+#include "toonz/preferences.h"
 
 #include <QByteArray>
 
@@ -1501,7 +1502,13 @@ TLevelReaderTzl::TLevelReaderTzl(const TFilePath &path)
     fread(&historyData[0], 1, lSize, historyChan);
     fclose(historyChan);
 
-    if (!m_contentHistory) m_contentHistory = new TContentHistory(true);
+    if (!m_contentHistory) {
+      QString altUsername =
+          Preferences::instance()->getStringValue(recordAsUsername);
+      bool recordEdit =
+          Preferences::instance()->getBoolValue(recordFileHistory);
+      m_contentHistory = new TContentHistory(true, altUsername, recordEdit);
+    }
     m_contentHistory->deserialize(QString::fromStdString(historyData));
   }
 

--- a/toonz/sources/include/tcontenthistory.h
+++ b/toonz/sources/include/tcontenthistory.h
@@ -29,12 +29,14 @@ class DVAPI TContentHistory {
   bool m_isLevel;
   std::map<TFrameId, QDateTime> m_records;
   QString m_frozenHistory;
+  QString m_altUsername;
+  bool m_recordEdit;
 
   const QString currentToString() const;
 
 public:
   //! set isLevel=true if you want to keep track of single-frames modifications
-  TContentHistory(bool isLevel);
+  TContentHistory(bool isLevel, QString altUsername, bool recordEdit);
 
   ~TContentHistory();
 

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -73,6 +73,8 @@ enum PreferencesItemId {
   rasterBackgroundColor,
   resetUndoOnSavingLevel,
   defaultProjectPath,
+  recordFileHistory,
+  recordAsUsername,
 
   //----------
   // Import / Export

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -102,10 +102,12 @@ private:
 
   QWidget* createUI(
       PreferencesItemId id,
-      const QList<ComboBoxItem>& comboItems = QList<ComboBoxItem>());
+      const QList<ComboBoxItem>& comboItems = QList<ComboBoxItem>(),
+      bool isLineEdit                       = false);
   QGridLayout* insertGroupBoxUI(PreferencesItemId id, QGridLayout* layout);
   void insertUI(PreferencesItemId id, QGridLayout* layout,
-                const QList<ComboBoxItem>& comboItems = QList<ComboBoxItem>());
+                const QList<ComboBoxItem>& comboItems = QList<ComboBoxItem>(),
+                bool isLineEdit                       = false);
   void insertDualUIs(
       PreferencesItemId leftId, PreferencesItemId rightId, QGridLayout* layout,
       const QList<ComboBoxItem>& leftComboItems  = QList<ComboBoxItem>(),
@@ -149,6 +151,8 @@ private:
   void onUnitChanged();
   void beforeRoomChoiceChanged();
   void onColorCalibrationChanged();
+  // Saving
+  void onRecordAsUserChanged();
   // Drawing
   void onDefLevelTypeChanged();
   void onUseNumpadForSwitchingStylesClicked();

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -497,6 +497,11 @@ void Preferences::definePreferenceItems() {
   define(defaultProjectPath, "defaultProjectPath", QMetaType::QString,
          documentsPath);
 
+  define(recordFileHistory, "recordFileHistory", QMetaType::Bool, true);
+
+  QString userName = TSystem::getUserName();
+  define(recordAsUsername, "recordAsUsername", QMetaType::QString, userName);
+
   // Import / Export
   define(ffmpegPath, "ffmpegPath", QMetaType::QString, "");
   define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, 0, 0,

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1498,8 +1498,12 @@ TCamera *ToonzScene::getCurrentPreviewCamera() {
 //-----------------------------------------------------------------------------
 
 TContentHistory *ToonzScene::getContentHistory(bool createIfNeeded) {
-  if (!m_contentHistory && createIfNeeded)
-    m_contentHistory = new TContentHistory(false);
+  if (!m_contentHistory && createIfNeeded) {
+    QString altUsername =
+        Preferences::instance()->getStringValue(recordAsUsername);
+    bool recordEdit  = Preferences::instance()->getBoolValue(recordFileHistory);
+    m_contentHistory = new TContentHistory(false, altUsername, recordEdit);
+  }
   return m_contentHistory;
 }
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -331,7 +331,10 @@ void TXshSimpleLevel::touchFrame(const TFrameId &fid) {
   m_properties->setDirtyFlag(true);
   TContentHistory *ch = getContentHistory();
   if (!ch) {
-    ch = new TContentHistory(true);
+    QString altUsername =
+        Preferences::instance()->getStringValue(recordAsUsername);
+    bool recordEdit = Preferences::instance()->getBoolValue(recordFileHistory);
+    ch              = new TContentHistory(true, altUsername, recordEdit);
     setContentHistory(ch);
   }
   ch->frameModifiedNow(fid);

--- a/toonz/sources/toonzqt/infoviewer.cpp
+++ b/toonz/sources/toonzqt/infoviewer.cpp
@@ -225,7 +225,7 @@ InfoViewerImp::InfoViewerImp()
   create(eSampleSize, QObject::tr("Sample Size:      "));
   create(eSampleType, QObject::tr("Sample Type: "));
 
-  m_historyLabel.setStyleSheet("color: rgb(0, 0, 200);");
+  setLabelStyle(&m_historyLabel);
   m_history.setStyleSheet("font-size: 12px; font-family: \"courier\";");
   // m_history.setStyleSheet("font-family: \"courier\";");
   m_history.setReadOnly(true);
@@ -343,6 +343,12 @@ void InfoViewerImp::setImageInfo() {
     ii = lr->getImageInfo(m_fids[m_currentIndex]);
   } catch (...) {
     return;
+  }
+  if (lr && m_path.getType() == "pli") {
+    try {
+      lr->loadInfo();
+    } catch (...) {
+    }
   }
   if (!m_fids.empty() && lr && ii) {
     setVal(eImageSize,


### PR DESCRIPTION
File history is written in scene files (tnz), in vector files (pli) and, under certain circumstances, in smart raster history files (hst).  It  records the last time the file was saved along with machine and user information.  You can view this information by opening the file directly or by right-clicking a scene or level and selecting `Info...` in the Browser.

At a user's request, I 've added the following to control file history in `Preferences` -> `Saving`:

![image](https://github.com/tahoma2d/tahoma2d/assets/19245851/649588ff-b8a8-40fb-bb02-453b3ac177ec)

This allows the user to:
- Disable adding new entries to file history.
   - This only affect writing new entries.  Existing entries are kept.
- Specify an alternate username for file history instead of the default username

Changes to these settings requires a restart.