### PR TITLE
Fix wrong raster project palette

### DIFF
--- a/toonz/sources/tnztools/symmetrytool.cpp
+++ b/toonz/sources/tnztools/symmetrytool.cpp
@@ -239,17 +239,6 @@ SymmetryTool::SymmetryTool()
   m_color.setId("Color");
   m_useLineSymmetry.setId("UseLineSymmetry");
   m_preset.setId("SymmetryPreset");
-
-  std::wstring wpreset =
-      QString::fromStdString(SymmetryPreset.getValue()).toStdWString();
-  if (wpreset != CUSTOM_WSTR) {
-    initPresets();
-    if (!m_preset.isValue(wpreset)) wpreset = CUSTOM_WSTR;
-    m_preset.setValue(wpreset);
-    SymmetryPreset = m_preset.getValueAsString();
-    loadPreset();
-  } else
-    loadLastSymmetry();
 }
 
 //----------------------------------------------------------------------------------------------
@@ -464,6 +453,21 @@ void SymmetryTool::loadLastSymmetry() {
       TPointD(SymmetryRotationPosX, SymmetryRotationPosY));
 
   updateMeasuredValueToolOptions();
+}
+
+//----------------------------------------------------------------------------------------------
+
+void SymmetryTool::loadTool() {
+  std::wstring wpreset =
+      QString::fromStdString(SymmetryPreset.getValue()).toStdWString();
+  if (wpreset != CUSTOM_WSTR) {
+    initPresets();
+    if (!m_preset.isValue(wpreset)) wpreset = CUSTOM_WSTR;
+    m_preset.setValue(wpreset);
+    SymmetryPreset = m_preset.getValueAsString();
+    loadPreset();
+  } else
+    loadLastSymmetry();
 }
 
 //----------------------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/symmetrytool.h
+++ b/toonz/sources/tnztools/symmetrytool.h
@@ -269,6 +269,8 @@ public:
   void removePreset();
   void loadLastSymmetry();
 
+  void loadTool() override;
+
 protected:
   TPropertyGroup m_prop;
   std::vector<SymmetryToolOptionBox *> m_toolOptionsBox;

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1949,6 +1949,9 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   }
   if (sceneProject && !sceneProject->isCurrent()) {
     pm->setCurrentProjectPath(sceneProject->getProjectPath());
+    // Clear existing raster palette so it forces a reloads of the new project's
+    // raster palette when loading scene
+    FullColorPalette::instance()->clear();
     //    QString currentProjectName = QString::fromStdWString(
     //        pm->getCurrentProject()->getName().getWideString());
     //    QString sceneProjectName =

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -761,6 +761,15 @@ int main(int argc, char *argv[]) {
       TTool::getTool(T_PerspectiveGrid, TTool::VectorImage);
   if (perspectiveTool) perspectiveTool->loadTool();
 
+  // Symmetry tool - 
+  splash.showMessage(offsetStr + QObject::tr("Loading Symmetry Guide..."),
+                     Qt::AlignRight | Qt::AlignBottom, Qt::black);
+  a.processEvents();
+
+  TTool *symmetryTool =
+      TTool::getTool(T_Symmetry, TTool::VectorImage);
+  if (symmetryTool) symmetryTool->loadTool();
+
   w.setWindowTitle(QString::fromStdString(TEnv::getApplicationFullName()));
   if (TEnv::getIsPortable()) {
     splash.showMessage(offsetStr + QObject::tr("Starting Tahoma2D..."),


### PR DESCRIPTION
This fixes #1229.

- The loading of the Symmetry tool at startup was causing the default environment file to load instead of the one in user's profile, so it would start with the sandbox project.

Similar to the Perspective Tool, delayed the initialization of the Symmetry tool until after the user's profile information was loaded.

- Fixed a bug where the wrong raster palette was being shown when switching to a scene in a different project.

The raster palette for the old project was not being changed to the new project's raster palette.

In this scenario, I forced the new project's raster palette to load.