### PR TITLE
Fix broken column toggle shortcuts

### DIFF
--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -1437,7 +1437,7 @@ public:
         TApp::instance()->getCurrentSelection()->getSelection());
     TXsheet *xsh          = TApp::instance()->getCurrentXsheet()->getXsheet();
     XsheetViewer *xviewer = TApp::instance()->getCurrentXsheetViewer();
-    int cc                = xviewer->getClickedColumn();
+    int cc                = TApp::instance()->getCurrentColumn()->getColumnIndex();
     bool sound_changed    = false;
     TTool *tool           = TApp::instance()->getCurrentTool()->getTool();
     TTool::Viewer *viewer = tool ? tool->getViewer() : nullptr;

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -1437,7 +1437,9 @@ public:
         TApp::instance()->getCurrentSelection()->getSelection());
     TXsheet *xsh          = TApp::instance()->getCurrentXsheet()->getXsheet();
     XsheetViewer *xviewer = TApp::instance()->getCurrentXsheetViewer();
-    int cc                = TApp::instance()->getCurrentColumn()->getColumnIndex();
+    int mc                = xviewer->getMenuColumnTarget();
+    int cc =
+        mc >= -1 ? mc : TApp::instance()->getCurrentColumn()->getColumnIndex();
     bool sound_changed    = false;
     TTool *tool           = TApp::instance()->getCurrentTool()->getTool();
     TTool::Viewer *viewer = tool ? tool->getViewer() : nullptr;

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -325,6 +325,9 @@ class ColumnArea final : public QWidget {
   QAction *m_subsampling3;
   QAction *m_subsampling4;
 
+  int m_menuCol;
+  QTimer *m_menuTimer;
+
   DragTool *getDragTool() const;
   void setDragTool(DragTool *dragTool);
   void startTransparencyPopupTimer(QMouseEvent *e);
@@ -384,7 +387,7 @@ public:
 
   QPixmap getColumnIcon(int columnIndex);
 
-  int getClickedColumn() { return m_col; }
+  int getMenuColumnTarget() { return m_menuCol; }
 
   class Pixmaps {
   public:
@@ -412,6 +415,8 @@ protected slots:
   void onCameraColumnChangedTriggered();
   void onCameraColumnLockToggled(bool);
   void onXsheetCameraChange(int);
+  void onMenuAboutToHide();
+  void onResetContextMenuTarget();
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -500,14 +500,6 @@ int XsheetViewer::getCurrentColumn() const {
 
 //-----------------------------------------------------------------------------
 
-int XsheetViewer::getClickedColumn() const {
-  if (!m_columnArea) return -1;
-
-  return m_columnArea->getClickedColumn();
-}
-
-//-----------------------------------------------------------------------------
-
 int XsheetViewer::getCurrentRow() const {
   return TApp::instance()->getCurrentFrame()->getFrame();
 }

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -500,6 +500,13 @@ int XsheetViewer::getCurrentColumn() const {
 
 //-----------------------------------------------------------------------------
 
+int XsheetViewer::getMenuColumnTarget() const {
+  if (!m_columnArea) return -999;
+  return m_columnArea->getMenuColumnTarget();
+}
+
+//-----------------------------------------------------------------------------
+
 int XsheetViewer::getCurrentRow() const {
   return TApp::instance()->getCurrentFrame()->getFrame();
 }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -683,6 +683,7 @@ public:
 
   TXsheet *getXsheet() const;
   int getCurrentColumn() const;
+  int getMenuColumnTarget() const;
   int getCurrentRow() const;
   //! Restituisce la \b objectId corrispondente alla colonna \b col
   TStageObjectId getObjectId(int col) const;

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -683,7 +683,6 @@ public:
 
   TXsheet *getXsheet() const;
   int getCurrentColumn() const;
-  int getClickedColumn() const;
   int getCurrentRow() const;
   //! Restituisce la \b objectId corrispondente alla colonna \b col
   TStageObjectId getObjectId(int col) const;


### PR DESCRIPTION
This fixes column toggle shortcuts that I inadvertently broke in v1.3 with #758 (Stop switching columns on column button press).
