### PR TITLE
OpenToonz Patches thru 10/12/2023

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -520,7 +520,7 @@ elseif(BUILD_ENV_UNIXLIKE)
     find_package(LZO REQUIRED)
     message("LZO:" ${LZO_INCLUDE_DIR})
 
-    if(HAIKU)
+    if(BUILD_TARGET_BSD OR HAIKU)
         find_library(EXECINFO_LIBRARY execinfo)
     endif()
     find_library(PTHREAD_LIBRARY pthread)

--- a/toonz/sources/common/tsystem/tpluginmanager.cpp
+++ b/toonz/sources/common/tsystem/tpluginmanager.cpp
@@ -15,12 +15,12 @@
 #include <sys/param.h>
 #include <unistd.h>
 #include <sys/types.h>
-#ifndef FREEBSD
+#if !defined(FREEBSD) || __FreeBSD_version >= 1300040
 #include <dirent.h>
 #endif
 #include <stdio.h>
 #include <unistd.h>
-#ifndef HAIKU
+#if !defined(HAIKU) && (!defined(FREEBSD) || __FreeBSD_version < 1300040)
 #include <sys/dir.h>
 #endif
 #include <sys/param.h>  // for getfsstat

--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -162,6 +162,11 @@ void DVAPI addImagesToIcon(QIcon &icon, const QImage &baseImg,
 
 //-----------------------------------------------------------------------------
 
+void DVAPI addSpecifiedSizedImageToIcon(QIcon &icon, const char *iconSVGName,
+                                        QSize newSize = QSize());
+
+//-----------------------------------------------------------------------------
+
 void DVAPI addPixmapToAllModesAndStates(QIcon &icon, const QPixmap &pixmap);
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -1749,8 +1749,8 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
       }
       m_tabBarContainer->setLayout(hLayout);
 
-      mainLayout->addWidget(m_tabBarContainer, 0, 0);
-      mainLayout->addWidget(m_stackedChooser, 1, 0);
+      mainLayout->addWidget(m_tabBarContainer, 0);
+      mainLayout->addWidget(m_stackedChooser, 1);
       mainLayout->addWidget(opacityFrame, 0);
       mainLayout->addWidget(controlButtonFrame, 0);
       setLayout(mainLayout);

--- a/toonz/sources/tnztools/levelselection.cpp
+++ b/toonz/sources/tnztools/levelselection.cpp
@@ -14,7 +14,6 @@
 
 // Boost includes
 #include <boost/iterator/counting_iterator.hpp>
-#include <boost/bind.hpp>
 
 //*******************************************************************************
 //    Local namespace  stuff
@@ -108,7 +107,7 @@ void getBoundaries(TVectorImage &vi, std::vector<int> &strokes) {
   std::copy_if(boost::make_counting_iterator(0u),
                boost::make_counting_iterator(vi.getStrokeCount()),
                std::back_inserter(strokes),
-               boost::bind(locals::isBoundary, sData, _1));
+               [&](UINT e) { return locals::isBoundary(sData, e); });
 }
 
 }  // namespace

