### PR TITLE
Save/Restore tool settings + Import environment preference fix

### DIFF
--- a/toonz/sources/include/tools/pinchtool.h
+++ b/toonz/sources/include/tools/pinchtool.h
@@ -37,6 +37,7 @@ class StrokeDeformation;
 class DVAPI PinchTool : public TTool {
   Q_DECLARE_TR_FUNCTIONS(PinchTool)
 
+  bool m_firstTime;
   TMouseEvent m_lastMouseEvent;
   ToonzExt::StrokeDeformation *m_deformation;
   ToonzExt::ContextStatus m_status;
@@ -88,6 +89,7 @@ public:
 
   bool keyDown(QKeyEvent *) override;
 
+  bool onPropertyChanged(std::string propertyName) override;
   void onActivate() override;
   void onDeactivate() override;
 

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -62,6 +62,9 @@ TEnv::IntVar ShowHVscale("EditToolShowHVscale", 1);
 TEnv::IntVar ShowShear("EditToolShowShear", 0);
 TEnv::IntVar ShowCenterPosition("EditToolShowCenterPosition", 0);
 TEnv::StringVar Active("EditToolActiveAxis", "Position");
+TEnv::StringVar AutoSelect("EditToolAutoSelect", "None");
+TEnv::StringVar ScaleConstraint("EditToolScaleConstraint", "None");
+TEnv::IntVar ArrowGlobalKeyFrame("EditToolGlobalKeyFrame", 0);
 
 //=============================================================================
 namespace {
@@ -1483,6 +1486,11 @@ void EditTool::onActivate() {
 
     m_fxGadgetController = new FxGadgetController(this);
 
+    m_activeAxis.setValue(::to_wstring(Active.getValue()));
+    m_autoSelect.setValue(::to_wstring(AutoSelect.getValue()));
+    m_scaleConstraint.setValue(::to_wstring(ScaleConstraint.getValue()));
+    m_globalKeyframes.setValue(ArrowGlobalKeyFrame ? 1 : 0);
+
     /*
 m_foo.setTool(this);
 m_foo.setFxHandle(getApplication()->getCurrentFx());
@@ -1586,7 +1594,18 @@ bool EditTool::onPropertyChanged(std::string propertyName) {
       m_what = Center;
     else if (activeAxis == L"All")
       m_what = None;
+
+    Active = ::to_string(activeAxis);
   }
+
+  else if (propertyName == m_autoSelect.getName())
+    AutoSelect = ::to_string(m_autoSelect.getValue());
+
+  else if (propertyName == m_scaleConstraint.getName())
+    ScaleConstraint = ::to_string(m_scaleConstraint.getValue());
+
+  else if (propertyName == m_globalKeyframes.getName())
+    ArrowGlobalKeyFrame = (int)m_globalKeyframes.getValue();
 
   return true;
 }

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -77,6 +77,7 @@ TEnv::IntVar FillOnlySavebox("InknpaintFillOnlySavebox", 0);
 TEnv::IntVar FillReferenced("InknpaintFillReferenced", 0);
 
 TEnv::StringVar RasterGapSetting("RasterGapSetting", "Ignore Gaps");
+TEnv::IntVar AutoPaintLines("InknpaintAutoPaintLines", 1);
 extern TEnv::DoubleVar AutocloseDistance;
 extern TEnv::DoubleVar AutocloseAngle;
 extern TEnv::IntVar AutocloseInk;
@@ -2722,6 +2723,7 @@ bool FillTool::onPropertyChanged(std::string propertyName) {
 
   // Autopaint
   else if (propertyName == m_autopaintLines.getName()) {
+    AutoPaintLines      = (int)m_autopaintLines.getValue();
     rectPropChangedflag = true;
   }
 
@@ -2991,6 +2993,8 @@ void FillTool::onActivate() {
     m_frameRange.setValue(FillRange ? 1 : 0);
     m_fillOnlySavebox.setValue(FillOnlySavebox ? 1 : 0);
     m_referenced.setValue(FillReferenced ? 1 : 0);
+    m_autopaintLines.setValue(AutoPaintLines ? 1 : 0);
+
     m_firstTime = false;
 
     if (m_fillType.getValue() != NORMALFILL) {

--- a/toonz/sources/tnztools/magnettool.cpp
+++ b/toonz/sources/tnztools/magnettool.cpp
@@ -11,10 +11,13 @@
 #include "tproperty.h"
 #include "drawutil.h"
 #include "tcurveutil.h"
+#include "tenv.h"
 
 #include "toonz/tobjecthandle.h"
 #include "toonz/txshlevelhandle.h"
 #include "toonz/tstageobject.h"
+
+TEnv::IntVar MagnetSize("MagnetToolSize", 20);
 
 using namespace ToolUtils;
 
@@ -109,7 +112,7 @@ void drawQuadratic(const TQuadratic &quad, double pixelSize) {
 class MagnetTool final : public TTool {
   Q_DECLARE_TR_FUNCTIONS(MagnetTool)
 
-  bool m_active;
+  bool m_active, m_firstTime;
 
   TPointD m_startingPos;
 
@@ -438,6 +441,10 @@ lefrightButtonDown(p);
   }
 
   void onActivate() override {
+    if (!m_firstTime) {
+      m_firstTime = true;
+      m_toolSize.setValue(MagnetSize);
+    }
     //        getApplication()->editImageOrSpline();
   }
 
@@ -451,6 +458,7 @@ lefrightButtonDown(p);
 
   bool onPropertyChanged(std::string propertyName) override {
     if (propertyName == m_toolSize.getName()) {
+      MagnetSize = m_toolSize.getValue();
       invalidate();
     }
 

--- a/toonz/sources/tnztools/rasterselectiontool.cpp
+++ b/toonz/sources/tnztools/rasterselectiontool.cpp
@@ -461,6 +461,10 @@ void DragSelectionTool::RasterScaleTool::leftButtonUp(const TPointD &pos,
 
 TEnv::IntVar ModifySavebox("ModifySavebox", 0);
 TEnv::IntVar NoAntialiasing("NoAntialiasing", 0);
+TEnv::StringVar RasterSelectionType("SelectionToolInknpaintType",
+                                    "Rectangular");
+TEnv::StringVar FullColorSelectionType("SelectionToolFullcolorType",
+                                       "Rectangular");
 
 //=============================================================================
 // RasterSelectionTool
@@ -1054,8 +1058,13 @@ void RasterSelectionTool::decreaseTransformationCount() {
 
 void RasterSelectionTool::onActivate() {
   if (m_firstTime) {
-    if (m_targetType & ToonzImage)
+    if (m_targetType & ToonzImage) {
+      m_strokeSelectionType.setValue(
+          ::to_wstring(RasterSelectionType.getValue()));
       m_modifySavebox.setValue(ModifySavebox ? 1 : 0);
+    } else
+      m_strokeSelectionType.setValue(
+          ::to_wstring(FullColorSelectionType.getValue()));
   }
 
   SelectionTool::onActivate();
@@ -1066,7 +1075,15 @@ void RasterSelectionTool::onActivate() {
 bool RasterSelectionTool::onPropertyChanged(std::string propertyName) {
   if (!m_rasterSelection.isEditable()) return false;
 
+  if (propertyName == m_strokeSelectionType.getName()) {
+    if (m_targetType & ToonzImage)
+      RasterSelectionType = ::to_string(m_strokeSelectionType.getValue());
+    else
+      FullColorSelectionType = ::to_string(m_strokeSelectionType.getValue());
+  }
+
   if (SelectionTool::onPropertyChanged(propertyName)) return true;
+
   if (m_targetType & ToonzImage) {
     ModifySavebox = (int)(m_modifySavebox.getValue());
     invalidate();

--- a/toonz/sources/tnztools/selectiontool.cpp
+++ b/toonz/sources/tnztools/selectiontool.cpp
@@ -19,8 +19,6 @@
 using namespace ToolUtils;
 using namespace DragSelectionTool;
 
-TEnv::StringVar SelectionType("SelectionType", "Rectangular");
-
 //-----------------------------------------------------------------------------
 
 template <typename Tv, typename Tr, typename... Args>
@@ -1324,7 +1322,6 @@ void SelectionTool::drawCommandHandle(const TImage *image) {
 
 void SelectionTool::onActivate() {
   if (m_firstTime) {
-    m_strokeSelectionType.setValue(::to_wstring(SelectionType.getValue()));
     m_firstTime = false;
   }
   if (isLevelType() || isSelectedFramesType()) return;
@@ -1352,7 +1349,6 @@ void SelectionTool::onSelectionChanged() {
 
 bool SelectionTool::onPropertyChanged(std::string propertyName) {
   if (propertyName == m_strokeSelectionType.getName()) {
-    SelectionType = ::to_string(m_strokeSelectionType.getValue());
     if (m_strokeSelectionType.getValue() == POLYLINE_SELECTION)
       m_polyline.reset();
     return true;

--- a/toonz/sources/tnztools/stylepickertool.cpp
+++ b/toonz/sources/tnztools/stylepickertool.cpp
@@ -31,10 +31,14 @@
 #include "ttoonzimage.h"
 #include "tundo.h"
 #include "tmsgcore.h"
+#include "tenv.h"
 
 #define LINES L"Lines"
 #define AREAS L"Areas"
 #define ALL L"Lines & Areas"
+
+TEnv::StringVar StylePickVectorType("InknpaintStylePickVectorType", "Areas");
+TEnv::IntVar StylePickPassive("InknpaintStylePickPassive", 0);
 
 //========================================================================
 // Pick Style Tool
@@ -46,7 +50,8 @@ StylePickerTool::StylePickerTool()
     , m_colorType("Mode:")
     , m_passivePick("Passive Pick", false)
     , m_organizePalette("Organize Palette", false)
-    , m_paletteToBeOrganized(NULL) {
+    , m_paletteToBeOrganized(NULL)
+    , m_firstTime(true) {
   m_prop.bind(m_colorType);
   m_colorType.addValue(AREAS);
   m_colorType.addValue(LINES);
@@ -261,8 +266,20 @@ bool StylePickerTool::onPropertyChanged(std::string propertyName) {
       std::cout << "End Organize Palette" << std::endl;
       m_paletteToBeOrganized = NULL;
     }
-  }
+  } else if (propertyName == m_colorType.getName())
+    StylePickVectorType = ::to_string(m_colorType.getValue());
+  else if (propertyName == m_passivePick.getName())
+    StylePickPassive = m_passivePick.getValue();
+
   return true;
+}
+
+void StylePickerTool::onActivate() {
+  if (m_firstTime) {
+    m_colorType.setValue(::to_wstring(StylePickVectorType.getValue()));
+    m_passivePick.setValue(StylePickPassive ? 1 : 0);
+    m_firstTime = false;
+  }
 }
 
 bool StylePickerTool::startOrganizePalette() {

--- a/toonz/sources/tnztools/stylepickertool.h
+++ b/toonz/sources/tnztools/stylepickertool.h
@@ -12,6 +12,7 @@
 class StylePickerTool final : public TTool, public QObject {
   Q_DECLARE_TR_FUNCTIONS(StylePickerTool)
 
+  bool m_firstTime;
   int m_oldStyleId, m_currentStyleId;
 
   TEnumProperty m_colorType;
@@ -43,6 +44,8 @@ public:
   int getCursorId() const override;
 
   bool onPropertyChanged(std::string propertyName) override;
+
+  void onActivate() override;
 
   bool isOrganizePaletteActive() { return m_organizePalette.getValue(); }
 

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -65,8 +65,6 @@
 
 using namespace ToolOptionsControls;
 
-TEnv::IntVar ArrowGlobalKeyFrame("EditToolGlobalKeyFrame", 0);
-
 //=============================================================================
 // ToolOptionToolBar
 

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -41,6 +41,9 @@ TEnv::IntVar l_strokeSelectConstantThickness("SelectionToolConstantThickness",
                                              0);
 TEnv::IntVar l_strokeSelectIncludeIntersection(
     "SelectionToolIncludeIntersection", 0);
+TEnv::StringVar l_strokeSelectionTarget("SelectionToolVectorTarget",
+                                        "Standard");
+TEnv::StringVar l_strokeSelectionType("SelectionToolVectorType", "Rectangular");
 
 const int l_dragThreshold = 10;  //!< Distance, in pixels, the user has to
                                  //!  move from a button press to trigger a
@@ -1964,6 +1967,10 @@ void VectorSelectionTool::onActivate() {
     m_constantThickness.setValue(l_strokeSelectConstantThickness ? 1 : 0);
     m_strokeSelection.setSceneHandle(
         TTool::getApplication()->getCurrentScene());
+    m_selectionTarget.setValue(
+        ::to_wstring(l_strokeSelectionTarget.getValue()));
+    m_strokeSelectionType.setValue(
+        ::to_wstring(l_strokeSelectionType.getValue()));
   }
 
   SelectionTool::onActivate();
@@ -2059,15 +2066,19 @@ TPropertyGroup *VectorSelectionTool::getProperties(int idx) {
 bool VectorSelectionTool::onPropertyChanged(std::string propertyName) {
   if (!m_strokeSelection.isEditable()) return false;
 
+  if (propertyName == m_strokeSelectionType.getName())
+    l_strokeSelectionType = ::to_string(m_strokeSelectionType.getValue());
+
   if (SelectionTool::onPropertyChanged(propertyName)) return true;
 
   if (propertyName == m_includeIntersection.getName())
     l_strokeSelectIncludeIntersection = (int)(m_includeIntersection.getValue());
-  if (propertyName == m_constantThickness.getName())
+  else if (propertyName == m_constantThickness.getName())
     l_strokeSelectConstantThickness = (int)(m_constantThickness.getValue());
-  else if (propertyName == m_selectionTarget.getName())
+  else if (propertyName == m_selectionTarget.getName()) {
+    l_strokeSelectionTarget = ::to_string(m_selectionTarget.getValue());
     doOnActivate();
-  else if (propertyName == m_capStyle.getName()) {
+  } else if (propertyName == m_capStyle.getName()) {
     if (m_strokeSelection.isEmpty()) return true;
 
     TXshSimpleLevel *level =

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2505,8 +2505,8 @@ void PreferencesPopup::onImport() {
       Preferences::instance()->setValue(rhubarbPath, origRhubarbPath);
     }
 
+    // -- Environment variables
     if (useLegacy) {
-      // -- Environment variables
       srcDir = oldStuffPath + TFilePath("profiles/env");
       if (!TFileStatus(srcDir).doesExist())
         DVGui::warning("Failed to process Env.\nCould not find " +
@@ -2518,12 +2518,15 @@ void PreferencesPopup::onImport() {
           TSystem::copyFile(
               destDir + L"env.ini",
               srcDir + (TSystem::getUserName().toStdWString() + L".env"), true);
-          // Force reload now because it will automatically save on quit
-          TEnv::loadAllEnvVariables();
         }
       }
+    }
+    // Force reload now because it will automatically save on quit
+    if (TFileStatus(destDir + L"env.ini").doesExist())
+      TEnv::loadAllEnvVariables();
 
-      // -- Config
+    // -- Config
+    if (useLegacy) {
       srcDir = oldStuffPath + L"config";
       if (!TFileStatus(srcDir).doesExist())
         DVGui::warning("Failed to process Config.\nCould not find " +


### PR DESCRIPTION
After a mention that some tool options don't get saved and restored, I reviewed all tools and options to see what was already saving/restoring and identified the following options that would good to also save/restore:

- Animate Tool
	- Mode
	- Pick (All mode)
	- Maintain (Scale)
	- Global Key
- Selection Tool
	- Type - Updated so each level type now saves separately
	- Mode (Vector level)
- Fill Tool
	- Autopaint Lines
- Style Picker Tool
	- Mode
	- Passive Pick
- Pinch Tool
	- Corner
	- Manual
	- Size
- Pump Tool
	- Size
	- Accuracy
- Magnet Tool
	- Size
- Hook Tool
	- Snap

This PR also contains a bug fix for `Import Preferences` overwriting the copied environment settings file.