### PR TITLE
Change when Magnet tool's non-linear preference is applied

### DIFF
--- a/toonz/sources/tnztools/magnettool.cpp
+++ b/toonz/sources/tnztools/magnettool.cpp
@@ -150,9 +150,6 @@ public:
   {
     bind(TTool::Vectors);
 
-    if (Preferences::instance()->getBoolValue(magnetNonLinearSliderEnabled))
-      m_toolSize.setNonLinearSlider();
-
     m_prop.bind(m_toolSize);
   }
 
@@ -446,6 +443,9 @@ lefrightButtonDown(p);
     if (!m_firstTime) {
       m_firstTime = true;
       m_toolSize.setValue(MagnetSize);
+
+      if (Preferences::instance()->getBoolValue(magnetNonLinearSliderEnabled))
+        m_toolSize.setNonLinearSlider();
     }
     //        getApplication()->editImageOrSpline();
   }


### PR DESCRIPTION
This PR changes the application of the Magnet tool's non-linear preference setting, added in #1221, to when the tool is first activated instead of first created.

Checking preferences at tool creation has a negative side effect on macOS (Linux too?) which results in the same issue as #1200. The crash is caused by preferences loading before the application name is set since tools are created  before T2D actually starts running to set the name. 

I plan on merging this once I confirm the macOS artifact imports preferences successfully. 