### PR TITLE
Minor documentation fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,25 +10,25 @@ I will first review the request, then I'll accept it, add comments for rework, o
 
 ### Workflow
 
-0. `fork` Tahoma2D to your GitHub account from `tahoma2d/tahoma2d`.
+1. `fork` Tahoma2D to your GitHub account from `tahoma2d/tahoma2d`.
   - (use the `fork` button at the https://github.com/tahoma2d/tahoma2d)
-0. `clone` the repository.
+2. `clone` the repository.
   - `git clone git@github.com:your-github-account/tahoma2d.git`
   - `git remote add upstream https://github.com/tahoma2d/tahoma2d.git`, additionally.
-0. modify the codes.
+3. modify the codes.
   - `git checkout -b your-branch-name`
     - `your-branch-name` is a name of your modifications, for example,
       `fix/fatal-bugs`, `feature/new-useful-gui` and so on.
   - fix codes, then test them.
   - `git commit` them with good commit messages.
-0. `pull` the latest changes form the `master` branch of the upstream.
+4. `pull` the latest changes from the `master` branch of the upstream.
   - `git pull upstream master` or `git pull --rebase upstream master`.
   - apply [clang-format](http://clang.llvm.org/docs/ClangFormat.html) with `toonz/sources/.clang-format`.
     - `cd toonz/sources`
     - `./beautification.sh` or `beautification.bat`.
   - `git commit` them.
   - `git push origin your-branch-name`.
-0. make a pull request.
+5. make a pull request.
 
 ## Bugs
 
@@ -38,7 +38,7 @@ and information directly relating to the issue. Links to screen captures of what
 observed on screen or video of specific steps to produce the problem are very helpful.  
 Then we will try to reproduce the bugs and fix them.
 Unfortunately, bugs can sometimes only be reproduced in your own environment, 
-so we cannot reproduce them. 
+so we cannot reproduce them.
 If you believe you can fix the bug, please submit a pull request.
 
 ## Features

--- a/doc/how_to_build_win.md
+++ b/doc/how_to_build_win.md
@@ -108,7 +108,7 @@ You will need two additional libraries.
 Copy the following folders into the `$tahoma2d/thirdparty` folder.
  - [ ] Copy the Header and library folders from the Canon SDK to `$tahoma2d/thirdparty/canon`
  - Make sure that the library is the one from the EDSDK_64 folder.
- - [ ] Copy the lib and include folders from libjpeg-turbo64 into `$tahoma2d/thirdparty/libjpeg-turbo64`.
+ - [ ] Copy the lib and include folders from libjpeg-turbo64 into `$tahoma2d/thirdparty/libjpeg-turbo`.
  - [ ] Check the checkbox in CMake to build with stop motion support.
 
 To run the program with stop motion support, you will need to copy the .dll files from opencv2, libjpeg-turbo and the Canon SDK into the folder where your project is built.


### PR DESCRIPTION
While editing the CMake files for https://github.com/tahoma2d/tahoma2d/pull/1274, I noticed that the instructions for building on Windows said to put the libjpeg-turbo64 files into libjpeg-turbo64, but the CMake file itself looks for libjpeg-turbo, so I corrected that. In the process, I also noticed that the numbered list in [CONTRIBUTING.md](https://github.com/tahoma2d/tahoma2d/blob/master/CONTRIBUTING.md) was all zeros, so I fixed that too.