### PR TITLE
Fix potential pen-drag actions when tapping

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -400,6 +400,12 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
         m_tabletState       = Released;
         mouseEvent.m_button = Qt::LeftButton;
         onRelease(mouseEvent);
+      } else if (m_tabletState == StartStroke) {
+        // Single tap of stylus still records TableMoves before TabletRelease.
+        // Skip the 1st TabletMove to give time for TabletRelease to show up
+        // This way we don't try to do a LeftButtonDrag operation (i.e. normal
+        // fill) too soon.
+        m_tabletState = OnStroke;
       } else {
         m_tabletMove = true;
         onMove(mouseEvent);  // m_tabletState is set to OnStrole here


### PR DESCRIPTION
 This is in response to the issue 2 noted in https://github.com/tahoma2d/tahoma2d/issues/1238#issuecomment-1755218767.

Currently after a `TabletPress` event, the 1st `TabletMove` event is processed and the internal timer skips any following move events for a very brief period.  The problem this fixes is a simple pen tap can create a series of `TabletMove` events before the `TabletRelease` event shows up.  Depending on the tool, a pen-drag action could be triggered.

In the case of the Fill tool, this can cause unwanted fills depending on where the pen detects the cursor immediately after the tap.  I've modified the logic to ignore the 1st `TableMove` after a `TabletPress` so there is time for the `TabletRelease` to appear.  If the release doesn't show up in time, assumed an intential pen drag, then the next `TabletMove` after the skip timer will take over as normal.

I would have included this with #1239, however, this change can impact all tools and requires a bit more testing on all OSes to make sure nothing is broken.
