### PR TITLE
Warn when unable to load/read file

### DIFF
--- a/toonz/sources/common/tiio/tiio_bmp.cpp
+++ b/toonz/sources/common/tiio/tiio_bmp.cpp
@@ -10,6 +10,7 @@
 #include "tpixelgr.h"
 #include "tproperty.h"
 //#include "tconvert.h"
+#include "texception.h"
 #include <stdio.h>
 
 //=========================================================
@@ -156,7 +157,10 @@ void BmpReader::open(FILE *file) {
 //---------------------------------------------------------
 
 void BmpReader::readHeader() {
-  if (!m_chan) return;
+  if (!m_chan) {
+    throw TException("Can't open file");
+    return;
+  }
 
   fseek(m_chan, 0L, SEEK_END);
   m_header.biFilesize = ftell(m_chan);
@@ -168,6 +172,7 @@ void BmpReader::readHeader() {
   signature[1] = fgetc(m_chan);
   if (signature[0] != 'B' || signature[1] != 'M') {
     m_corrupted = true;
+    throw TException("Unable to read file");
     return;
   }
 

--- a/toonz/sources/common/tiio/tiio_jpg.cpp
+++ b/toonz/sources/common/tiio/tiio_jpg.cpp
@@ -13,6 +13,10 @@
 #include "tproperty.h"
 #include "tpixel.h"
 
+#include "../../libjpeg-turbo/include/jerror.h"
+
+#include "texception.h"
+
 /*
  * Include file for users of JPEG library.
  * You will need to have included system headers that define at least
@@ -30,9 +34,18 @@ const std::string Tiio::JpgWriterProperties::QUALITY("Quality");
 
 //=========================================================
 
+int tnz_err_code;
+char tnz_err_msg[JMSG_LENGTH_MAX];
+
 extern "C" {
 static void tnz_error_exit(j_common_ptr cinfo) {
   //  throw "merda";
+}
+
+METHODDEF(void)
+tnz_output_message(j_common_ptr cinfo) {
+  tnz_err_code = cinfo->err->msg_code;
+  (*cinfo->err->format_message)(cinfo, tnz_err_msg);
 }
 }
 
@@ -73,8 +86,12 @@ JpgReader::~JpgReader() {
 Tiio::RowOrder JpgReader::getRowOrder() const { return Tiio::TOP2BOTTOM; }
 
 void JpgReader::open(FILE *file) {
-  m_cinfo.err             = jpeg_std_error(&m_jerr);
-  m_cinfo.err->error_exit = tnz_error_exit;
+  m_cinfo.err                 = jpeg_std_error(&m_jerr);
+  m_cinfo.err->error_exit     = tnz_error_exit;
+  m_cinfo.err->output_message = tnz_output_message;
+
+  tnz_err_code = 0;
+  memset(&tnz_err_msg, 0, JMSG_LENGTH_MAX);
 
   jpeg_create_decompress(&m_cinfo);
 
@@ -82,6 +99,11 @@ void JpgReader::open(FILE *file) {
   jpeg_stdio_src(&m_cinfo, m_chan);
   jpeg_save_markers(&m_cinfo, JPEG_APP0 + 1, 0xffff);  // EXIF
   bool ret = jpeg_read_header(&m_cinfo, TRUE);
+
+  if (tnz_err_code > 0) {
+    throw TException("Unable to read file. " + std::string(tnz_err_msg));
+    return;
+  }
 
   bool resolutionFoundInExif = false;
   jpeg_saved_marker_ptr mark;
@@ -107,7 +129,10 @@ void JpgReader::open(FILE *file) {
   }
 
   ret = ret && jpeg_start_decompress(&m_cinfo);
-  if (!ret) return;
+  if (!ret) {
+    throw TException("Unable to read file");
+    return;
+  }
 
   int row_stride = m_cinfo.output_width * m_cinfo.output_components;
   m_buffer = (*m_cinfo.mem->alloc_sarray)((j_common_ptr)&m_cinfo, JPOOL_IMAGE,

--- a/toonz/sources/common/tiio/tiio_jpg.cpp
+++ b/toonz/sources/common/tiio/tiio_jpg.cpp
@@ -86,6 +86,15 @@ JpgReader::~JpgReader() {
 Tiio::RowOrder JpgReader::getRowOrder() const { return Tiio::TOP2BOTTOM; }
 
 void JpgReader::open(FILE *file) {
+  // Let's check to see if it is really a JPEG file
+  unsigned char signature[3];
+  fread(signature, 3, 1, file);
+  fseek(file, 0, SEEK_SET);
+  if (signature[0] != 0xff || signature[1] != 0xd8 || signature[2] != 0xff) {
+    throw TException("Can't open file");
+    return;
+  }
+
   m_cinfo.err                 = jpeg_std_error(&m_jerr);
   m_cinfo.err->error_exit     = tnz_error_exit;
   m_cinfo.err->output_message = tnz_output_message;

--- a/toonz/sources/common/timage_io/timage_io.cpp
+++ b/toonz/sources/common/timage_io/timage_io.cpp
@@ -132,12 +132,14 @@ void TImageReader::open() {
       }
     } catch (TException &e) {
       close();  // close() chiude il file e setta m_file a NULL.
-      QString msg = QString::fromStdWString(e.getMessage());
-      if (msg == QString("Old 4.1 Palette")) throw e;
-    } catch (std::string str) {
-      if (str == "Tiff file closed") m_file = NULL;
+//      QString msg = QString::fromStdWString(e.getMessage());
+//      if (msg == QString("Old 4.1 Palette")) throw e;
+      throw e;
+//    } catch (std::string str) {
+//      if (str == "Tiff file closed") m_file = NULL;
     } catch (...) {
       close();
+      throw;
     }
   }
 }

--- a/toonz/sources/image/png/tiio_png.cpp
+++ b/toonz/sources/image/png/tiio_png.cpp
@@ -120,18 +120,24 @@ public:
     try {
       m_chan = file;
     } catch (...) {
-      perror("uffa");
+      throw TException("Can't open file");
       return;
     }
 
     unsigned char signature[8];  // da 1 a 8 bytes
     fread(signature, 1, sizeof signature, m_chan);
     bool isPng = !png_sig_cmp(signature, 0, sizeof signature);
-    if (!isPng) return;
+    if (!isPng) {
+      throw TException("Can't open file");
+      return;
+    }
 
     m_png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, &m_canDelete,
                                        tnz_error_fun, 0);
-    if (!m_png_ptr) return;
+    if (!m_png_ptr) {
+      throw TException("Unable to read file");
+      return;
+    }
 
 #if defined(PNG_LIBPNG_VER)
 #if (PNG_LIBPNG_VER >= 10527)
@@ -144,11 +150,13 @@ public:
     m_info_ptr  = png_create_info_struct(m_png_ptr);
     if (!m_info_ptr) {
       png_destroy_read_struct(&m_png_ptr, (png_infopp)0, (png_infopp)0);
+      throw TException("Unable to read file");
       return;
     }
     m_end_info_ptr = png_create_info_struct(m_png_ptr);
     if (!m_end_info_ptr) {
       png_destroy_read_struct(&m_png_ptr, &m_info_ptr, (png_infopp)0);
+      throw TException("Unable to read file");
       return;
     }
 
@@ -268,11 +276,15 @@ public:
       if (m_tempBuffer && m_y == ly) {
         m_tempBuffer.reset();
       }
+      throw TException("Unable to read file");
       return;
     }
 
     int y = m_info.m_ly - 1 - m_y;
-    if (y < 0) return;
+    if (y < 0) {
+      throw TException("Unable to read file");
+      return;
+    }
     m_y++;
 
     png_bytep row_pointer = m_rowBuffer.get();

--- a/toonz/sources/image/tga/tiio_tga.cpp
+++ b/toonz/sources/image/tga/tiio_tga.cpp
@@ -5,7 +5,7 @@
 #pragma warning(disable : 4996)
 #endif
 
-//#include "texception.h"
+#include "texception.h"
 //#include "tfilepath.h"
 #include "tiio_tga.h"
 #include "tpixel.h"
@@ -216,7 +216,7 @@ void TgaReader::open(FILE *file) {
     try {
       m_chan = file;
     } catch (...) {
-      perror("uffa");
+      throw TException("Can't open file");
       return;
     }
     readTgaHeader(m_header, m_chan);

--- a/toonz/sources/image/tif/tiio_tif.cpp
+++ b/toonz/sources/image/tif/tiio_tif.cpp
@@ -108,8 +108,9 @@ void TifReader::open(FILE *file) {
   m_tiff = TIFFFdOpen(dup(fd), "", "rb");
 #endif
   if (!m_tiff) {
-    std::string str("Tiff file closed");
-    throw(str);
+//    std::string str("Tiff file closed");
+//    throw(str);
+    throw TException("Can't open file");
   }
 
   uint32 w = 0, h = 0, rps = 0;

--- a/toonz/sources/image/tzp/tiio_plt.cpp
+++ b/toonz/sources/image/tzp/tiio_plt.cpp
@@ -6,6 +6,7 @@
 #include "toonztags.h"
 
 #include "tiffio.h"
+#include "texception.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996)
@@ -141,7 +142,10 @@ void PltReader::open(FILE *file) {
   m_tiff     = TIFFFdOpen(fd, "", "rb");
   TIFFSetWarningHandler(oldhandler);
 
-  if (!m_tiff) return;
+  if (!m_tiff) {
+    throw TException("Can't open file");
+    return;
+  }
 
   uint32 w = 0, h = 0, rps = 0;
   uint32 tileWidth = 0, tileLength = 0;

--- a/toonz/sources/image/tzp/tiio_tzp.cpp
+++ b/toonz/sources/image/tzp/tiio_tzp.cpp
@@ -83,7 +83,10 @@ void TzpReader::open(FILE *file) {
   oldhandler = TIFFSetWarningHandler(NULL);
   m_tiff     = TIFFFdOpen(fd, "", "rb");
   TIFFSetWarningHandler(oldhandler);
-  if (!m_tiff) return;
+  if (!m_tiff) {
+    throw TException("Can't open file");
+    return;
+  }
 
   uint32 w = 0, h = 0, bps = 0, spp = 0, rps = 0;
   uint32 tileWidth = 0, tileLength = 0;

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -1243,6 +1243,14 @@ void FlipBook::setLevel(const TFilePath &fp, TPalette *palette, int from,
     m_flipConsole->enableButton(FlipConsole::eSave, isSavable());
     m_flipConsole->showCurrentFrame();
     if (m_flags & eDontKeepFilesOpened) m_lr = TLevelReaderP();
+  } catch (TException &e) {
+//    QString msg = QString::fromStdWString(e.getMessage());
+
+    QString msg;
+    msg = QObject::tr("It is not possible to load file %1.").arg(fp.getQString());
+    DVGui::error(msg);
+
+    return;
   } catch (...) {
     return;
   }

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -31,6 +31,8 @@
 #include "toonz/toonzfolders.h"
 #include "toonz/tcolumnfx.h"
 
+#include "toonzqt/dvdialog.h"
+
 // TnzCore includes
 #include "timagecache.h"
 #include "tstream.h"
@@ -440,6 +442,11 @@ void ToonzScene::loadResources(bool withProgressDialog) {
     TXshLevel *level = m_levelSet->getLevel(i);
     try {
       level->load();
+    } catch (TException &e) {
+      QString msg;
+      msg = QObject::tr("It is not possible to load file %1.")
+                .arg(level->getPath().getQString());
+      DVGui::error(msg);
     } catch (...) {
     }
   }


### PR DESCRIPTION
This change was primarily to fix a crash that was caused when a user loaded a JPEG file but could not be properly read. The file was actually a WEBP file with a JPEG extension for some reason.

When a file cannot be opened or read properly, it will give a message that it can't load the file and abort the operation.

I've extended this fix to loading other file types which can happen via Load Level, loading into Flipbook or loading a scene.