### PR TITLE
Onion Skin All Frames or New Exposures Toggle

### DIFF
--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -46,8 +46,7 @@ public:
   };
 
 public:
-  OnionSkinMask()
-      : m_enabled(false), m_wholeScene(false), m_everyFrame(false), m_LightTableStatus(false) {}
+  OnionSkinMask();
 
   void clear();
 
@@ -87,10 +86,10 @@ public:
   void enable(bool on) { m_enabled = on; }
 
   bool isWholeScene() const { return m_wholeScene; }
-  void setIsWholeScene(bool wholeScene) { m_wholeScene = wholeScene; }
+  void setIsWholeScene(bool wholeScene);
 
   bool isEveryFrame() const { return m_everyFrame; }
-  void setIsEveryFrame(bool everyFrame) { m_everyFrame = everyFrame; }
+  void setIsEveryFrame(bool everyFrame);
 
   /*!
 Returns the fade (transparency) value, in the [0.0, 1.0] range, corresponding to

--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -47,7 +47,7 @@ public:
 
 public:
   OnionSkinMask()
-      : m_enabled(false), m_wholeScene(false), m_LightTableStatus(false) {}
+      : m_enabled(false), m_wholeScene(false), m_everyFrame(false), m_LightTableStatus(false) {}
 
   void clear();
 
@@ -88,6 +88,9 @@ public:
 
   bool isWholeScene() const { return m_wholeScene; }
   void setIsWholeScene(bool wholeScene) { m_wholeScene = wholeScene; }
+
+  bool isEveryFrame() const { return m_everyFrame; }
+  void setIsEveryFrame(bool everyFrame) { m_everyFrame = everyFrame; }
 
   /*!
 Returns the fade (transparency) value, in the [0.0, 1.0] range, corresponding to
@@ -142,6 +145,7 @@ private:
   std::vector<int> m_fos, m_mos;  //!< Fixed and Mobile Onion Skin indices
   bool m_enabled;                 //!< Whether onion skin is enabled
   bool m_wholeScene;              //!< Whether the OS works on the entire scene
+  bool m_everyFrame;              //!< Whether the OS renders every frame or only on new exposures.
 
   ShiftTraceStatus m_shiftTraceStatus;
   TAffine m_ghostAff[2];

--- a/toonz/sources/toonz/onionskinmaskgui.cpp
+++ b/toonz/sources/toonz/onionskinmaskgui.cpp
@@ -150,12 +150,12 @@ void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
       }
       if (!switcher.isEveryFrame()) {
         QAction *onionSkinEveryFrame =
-            menu->addAction(QString(QObject::tr("Onion Skin Every Frame")));
+            menu->addAction(QString(QObject::tr("Onion Skin On All Frames")));
         menu->connect(onionSkinEveryFrame, SIGNAL(triggered()), &switcher,
                       SLOT(setEveryFrame()));
       } else {
         QAction *onionSkinNewExposure =
-            menu->addAction(QString(QObject::tr("Onion Skin On New Exposure")));
+            menu->addAction(QString(QObject::tr("Onion Skin On New Exposures")));
         menu->connect(onionSkinNewExposure, SIGNAL(triggered()), &switcher,
                       SLOT(setNewExposure()));
       }

--- a/toonz/sources/toonz/onionskinmaskgui.cpp
+++ b/toonz/sources/toonz/onionskinmaskgui.cpp
@@ -155,7 +155,7 @@ void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
                       SLOT(setEveryFrame()));
       } else {
         QAction *onionSkinNewExposure =
-            menu->addAction(QString(QObject::tr("Onion Skin On New Exposures")));
+            menu->addAction(QString(QObject::tr("Onion Skin On Drawings")));
         menu->connect(onionSkinNewExposure, SIGNAL(triggered()), &switcher,
                       SLOT(setNewExposure()));
       }

--- a/toonz/sources/toonz/onionskinmaskgui.cpp
+++ b/toonz/sources/toonz/onionskinmaskgui.cpp
@@ -44,6 +44,13 @@ bool OnioniSkinMaskGUI::OnionSkinSwitcher::isWholeScene() const {
 
 //------------------------------------------------------------------------------
 
+bool OnioniSkinMaskGUI::OnionSkinSwitcher::isEveryFrame() const {
+  OnionSkinMask osm = getMask();
+  return osm.isEveryFrame();
+}
+
+//------------------------------------------------------------------------------
+
 void OnioniSkinMaskGUI::OnionSkinSwitcher::activate() {
   OnionSkinMask osm = getMask();
   if (osm.isEnabled() && !osm.isEmpty()) return;
@@ -78,6 +85,22 @@ void OnioniSkinMaskGUI::OnionSkinSwitcher::setWholeScene() {
 void OnioniSkinMaskGUI::OnionSkinSwitcher::setSingleLevel() {
   OnionSkinMask osm = getMask();
   osm.setIsWholeScene(false);
+  setMask(osm);
+}
+
+//------------------------------------------------------------------------------
+
+void OnioniSkinMaskGUI::OnionSkinSwitcher::setEveryFrame() {
+  OnionSkinMask osm = getMask();
+  osm.setIsEveryFrame(true);
+  setMask(osm);
+}
+
+//------------------------------------------------------------------------------
+
+void OnioniSkinMaskGUI::OnionSkinSwitcher::setNewExposure() {
+  OnionSkinMask osm = getMask();
+  osm.setIsEveryFrame(false);
   setMask(osm);
 }
 
@@ -124,6 +147,17 @@ void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
             menu->addAction(QString(QObject::tr("Extend Onion Skin To Scene")));
         menu->connect(extendOnionSkinToScene, SIGNAL(triggered()), &switcher,
                       SLOT(setWholeScene()));
+      }
+      if (!switcher.isEveryFrame()) {
+        QAction *onionSkinEveryFrame =
+            menu->addAction(QString(QObject::tr("Onion Skin Every Frame")));
+        menu->connect(onionSkinEveryFrame, SIGNAL(triggered()), &switcher,
+                      SLOT(setEveryFrame()));
+      } else {
+        QAction *onionSkinNewExposure =
+            menu->addAction(QString(QObject::tr("Onion Skin On New Exposure")));
+        menu->connect(onionSkinNewExposure, SIGNAL(triggered()), &switcher,
+                      SLOT(setNewExposure()));
       }
       OnionSkinMask osm = switcher.getMask();
       if (osm.getFosCount() || osm.getMosCount()) {

--- a/toonz/sources/toonz/onionskinmaskgui.h
+++ b/toonz/sources/toonz/onionskinmaskgui.h
@@ -33,12 +33,15 @@ public:
 
   bool isActive() const;
   bool isWholeScene() const;
+  bool isEveryFrame() const;
 
 public slots:
   void activate();
   void deactivate();
   void setWholeScene();
   void setSingleLevel();
+  void setEveryFrame();
+  void setNewExposure();
   void clearFOS();
   void clearMOS();
   void clearOS();

--- a/toonz/sources/toonzlib/onionskinmask.cpp
+++ b/toonz/sources/toonzlib/onionskinmask.cpp
@@ -2,6 +2,7 @@
 
 // TnzCore includes
 #include "tfilepath.h"
+#include "tenv.h"
 
 // TnzLib includes
 #include "toonz/txshsimplelevel.h"
@@ -53,6 +54,16 @@ double inline getIncrement(int paperThickness) {
 //***************************************************************************
 //    OnionSkinMask  implementation
 //***************************************************************************
+
+TEnv::IntVar WholeScene("OnionSkinWholeScene", 0);
+TEnv::IntVar EveryFrame("OnionSkinEveryFrame", 1);
+
+OnionSkinMask::OnionSkinMask() {
+  m_enabled = false;
+  m_wholeScene = WholeScene;
+  m_everyFrame = EveryFrame;
+  m_LightTableStatus = false;
+}
 
 void OnionSkinMask::clear() {
   m_fos.clear();
@@ -151,6 +162,20 @@ bool OnionSkinMask::getMosRange(int &drow0, int &drow1) const {
     drow0 = m_mos.front(), drow1 = m_mos.back();
     return true;
   }
+}
+
+//-------------------------------------------------------------------
+
+void OnionSkinMask::setIsWholeScene(bool wholeScene) { 
+  m_wholeScene = wholeScene; 
+  WholeScene = (int)m_wholeScene;
+}
+
+//-------------------------------------------------------------------
+
+void OnionSkinMask::setIsEveryFrame(bool everyFrame) { 
+  m_everyFrame = everyFrame; 
+  EveryFrame = (int)m_everyFrame;
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -633,7 +633,7 @@ void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
 #ifdef NUOVO_ONION
       m_onionSkinDistance = rows[i] - row;
 #else
-      if (!Preferences::instance()->isAnimationSheetEnabled() ||
+      if (m_onionSkinMask.isEveryFrame() ||
           !alreadyAdded(xsh, row, i, rows, col)) {
         m_onionSkinDistance = (rows[i] - row) < 0 ? --backPos : ++frontPos;
         addCell(players, scene, xsh, rows[i], col, level, subSheetColIndex);


### PR DESCRIPTION
Adds the onion skin `Onion Skin On All Frames` or `Onion Skin On New Exposures` setting to the right click menu replacing the numbering mode check. Saves and restores both the `Onion Skin On All Frames` and `Extend Onion Skin to Scene` settings.

Rendering the onion skin on all frames is the default. Option is only visible when the onion skin is enabled, same as other onion skin settings.