### PR TITLE
Fix SVG import from Browser

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -959,7 +959,8 @@ TXshLevel *loadLevel(ToonzScene *scene,
       std::string format = actualPath.getType();
       if (format == "tzp" || format == "tzu") convertingPopup->show();
 
-      if (fIds.size() != 0 && doesFileActuallyExist)
+      // SVGs are treated as PLI. Ignore the fIds lists
+      if (format != "svg" && fIds.size() != 0 && doesFileActuallyExist)
         xl = scene->loadLevel(actualPath, rd.m_options ? &*rd.m_options : 0,
                               levelName, fIds);
       else


### PR DESCRIPTION
This is a followup to #1212.

This fixes a crash when loading SVG from the Browser.  It was loading the SVGs without a palette because it was treating it as a normal image file rather than a PLI converted image and would crash when trying to display the image to screen.