### PR TITLE
Invert raster fill depth value calculation

### DIFF
--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -1003,7 +1003,7 @@ void fullColorFill(const TRaster32P &ras, const FillParameters &params,
   TPointD m_firstPoint, m_clickPoint;
 
   // convert fillDepth range from [0 - 15] to [0 - 255]
-  fillDepth = (fillDepth << 4) | fillDepth;
+  fillDepth = ((15 - fillDepth) << 4) | (15 - fillDepth);
 
   std::stack<FillSeed> seeds;
   std::map<int, std::vector<std::pair<int, int>>> segments;


### PR DESCRIPTION
The Fill tool's `Fill Depth` slider value meaning on Raster levels is the opposite to that of Smart Raster levels.  In order to get the same results between both level types, Smart Raster has to go high, while Raster needs to go low.

I'm not sure if this was an oversite when Raster fill was implemented 4 years ago,  but to make things consistent, I'm inverting the Raster's slider value meaning to match the Smart Raster's slider meaning.