### PR TITLE
Current Drawing on Top

### DIFF
--- a/toonz/sources/include/toonz/stageplayer.h
+++ b/toonz/sources/include/toonz/stageplayer.h
@@ -116,6 +116,8 @@ public:
 
   static bool m_isLightTableEnabled;
 
+  bool m_currentDrawingOnTop;
+
 public:
   Player();
 

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -141,6 +141,7 @@ struct DVAPI VisitArgs {
   TRasterImageP m_lineupImage   = 0;
   Stage::Player m_liveViewPlayer;
   Stage::Player m_lineupPlayer;
+  bool m_currentDrawingOnTop;
 
 public:
   VisitArgs()
@@ -157,7 +158,8 @@ public:
       , m_isGuidedDrawingEnabled(0)
       , m_guidedFrontStroke(-1)
       , m_guidedBackStroke(-1)
-      , m_rasterizePli(false) {}
+      , m_rasterizePli(false)
+      , m_currentDrawingOnTop(false) {}
 };
 
 //=============================================================================

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -166,6 +166,8 @@ private:
 
   TXsheetColumnChangeObserver *m_observer;
 
+  bool m_currentDrawingOnTop;
+
   DECLARE_CLASS_CODE
 
 public:
@@ -598,6 +600,9 @@ in TXsheetImp.
   NavigationTags *getNavigationTags() const { return m_navigationTags; }
   bool isFrameTagged(int frame) const;
   void toggleTaggedFrame(int frame);
+
+  bool isCurrentDrawingOnTop() { return m_currentDrawingOnTop; }
+  void setCurrentDrawingOnTop(bool onTop) { m_currentDrawingOnTop = onTop; }
 
 protected:
   bool checkCircularReferences(TXsheet *childCandidate);

--- a/toonz/sources/toonz/icons/dark/actions/16/current_on_top.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/current_on_top.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg20"
+   sodipodi:docname="current_on_top.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs24" /><sodipodi:namedview
+   id="namedview22"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:snap-grids="false"
+   inkscape:zoom="44.9375"
+   inkscape:cx="8"
+   inkscape:cy="7.9888734"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g18"><inkscape:grid
+     type="xygrid"
+     id="grid841" /></sodipodi:namedview>
+    <g
+   transform="matrix(1,0,0,1,-170,-210)"
+   id="g18">
+        <g
+   id="new_vector_level"
+   transform="matrix(1,0,0,1,60,-20)">
+            <g
+   id="bg"
+   transform="matrix(0.110345,0,0,0.121212,93.7793,211.091)">
+                <rect
+   x="147"
+   y="156"
+   width="145"
+   height="132"
+   style="fill:rgb(135,135,135);fill-opacity:0;"
+   id="rect2" />
+            </g>
+            <g
+   id="g11">
+                <g
+   transform="matrix(1,0,0,1,1,0)"
+   id="g7">
+                    <path
+   d="M120,231.5L123.5,235L120,235L120,231.5Z"
+   id="path5" />
+                </g>
+                <path
+   d="m 125,235 c 0,-0.265 -0.105,-0.52 -0.293,-0.707 l -3,-3 C 121.52,231.105 121.265,231 121,231 h -9 c -0.552,0 -1,0.448 -1,1 v 5 c 0,0.552 0.448,1 1,1 h 12 c 0.552,0 1,-0.448 1,-1 z m -1,0 -3,-3 h -9 v 5 h 12 z"
+   id="path9"
+   sodipodi:nodetypes="sccsssssssscccccc" />
+            </g>
+            <g
+   transform="matrix(1,0,0,1,108,227)"
+   id="g15">
+                
+            </g>
+        </g>
+    <rect
+   style="fill:#000000;stroke:#000000;stroke-width:1.24066;stroke-linecap:round;stroke-dashoffset:0.9"
+   id="rect3568"
+   width="12.880068"
+   height="0.75934029"
+   x="171.49828"
+   y="220.12033" /><rect
+   style="clip-rule:evenodd;fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:1.24067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dashoffset:0.9"
+   id="rect3568-5"
+   width="12.880322"
+   height="0.7593298"
+   x="171.51547"
+   y="223.62033" /></g>
+</svg>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2334,6 +2334,8 @@ void MainWindow::defineActions() {
     RasterizePliToggleAction = 0;
   createToggle(MI_ToggleLightTable, QT_TR_NOOP("Light Table"), "", false,
                MenuViewCommandType, "light_table");
+  createToggle(MI_CurrentDrawingOnTop, QT_TR_NOOP("Current Drawing On Top"), "", false,
+               MenuViewCommandType, "current_on_top");
 
   // Menu - Panes
 

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -619,6 +619,8 @@ void TopBar::loadMenubar() {
   addMenuItem(viewMenu, MI_NoShift);
   addMenuItem(viewMenu, MI_ResetShift);
   viewMenu->addSeparator();
+  addMenuItem(viewMenu, MI_CurrentDrawingOnTop);
+  viewMenu->addSeparator();
   addMenuItem(viewMenu, MI_VectorGuidedDrawing);
   viewMenu->addSeparator();
   addMenuItem(viewMenu, MI_RasterizePli);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -513,4 +513,5 @@
 
 #define MI_ToggleLightTable "MI_ToggleLightTable"
 
+#define MI_CurrentDrawingOnTop "MI_CurrentDrawingOnTop"
 #endif

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -785,6 +785,24 @@ public:
   }
 } TLightTableToggleCommand;
 
