### PR TITLE
Viewer Event Log

### DIFF
--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -141,6 +141,7 @@ set(MOC_HEADERS
     ../stopmotion/gphotocam.h
     cameracapturelevelcontrol.h
     navtageditorpopup.h
+    viewereventlogpopup.h
 )
 
 set(HEADERS
@@ -388,6 +389,7 @@ set(SOURCES
     ../stopmotion/gphotocam.cpp
 	cameracapturelevelcontrol.cpp
     navtageditorpopup.cpp
+    viewereventlogpopup.cpp
 )
 
 if(WITH_TRANSLATION)

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -34,6 +34,7 @@
 #include "toonz/tonionskinmaskhandle.h"
 #include "toonz/stage.h"
 #include "toonz/toonzfolders.h"
+#include "viewereventlogpopup.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -981,6 +982,18 @@ void PreferencesPopup::onImportPolicyExternallyChanged(int policy) {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onOpenViewerEventLog() {
+  if (!m_viewerEventLogPopup) {
+    m_viewerEventLogPopup = new ViewerEventLogPopup();
+    ViewerEventLogManager::instance()->setViewerEventLogPopup(
+        m_viewerEventLogPopup);
+  }
+
+  m_viewerEventLogPopup->show();
+}
+
+//-----------------------------------------------------------------------------
+
 QWidget* PreferencesPopup::createUI(PreferencesItemId id,
                                     const QList<ComboBoxItem>& comboItems,
                                     bool isLineEdit) {
@@ -1554,7 +1567,8 @@ inline T PreferencesPopup::getUI(PreferencesItemId id) {
 PreferencesPopup::PreferencesPopup()
     : QDialog(TApp::instance()->getMainWindow())
     , m_formatProperties()
-    , m_additionalStyleEdit(nullptr) {
+    , m_additionalStyleEdit(nullptr)
+    , m_viewerEventLogPopup(0) {
   setWindowTitle(tr("Preferences"));
   setObjectName("PreferencesPopup");
 
@@ -2307,11 +2321,15 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
       new CheckBox(tr("Enable Touch Gesture Controls"));
   enableTouchGestures->setChecked(touchAction->isChecked());
 
+  QPushButton* viewerEventLogBtn =
+      new QPushButton(tr("Open Viewer Event Log"));
+
   QWidget* widget  = new QWidget(this);
   QGridLayout* lay = new QGridLayout();
   setupLayout(lay);
 
   lay->addWidget(enableTouchGestures, 0, 0, 1, 2);
+  lay->addWidget(viewerEventLogBtn, 0, 3, 1, 1);
   if (winInkAvailable) insertUI(winInkEnabled, lay);
 #ifdef WITH_WINTAB
   insertUI(useQtNativeWinInk, lay);
@@ -2326,6 +2344,9 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
                        SLOT(setChecked(bool)));
   ret = ret && connect(touchAction, SIGNAL(triggered(bool)),
                        enableTouchGestures, SLOT(setChecked(bool)));
+  ret = ret && connect(viewerEventLogBtn, SIGNAL(clicked()), this,
+                       SLOT(onOpenViewerEventLog()));
+
   assert(ret);
 
   return widget;

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -14,6 +14,8 @@
 // TnzLib includes
 #include "toonz/preferences.h"
 
+#include "viewereventlogpopup.h"
+
 // Qt includes
 #include <QComboBox>
 #include <QFontComboBox>
@@ -95,6 +97,8 @@ private:
   QCheckBox* m_importStudioPalettesCB;
   QCheckBox* m_importLibraryCB;
   QCheckBox* m_importToonzfarmCB;
+
+  ViewerEventLogPopup *m_viewerEventLogPopup;
 
 private:
   void rebuildFormatsList();
@@ -193,6 +197,7 @@ private slots:
   void onLutPathChanged();
   void onCheck30bitDisplay();
   void onFrameFormatButton();
+  void onOpenViewerEventLog();
 
   void onAddLevelFormat();
   void onRemoveLevelFormat();

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -21,6 +21,8 @@
 #include "stopmotion.h"
 #include "tstopwatch.h"
 
+#include "viewereventlogpopup.h"
+
 // TnzQt includes
 #include "toonzqt/tselectionhandle.h"
 #include "toonzqt/styleselection.h"
@@ -1284,88 +1286,28 @@ void SceneViewer::touchEvent(QTouchEvent *e, int type) {
 //-----------------------------------------------------------------------------
 
 bool SceneViewer::event(QEvent *e) {
-  /*
   switch (e->type()) {
-  //	case QEvent::Enter:
-  //	qDebug() << "[enter] ************************** Enter";
-  //	break;
-  //	case QEvent::Leave:
-  //	qDebug() << "[enter] ************************** Leave";
-  //	break;
-
-  case QEvent::TabletPress: {
-    QTabletEvent *te = static_cast<QTabletEvent *>(e);
-    qDebug() << "[enter] ************************** TabletPress mouseState("
-             << m_mouseState << ") tabletState(" << m_tabletState
-             << ") pressure(" << m_pressure << ") pointerType("
-             << te->pointerType() << ") device(" << te->device() << ")";
-  } break;
-  //	case QEvent::TabletMove:
-  //	qDebug() << "[enter] ************************** TabletMove
-  //mouseState("<<m_mouseState<<") tabletState("<<m_tabletState<<") pressure("
-  //<< m_pressure << ")";
-  //	break;
+  case QEvent::Enter:
+  case QEvent::Leave:
+  case QEvent::TabletPress:
+  case QEvent::TabletMove:
   case QEvent::TabletRelease:
-    qDebug() << "[enter] ************************** TabletRelease mouseState("
-             << m_mouseState << ") tabletState(" << m_tabletState << ")";
-    break;
-
   case QEvent::TouchBegin:
-    qDebug() << "[enter] ************************** TouchBegin";
-    break;
   case QEvent::TouchEnd:
-    qDebug() << "[enter] ************************** TouchEnd";
-    break;
   case QEvent::TouchCancel:
-    qDebug() << "[enter] ************************** TouchCancel";
-    break;
-
   case QEvent::Gesture:
-    qDebug() << "[enter] ************************** Gesture";
-    break;
-
   case QEvent::MouseButtonPress:
-    qDebug()
-        << "[enter] ************************** MouseButtonPress mouseState("
-        << m_mouseState << ") tabletState(" << m_tabletState << ") pressure("
-        << m_pressure << ") tabletEvent(" << m_tabletEvent << ")";
-    break;
-  //	case QEvent::MouseMove:
-  //	qDebug() << "[enter] ************************** MouseMove mouseState("
-  //<< m_mouseState << ") tabletState("<<m_tabletState<<") pressure(" <<
-  //m_pressure << ")";
-  //	break;
+  case QEvent::MouseMove:
   case QEvent::MouseButtonRelease:
-    qDebug()
-        << "[enter] ************************** MouseButtonRelease mouseState("
-        << m_mouseState << ") tabletState(" << m_tabletState << ")";
-    break;
-
   case QEvent::MouseButtonDblClick:
-    qDebug() << "[enter] ************************** MouseButtonDblClick";
-    break;
-
-  case QEvent::KeyPress: {
-    QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
-    QString keyStr = QKeySequence(keyEvent->key() + keyEvent->modifiers())
-      .toString();
-    qDebug() << "[enter] ************************** KeyPress key=" <<
-  keyStr;
-  }
-    break;
-
-  case QEvent::KeyRelease: {
-    QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
-    QString keyStr = QKeySequence(keyEvent->key() + keyEvent->modifiers())
-      .toString();
-    qDebug() << "[enter] ************************** KeyRelease key=" <<
-  keyStr;
-  }
+  case QEvent::KeyPress:
+  case QEvent::KeyRelease:
+    ViewerEventLogManager::instance()->addEventMessage(e);
     break;
   default:
-    qDebug() << "[enter] ************************** Event: "<< e;
+    //    qDebug() << "[enter] ************************** Event: "<< e;
+    break;
   }
-  */
 
   int key = 0;
   if (e->type() == QEvent::KeyPress) {

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -141,10 +141,11 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     if (!m_eventTabletPress->isChecked()) return;
 
     QTabletEvent *te = dynamic_cast<QTabletEvent *>(e);
-    eventMsg         = tr("Stylus pressed at X=%1 Y=%2 Pressure=%3")
+    float pressure   = (int)(te->pressure() * 1000 + 0.5);
+    eventMsg         = tr("Stylus pressed at X=%1 Y=%2 Pressure=%3%")
                    .arg(te->pos().x())
                    .arg(te->pos().y())
-                   .arg(te->pressure());
+                   .arg(pressure / 10.0);
   } break;
 
   case QEvent::TabletMove: {
@@ -156,11 +157,12 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
          (te->buttons() & Qt::RightButton) || (te->buttons() & Qt::MidButton))
             ? tr("dragged")
             : tr("moved");
-    eventMsg = tr("Stylus %1 to X=%2 Y=%3 Pressure=%4")
+    float pressure = (int)(te->pressure() * 1000 + 0.5);
+    eventMsg       = tr("Stylus %1 to X=%2 Y=%3 Pressure=%4%")
                    .arg(operation)
                    .arg(te->pos().x())
                    .arg(te->pos().y())
-                   .arg(te->pressure());
+                   .arg(pressure / 10.0);
   } break;
 
   case QEvent::TabletRelease: {

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -14,8 +14,8 @@
 //-----------------------------------------------------------------------------
 
 ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
-    : QSplitter(parent), m_logging(false), m_lastMsgCount(0) {
-  setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint);
+    : QSplitter(parent), m_logging(true), m_lastMsgCount(0) {
+  setWindowFlags(Qt::WindowStaysOnTopHint);
   setWindowTitle(tr("Viewer Event Log"));
 
   // style sheet
@@ -316,12 +316,6 @@ void ViewerEventLogPopup::onClearButtonPressed() { m_eventLog->clear(); }
 
 //--------------------------------------------------
 
-void ViewerEventLogPopup::showEvent(QShowEvent *e) {
-  m_logging = true;
-  m_pauseBtn->setText("Pause");
-  m_eventLog->clear();
+void ViewerEventLogPopup::hideEvent(QHideEvent *e) {
+  if (m_logging) onPauseButtonPressed();
 }
-
-//--------------------------------------------------
-
-void ViewerEventLogPopup::hideEvent(QHideEvent *e) { m_logging = false; }

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -1,0 +1,284 @@
+#include "viewereventlogpopup.h"
+
+#include <QCheckbox>
+#include <QLabel>
+#include <QPushButton>
+#include <QTabletEvent>
+#include <QTextEdit>
+#include <QVBoxLayout>
+
+//=============================================================================
+// ViewerEventLog
+//-----------------------------------------------------------------------------
+
+ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
+    : QSplitter(parent), m_logging(false), m_lastMsgCount(0) {
+  setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint);
+  setWindowTitle("Viewer Event Log");
+
+  // style sheet
+  setObjectName("ViewerEventLog");
+  setFrameStyle(QFrame::StyledPanel);
+
+  //-------Left side
+  m_eventEnter              = new QCheckBox(tr("Enter"), this);
+  m_eventLeave              = new QCheckBox(tr("Leave"), this);
+  m_eventTabletPress        = new QCheckBox(tr("Stylus Press"), this);
+  m_eventTabletMove         = new QCheckBox(tr("Stylus Move"), this);
+  m_eventTabletRelease      = new QCheckBox(tr("Stylus Release"), this);
+  m_eventTouchBegin         = new QCheckBox(tr("Touch Begin"), this);
+  m_eventTouchEnd           = new QCheckBox(tr("Touch End"), this);
+  m_eventTouchCancel        = new QCheckBox(tr("Touch Cancel"), this);
+  m_eventGesture            = new QCheckBox(tr("Gesture"), this);
+  m_eventMouseButtonPress   = new QCheckBox(tr("Mouse Button Press"), this);
+  m_eventMouseMove          = new QCheckBox(tr("Mouse Move"), this);
+  m_eventMouseButtonRelease = new QCheckBox(tr("Mouse Button Release"), this);
+  m_eventMouseButtonDblClick =
+      new QCheckBox(tr("Mouse Button Double-Click"), this);
+  m_eventKeyPress   = new QCheckBox(tr("Key Press"), this);
+  m_eventKeyRelease = new QCheckBox(tr("Key Release"), this);
+
+  m_eventEnter->setChecked(true);
+  m_eventLeave->setChecked(true);
+  m_eventTabletPress->setChecked(true);
+  m_eventTabletMove->setChecked(true);
+  m_eventTabletRelease->setChecked(true);
+  m_eventTouchBegin->setChecked(true);
+  m_eventTouchEnd->setChecked(true);
+  m_eventTouchCancel->setChecked(true);
+  m_eventGesture->setChecked(true);
+  m_eventMouseButtonPress->setChecked(true);
+  m_eventMouseMove->setChecked(true);
+  m_eventMouseButtonRelease->setChecked(true);
+  m_eventMouseButtonDblClick->setChecked(true);
+  m_eventKeyPress->setChecked(true);
+  m_eventKeyRelease->setChecked(true);
+
+  QFrame *filterBox          = new QFrame(this);
+  QVBoxLayout *vFilterLayout = new QVBoxLayout(filterBox);
+  vFilterLayout->setMargin(10);
+  vFilterLayout->setSpacing(5);
+
+  vFilterLayout->addWidget(new QLabel(tr("Capture events:"), this));
+  vFilterLayout->addWidget(m_eventEnter);
+  vFilterLayout->addWidget(m_eventLeave);
+  vFilterLayout->addWidget(m_eventTabletPress);
+  vFilterLayout->addWidget(m_eventTabletMove);
+  vFilterLayout->addWidget(m_eventTabletRelease);
+  vFilterLayout->addWidget(m_eventTouchBegin);
+  vFilterLayout->addWidget(m_eventTouchEnd);
+  vFilterLayout->addWidget(m_eventTouchCancel);
+  vFilterLayout->addWidget(m_eventGesture);
+  vFilterLayout->addWidget(m_eventMouseButtonPress);
+  vFilterLayout->addWidget(m_eventMouseMove);
+  vFilterLayout->addWidget(m_eventMouseButtonRelease);
+  vFilterLayout->addWidget(m_eventMouseButtonDblClick);
+  vFilterLayout->addWidget(m_eventKeyPress);
+  vFilterLayout->addWidget(m_eventKeyRelease);
+
+  vFilterLayout->addStretch();
+
+  filterBox->setLayout(vFilterLayout);
+
+  addWidget(filterBox);
+  //------end left side
+
+  //------begin right side
+
+  QPushButton *clearBtn = new QPushButton(tr("Clear Log"), this);
+  connect(clearBtn, SIGNAL(pressed()), this, SLOT(onClearButtonPressed()));
+
+  m_eventLog = new QTextEdit(this);
+  m_eventLog->setReadOnly(true);
+
+  QFrame *logBox          = new QFrame(this);
+  QVBoxLayout *vLogLayout = new QVBoxLayout(logBox);
+
+  vLogLayout->addWidget(m_eventLog);
+  vLogLayout->addWidget(clearBtn);
+
+  logBox->setLayout(vFilterLayout);
+
+  addWidget(logBox);
+
+  //------end right side (the task sheet)
+
+  setStretchFactor(1, 2);
+}
+
+//--------------------------------------------------
+
+void ViewerEventLogPopup::addEventMessage(QEvent *e) {
+  if (!m_logging) return;
+
+  QString eventMsg = "Unknown event";
+
+  switch (e->type()) {
+  case QEvent::Enter: {
+    if (!m_eventEnter->isChecked()) return;
+    eventMsg = "Entered viewer";
+  } break;
+
+  case QEvent::Leave: {
+    if (!m_eventLeave->isChecked()) return;
+    eventMsg = "Left viewer";
+  } break;
+
+  case QEvent::TabletPress: {
+    if (!m_eventTabletPress->isChecked()) return;
+
+    QTabletEvent *te = dynamic_cast<QTabletEvent *>(e);
+    eventMsg = "Stylus pressed at X=" + QString::number(te->pos().x()) + " Y=" +
+               QString::number(te->pos().y()) + " Pressure=" +
+               QString::number(te->pressure());
+  } break;
+
+  case QEvent::TabletMove: {
+    if (!m_eventTabletMove->isChecked()) return;
+
+    QTabletEvent *te = dynamic_cast<QTabletEvent *>(e);
+    QString operation =
+        ((te->buttons() & Qt::LeftButton) ||
+         (te->buttons() & Qt::RightButton) || (te->buttons() & Qt::MidButton))
+            ? "dragged"
+            : "moved";
+    eventMsg = "Stylus " + operation + " to X=" +
+               QString::number(te->pos().x()) + " Y=" +
+               QString::number(te->pos().y()) + " Pressure=" +
+               QString::number(te->pressure());
+  } break;
+
+  case QEvent::TabletRelease: {
+    if (!m_eventTabletRelease->isChecked()) return;
+
+    eventMsg = "Stylus released";
+  } break;
+
+  case QEvent::TouchBegin: {
+    if (!m_eventTouchBegin->isChecked()) return;
+
+    eventMsg = "Touch begins";
+  } break;
+
+  case QEvent::TouchEnd: {
+    if (!m_eventTouchEnd->isChecked()) return;
+
+    eventMsg = "Touch ended";
+  } break;
+
+  case QEvent::TouchCancel: {
+    if (!m_eventTouchCancel->isChecked()) return;
+
+    eventMsg = "Touch cancelled";
+  } break;
+
+  case QEvent::Gesture: {
+    if (!m_eventGesture->isChecked()) return;
+
+    eventMsg = "Gesture encountered";
+  } break;
+
+  case QEvent::MouseButtonPress: {
+    if (!m_eventMouseButtonPress->isChecked()) return;
+
+    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    QString usedButton =
+        (me->buttons() & Qt::LeftButton)
+            ? "LEFT"
+            : (me->buttons() & Qt::RightButton)
+                  ? "RIGHT"
+                  : (me->buttons() & Qt::MidButton) ? "MIDDLE" : "NO";
+
+    eventMsg = "Mouse " + usedButton + " button pressed at X=" +
+               QString::number(me->pos().x()) + " Y=" +
+               QString::number(me->pos().y());
+  } break;
+
+  case QEvent::MouseMove: {
+    if (!m_eventMouseMove->isChecked()) return;
+
+    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    QString operation =
+        ((me->buttons() & Qt::LeftButton) ||
+         (me->buttons() & Qt::RightButton) || (me->buttons() & Qt::MidButton))
+            ? "dragged"
+            : "moved";
+    eventMsg = "Mouse " + operation + " to X=" +
+               QString::number(me->pos().x()) + " Y=" +
+               QString::number(me->pos().y());
+  } break;
+
+  case QEvent::MouseButtonRelease: {
+    if (!m_eventMouseButtonRelease->isChecked()) return;
+
+    eventMsg = "Mouse button released";
+  } break;
+
+  case QEvent::MouseButtonDblClick: {
+    if (!m_eventMouseButtonDblClick->isChecked()) return;
+
+    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    QString usedButton =
+        (me->buttons() & Qt::LeftButton)
+            ? "LEFT"
+            : (me->buttons() & Qt::RightButton)
+                  ? "RIGHT"
+                  : (me->buttons() & Qt::MidButton) ? "MIDDLE" : "NO";
+
+    eventMsg = "Mouse " + usedButton + " button double-clicked at X=" +
+               QString::number(me->pos().x()) + " Y=" +
+               QString::number(me->pos().y());
+  } break;
+
+  case QEvent::KeyPress: {
+    if (!m_eventKeyPress->isChecked()) return;
+
+    QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>(e);
+    QString keyStr =
+        QKeySequence(keyEvent->key() + keyEvent->modifiers()).toString();
+    eventMsg = "Key pressed: " + keyStr;
+  } break;
+
+  case QEvent::KeyRelease: {
+    if (!m_eventKeyRelease->isChecked()) return;
+
+    QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>(e);
+    QString keyStr =
+        QKeySequence(keyEvent->key() + keyEvent->modifiers()).toString();
+    eventMsg = "Key released: " + keyStr;
+  } break;
+
+  default:
+    return;
+  }
+
+  if (m_lastMsg == eventMsg) {
+    m_lastMsgCount++;
+    return;
+  }
+
+  m_lastMsg = eventMsg;
+
+  if (m_lastMsgCount > 1)
+    eventMsg += " [x" + QString::number(m_lastMsgCount) + "]";
+
+  m_eventLog->append(eventMsg);
+  m_eventLog->moveCursor(QTextCursor::End);
+
+  m_lastMsgCount = 1;
+}
+
+//--------------------------------------------------
+
+void ViewerEventLogPopup::onClearButtonPressed() { m_eventLog->clear(); }
+
+//--------------------------------------------------
+
+void ViewerEventLogPopup::showEvent(QShowEvent *e) {
+  m_logging = true;
+  m_eventLog->clear();
+}
+
+//--------------------------------------------------
+
+void ViewerEventLogPopup::hideEvent(QHideEvent *e) { m_logging = false; }

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -1,6 +1,6 @@
 #include "viewereventlogpopup.h"
 
-#include <QCheckbox>
+#include <QCheckBox>
 #include <QLabel>
 #include <QPushButton>
 #include <QTabletEvent>

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -16,7 +16,7 @@
 ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
     : QSplitter(parent), m_logging(false), m_lastMsgCount(0) {
   setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint);
-  setWindowTitle("Viewer Event Log");
+  setWindowTitle(tr("Viewer Event Log"));
 
   // style sheet
   setObjectName("ViewerEventLog");
@@ -97,7 +97,7 @@ ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
   m_eventLog = new QTextEdit(this);
   m_eventLog->setReadOnly(true);
 
-  QFrame *logBox          = new QFrame(this);
+  QFrame *logBox = new QFrame(this);
 
   QVBoxLayout *vLogLayout = new QVBoxLayout(logBox);
 
@@ -124,26 +124,27 @@ ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
 void ViewerEventLogPopup::addEventMessage(QEvent *e) {
   if (!m_logging) return;
 
-  QString eventMsg = "Unknown event";
+  QString eventMsg = tr("Unknown event");
 
   switch (e->type()) {
   case QEvent::Enter: {
     if (!m_eventEnter->isChecked()) return;
-    eventMsg = "Entered viewer";
+    eventMsg = tr("Entered viewer");
   } break;
 
   case QEvent::Leave: {
     if (!m_eventLeave->isChecked()) return;
-    eventMsg = "Left viewer";
+    eventMsg = tr("Left viewer");
   } break;
 
   case QEvent::TabletPress: {
     if (!m_eventTabletPress->isChecked()) return;
 
     QTabletEvent *te = dynamic_cast<QTabletEvent *>(e);
-    eventMsg = "Stylus pressed at X=" + QString::number(te->pos().x()) + " Y=" +
-               QString::number(te->pos().y()) + " Pressure=" +
-               QString::number(te->pressure());
+    eventMsg         = tr("Stylus pressed at X=%1 Y=%2 Pressure=%3")
+                   .arg(te->pos().x())
+                   .arg(te->pos().y())
+                   .arg(te->pressure());
   } break;
 
   case QEvent::TabletMove: {
@@ -153,42 +154,43 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QString operation =
         ((te->buttons() & Qt::LeftButton) ||
          (te->buttons() & Qt::RightButton) || (te->buttons() & Qt::MidButton))
-            ? "dragged"
-            : "moved";
-    eventMsg = "Stylus " + operation + " to X=" +
-               QString::number(te->pos().x()) + " Y=" +
-               QString::number(te->pos().y()) + " Pressure=" +
-               QString::number(te->pressure());
+            ? tr("dragged")
+            : tr("moved");
+    eventMsg = tr("Stylus %1 to X=%2 Y=%3 Pressure=%4")
+                   .arg(operation)
+                   .arg(te->pos().x())
+                   .arg(te->pos().y())
+                   .arg(te->pressure());
   } break;
 
   case QEvent::TabletRelease: {
     if (!m_eventTabletRelease->isChecked()) return;
 
-    eventMsg = "Stylus released";
+    eventMsg = tr("Stylus released");
   } break;
 
   case QEvent::TouchBegin: {
     if (!m_eventTouchBegin->isChecked()) return;
 
-    eventMsg = "Touch begins";
+    eventMsg = tr("Touch begins");
   } break;
 
   case QEvent::TouchEnd: {
     if (!m_eventTouchEnd->isChecked()) return;
 
-    eventMsg = "Touch ended";
+    eventMsg = tr("Touch ended");
   } break;
 
   case QEvent::TouchCancel: {
     if (!m_eventTouchCancel->isChecked()) return;
 
-    eventMsg = "Touch cancelled";
+    eventMsg = tr("Touch cancelled");
   } break;
 
   case QEvent::Gesture: {
     if (!m_eventGesture->isChecked()) return;
 
-    eventMsg = "Gesture encountered";
+    eventMsg = tr("Gesture encountered");
   } break;
 
   case QEvent::MouseButtonPress: {
@@ -197,14 +199,15 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
     QString usedButton =
         (me->buttons() & Qt::LeftButton)
-            ? "LEFT"
+            ? tr("LEFT")
             : (me->buttons() & Qt::RightButton)
-                  ? "RIGHT"
-                  : (me->buttons() & Qt::MidButton) ? "MIDDLE" : "NO";
+                  ? tr("RIGHT")
+                  : (me->buttons() & Qt::MidButton) ? tr("MIDDLE") : tr("NO");
 
-    eventMsg = "Mouse " + usedButton + " button pressed at X=" +
-               QString::number(me->pos().x()) + " Y=" +
-               QString::number(me->pos().y());
+    eventMsg = tr("Mouse %1 button pressed at X=%2 Y=%3")
+                   .arg(usedButton)
+                   .arg(me->pos().x())
+                   .arg(me->pos().y());
   } break;
 
   case QEvent::MouseMove: {
@@ -214,17 +217,18 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QString operation =
         ((me->buttons() & Qt::LeftButton) ||
          (me->buttons() & Qt::RightButton) || (me->buttons() & Qt::MidButton))
-            ? "dragged"
-            : "moved";
-    eventMsg = "Mouse " + operation + " to X=" +
-               QString::number(me->pos().x()) + " Y=" +
-               QString::number(me->pos().y());
+            ? tr("dragged")
+            : tr("moved");
+    eventMsg = tr("Mouse %1 to X=%2 Y=%3")
+                   .arg(operation)
+                   .arg(me->pos().x())
+                   .arg(me->pos().y());
   } break;
 
   case QEvent::MouseButtonRelease: {
     if (!m_eventMouseButtonRelease->isChecked()) return;
 
-    eventMsg = "Mouse button released";
+    eventMsg = tr("Mouse button released");
   } break;
 
   case QEvent::MouseButtonDblClick: {
@@ -233,14 +237,15 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
     QString usedButton =
         (me->buttons() & Qt::LeftButton)
-            ? "LEFT"
+            ? tr("LEFT")
             : (me->buttons() & Qt::RightButton)
-                  ? "RIGHT"
-                  : (me->buttons() & Qt::MidButton) ? "MIDDLE" : "NO";
+                  ? tr("RIGHT")
+                  : (me->buttons() & Qt::MidButton) ? tr("MIDDLE") : tr("NO");
 
-    eventMsg = "Mouse " + usedButton + " button double-clicked at X=" +
-               QString::number(me->pos().x()) + " Y=" +
-               QString::number(me->pos().y());
+    eventMsg = tr("Mouse %1 button double-clicked at X=%2 Y=%3")
+                   .arg(usedButton)
+                   .arg(me->pos().x())
+                   .arg(me->pos().y());
   } break;
 
   case QEvent::KeyPress: {
@@ -249,7 +254,7 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>(e);
     QString keyStr =
         QKeySequence(keyEvent->key() + keyEvent->modifiers()).toString();
-    eventMsg = "Key pressed: " + keyStr;
+    eventMsg = tr("Key pressed: %1").arg(keyStr);
   } break;
 
   case QEvent::KeyRelease: {
@@ -258,7 +263,7 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>(e);
     QString keyStr =
         QKeySequence(keyEvent->key() + keyEvent->modifiers()).toString();
-    eventMsg = "Key released: " + keyStr;
+    eventMsg = tr("Key released: %1").arg(keyStr);
   } break;
 
   default:

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -96,6 +96,8 @@ ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
 
   m_eventLog = new QTextEdit(this);
   m_eventLog->setReadOnly(true);
+  m_eventLog->setLineWrapMode(QTextEdit::LineWrapMode::NoWrap);
+  m_eventLog->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 
   QFrame *logBox = new QFrame(this);
 

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -6,6 +6,8 @@
 #include <QTabletEvent>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <QApplication>
+#include <QClipboard>
 
 //=============================================================================
 // ViewerEventLog
@@ -85,6 +87,10 @@ ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
 
   //------begin right side
 
+  m_pauseBtn = new QPushButton(tr("Pause"), this);
+  connect(m_pauseBtn, SIGNAL(pressed()), this, SLOT(onPauseButtonPressed()));
+  QPushButton *copyBtn = new QPushButton(tr("Copy to Clipboard"), this);
+  connect(copyBtn, SIGNAL(pressed()), this, SLOT(onCopyButtonPressed()));
   QPushButton *clearBtn = new QPushButton(tr("Clear Log"), this);
   connect(clearBtn, SIGNAL(pressed()), this, SLOT(onClearButtonPressed()));
 
@@ -92,10 +98,17 @@ ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
   m_eventLog->setReadOnly(true);
 
   QFrame *logBox          = new QFrame(this);
+
   QVBoxLayout *vLogLayout = new QVBoxLayout(logBox);
 
   vLogLayout->addWidget(m_eventLog);
-  vLogLayout->addWidget(clearBtn);
+
+  QHBoxLayout *btnLayout = new QHBoxLayout();
+  btnLayout->addWidget(m_pauseBtn);
+  btnLayout->addWidget(copyBtn);
+  btnLayout->addWidget(clearBtn);
+
+  vLogLayout->addLayout(btnLayout);
 
   logBox->setLayout(vFilterLayout);
 
@@ -270,12 +283,33 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
 
 //--------------------------------------------------
 
+void ViewerEventLogPopup::onPauseButtonPressed() {
+  m_logging = !m_logging;
+  if (m_logging) {
+    m_pauseBtn->setText("Pause");
+    m_eventLog->append("*** Event logging resumed ***");
+  } else {
+    m_pauseBtn->setText("Resume");
+    m_eventLog->append("*** Event logging paused ***");
+  }
+}
+
+//--------------------------------------------------
+
+void ViewerEventLogPopup::onCopyButtonPressed() {
+  QClipboard *clipboard = QApplication::clipboard();
+  clipboard->setText(m_eventLog->toPlainText());
+}
+
+//--------------------------------------------------
+
 void ViewerEventLogPopup::onClearButtonPressed() { m_eventLog->clear(); }
 
 //--------------------------------------------------
 
 void ViewerEventLogPopup::showEvent(QShowEvent *e) {
   m_logging = true;
+  m_pauseBtn->setText("Pause");
   m_eventLog->clear();
 }
 

--- a/toonz/sources/toonz/viewereventlogpopup.h
+++ b/toonz/sources/toonz/viewereventlogpopup.h
@@ -8,6 +8,7 @@
 
 class QTextEdit;
 class QCheckBox;
+class QPushButton;
 
 //**************************************************************
 //    Viewer Event Log Popup
@@ -23,6 +24,8 @@ class ViewerEventLogPopup final : public QSplitter {
       *m_eventMouseButtonPress, *m_eventMouseMove, *m_eventMouseButtonRelease,
       *m_eventMouseButtonDblClick, *m_eventKeyPress, *m_eventKeyRelease;
 
+  QPushButton *m_pauseBtn;
+
   QString m_lastMsg;
   int m_lastMsgCount;
 
@@ -37,6 +40,8 @@ public:
   void hideEvent(QHideEvent *e) override;
 
 public slots:
+  void onPauseButtonPressed();
+  void onCopyButtonPressed();
   void onClearButtonPressed();
 };
 

--- a/toonz/sources/toonz/viewereventlogpopup.h
+++ b/toonz/sources/toonz/viewereventlogpopup.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#ifndef VIEWER_EVENT_LOG_H
+#define VIEWER_EVENT_LOG_H
+
+#include <QSplitter>
+#include <QEvent>
+
+class QTextEdit;
+class QCheckBox;
+
+//**************************************************************
+//    Viewer Event Log Popup
+//**************************************************************
+
+class ViewerEventLogPopup final : public QSplitter {
+  Q_OBJECT
+
+  QTextEdit *m_eventLog;
+  QCheckBox *m_eventEnter, *m_eventLeave, *m_eventTabletPress,
+      *m_eventTabletMove, *m_eventTabletRelease, *m_eventTouchBegin,
+      *m_eventTouchEnd, *m_eventTouchCancel, *m_eventGesture,
+      *m_eventMouseButtonPress, *m_eventMouseMove, *m_eventMouseButtonRelease,
+      *m_eventMouseButtonDblClick, *m_eventKeyPress, *m_eventKeyRelease;
+
+  QString m_lastMsg;
+  int m_lastMsgCount;
+
+  bool m_logging;
+
+public:
+  ViewerEventLogPopup(QWidget *parent = 0);
+
+  void addEventMessage(QEvent *e);
+
+  void showEvent(QShowEvent *e) override;
+  void hideEvent(QHideEvent *e) override;
+
+public slots:
+  void onClearButtonPressed();
+};
+
+//**************************************************************
+//    Viewer Event Log Manager
+//**************************************************************
+
+class ViewerEventLogManager {  // singleton
+
+  ViewerEventLogPopup *m_viewerEventLogPopup;
+
+  ViewerEventLogManager() {}
+
+public:
+  static ViewerEventLogManager *instance() {
+    static ViewerEventLogManager _instance;
+    return &_instance;
+  }
+
+  void setViewerEventLogPopup(ViewerEventLogPopup *popup) {
+    m_viewerEventLogPopup = popup;
+  }
+
+  void addEventMessage(QEvent *e) {
+    if (!m_viewerEventLogPopup) return;
+    m_viewerEventLogPopup->addEventMessage(e);
+  }
+};
+
+#endif  // VIEWER_EVENT_LOG_H

--- a/toonz/sources/toonz/viewereventlogpopup.h
+++ b/toonz/sources/toonz/viewereventlogpopup.h
@@ -36,7 +36,6 @@ public:
 
   void addEventMessage(QEvent *e);
 
-  void showEvent(QShowEvent *e) override;
   void hideEvent(QHideEvent *e) override;
 
 public slots:


### PR DESCRIPTION
To aid in debugging, especially with tablets, I've created a simple Viewer Event Log popup which will capture certain events that are processed by the Viewer. 

<image src="https://github.com/tahoma2d/tahoma2d/assets/19245851/f6787268-06d2-4d15-afe0-055c42e6d4af" width="65%" height="65%" />


To use, open the log viewer by pressing the `Preferences -> Touch/Tablet Settings -> Open Viewer Event Log` button and start working in the viewer as normal. Information will be sent to the event viewer.