--- a/toonz/sources/toonz/batchserversviewer.h
+++ b/toonz/sources/toonz/batchserversviewer.h
@@ -44,7 +44,7 @@ class BatchServersViewer final : public QFrame {
   Q_OBJECT
 
 public:
-  BatchServersViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  BatchServersViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~BatchServersViewer();
 
   void updateSelected();

--- a/toonz/sources/toonz/castviewer.h
+++ b/toonz/sources/toonz/castviewer.h
@@ -78,7 +78,7 @@ class CastBrowser final : public QSplitter, public DvItemListModel {
   std::unique_ptr<CastItems> m_castItems;
 
 public:
-  CastBrowser(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  CastBrowser(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~CastBrowser();
 
   CastItems const &getCastItems() const { return *m_castItems; }

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -1453,7 +1453,9 @@ public:
       TXshColumn *column = xsh->getColumn(i);
       if (!column) continue;
       /*- Skip if target is in selected column mode and not selected -*/
-      bool isSelected = selection && selection->isColumnSelected(i);
+      bool isSelected = selection && !selection->isEmpty()
+                      ? selection->isColumnSelected(i)
+                      : cc == i;
       if (m_target == TARGET_SELECTED && !isSelected) continue;
 
       /*-

--- a/toonz/sources/toonz/comboviewerpane.h
+++ b/toonz/sources/toonz/comboviewerpane.h
@@ -21,7 +21,7 @@ class ComboViewerPanel final : public BaseViewerPanel {
   Ruler *m_hRuler;
 
 public:
-  ComboViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  ComboViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ComboViewerPanel() {}
 
   ToolOptions *getToolOptions() { return m_toolOptions; }

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -29,7 +29,7 @@ protected:
   QString m_barId;
 
 public:
-  CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = 0,
+  CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
              bool isCollapsible = false, bool isQuickToolbar = false);
 
   QString getBarId() { return m_barId; }

--- a/toonz/sources/toonz/exportpanel.h
+++ b/toonz/sources/toonz/exportpanel.h
@@ -90,7 +90,7 @@ class ExportPanel final : public TPanel {
   QCheckBox *m_useMarker;
 
 public:
-  ExportPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  ExportPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ExportPanel();
   void loadExportSettings();
   void saveExportSettings();

--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -60,7 +60,7 @@ class FileBrowser final : public QFrame, public DvItemListModel {
   Q_OBJECT
 
 public:
-  FileBrowser(QWidget *parent, Qt::WindowFlags flags = 0,
+  FileBrowser(QWidget *parent, Qt::WindowFlags flags = Qt::WindowFlags(),
               bool noContextMenu = false, bool multiSelectionEnabled = false);
   ~FileBrowser();
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -87,7 +87,7 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
   setWindowTitle(title);
   setModal(false);
 
-  m_browser        = new FileBrowser(this, 0, false, m_multiSelectionEnabled);
+  m_browser        = new FileBrowser(this, Qt::WindowFlags(), false, m_multiSelectionEnabled);
   m_nameFieldLabel = new QLabel(tr("File name:"));
   m_nameField      = new DVGui::LineEdit(this);
   m_okButton       = new QPushButton(tr("OK"), this);

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -236,7 +236,7 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
   bool m_showComboBox  = true;
 
 public:
-  Filmstrip(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  Filmstrip(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~Filmstrip();
 
   // SaveLoadQSettings

--- a/toonz/sources/toonz/historypane.h
+++ b/toonz/sources/toonz/historypane.h
@@ -33,7 +33,7 @@ class HistoryPane final : public QWidget {
   QScrollArea *m_frameArea;
 
 public:
-  HistoryPane(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  HistoryPane(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~HistoryPane(){};
 
 protected:

--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -289,7 +289,7 @@ InsertFxPopup::InsertFxPopup()
   m_buttonLayout->addWidget(addBtn);
 
   QPushButton *replaceBtn = new QPushButton(tr("Replace"), this);
-  addBtn->setMinimumSize(65, 25);
+  replaceBtn->setMinimumSize(65, 25);
   replaceBtn->setObjectName("PushButton_NoPadding");
   connect(replaceBtn, SIGNAL(clicked()), this, SLOT(onReplace()));
   m_buttonLayout->addWidget(replaceBtn);

--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -276,20 +276,20 @@ InsertFxPopup::InsertFxPopup()
   addWidget(m_fxTree);
 
   QPushButton *insertBtn = new QPushButton(tr("Insert"), this);
-  insertBtn->setFixedSize(65, 25);
+  insertBtn->setMinimumSize(65, 25);
   insertBtn->setObjectName("PushButton_NoPadding");
   connect(insertBtn, SIGNAL(clicked()), this, SLOT(onInsert()));
   insertBtn->setDefault(true);
   m_buttonLayout->addWidget(insertBtn);
 
   QPushButton *addBtn = new QPushButton(tr("Add"), this);
-  addBtn->setFixedSize(65, 25);
+  addBtn->setMinimumSize(65, 25);
   addBtn->setObjectName("PushButton_NoPadding");
   connect(addBtn, SIGNAL(clicked()), this, SLOT(onAdd()));
   m_buttonLayout->addWidget(addBtn);
 
   QPushButton *replaceBtn = new QPushButton(tr("Replace"), this);
-  replaceBtn->setFixedHeight(25);
+  addBtn->setMinimumSize(65, 25);
   replaceBtn->setObjectName("PushButton_NoPadding");
   connect(replaceBtn, SIGNAL(clicked()), this, SLOT(onReplace()));
   m_buttonLayout->addWidget(replaceBtn);

--- a/toonz/sources/toonz/layerfooterpanel.h
+++ b/toonz/sources/toonz/layerfooterpanel.h
@@ -34,7 +34,7 @@ private:
 
 public:
   LayerFooterPanel(XsheetViewer *viewer, QWidget *parent = 0,
-                   Qt::WindowFlags flags = 0);
+                   Qt::WindowFlags flags = Qt::WindowFlags());
   ~LayerFooterPanel();
 
   void showOrHide(const Orientation *o);

--- a/toonz/sources/toonz/messagepanel.h
+++ b/toonz/sources/toonz/messagepanel.h
@@ -54,7 +54,7 @@ class LogPanel final : public TPanel, public TLogger::Listener {
   int m_poolIndex;
 
 public:
-  LogPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  LogPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~LogPanel();
 
   void onLogChanged() override;

--- a/toonz/sources/toonz/previewfxmanager.cpp
+++ b/toonz/sources/toonz/previewfxmanager.cpp
@@ -1082,7 +1082,7 @@ void PreviewFxInstance::doOnRenderRasterCompleted(
 
   /*-- 16bpc縺ｧ險育ｮ励＆繧後◆蝣ｴ蜷医∫ｵ先棡繧奪ithering縺吶ｋ --*/
   // dither the 16bpc image IF the "30bit display" preference option is OFF
-  if ((rasA->getPixelSize() == 8 || rasA->getPixelSize() == 16) &&
+  if (rasA->getPixelSize() == 8 &&
       !Preferences::instance()->is30bitDisplayEnabled())  // render in 64 bits
   {
     TRaster32P auxA(rasA->getLx(), rasA->getLy());

--- a/toonz/sources/toonz/quicktoolbar.h
+++ b/toonz/sources/toonz/quicktoolbar.h
@@ -31,7 +31,7 @@ class QuickToolbar final : public CommandBar {
   XsheetViewer *m_viewer;
 
 public:
-  QuickToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0,
+  QuickToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
                 bool isCollapsible = false);
   static void toggleQuickToolbar();
   void showToolbar(bool show);

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -81,7 +81,6 @@
 #include "tcg/boost/permuted_range.h"
 
 // boost includes
-#include <boost/bind.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
@@ -419,7 +418,7 @@ void SceneBrowser::sortByDataModel(DataType dataType, bool isDiscendent) {
 
     std::stable_sort(
         new2OldIdx.begin(), new2OldIdx.end(),
-        boost::bind(locals::itemLess, _1, _2, boost::ref(*this), dataType));
+        [this, dataType](int x, int y){ return locals::itemLess(x, y, *this, dataType); });
 
     // Use the renumbering table to permutate elements
     std::vector<Item>(
@@ -437,15 +436,13 @@ void SceneBrowser::sortByDataModel(DataType dataType, bool isDiscendent) {
           boost::make_counting_iterator(int(m_items.size())));
 
       std::sort(old2NewIdx.begin(), old2NewIdx.end(),
-                boost::bind(locals::indexLess, _1, _2, boost::ref(new2OldIdx)));
+                [&new2OldIdx](int x, int y){ return locals::indexLess(x, y, new2OldIdx); });
 
       std::vector<int> newSelectedIndices;
       tcg::substitute(
           newSelectedIndices,
           tcg::permuted_range(old2NewIdx, fs->getSelectedIndices() |
-                                              ba::filtered(boost::bind(
-                                                  std::less<int>(), _1,
-                                                  int(old2NewIdx.size())))));
+              ba::filtered([&old2NewIdx](int x){ return x < old2NewIdx.size(); })));
 
       fs->select(!newSelectedIndices.empty() ? &newSelectedIndices.front() : 0,
                  int(newSelectedIndices.size()));
@@ -470,8 +467,8 @@ void SceneBrowser::sortByDataModel(DataType dataType, bool isDiscendent) {
       tcg::substitute(
           newSelectedIndices,
           fs->getSelectedIndices() |
-              ba::filtered(boost::bind(std::less<int>(), _1, iCount)) |
-              ba::transformed(boost::bind(locals::complement, _1, lastIdx)));
+              ba::filtered([iCount](int x){ return x < iCount; }) |
+              ba::transformed([lastIdx](int x){ return locals::complement(x, lastIdx); }));
 
       fs->select(!newSelectedIndices.empty() ? &newSelectedIndices.front() : 0,
                  int(newSelectedIndices.size()));

--- a/toonz/sources/toonz/scenebrowser.h
+++ b/toonz/sources/toonz/scenebrowser.h
@@ -43,7 +43,7 @@ class SceneBrowser final : public QFrame, public DvItemListModel {
   Q_OBJECT
 
 public:
-  SceneBrowser(QWidget *parent, Qt::WindowFlags flags = 0,
+  SceneBrowser(QWidget *parent, Qt::WindowFlags flags = Qt::WindowFlags(),
                bool noContextMenu = false, bool multiSelectionEnabled = false);
   ~SceneBrowser();
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -13,7 +13,6 @@
 #include "menubarcommandids.h"
 #include "onionskinmaskgui.h"
 #include "ruler.h"
-#include "comboviewerpane.h"
 #include "locatorpopup.h"
 #include "cellselection.h"
 #include "styleshortcutswitchablepanel.h"

--- a/toonz/sources/toonz/selectionutils.cpp
+++ b/toonz/sources/toonz/selectionutils.cpp
@@ -24,7 +24,6 @@
 #include "tcg/boost/range_utility.h"
 
 // Boost includes
-#include <boost/bind.hpp>
 #include <boost/range/counting_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
@@ -63,8 +62,7 @@ void getSelectedFrames<TXshSimpleLevel>(
     if (!sl) continue;
 
     tcg::substitute(frames[sl], boost::counting_range(0, sl->getFrameCount()) |
-                                    boost::adaptors::transformed(boost::bind(
-                                        &TXshSimpleLevel::getFrameId, sl, _1)));
+      boost::adaptors::transformed([&sl](int index){ return sl->getFrameId(index); }));
   }
 }
 

--- a/toonz/sources/toonz/tasksviewer.h
+++ b/toonz/sources/toonz/tasksviewer.h
@@ -173,7 +173,7 @@ public:
   TaskTreeView *m_treeView;
   QTimer *m_timer;
 
-  TasksViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  TasksViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~TasksViewer();
 
   void update() override;

--- a/toonz/sources/toonz/testpanel.h
+++ b/toonz/sources/toonz/testpanel.h
@@ -13,7 +13,7 @@ class TestPanel final : public TPanel {
   Q_OBJECT
 
 public:
-  TestPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  TestPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~TestPanel();
 
 public slots:

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1033,7 +1033,7 @@ public:
 
 //-----------------------------------------------------------------------------
 CommandBarPanel::CommandBarPanel(QWidget *parent)
-    : TPanel(parent, 0, TDockWidget::horizontal) {
+    : TPanel(parent, Qt::WindowFlags(), TDockWidget::horizontal) {
   CommandBar *xsheetToolbar = new CommandBar(this);
   setWidget(xsheetToolbar);
   setIsMaximizable(false);
@@ -1064,7 +1064,7 @@ OpenFloatingPanel openCommandBarCommand(MI_OpenCommandToolbar, "CommandBar",
 //---------------------------------------------------------
 
 ToolOptionPanel::ToolOptionPanel(QWidget *parent)
-    : TPanel(parent, 0, TDockWidget::horizontal) {
+    : TPanel(parent, Qt::WindowFlags(), TDockWidget::horizontal) {
   TApp *app    = TApp::instance();
   m_toolOption = new ToolOptions;
 
@@ -1221,7 +1221,7 @@ class BrowserFactory final : public TPanelFactory {
 public:
   BrowserFactory() : TPanelFactory("Browser") {}
   void initialize(TPanel *panel) override {
-    FileBrowser *browser = new FileBrowser(panel, 0, false, true);
+    FileBrowser *browser = new FileBrowser(panel, Qt::WindowFlags(), false, true);
     panel->setWidget(browser);
     panel->setWindowTitle(QObject::tr("File Browser"));
     panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
@@ -1241,7 +1241,7 @@ class PreproductionBoardFactory final : public TPanelFactory {
 public:
   PreproductionBoardFactory() : TPanelFactory("PreproductionBoard") {}
   void initialize(TPanel *panel) override {
-    SceneBrowser *browser = new SceneBrowser(panel, 0, false, true);
+    SceneBrowser *browser = new SceneBrowser(panel, Qt::WindowFlags(), false, true);
     panel->setWidget(browser);
     panel->setWindowTitle(QObject::tr("Preproduction Board"));
     TFilePath scenesFolder =

--- a/toonz/sources/toonz/vectorguideddrawingpane.h
+++ b/toonz/sources/toonz/vectorguideddrawingpane.h
@@ -26,7 +26,7 @@ class VectorGuidedDrawingPane final : public QFrame {
       *m_FlipNextDirectionBtn, *m_FlipPrevDirectionBtn;
 
 public:
-  VectorGuidedDrawingPane(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  VectorGuidedDrawingPane(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~VectorGuidedDrawingPane(){};
 
   void updateStatus();

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -67,7 +67,7 @@ protected:
   bool m_isActive = false;
 
 public:
-  BaseViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  BaseViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~BaseViewerPanel() {}
 
   virtual void updateShowHide();

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3748,7 +3748,7 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
 //-----------------------------------------------------------------------------
 
 void CellArea::mouseReleaseEvent(QMouseEvent *event) {
-  m_viewer->setQtModifiers(0);
+  m_viewer->setQtModifiers(Qt::KeyboardModifiers());
   m_isMousePressed = false;
   m_viewer->stopAutoPan();
   m_isPanning = false;

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2861,7 +2861,7 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
 
   if (m_transparencyPopupTimer) m_transparencyPopupTimer->stop();
 
-  m_viewer->setQtModifiers(0);
+  m_viewer->setQtModifiers(Qt::KeyboardModifiers());
   m_viewer->dragToolRelease(event);
   m_isPanning = false;
   m_viewer->stopAutoPan();

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -50,7 +50,7 @@ class MotionPathMenu final : public QWidget {
   QPoint m_pos;
 
 public:
-  MotionPathMenu(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  MotionPathMenu(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~MotionPathMenu();
 
 protected:

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -72,8 +72,6 @@
 #include "tcg/boost/range_utility.h"
 
 // boost includes
-#include <boost/bind.hpp>
-#include <boost/bind/make_adaptable.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
@@ -506,8 +504,7 @@ public:
       : GlobalKeyframeUndo(frame) {
     tcg::substitute(
         m_columns,
-        columns | ba::filtered(std::not1(boost::make_adaptable<bool, int>(
-                      boost::bind(isKeyframe, frame, _1)))));
+        columns | ba::filtered([frame](int c){ return !isKeyframe(frame, c); }));
   }
 
   void redo() const override {
@@ -581,11 +578,10 @@ public:
     };  // locals
 
     tcg::substitute(m_columns,
-                    columns | ba::filtered(boost::bind(isKeyframe, frame, _1)));
+                    columns | ba::filtered([frame](int c){ return isKeyframe(frame, c); }));
 
     tcg::substitute(m_keyframes,
-                    m_columns | ba::transformed(boost::bind(locals::getKeyframe,
-                                                            frame, _1)));
+                    m_columns | ba::transformed([frame](int c){ return locals::getKeyframe(frame, c); }));
   }
 
   void redo() const override {

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -231,7 +231,7 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WindowFlags flags)
     , m_isCurrentColumnSwitched(false)
     , m_isComputingSize(false)
     , m_currentNoteIndex(0)
-    , m_qtModifiers(0)
+    , m_qtModifiers(Qt::KeyboardModifiers())
     , m_frameDisplayStyle(to_enum(FrameDisplayStyleInXsheetRowArea))
     , m_orientation(nullptr)
     , m_xsheetLayout("Classic")
@@ -252,7 +252,7 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WindowFlags flags)
   m_toolbarScrollArea = new XsheetScrollArea(this);
   m_toolbarScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_toolbarScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  m_toolbar = new XsheetGUI::QuickToolbar(this, 0, true);
+  m_toolbar = new XsheetGUI::QuickToolbar(this, Qt::WindowFlags(), true);
   m_toolbarScrollArea->setWidget(m_toolbar);
 
   m_noteArea       = new XsheetGUI::NoteArea(this);
@@ -704,7 +704,7 @@ void XsheetViewer::timerEvent(QTimerEvent *) {
   scroll(m_autoPanSpeed);
   if (!m_dragTool) return;
   QMouseEvent mouseEvent(QEvent::MouseMove, m_lastAutoPanPos - m_autoPanSpeed,
-                         Qt::NoButton, 0, m_qtModifiers);
+                         Qt::NoButton, Qt::MouseButtons(), m_qtModifiers);
   m_dragTool->onDrag(&mouseEvent);
   m_lastAutoPanPos += m_autoPanSpeed;
 }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -163,7 +163,7 @@ class XsheetScrollArea final : public QScrollArea {
   Q_OBJECT
 
 public:
-  XsheetScrollArea(QWidget *parent = 0, Qt::WindowFlags flags = 0)
+  XsheetScrollArea(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags())
       : QScrollArea(parent) {
     setObjectName("xsheetScrollArea");
     setFrameStyle(QFrame::StyledPanel);
@@ -640,7 +640,7 @@ private:
   }
 
 public:
-  XsheetViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  XsheetViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~XsheetViewer();
 
   TColumnSelection *getColumnSelection() const { return m_columnSelection; }

--- a/toonz/sources/toonz/xshnoteviewer.h
+++ b/toonz/sources/toonz/xshnoteviewer.h
@@ -137,7 +137,7 @@ class NoteArea final : public QFrame {
   QLayout *m_currentLayout;
 
 public:
-  NoteArea(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0);
+  NoteArea(XsheetViewer *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
 
   void updateButtons();
 
@@ -172,7 +172,7 @@ class FooterNoteArea final : public QFrame {
 
 public:
   FooterNoteArea(QWidget *parent = 0, XsheetViewer *viewer = 0,
-                 Qt::WindowFlags flags = 0);
+                 Qt::WindowFlags flags = Qt::WindowFlags());
 
   void updateButtons();
 

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1338,7 +1338,7 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
 //-----------------------------------------------------------------------------
 
 void RowArea::mouseReleaseEvent(QMouseEvent *event) {
-  m_viewer->setQtModifiers(0);
+  m_viewer->setQtModifiers(Qt::KeyboardModifiers());
   m_viewer->stopAutoPan();
   m_isPanning = false;
   m_viewer->dragToolRelease(event);

--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -39,7 +39,6 @@
 #include "tcg/boost/range_utility.h"
 
 // boost includes
-#include <boost/bind.hpp>
 #include <boost/range/counting_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/filtered.hpp>
@@ -585,8 +584,7 @@ void PaletteCmd::eraseStyles(const std::set<TXshSimpleLevel *> &levels,
       tcg::substitute(
           levelImages.second,
           boost::counting_range(0, levelImages.first->getFrameCount()) |
-              boost::adaptors::transformed(boost::bind(
-                  cloneImage, boost::cref(*levelImages.first), _1)));
+              boost::adaptors::transformed([&levelImages](int f){ return cloneImage(*levelImages.first, f); }));
     }
 
     static void restoreImage(const TXshSimpleLevelP &level, int f,

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -28,9 +28,6 @@
 #include <QTextStream>
 #include <QStandardPaths>
 
-// boost includes
-#include <boost/bind.hpp>
-
 //**********************************************************************************
 //    Local namespace  stuff
 //**********************************************************************************
@@ -1130,7 +1127,7 @@ int Preferences::levelFormatsCount() const {
 int Preferences::matchLevelFormat(const TFilePath &fp) const {
   LevelFormatVector::const_iterator lft =
       std::find_if(m_levelFormats.begin(), m_levelFormats.end(),
-                   boost::bind(&LevelFormat::matches, _1, boost::cref(fp)));
+                   [&fp](const LevelFormat &format) { return format.matches(fp); });
 
   return (lft != m_levelFormats.end()) ? lft - m_levelFormats.begin() : -1;
 }

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -508,6 +508,27 @@ void addImagesToIcon(QIcon &icon, const QImage &baseImg, const QImage &overImg,
 
 //-----------------------------------------------------------------------------
 
+void addSpecifiedSizedImageToIcon(QIcon &icon, const char *iconSVGName,
+                                  QSize newSize) {
+  static int devPixRatio = getHighestDevicePixelRatio();
+  newSize *= devPixRatio;
+
+  // Construct icon filenames
+  QString iconName     = QString::fromUtf8(iconSVGName);
+  QString overIconName = iconName + "_over";
+  QString onIconName   = iconName + "_on";
+
+  // Generate icon images
+  QImage baseImg = generateIconImage(iconName, 1.0, newSize);
+  QImage overImg = generateIconImage(overIconName, 1.0, newSize);
+  QImage onImg   = generateIconImage(onIconName, 1.0, newSize);
+
+  // Add newly sized images to the icon
+  addImagesToIcon(icon, baseImg, overImg, onImg);
+}
+
+//-----------------------------------------------------------------------------
+
 // Add the same pixmap to all modes and states of a QIcon
 void addPixmapToAllModesAndStates(QIcon &icon, const QPixmap &pixmap) {
   QIcon::Mode modes[]   = {QIcon::Normal, QIcon::Disabled, QIcon::Selected};

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -424,7 +424,7 @@ void CommandManager::enlargeIcon(CommandId id, const QSize dstSize) {
       return;
   }
 
-  icon = createQIcon(iconSVGName, false, false, dstSize);
+  addSpecifiedSizedImageToIcon(icon, iconSVGName, dstSize);
 
   action->setIcon(icon);
 }

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -413,7 +413,7 @@ void CommandManager::enlargeIcon(CommandId id, const QSize dstSize) {
   if (!action) return;
 
   const char *iconSVGName = getIconSVGName(id);
-  if (iconSVGName == "") return;
+  if (strcmp(iconSVGName, "") == 0) return;
 
   QIcon icon = action->icon();
 

--- a/toonz/sources/toonzqt/tdockwindows.h
+++ b/toonz/sources/toonzqt/tdockwindows.h
@@ -43,7 +43,7 @@ class DVAPI TMainWindow : public QWidget {
   QWidget *m_menu;
 
 public:
-  TMainWindow(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  TMainWindow(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   virtual ~TMainWindow();
 
   void addDockWidget(TDockWidget *item);
@@ -85,8 +85,8 @@ class DVAPI TDockWidget : public DockWidget {
 
 public:
   TDockWidget(const QString &title, QWidget *parent = 0,
-              Qt::WindowFlags flags = 0);
-  TDockWidget(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+              Qt::WindowFlags flags = Qt::WindowFlags());
+  TDockWidget(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~TDockWidget() {}
 
   void setTitleBarWidget(QWidget *titlebar);


### PR DESCRIPTION
The following have been ported from OT with some corrections and adjustments for T2D:

opentoonz/opentoonz/#4932 - Replace fx fixed sized buttons with minimum size hint  by @flurick
opentoonz/opentoonz/#5024 - Fix 32bit preview  by @shun-iwasawa
opentoonz/opentoonz/#5049 - Fix Use default constructor instead  by @otakuto[^1]
opentoonz/opentoonz/#5077 - refactor: Use strcmp and restore addSpecifiedSizedImageToIcon function  by @konero
opentoonz/opentoonz/#5083 - Update sceneviewerevents.cpp remove identical include  by @maddin200
opentoonz/opentoonz/#5093 - Fix build on FreeBSD 13+  by @rozhuk-im
opentoonz/opentoonz/#5048 - Remove boost::bind  by @otakuto
opentoonz/opentoonz/#5109 - fix column right-click action  by @blackwarthog

[^1]: Minor modifications for T2D differences
