### PR TITLE
Update macOS  build env to Monterey

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   macOS:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies


### PR DESCRIPTION
Homebrew has stopped supporting qt@5 on Big Sur.  This is causing builds on Big Sur to fail when it tries to compile qt@5 and exceeds the build timeout of 6 hours.

This change will update to build on macOS 12 (Monterey).