+class TCurrentDrawingOnTopCommand final : public MenuItemHandler {
+public:
+  TCurrentDrawingOnTopCommand() : MenuItemHandler(MI_CurrentDrawingOnTop) {}
+  void execute() override {
+    CommandManager *cm = CommandManager::instance();
+    QAction *action    = cm->getAction(MI_CurrentDrawingOnTop);
+
+    TApp::instance()->getCurrentXsheet()->getXsheet()->setCurrentDrawingOnTop(
+        action->isChecked());
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  bool isChecked(CommandId id) const {
+    QAction *action = CommandManager::instance()->getAction(id);
+    return action != 0 && action->isChecked();
+  }
+} TCurrentDrawingOnTopCommand;
+
 //=============================================================================
 // SceneViewer
 //-----------------------------------------------------------------------------
@@ -2200,6 +2218,8 @@ void SceneViewer::drawScene() {
     args.m_isGuidedDrawingEnabled = useGuidedDrawing;
     args.m_guidedFrontStroke      = guidedFrontStroke;
     args.m_guidedBackStroke       = guidedBackStroke;
+    args.m_currentDrawingOnTop =
+        app->getCurrentXsheet()->getXsheet()->isCurrentDrawingOnTop();
 
     // args.m_currentFrameId = app->getCurrentFrame()->getFid();
 
@@ -2317,6 +2337,8 @@ void SceneViewer::drawScene() {
       args.m_isGuidedDrawingEnabled = useGuidedDrawing;
       args.m_guidedFrontStroke      = guidedFrontStroke;
       args.m_guidedBackStroke       = guidedBackStroke;
+      args.m_currentDrawingOnTop =
+          app->getCurrentXsheet()->getXsheet()->isCurrentDrawingOnTop();
 
       if (m_stopMotion->m_alwaysUseLiveViewImages &&
           m_stopMotion->m_liveViewStatus > 0 &&

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -469,6 +469,8 @@
 		<file>icons/dark/actions/16/tape_end_to_line.svg</file>
 		<file>icons/dark/actions/16/tape_line_to_line.svg</file>
 
+		<file>icons/dark/actions/16/current_on_top.svg</file>
+
 		<file>icons/dark/actions/16/shift_and_trace.svg</file>
 		<file>icons/dark/actions/16/shift_and_trace_edit.svg</file>
 		<file>icons/dark/actions/16/shift_and_trace_no_shift.svg</file>

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1413,6 +1413,8 @@ void RowArea::contextMenuEvent(QContextMenuEvent *event) {
   menu->addAction(cmdManager->getAction(MI_EditShift));
   menu->addAction(cmdManager->getAction(MI_NoShift));
   menu->addAction(cmdManager->getAction(MI_ResetShift));
+  menu->addSeparator();
+  menu->addAction(cmdManager->getAction(MI_CurrentDrawingOnTop));
 
   // Tags
   menu->addSeparator();

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -219,6 +219,8 @@ public:
   Stage::Player m_liveViewPlayer;
   Stage::Player m_lineupPlayer;
 
+  bool m_currentDrawingOnTop;
+
 public:
   StageBuilder();
   virtual ~StageBuilder();
@@ -285,7 +287,8 @@ StageBuilder::StageBuilder()
     , m_fade(0)
     , m_shiftTraceGhostId(NO_GHOST)
     , m_currentXsheetLevel(0)
-    , m_xsheetLevel(0) {
+    , m_xsheetLevel(0)
+    , m_currentDrawingOnTop(false) {
   m_placementStack.push_back(ZPlacement());
 }
 
@@ -482,6 +485,10 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         }
       }
     }
+
+    player.m_currentDrawingOnTop = m_currentDrawingOnTop;
+    if (m_currentDrawingOnTop && player.m_isCurrentColumn)
+      player.m_bingoOrder = 10;
 
     players.push_back(player);
   } else if (TXshChildLevel *cl = xl->getChildLevel()) {
@@ -828,6 +835,7 @@ void StageBuilder::addSimpleLevelFrame(PlayerSet &players,
   player.m_isEditingLevel       = true;
   player.m_ancestorColumnIndex  = -1;
   player.m_dpiAff               = getDpiAffine(level, fid);
+  player.m_currentDrawingOnTop  = m_currentDrawingOnTop;
 }
 
 //-----------------------------------------------------------------------------
@@ -922,6 +930,7 @@ void Stage::visit(Visitor &visitor, const VisitArgs &args) {
   sb.m_isGuidedDrawingEnabled = args.m_isGuidedDrawingEnabled;
   sb.m_guidedFrontStroke      = args.m_guidedFrontStroke;
   sb.m_guidedBackStroke       = args.m_guidedBackStroke;
+  sb.m_currentDrawingOnTop    = args.m_currentDrawingOnTop;
   if (args.m_liveViewImage) {
     sb.m_liveViewImage  = args.m_liveViewImage;
     sb.m_liveViewPlayer = args.m_liveViewPlayer;

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -45,7 +45,8 @@ Stage::Player::Player()
     , m_frame(0)
     , m_isPlaying(false)
     , m_opacity(255)
-    , m_bingoOrder(0) {}
+    , m_bingoOrder(0)
+    , m_currentDrawingOnTop(false) {}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -199,7 +199,8 @@ TXsheet::TXsheet()
     , m_notes(new TXshNoteSet())
     , m_cameraColumnIndex(0)
     , m_observer(nullptr)
-    , m_navigationTags(new NavigationTags()) {
+    , m_navigationTags(new NavigationTags())
+    , m_currentDrawingOnTop(false) {
   // extern TSyntax::Grammar *createXsheetGrammar(TXsheet*);
   m_soundProperties      = new TXsheet::SoundProperties();
   m_imp->m_handleManager = new XshHandleManager(this);


### PR DESCRIPTION
This PR adds a new feature that mimics ToonBoom's Current Drawing on Top feature.

<img src="https://github.com/tahoma2d/tahoma2d/assets/19245851/47f09f50-8f2b-4ab1-91a1-e4bbfa10719e" width="50%" height="50%" />

The feature can be toggled on via menu option `View` -> `Current Drawing On Top` or right-click the Frames area on the Xsheet/Timeline and select `Current Drawing On Top` from the context menu.

If added to Command/Quick toolbars, the icon will appear as <img src="https://github.com/tahoma2d/tahoma2d/assets/19245851/579d781b-4f25-4a1d-8f7c-01cd3a674355" width="5%" height="5%" />
