### PR TITLE
Fix dragging on Smart Raster reference fill

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2596,10 +2596,11 @@ void FillTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
       closeStyleIndex =
           TTool::getApplication()->getCurrentPalette()->getStyleIndex();
     }
+    TTool::Application *app = TTool::getApplication();
     applyFill(img, pos, params, e.isShiftPressed(), m_level.getPointer(),
            getCurrentFid(), m_autopaintLines.getValue(),
-           m_closeRasterGaps.getIndex() > 0, m_closeRasterGaps.getIndex() > 1,
-           closeStyleIndex);
+           m_closeRasterGaps.getIndex() > 0, m_closeRasterGaps.getIndex() > 1, closeStyleIndex,
+              app->getCurrentFrame()->getFrameIndex());
     invalidate();
   }
 }


### PR DESCRIPTION
This fixes a bug mentioned as issue 1 in https://github.com/tahoma2d/tahoma2d/issues/1238#issuecomment-1755218767.

The drag fill operation was missing a frame index so the internally rendered frame that is used for reference fills is blank.  this would result in the reference fill being flood filled and transfered to all unfilled pixels in the real frame.

This may help, to some degree, issue 2 in the same comment. 