### PR TITLE
Fix removing .gitkeep files when packaging macos builds

### DIFF
--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -21,8 +21,6 @@ then
    rm -rf $TOONZDIR/Tahoma2D.app/tahomastuff
 fi
 
-find $TOONZDIR/Tahoma2D.app/tahomastuff -name .gitkeep -exec rm -f {} \;
-
 if [ -d thirdparty/apps/ffmpeg/bin ]
 then
    echo ">>> Copying FFmpeg to Tahoma2D.app/ffmpeg"
@@ -187,6 +185,8 @@ echo ">>> Creating Tahoma2D-portable-osx.dmg"
 
 cp -R stuff $TOONZDIR/Tahoma2D.app/tahomastuff
 chmod -R 777 $TOONZDIR/Tahoma2D.app/tahomastuff
+
+find $TOONZDIR/Tahoma2D.app/tahomastuff -name .gitkeep -exec rm -f {} \;
    
 $QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -dmg -verbose=0
 


### PR DESCRIPTION
Moves the line that removes .gitkeep files in the `tahomastuff` directory to after the stuff folder is moved into place for packaging the portable.

Missed moving this line when I modified the scripts for building the installer version first, followed by the portable. (PR #990)