### PR TITLE
Fix missing GPHOTO2 compile define option + other issues

### DIFF
--- a/toonz/sources/stopmotion/canon.cpp
+++ b/toonz/sources/stopmotion/canon.cpp
@@ -1556,7 +1556,7 @@ EdsError Canon::handleStateEvent(EdsStateEvent event, EdsUInt32 parameter,
     if (instance()->m_sessionOpen && instance()->getCameraCount() > 0) {
       // instance()->closeCameraSession();
     }
-    StopMotion::instance()->m_liveViewStatus = 0;
+    StopMotion::instance()->stopLiveView();
     emit(instance()->canonCameraChanged(QString("")));
   }
   if (event == kEdsStateEvent_WillSoonShutDown) {

--- a/toonz/sources/stopmotion/canon.cpp
+++ b/toonz/sources/stopmotion/canon.cpp
@@ -1352,6 +1352,10 @@ bool Canon::downloadEVFData() {
 
     l_quitLoop                                 = false;
     StopMotion::instance()->m_liveViewImage    = converter->getImage();
+
+    if (!StopMotion::instance()->m_liveViewImage)
+      return false;
+
     StopMotion::instance()->m_hasLiveViewImage = true;
 
     uchar* imgBuf = StopMotion::instance()->m_liveViewImage->getRawData();

--- a/toonz/sources/stopmotion/gphotocam.cpp
+++ b/toonz/sources/stopmotion/gphotocam.cpp
@@ -693,6 +693,12 @@ bool GPhotoCam::getGPhotocamImage() {
 
   l_quitLoop = false;
   StopMotion::instance()->m_liveViewImage = converter->getImage();
+
+  if (!StopMotion::instance()->m_liveViewImage) {
+    m_previewImageReady = false;
+    return false;
+  }
+
   StopMotion::instance()->m_hasLiveViewImage = true;
 
   m_previewImageReady = false;

--- a/toonz/sources/stopmotion/gphotocam.cpp
+++ b/toonz/sources/stopmotion/gphotocam.cpp
@@ -35,12 +35,21 @@ void doGPSleep(int ms) {
 #include <QDebug>
 
 //-----------------------------------------------------------------------------
+bool gp_crit_error;
+QString gp_error_msg;
+char *gp_error_data;
 
 static void logdump(GPLogLevel level, const char *domain, const char *str,
                     void *data) {
-  if (level == GP_LOG_ERROR)
+  if (level == GP_LOG_ERROR) {
     qDebug() << "[GP_ERROR] " << QString(str);
-  else if (level == GP_LOG_VERBOSE) {
+    if (QString(str).contains("PTP No Device") ||
+        QString(str).contains("No such device")) {
+      gp_crit_error = true;
+      gp_error_msg  = QString(str);
+      gp_error_data = (char *)data;
+    }
+  } else if (level == GP_LOG_VERBOSE) {
     qDebug() << "[GP_VERBOSE] " << QString(str);
   } else if (level == GP_LOG_DEBUG) {
     qDebug() << "[GP_DEBUG] " << QString(str);
@@ -312,6 +321,21 @@ void GPhotoCam::onTimeout() {
   while (1) {
     if (!m_gpContext || !m_camera || m_exitRequested) break;
 
+    if (gp_crit_error) {
+      if (debug)
+        qDebug() << "[GphotoCamEventHandler] GP_ERROR " << (char *)gp_error_data
+                 << " encountered: " << gp_error_msg;
+      gp_crit_error = false;
+      gp_error_msg  = "";
+      free(gp_error_data);
+
+      m_sessionOpen = false;
+      releaseCamera();
+      StopMotion::instance()->stopLiveView();
+      emit gphotoCameraChanged(QString(""));
+      break;
+    }
+
     retVal =
         gp_camera_wait_for_event(m_camera, 1, &evttype, &evtdata, m_gpContext);
     if (retVal < GP_OK) break;
@@ -527,6 +551,10 @@ bool GPhotoCam::getCamera(int index) {
 
 bool GPhotoCam::initializeCamera() {
   if (!m_camera) return false;
+
+  gp_crit_error = false;
+  gp_error_msg  = "";
+  gp_error_data = 0;
 
   int retVal = gp_camera_init(m_camera, m_gpContext);
   if (retVal < GP_OK) return false;

--- a/toonz/sources/stopmotion/gphotocam.h
+++ b/toonz/sources/stopmotion/gphotocam.h
@@ -252,6 +252,7 @@ signals:
   void liveViewOffsetChangedSignal(int);
   void focusCheckToggled(bool);
   void pickFocusCheckToggled(bool);
+  void gphotoCameraChanged(QString);
 };
 
 #endif  // GPHOTOCAM_H

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -1831,6 +1831,12 @@ void StopMotion::captureImage() {
     return;
   }
 
+  if (m_currentCameraType == CameraType::Web &&
+      (!m_hasLiveViewImage || m_liveViewStatus != LiveViewOpen)) {
+    DVGui::warning(tr("Cannot capture image unless live view is active."));
+    return;
+  }
+
   if (m_isTimeLapse && !m_intervalStarted) {
     startInterval();
     return;
@@ -1839,12 +1845,6 @@ void StopMotion::captureImage() {
     stopInterval();
     return;
   }
-/*
-  if (!m_hasLiveViewImage || m_liveViewStatus != LiveViewOpen) {
-    DVGui::warning(tr("Cannot capture image unless live view is active."));
-    return;
-  }
-*/
 
   bool sessionOpen = false;
 #ifdef WITH_CANON

--- a/toonz/sources/stopmotion/stopmotion.h
+++ b/toonz/sources/stopmotion/stopmotion.h
@@ -276,6 +276,8 @@ signals:
   void updateCameraList(QString);
   void changeCameraIndex(int);
   void updateStopMotionControls();
+  void captureStarted();
+  void captureComplete();
 
   // live view and images
   void newLiveViewImageReady();

--- a/toonz/sources/stopmotion/stopmotion.h
+++ b/toonz/sources/stopmotion/stopmotion.h
@@ -252,6 +252,8 @@ public:
   void setZoomPoint();
   void adjustLiveViewZoomPickPoint(int x, int y);
 
+  void stopLiveView();
+
 public slots:
   // timers
   void onTimeout();
@@ -263,7 +265,7 @@ public slots:
   void directDslrImage();
   void onSceneSwitched();
   void onPlaybackChanged();
-  void onCanonCameraChanged(QString);
+  void onCameraChanged(QString);
 
 signals:
   // camera stuff

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -1907,6 +1907,10 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
                        SLOT(onCameraIndexChanged(int)));
   ret = ret && connect(m_stopMotion, SIGNAL(updateStopMotionControls()), this,
                        SLOT(onUpdateStopMotionControls()));
+  ret = ret && connect(m_stopMotion, SIGNAL(captureStarted()), this,
+                       SLOT(onCaptureStarted()));
+  ret = ret && connect(m_stopMotion, SIGNAL(captureComplete()), this,
+                       SLOT(onCaptureComplete()));
 
   // EOS Connections
   ret = ret &&
@@ -3348,6 +3352,14 @@ void StopMotionController::onUpdateStopMotionControls() {
 
 //-----------------------------------------------------------------------------
 
+void StopMotionController::onCaptureStarted() { updateCaptureButton(true); }
+
+//-----------------------------------------------------------------------------
+
+void StopMotionController::onCaptureComplete() { updateCaptureButton(false); }
+
+//-----------------------------------------------------------------------------
+
 void StopMotionController::onWebcamResolutionsChanged() {
   m_resolutionCombo->clear();
   QList<QSize> resolutions = m_stopMotion->m_webcam->getWebcamResolutions();
@@ -4516,9 +4528,7 @@ void StopMotionController::updateStopMotion() {}
 //-----------------------------------------------------------------------------
 
 void StopMotionController::onTakeTestButtonClicked() {
-  if (m_stopMotion->m_liveViewStatus == StopMotion::LiveViewOpen) {
-    m_stopMotion->takeTestShot();
-  }
+  m_stopMotion->takeTestShot();
 }
 
 //-----------------------------------------------------------------------------
@@ -4708,6 +4718,16 @@ void StopMotionController::reflowTestShots() {
     // m_testsOutsideLayout->addLayout(layout);
     m_testsInsideLayout->insertLayout(m_testsInsideLayout->count() - 1, layout);
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void StopMotionController::updateCaptureButton(bool captureStarted) {
+  // If checkable, it's interval capture. Don't disable the button
+  if (!m_captureButton->isCheckable())
+    m_captureButton->setDisabled(captureStarted);
+
+  m_settingsTakeTestButton->setDisabled(captureStarted);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/stopmotion/stopmotioncontroller.h
+++ b/toonz/sources/stopmotion/stopmotioncontroller.h
@@ -263,6 +263,8 @@ protected:
   void resizeEvent(QResizeEvent *event) override;
   void reflowTestShots();
 
+  void updateCaptureButton(bool captureStarted);
+
 protected slots:
   void refreshCameraList(QString activeCamera = "");
   void refreshCameraListCalled();
@@ -414,6 +416,8 @@ protected slots:
   void onNewCameraSelected(int);
   void onCameraIndexChanged(int);
   void onUpdateStopMotionControls();
+  void onCaptureStarted();
+  void onCaptureComplete();
 
   // webcam
   void onWebcamResolutionsChanged();

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -455,6 +455,10 @@ if (WITH_CANON)
     add_definitions(-DWITH_CANON)
 endif()
 
+if (WITH_GPHOTO2)
+    add_definitions(-DWITH_GPHOTO2)
+endif()
+
 if (WITH_WINTAB AND BUILD_TARGET_WIN AND (PLATFORM EQUAL 64))
     add_definitions(-DWITH_WINTAB)
 endif()


### PR DESCRIPTION
This fixes the following:

1. An issue with GPhoto2 not being compiled into T2D for all builds.

This was due to an accidental deletion of some lines in the CMake file when OT's crashhandler replaced the crashrpt (PR #1187) .

2. Fixes #1288 . This applies to both Canon and non-Canon cameras

3. Fixes a crash that can occur  when it cannot display a live View image. This applies to both Canon and non-Canon cameras.

4. Fixes a crash caused by clicking Capture button when using Webcam without Live View turned on. 

5. Fixes #1289 . Applies to any camera in use. 