### PR TITLE
Update Canon EDSDK to v13.17.10

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Get CanonSDK
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' }}
         run: |
-          wget --header="Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" --header="Accept:application/octet-stream" -O EDSDK_v131231_Macintosh.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/25267390
-          unzip EDSDK_v131231_Macintosh.zip -d EDSDK_v131231_Macintosh
-          unzip EDSDK_v131231_Macintosh/Macintosh.dmg.zip -d EDSDK_v131231_Macintosh
-          7z x EDSDK_v131231_Macintosh/Macintosh.dmg -oEDSDK_v131231_Macintosh
-          mv EDSDK_v131231_Macintosh/Macintosh/EDSDK/* thirdparty/canon
+          wget --header="Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" --header="Accept:application/octet-stream" -O EDSDK_Macintosh.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/132789028
+          unzip EDSDK_Macintosh.zip -d EDSDK_Macintosh
+          unzip EDSDK_Macintosh/Macintosh.dmg.zip -d EDSDK_Macintosh
+          7z x EDSDK_Macintosh/Macintosh.dmg -oEDSDK_Macintosh
+          mv EDSDK_Macintosh/Macintosh/EDSDK/* thirdparty/canon
           cd thirdparty/canon/framework/EDSDK.framework/Versions
           rm Current
           ln -s A Current

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Get CanonSDK
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' }}
         run: |
-          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_v131231_Windows.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/25267396
-          7z x EDSDK_v131231_Windows.zip -oEDSDK_v131231_Windows
-          move EDSDK_v131231_Windows\EDSDK\Header thirdparty\canon
-          move EDSDK_v131231_Windows\EDSDK_64\Dll thirdparty\canon
-          move EDSDK_v131231_Windows\EDSDK_64\Library thirdparty\canon
+          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Windows.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/132789036
+          7z x EDSDK_Windows.zip -oEDSDK_Windows
+          move EDSDK_Windows\EDSDK\Header thirdparty\canon
+          move EDSDK_Windows\EDSDK_64\Dll thirdparty\canon
+          move EDSDK_Windows\EDSDK_64\Library thirdparty\canon
       - name: Get 3rd Party Apps
         run: |
           ci-scripts\windows\tahoma-get3rdpartyapps.bat

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -153,7 +153,7 @@ function checkLibFile() {
             echo "Fixing $DEPFILE in $LIBFILE"
             if [ "$X" != "" ]
             then
-               local Y=`echo $DEPFILE | sed -e"s/^.*\/\.\.\///"`
+               local Y=`echo $DEPFILE | sed -e"s/^.*\/\.\.\///" -e"s/@rpath.//"`
                install_name_tool -change $DEPFILE @executable_path/../Frameworks/$Y $LIBFILE
             else
                install_name_tool -change $DEPFILE @executable_path/../Frameworks/$Y $LIBFILE

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -2022,8 +2022,9 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
   ret = ret && connect(m_stopMotion->m_gphotocam,
                        SIGNAL(liveViewOffsetChangedSignal(int)), this,
                        SLOT(onLiveViewCompensationChangedSignal(int)));
-  ret = ret && connect(m_stopMotion->m_canon, SIGNAL(focusCheckToggled(bool)),
-                       this, SLOT(onFocusCheckToggled(bool)));
+  ret =
+      ret && connect(m_stopMotion->m_gphotocam, SIGNAL(focusCheckToggled(bool)),
+                     this, SLOT(onFocusCheckToggled(bool)));
   ret = ret &&
         connect(m_stopMotion->m_gphotocam, SIGNAL(pickFocusCheckToggled(bool)),
                 this, SLOT(onPickFocusCheckToggled(bool)));


### PR DESCRIPTION
Updating the Canon EDSDK library to the latest version for both Windows and macOS builds.

Hoping it will fix an issue some macOS users are experiencing on newer OS versions.

Also fixed a code issue that might have impacted non-Canon DSLR users.
