### PR TITLE
Scene Overlay Image

### DIFF
--- a/toonz/sources/include/toonz/sceneproperties.h
+++ b/toonz/sources/include/toonz/sceneproperties.h
@@ -98,6 +98,9 @@ private:
   bool m_columnColorFilterOnRender;
   TFilePath m_camCapSaveInPath;
 
+  TFilePath m_overlayFile;
+  int m_overlayOpacity;
+
 public:
   /*!
           The constructor creates:
@@ -311,6 +314,15 @@ and height.
   // templateFId in preview settings is used for "input" file format
   // such as new raster level, captured images by camera capture feature, etc.
   TFrameId &formatTemplateFIdForInput();
+
+  // Scene Overlay Image
+  TFilePath getOverlayFile() { return m_overlayFile; }
+  void setOverlayFile(TFilePath overlayFile) { m_overlayFile = overlayFile; }
+
+  int getOverlayOpacity() { return m_overlayOpacity; }
+  void setOverlayOpacity(int overlayOpacity) {
+    m_overlayOpacity = overlayOpacity;
+  }
 
 private:
   // not implemented

--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -32,6 +32,8 @@ class TXshLevel;
 class TXshSoundColumn;
 class TContentHistory;
 class LevelOptions;
+class TXshLevelColumn;
+class TLevelColumnFx;
 
 //========================================================================
 
@@ -263,6 +265,14 @@ If \b scene is in +scenes/name.tnz return name,
   bool isLoading() { return m_isLoading; }
   void setIsLoading(bool isLoading) { m_isLoading = isLoading; }
 
+  void loadOverlayFile(TFilePath overlayFP);
+  TXshLevel *getOverlayLevel();
+
+  int getOverlayOpacity() { return m_overlayOpacity; }
+  void setOverlayOpacity(int opacity);
+
+  TLevelColumnFx *getOverlayFx(int row);
+
 private:
   TFilePath m_scenePath;  //!< Full path to the scene file (.tnz).
 
@@ -281,6 +291,12 @@ private:
                      // is used when loading PSD levels, for defining whether to
                      // convert a layerId in the path to the layer name. See
                      // TXshSimpleLevel::load().
+
+  bool m_overlayLoaded;
+  TXshLevel *m_overlayLevel;
+  int m_overlayOpacity;
+  TXshLevelColumn *m_overlayLevelColumn;
+  TLevelColumnFx *m_overlayFx;
 
 private:
   // noncopyable

--- a/toonz/sources/include/toonzqt/camerasettingswidget.h
+++ b/toonz/sources/include/toonzqt/camerasettingswidget.h
@@ -92,7 +92,7 @@ class DVAPI CameraSettingsWidget final : public QFrame {
 
   QPushButton *m_fspChk;  // Force Squared Pixel => dpix == dpiy
 
-  QPushButton *m_useLevelSettingsBtn;
+  QPushButton *m_useLevelSettingsBtn, *m_useOverlaySettingsBtn;
   QComboBox *m_presetListOm;
   QPushButton *m_addPresetBtn, *m_removePresetBtn;
 
@@ -101,7 +101,7 @@ class DVAPI CameraSettingsWidget final : public QFrame {
   QString m_presetListFile;
 
   // needed by "use level settings"
-  TXshSimpleLevel *m_currentLevel;
+  TXshSimpleLevel *m_currentLevel, *m_overlayLevel;
 
   void savePresetList();
   void loadPresetList();
@@ -121,6 +121,7 @@ public:
   // Defines the level referred by the button "Use level settings".
   // Calling setCurrentLevel(0) disables the button
   void setCurrentLevel(TXshLevel *);
+  void setOverlayLevel(TXshLevel *);
 
   // camera => widget fields (i.e. initialize widget)
   void setFields(const TCamera *camera);
@@ -171,6 +172,8 @@ protected:
 
   void setArFld(double ar);
 
+  bool applyLevelSettings(TXshSimpleLevel *sl);
+
 protected slots:
   void onLxChanged();
   void onLyChanged();
@@ -185,12 +188,14 @@ protected slots:
   void addPreset();
   void removePreset();
   void useLevelSettings();
+  void useOverlaySettings();
 
 signals:
   void changed();  // some value has been changed
   void
   levelSettingsUsed();  // the "Use level settings" button has been pressed.
-  // Note: a changed() signal is always emitted after levelSettingsUsed()
+  void overlaySettingsUsed(); // the "Use Overlay settings" button has been pressed.
+  // Note: a changed() signal is always emitted after levelSettingsUsed()/overlaySettingsUsed()
 };
 
 #endif

--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -151,6 +151,7 @@ void CameraSettingsPopup::showEvent(QShowEvent *e) {
 
 void CameraSettingsPopup::hideEvent(QHideEvent *e) {
   m_cameraSettingsWidget->setCurrentLevel(0);
+  m_cameraSettingsWidget->setOverlayLevel(0);
 
   if (m_cameraId != TStageObjectId::NoneId) {
     // Remove the popup from currentlyOpened ones and schedule for deletion
@@ -254,6 +255,8 @@ void CameraSettingsPopup::updateFields() {
         TDimensionD(res.lx / Stage::standardDpi, res.ly / Stage::standardDpi));
   }
   if (camera) m_cameraSettingsWidget->setFields(camera);
+  m_cameraSettingsWidget->setOverlayLevel(
+      TApp::instance()->getCurrentScene()->getScene()->getOverlayLevel());
 }
 
 void CameraSettingsPopup::onLevelSwitched(TXshLevel *) {

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -53,6 +53,7 @@ extern TEnv::IntVar ShowFieldGuide;
 extern TEnv::IntVar GuideOpacity;
 extern TEnv::IntVar ShowPerspectiveGrids;
 extern TEnv::IntVar ShowSymmetryGuide;
+extern TEnv::IntVar ShowSceneOverlay;
 //=============================================================================
 // TPanel
 //-----------------------------------------------------------------------------
@@ -520,11 +521,19 @@ TPanelTitleBarButtonForGrids::TPanelTitleBarButtonForGrids(
   });
   symmetryCheckbox->setChecked(ShowSymmetryGuide != 0);
 
+  QCheckBox *sceneOverlayCheckbox = new QCheckBox(tr("Scene Overlay"), this);
+  connect(sceneOverlayCheckbox, &QCheckBox::stateChanged, [=](int value) {
+    ShowSceneOverlay = value > 0 ? 1 : 0;
+    emit updateViewer();
+  });
+  sceneOverlayCheckbox->setChecked(ShowSceneOverlay != 0);
+
   gridLayout->addWidget(thirdsCheckbox, 0, 0, 1, 2);
   gridLayout->addWidget(goldenRationCheckbox, 1, 0, 1, 2);
   gridLayout->addWidget(fieldGuideCheckbox, 2, 0, 1, 2);
   gridLayout->addWidget(perspectiveCheckbox, 3, 0, 1, 2);
   gridLayout->addWidget(symmetryCheckbox, 4, 0, 1, 2);
+  gridLayout->addWidget(sceneOverlayCheckbox, 5, 0, 1, 2);
 
   gridWidget->setLayout(gridLayout);
   gridsAction->setDefaultWidget(gridWidget);

--- a/toonz/sources/toonz/scenesettingspopup.h
+++ b/toonz/sources/toonz/scenesettingspopup.h
@@ -9,6 +9,7 @@
 #include "toonzqt/doublefield.h"
 #include "toonzqt/colorfield.h"
 #include "toonzqt/checkbox.h"
+#include "toonzqt/filefield.h"
 
 // forward declaration
 class TSceneProperties;
@@ -79,6 +80,9 @@ class SceneSettingsPopup final : public QDialog {
 
   DVGui::DoubleLineEdit *m_colorSpaceGammaFld;
 
+  DVGui::FileField *m_overlayFile;
+  DVGui::IntField *m_overlayOpacity;
+  
 public:
   SceneSettingsPopup();
   void configureNotify();
@@ -105,6 +109,9 @@ public slots:
 
   void onEditCellMarksButtonClicked();
   void onEditColorFiltersButtonClicked();
+
+  void onOverlayFileChanged();
+  void onOverlayOpacityChanged(bool isDragging);
 };
 
 #endif  // SCENESETTINGSPOPUP_H

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -356,6 +356,7 @@ protected:
   void drawViewerIndicators();
 
   void drawScene();
+  void drawSceneOverlay();
   void drawToolGadgets();
 
 protected:

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -17,6 +17,7 @@
 #include "toonz/txshcell.h"
 #include "toonz/txshleveltypes.h"
 #include "toonz/txshlevelcolumn.h"
+#include "toonz/txshcolumn.h"
 #include "toonz/txshpalettecolumn.h"
 #include "toonz/txshzeraryfxcolumn.h"
 #include "toonz/txshsimplelevel.h"
@@ -906,6 +907,11 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
   bool columnVisible =
       getColumnPlacement(pf, m_xsh, m_frame, pf.m_columnIndex, m_isPreview);
 
+  bool isOverlay = false;
+  if (!cell.isEmpty() &&
+      cell.getSimpleLevel()->getName() == L"__Scene Overlay__")
+    isOverlay = true;
+
   // if the cell is empty, only inherits its placement
   if ((m_particleDescendentCount == 0 && cell.isEmpty())) return pf;
 
@@ -933,7 +939,7 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
     addPlasticDeformerFx(pf);
   }
 
-  if (columnVisible) {
+  if (columnVisible || isOverlay) {
     // Column is visible, alright
     TXshSimpleLevel *sl = cell.isEmpty() || cell.getFrameId().isStopFrame()
                               ? 0
@@ -981,7 +987,8 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
 
     // Apply column's color filter and semi-transparency for rendering
     TXshLevelColumn *column = lcfx->getColumn();
-    if (m_scene->getProperties()->isColumnColorFilterOnRenderEnabled() &&
+    if ((m_scene->getProperties()->isColumnColorFilterOnRenderEnabled() ||
+         isOverlay) &&
         (column->getColorFilterId() != 0 ||  // None
          (column->isCamstandVisible() && column->getOpacity() != 255))) {
       TPixel32 colorScale = m_scene->getProperties()->getColorFilterColor(
@@ -1354,6 +1361,17 @@ TFxP buildSceneFx(ToonzScene *scene, TXsheet *xsh, double row, int whichLevels,
   // this creates an over fx to lay the current frame over the background color.
   fx = TFxUtil::makeOver(
       TFxUtil::makeColorCard(scene->getProperties()->getBgColor()), fx);
+
+  // this creates an over fx to lay the Scene Overlay, if there is one, over the
+  // current frame
+  TLevelColumnFx *overlayFx = scene->getOverlayFx(row);
+
+  if (overlayFx) {
+    PlacedFx overlayPf = builder.makePF(overlayFx);
+    TFxP overlayAffine = TFxUtil::makeAffine(overlayPf.makeFx(), aff);
+    fx                 = TFxUtil::makeOver(fx, overlayAffine);
+  }
+
   return fx;
 }
 

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -71,7 +71,9 @@ TSceneProperties::TSceneProperties()
     , m_fieldGuideSize(16)
     , m_fieldGuideAspectRatio(1.77778)
     , m_columnColorFilterOnRender(false)
-    , m_camCapSaveInPath() {
+    , m_camCapSaveInPath()
+    , m_overlayFile()
+    , m_overlayOpacity(255) {
   // Default color
   m_notesColor.push_back(TPixel32(255, 235, 140));
   m_notesColor.push_back(TPixel32(255, 160, 120));
@@ -126,6 +128,8 @@ void TSceneProperties::assign(const TSceneProperties *sprop) {
   m_fieldGuideSize            = sprop->m_fieldGuideSize;
   m_fieldGuideAspectRatio     = sprop->m_fieldGuideAspectRatio;
   m_columnColorFilterOnRender = sprop->m_columnColorFilterOnRender;
+  m_overlayFile               = sprop->m_overlayFile;
+  m_overlayOpacity            = sprop->m_overlayOpacity;
   int i;
   for (i = 0; i < m_notesColor.size(); i++)
     m_notesColor.replace(i, sprop->getNoteColor(i));
@@ -400,6 +404,8 @@ void TSceneProperties::saveData(TOStream &os) const {
       os << filter.name.toStdString() << filter.color;
     os.closeChild();
   }
+  if (!m_overlayFile.isEmpty())
+    os.child("overlayFile") << m_overlayFile << m_overlayOpacity;
 }
 
 //-----------------------------------------------------------------------------
@@ -835,6 +841,8 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
         m_colorFilters.replace(i, {QString::fromStdString(name), color});
         i++;
       }
+    } else if (tagName == "overlayFile") {
+      is >> m_overlayFile >> m_overlayOpacity;
     } else {
       throw TException("unexpected property tag: " + tagName);
     }

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -29,6 +29,7 @@
 #include "toonz/txshpalettecolumn.h"
 #include "toonz/txshpalettelevel.h"
 #include "toonz/toonzfolders.h"
+#include "toonz/tcolumnfx.h"
 
 // TnzCore includes
 #include "timagecache.h"
@@ -277,7 +278,14 @@ static void deleteAllUntitledScenes() {
 // ToonzScene
 
 ToonzScene::ToonzScene()
-    : m_contentHistory(0), m_isUntitled(true), m_isLoading(false) {
+    : m_contentHistory(0)
+    , m_isUntitled(true)
+    , m_isLoading(false)
+    , m_overlayLevel(0)
+    , m_overlayLevelColumn(0)
+    , m_overlayFx(0)
+    , m_overlayOpacity(255)
+    , m_overlayLoaded(false) {
   m_childStack = new ChildStack(this);
   m_properties = new TSceneProperties();
   m_levelSet   = new TLevelSet();
@@ -1618,4 +1626,78 @@ std::wstring ToonzScene::getLevelNameWithoutSceneNumber(std::wstring orgName) {
 
   return orgNameQstr.right(orgNameQstr.size() - orgNameQstr.indexOf("_") - 1)
       .toStdWString();
+}
+
+//-----------------------------------------------------------------------------
+
+void ToonzScene::loadOverlayFile(TFilePath overlayFP) {
+  TFilePath decodedFp = decodeFilePath(overlayFP);
+
+  if (m_overlayLevel) {
+    TFilePath currentFP = decodeFilePath(m_overlayLevel->getPath());
+    if (decodedFp == currentFP) return;
+    m_overlayFx->release();
+    m_overlayFx = 0;
+
+    m_overlayLevelColumn->release();
+    m_overlayLevelColumn = 0;
+
+    m_overlayLevel->release();
+    m_overlayLevel = 0;
+  }
+
+  m_overlayLoaded = false;
+
+  if (decodedFp.isEmpty() || !TFileStatus(decodedFp).doesExist()) return;
+
+  m_overlayLevel = loadLevel(decodedFp, 0, L"__Scene Overlay__");
+  if (!m_overlayLevel) return;
+
+  // Remove it from the level set but keep in memory
+  m_levelSet->removeLevel(m_overlayLevel, false);
+
+  // Construct the OverlayFX for later use
+  m_overlayLevelColumn = new TXshLevelColumn;
+  m_overlayLevelColumn->addRef();
+  m_overlayLevelColumn->setCamstandVisible(true);
+  m_overlayLevelColumn->setOpacity(m_overlayOpacity);
+
+  TXshCell cell(m_overlayLevel,
+                m_overlayLevel->getSimpleLevel()->getFirstFid());
+  m_overlayLevelColumn->setCell(0, cell);
+
+  m_overlayFx = new TLevelColumnFx;
+  m_overlayFx->addRef();
+  m_overlayFx->setColumn(m_overlayLevelColumn);
+
+  m_overlayLoaded = true;
+}
+
+//-----------------------------------------------------------------------------
+
+TXshLevel *ToonzScene::getOverlayLevel() {
+  if (!m_overlayLoaded) loadOverlayFile(m_properties->getOverlayFile());
+  return m_overlayLevel;
+}
+
+//-----------------------------------------------------------------------------
+
+void ToonzScene::setOverlayOpacity(int opacity) {
+  m_overlayOpacity = opacity;
+
+  if (m_overlayLevelColumn) m_overlayLevelColumn->setOpacity(m_overlayOpacity);
+}
+
+//-----------------------------------------------------------------------------
+
+TLevelColumnFx *ToonzScene::getOverlayFx(int row) {
+  if (!m_overlayLoaded) loadOverlayFile(m_properties->getOverlayFile());
+
+  // When not in implicit mode, create Cells for the requested row
+  if (!Preferences::instance()->isImplicitHoldEnabled() && m_overlayFx &&
+      m_overlayLevelColumn->getCell(row).isEmpty()) {
+    TXshCell cell = m_overlayLevelColumn->getCell(0);
+    m_overlayLevelColumn->setCell(row, cell);
+  }
+  return m_overlayFx;
 }


### PR DESCRIPTION
This was a request to be able to apply an image on top of every rendered frame automatically. Use cases includes applying/using an animation cell template used by studios or applying a watermark to the animation.

I've added this feature so animators can easily specify a scene overlay image (and opacity) which will automatically follow camera movements and be rendered on top of every frame.

The setting can be found in `Scene Settings`:

<img src="https://github.com/tahoma2d/tahoma2d/assets/19245851/cf12490a-da2d-4f0f-8d39-b96226a7bee7" width="80%" height="80%" />

To easily update the camera size to match the overlay dimension (i.e. for animation cell templates), I've added the `Use Scene Overlay Settings` buttton to camera settings:

<img src="https://github.com/tahoma2d/tahoma2d/assets/19245851/af866fc3-21ac-4597-ab6d-04deeaae6963" width="35%" height="35%" />

To show the overlay in the viewer, toggle on the `Grid and Overlays` button on the viewer and make sure `Scene Overlay` is toggled on:

<img src="https://github.com/tahoma2d/tahoma2d/assets/19245851/51a0b6e4-244b-427e-aa62-7f1ecf3fa5c3" width="20%" height="20%" />

----------------------------------------

Notes about Scene Overlays:
- Supported image types: PLI/SVG (vector), TLV (smart raster) and image files that load as a regular raster level (PNG, TIF/TIFF, GIF, etc...)
- If a level file with multiple frames is selected, only the 1st frame in the sequence is used.
- The overlay does not show in `Level Edit` mode
- **WARNING!** Scenes saved with an overlay cannot be opened in prior versions of T2D.
  - To reopen in older versions, save without the overlay or edit the .TNZ file and remove section `<overlayFile> .... </overlayFile>`

----------------------------------------

Demo:

https://github.com/tahoma2d/tahoma2d/assets/19245851/e2ff9ae0-f7aa-493d-a95a-1cbff610b40e

