### PR TITLE
Save syncColorSetting only if not default

### DIFF
--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -258,7 +258,8 @@ void TSceneProperties::saveData(TOStream &os) const {
     if (rs.m_colorSpaceGamma >= 1. &&
         !areAlmostEqual(rs.m_colorSpaceGamma, 2.2))
       os.child("colorSpaceGamma") << rs.m_colorSpaceGamma;
-    if (i == 1)  // preview
+    // Only save syncColorSetting if not the default value
+    if (i == 1 && !out.isColorSettingsSynced())  // preview
       os.child("syncColorSettings") << (out.isColorSettingsSynced() ? 1 : 0);
 
     os.child("multimedia") << out.getMultimediaRendering();


### PR DESCRIPTION
The OT port of `Floating point & Linear color space rendering`, introduced in #1139, added the tag `syncColorSetting`.  This new tag is automatically being added to the scene files and prevents scenes from being opened in prior versions of T2D.

I've modified the saving of this tag to only write it to the scene file if it is different from the default (`true`).

This way, if someone needs to drop back to a prior version or share a scene with someone using an older version, they can still open the scene.