### PR TITLE
Fix accidental fills with pen movement

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -752,6 +752,11 @@ void SceneViewer::mousePressEvent(QMouseEvent *event) {
   if (m_gestureActive && m_touchDevice == QTouchDevice::TouchScreen) {
     return;
   }
+
+  // Strangely, mousePressEvent seems to be called once just after releasing
+  // tablet. This condition avoids to proceed further in such case.
+  if (event->buttons() != Qt::NoButton && m_mouseButton == Qt::NoButton) return;
+
   // For now OSX has a critical problem that mousePressEvent is called just
   // after releasing the stylus, which causes the irregular stroke while
   // float-moving.


### PR DESCRIPTION
There was a reported issue that during Refer Visible fills, sometimes adjcent areas would fill if the mouse was moved while it was filling.

Though I could not duplicate the issue in my environments, I took a look at the Events being generated by pen activity and found that a `mousePressEvent` event was being called immediately after a `tabletRelease`.  When using the fill tool this would attempt to cause a second fill operation immediately after the 1st one.  If this 2nd fill attempt happened to pick a pixel that was not filled, it would begin fill operations in the new area.

@shun-iwasawa noted and fixed this event processing issue for `mouseMoveEvent` events when fixing defining sub-camera with stylus (OT-PR#4803).

I am applying the same fix to `mousePressEvent` event processing which seems to stop the 2nd fill operation.

This can potentially impact all tools, so really need help verifying there is no unintended impacts with this change.