### PR TITLE
Fix missing scene overlay for Multiple Rendering options

### DIFF
--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -1586,5 +1586,15 @@ DVAPI TFxP buildSceneFx(ToonzScene *scene, double frame, TXsheet *xsh,
 
   if (!aff.isIdentity()) fx = TFxUtil::makeAffine(fx, aff);
 
+  // this creates an over fx to lay the Scene Overlay, if there is one, over the
+  // current frame
+  TLevelColumnFx *overlayFx = scene->getOverlayFx(frame);
+
+  if (overlayFx) {
+    PlacedFx overlayPf = builder.makePF(overlayFx);
+    TFxP overlayAffine = TFxUtil::makeAffine(overlayPf.makeFx(), aff);
+    fx                 = TFxUtil::makeOver(fx, overlayAffine);
+  }
+
   return fx;
 }


### PR DESCRIPTION
If there is a Scene Overlay Image (#1222) configured, this will apply it to `Mutliple Rendering` outputs also.