### PR TITLE
Magnet Tool slider - non-linear preference

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -367,6 +367,9 @@ public:
   int getTempToolSwitchtimer() const {
     return getIntValue(temptoolswitchtimer);
   }
+  bool isMagnetNonLinearSliderEnabled() const {
+    return getBoolValue(magnetNonLinearSliderEnabled);
+  }
 
   // Xsheet  tab
   QString getXsheetLayoutPreference() const {

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -120,6 +120,7 @@ enum PreferencesItemId {
   levelBasedToolsDisplay,
   useCtrlAltToResizeBrush,
   temptoolswitchtimer,
+  magnetNonLinearSliderEnabled,
 
   //----------
   // Xsheet

--- a/toonz/sources/tnztools/magnettool.cpp
+++ b/toonz/sources/tnztools/magnettool.cpp
@@ -13,6 +13,7 @@
 #include "tcurveutil.h"
 #include "tenv.h"
 
+#include "toonz/preferences.h"
 #include "toonz/tobjecthandle.h"
 #include "toonz/txshlevelhandle.h"
 #include "toonz/tstageobject.h"
@@ -149,7 +150,8 @@ public:
   {
     bind(TTool::Vectors);
 
-    m_toolSize.setNonLinearSlider();
+    if (Preferences::instance()->getBoolValue(magnetNonLinearSliderEnabled))
+      m_toolSize.setNonLinearSlider();
 
     m_prop.bind(m_toolSize);
   }

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1342,6 +1342,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {useCtrlAltToResizeBrush, tr("Use Ctrl+Alt to Resize Brush")},
       {temptoolswitchtimer,
        tr("Temporary Tool Switch Shortcut Hold Time (ms):")},
+      {magnetNonLinearSliderEnabled,
+       tr("Magnet Tool Size Slider - Non-Linear mode*")},
 
       // Xsheet
       {xsheetLayoutPreference, tr("Column Header Layout*:")},
@@ -2076,6 +2078,7 @@ QWidget* PreferencesPopup::createToolsPage() {
   if (Preferences::instance()->isShowAdvancedOptionsEnabled())
     insertUI(useCtrlAltToResizeBrush, lay);
   insertUI(temptoolswitchtimer, lay);
+  insertUI(magnetNonLinearSliderEnabled, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -565,6 +565,8 @@ void Preferences::definePreferenceItems() {
          false);
   define(temptoolswitchtimer, "temptoolswitchtimer", QMetaType::Int, 500, 1,
          std::numeric_limits<int>::max());
+  define(magnetNonLinearSliderEnabled, "magnetNonLinearSliderEnabled",
+         QMetaType::Bool, false);
 
   // Xsheet
   define(xsheetLayoutPreference, "xsheetLayoutPreference", QMetaType::QString,


### PR DESCRIPTION
It was requested that the Magnet tool's slider non-linear mode be removed.

As some may still prefer the non-linear mode, I've added a `Preference` -> `Tools` setting to accommodate individual user preference.

<img src="https://github.com/tahoma2d/tahoma2d/assets/19245851/a0cd40df-f5c6-4018-b242-64748b900d7f" width="50%" height="50%" />

The option is enabled by default and requires a restart when changing this setting.

