### PR TITLE
Hide title bar for docked Custom Panel & Preproduction Board

### DIFF
--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -814,8 +814,12 @@ TPanel *TPanelFactory::createPanel(QWidget *parent, QString panelType) {
   if (it == tableInstance().end()) {
     if (panelType.startsWith("Custom_")) {
       panelType = panelType.right(panelType.size() - 7);
-      return CustomPanelManager::instance()->createCustomPanel(panelType,
-                                                               parent);
+      panel =
+          CustomPanelManager::instance()->createCustomPanel(panelType, parent);
+      panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
+      connect(TApp::instance(), SIGNAL(showTitleBars(bool)),
+              panel->getTitleBar(), SLOT(showTitleBar(bool)));
+      return panel;
     }
 
     TPanel *panel = new TPanel(parent);

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1244,6 +1244,9 @@ public:
     SceneBrowser *browser = new SceneBrowser(panel, Qt::WindowFlags(), false, true);
     panel->setWidget(browser);
     panel->setWindowTitle(QObject::tr("Preproduction Board"));
+    panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
+    connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
+            SLOT(showTitleBar(bool)));
     TFilePath scenesFolder =
         TProjectManager::instance()->getCurrentProject()->getScenesPath();
     browser->setFolder(scenesFolder, true);


### PR DESCRIPTION
Like most other panels, if a Custom Panel or Preproduction Board is docked, the title bar will now be hidden when the panels are locked.