### PR TITLE
Save/Restore palette swatch size setting for popups

### DIFF
--- a/toonz/sources/include/toonzqt/studiopaletteviewer.h
+++ b/toonz/sources/include/toonzqt/studiopaletteviewer.h
@@ -3,6 +3,7 @@
 #ifndef STUDIOPALETTEVIEWER_H
 #define STUDIOPALETTEVIEWER_H
 
+#include "saveloadqsettings.h"
 #include "toonz/studiopalette.h"
 #include "toonz/tapplication.h"
 #include "toonz/tproject.h"
@@ -214,7 +215,8 @@ protected:
                 allows to show and modify current studio palette selected in
    tree.
 */
-class DVAPI StudioPaletteViewer final : public QSplitter {
+class DVAPI StudioPaletteViewer final : public QSplitter,
+                                        public SaveLoadQSettings {
   Q_OBJECT
 
   StudioPaletteTreeViewer *m_studioPaletteTreeViewer;
@@ -240,6 +242,10 @@ public:
     if (m_studioPaletteViewer) m_studioPaletteViewer->setApplication(app);
   }
   TApplication *getApplication() { return m_app; }
+
+  // SaveLoadQSettings
+  void save(QSettings &settings, bool forPopupIni = false) const override;
+  void load(QSettings &settings) override;
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -312,27 +312,30 @@ void PaletteViewer::updateView() {
 
 void PaletteViewer::save(QSettings &settings, bool forPopupIni) const {
   int visibleParts = m_toolbarVisibleOtherParts;
+  int swatchSize   = m_pageViewer->getViewMode();
   if (m_visibleKeysAction->isChecked()) visibleParts |= 0x01;
-//  if (m_visibleNewAction->isChecked()) visibleParts |= 0x02;
+  //  if (m_visibleNewAction->isChecked()) visibleParts |= 0x02;
   if (m_visibleGizmoAction->isChecked()) visibleParts |= 0x04;
   if (m_visibleNameAction->isChecked()) visibleParts |= 0x08;
   settings.setValue("toolbarVisibleMsk", visibleParts);
- }
- 
- void PaletteViewer::load(QSettings &settings) {
-  int visibleParts;
-  QVariant visibleVar = settings.value("toolbarVisibleMsk");
-  if (visibleVar.canConvert(QVariant::Int)) {
-    visibleParts = visibleVar.toInt();
-  } else {
-    visibleParts = 3;  // Show keyframes and new style/page
-  }
+  settings.setValue("swatchSize", swatchSize);
+}
+
+void PaletteViewer::load(QSettings &settings) {
+  int visibleParts                = 3;  // Show keyframes and new style/page;
+  PageViewer::ViewMode swatchSize = PageViewer::SmallChips;
+  QVariant visibleVar             = settings.value("toolbarVisibleMsk");
+  QVariant swatchVar              = settings.value("swatchSize");
+  if (visibleVar.canConvert(QVariant::Int)) visibleParts = visibleVar.toInt();
+  if (swatchVar.canConvert(QVariant::Int))
+    swatchSize = (PageViewer::ViewMode)swatchVar.toInt();
 
   m_visibleKeysAction->setChecked(visibleParts & 0x01);
 //  m_visibleNewAction->setChecked(visibleParts & 0x02);
   m_visibleGizmoAction->setChecked(visibleParts & 0x04);
   m_visibleNameAction->setChecked(visibleParts & 0x08);
   m_toolbarVisibleOtherParts = visibleParts & ~0x0F;  // Reserve
+  m_pageViewer->setViewMode(swatchSize);
 
   applyToolbarPartVisibility(TBVisKeyframe, visibleParts & 0x01);
 //  applyToolbarPartVisibility(TBVisNewStylePage, visibleParts & 0x02);

--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -1265,3 +1265,20 @@ void StudioPaletteViewer::setViewMode(int mode) {
   m_studioPaletteViewer->setViewMode(
       (PaletteViewerGUI::PageViewer::ViewMode)mode);
 }
+
+//-----------------------------------------------------------------------------
+
+void StudioPaletteViewer::save(QSettings &settings, bool forPopupIni) const {
+  int swatchSize = getViewMode();
+  settings.setValue("swatchSize", swatchSize);
+}
+
+//-----------------------------------------------------------------------------
+
+void StudioPaletteViewer::load(QSettings &settings) {
+  int swatchSize     = PageViewer::SmallChips;
+  QVariant swatchVar = settings.value("swatchSize");
+  if (swatchVar.canConvert(QVariant::Int)) swatchSize = swatchVar.toInt();
+
+  setViewMode(swatchSize);
+}


### PR DESCRIPTION
This will save and restore the last palette swatch size setting for Palette and Studio Palette popup windows.

Docked palette/studio palettes swatch size is still determined by the room configuration settings..