### PR TITLE
Control Point Editor Tool enhancements

### DIFF
--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -718,7 +718,7 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
   TPointD delta = pos - m_pos;
 
   if (m_action == CP_MOVEMENT) {
-    if (!m_selection.isSelected(m_lastPointSelected) && e.isCtrlPressed())
+    if (!m_selection.isSelected(m_lastPointSelected) && e.isShiftPressed())
       m_selection.select(m_lastPointSelected);  // Controllo che non venga
                                                 // deselezionata l'ultima
                                                 // selezione nel movimento

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -625,6 +625,40 @@ void ControlPointEditorTool::rightButtonDown(const TPointD &pos,
 
 //---------------------------------------------------------------------------
 
+void ControlPointEditorTool::leftButtonDoubleClick(const TPointD &pos,
+                                                   const TMouseEvent &e) {
+  if (getViewer() && getViewer()->getGuidedStrokePickerMode())
+    return;
+
+  m_pos           = pos;
+  double pix      = getPixelSize() * 2.0f;
+  double maxDist  = 5 * pix;
+  double maxDist2 = maxDist * maxDist;
+  double dist2    = 0;
+  int pointIndex;
+  ControlPointEditorStroke::PointType pointType =
+      m_controlPointEditorStroke.getPointTypeAt(pos, maxDist2, pointIndex);
+
+  TVectorImageP vi = getImage(true);
+  if (!vi) return;
+
+  if (pointType != ControlPointEditorStroke::SEGMENT) return;
+
+  m_selection.selectNone();
+  // Aggiungo un punto
+  initUndo();
+  pointIndex = m_controlPointEditorStroke.addControlPoint(pos);
+  m_selection.select(pointIndex);
+  m_action = CP_MOVEMENT;
+  TUndoManager::manager()->add(m_undo);
+  m_lastPointSelected = -1;
+  notifyImageChanged();
+
+  m_selection.makeCurrent();
+}
+
+//---------------------------------------------------------------------------
+
 void ControlPointEditorTool::moveControlPoints(const TPointD &delta) {
   int i;
   int cpCount = m_controlPointEditorStroke.getControlPointCount();

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -504,7 +504,7 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
         startFreehand(pos);
       }
     }
-    if (e.isCtrlPressed())
+    if (e.isShiftPressed())
       m_selection.holdSelection();
     else
       m_selection.selectNone();
@@ -543,7 +543,7 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
       m_undo = 0;
       return;
     }
-    if (e.isCtrlPressed()) {
+    if (e.isShiftPressed()) {
       if (m_selection.isSelected(pointIndex))
         m_selection.unselect(pointIndex);
       else
@@ -726,7 +726,7 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
     if (m_selectingRect.y0 > m_selectingRect.y1)
       std::swap(m_selectingRect.y1, m_selectingRect.y0);
     int i;
-    if (e.isCtrlPressed())
+    if (e.isShiftPressed())
       m_selection.restoreSelection();
     else
       m_selection.selectNone();

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -504,7 +504,10 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
         startFreehand(pos);
       }
     }
-    m_selection.selectNone();
+    if (e.isCtrlPressed())
+      m_selection.holdSelection();
+    else
+      m_selection.selectNone();
     return;
   }
   TVectorImageP vi = getImage(true);
@@ -723,7 +726,10 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
     if (m_selectingRect.y0 > m_selectingRect.y1)
       std::swap(m_selectingRect.y1, m_selectingRect.y0);
     int i;
-    m_selection.selectNone();
+    if (e.isCtrlPressed())
+      m_selection.restoreSelection();
+    else
+      m_selection.selectNone();
     for (i = 0; i < cpCount; i++)
       if (m_selectingRect.contains(
               m_controlPointEditorStroke.getControlPoint(i)))

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -504,7 +504,7 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
         startFreehand(pos);
       }
     }
-    if (e.isShiftPressed())
+    if (e.isShiftPressed() || e.isAltPressed())
       m_selection.holdSelection();
     else
       m_selection.selectNone();
@@ -760,14 +760,18 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
     if (m_selectingRect.y0 > m_selectingRect.y1)
       std::swap(m_selectingRect.y1, m_selectingRect.y0);
     int i;
-    if (e.isShiftPressed())
+    if (e.isShiftPressed() || e.isAltPressed())
       m_selection.restoreSelection();
     else
       m_selection.selectNone();
     for (i = 0; i < cpCount; i++)
       if (m_selectingRect.contains(
-              m_controlPointEditorStroke.getControlPoint(i)))
-        m_selection.select(i);
+              m_controlPointEditorStroke.getControlPoint(i))) {
+        if (e.isAltPressed())
+          m_selection.unselect(i);
+        else
+          m_selection.select(i);
+      }
   } else if (m_action == FREEHAND_SELECTION) {
     freehandDrag(pos);
   }
@@ -776,7 +780,7 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
 }
 
 //---------------------------------------------------------------------------
-void ControlPointEditorTool::selectRegion(TStroke *stroke) {
+void ControlPointEditorTool::selectRegion(TStroke *stroke, bool unselect) {
   int cpCount = m_controlPointEditorStroke.getControlPointCount();
 
   TVectorImage img;
@@ -786,7 +790,10 @@ void ControlPointEditorTool::selectRegion(TStroke *stroke) {
     TRegion *region = img.getRegion(rI);
     for (int i = 0; i < cpCount; i++) {
       if (region->contains(m_controlPointEditorStroke.getControlPoint(i))) {
-        m_selection.select(i);
+        if (unselect)
+          m_selection.unselect(i);
+        else
+          m_selection.select(i);
       }
     }
   }
@@ -814,7 +821,7 @@ void ControlPointEditorTool::leftButtonUp(const TPointD &realPos,
   if (m_action == RECT_SELECTION || m_action == FREEHAND_SELECTION) {
     if (m_action == FREEHAND_SELECTION) {
       closeFreehand(pos);
-      selectRegion(m_stroke);
+      selectRegion(m_stroke, e.isAltPressed());
       m_track.clear();
     }
 

--- a/toonz/sources/tnztools/controlpointeditortool.h
+++ b/toonz/sources/tnztools/controlpointeditortool.h
@@ -70,7 +70,7 @@ class ControlPointEditorTool final : public TTool {
 
   TUndo* m_undo;
 
-  void selectRegion(TStroke* stroke);
+  void selectRegion(TStroke* stroke, bool unselect);
   void startFreehand(const TPointD& pos);
   void freehandDrag(const TPointD& pos);
   void closeFreehand(const TPointD& pos);

--- a/toonz/sources/tnztools/controlpointeditortool.h
+++ b/toonz/sources/tnztools/controlpointeditortool.h
@@ -105,6 +105,7 @@ public:
   void mouseMove(const TPointD& pos, const TMouseEvent& e) override;
   void leftButtonDown(const TPointD& pos, const TMouseEvent& e) override;
   void rightButtonDown(const TPointD& pos, const TMouseEvent&) override;
+  void leftButtonDoubleClick(const TPointD& pos, const TMouseEvent& e) override;
 
   void moveControlPoints(const TPointD& delta);
   void moveSpeed(const TPointD& delta, bool isIn);

--- a/toonz/sources/tnztools/controlpointselection.cpp
+++ b/toonz/sources/tnztools/controlpointselection.cpp
@@ -996,6 +996,7 @@ bool ControlPointSelection::isSelected(int index) const {
 //-----------------------------------------------------------------------------
 
 void ControlPointSelection::select(int index) {
+  if (isSelected(index)) return;
   m_selectedPoints.push_back(index);
 }
 
@@ -1005,6 +1006,18 @@ void ControlPointSelection::unselect(int index) {
   std::vector<int>::iterator it =
       std::find(m_selectedPoints.begin(), m_selectedPoints.end(), index);
   if (it != m_selectedPoints.end()) m_selectedPoints.erase(it);
+}
+
+//-----------------------------------------------------------------------------
+
+void ControlPointSelection::holdSelection() {
+  m_originalPoints = m_selectedPoints;
+}
+
+//-----------------------------------------------------------------------------
+
+void ControlPointSelection::restoreSelection() {
+  m_selectedPoints = m_originalPoints;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/controlpointselection.h
+++ b/toonz/sources/tnztools/controlpointselection.h
@@ -139,6 +139,7 @@ class ControlPointSelection final : public QObject, public TSelection {
 
 private:
   std::vector<int> m_selectedPoints;
+  std::vector<int> m_originalPoints;
   int m_strokeIndex;
   ControlPointEditorStroke *m_controlPointEditorStroke;
 
@@ -158,6 +159,9 @@ public:
   void unselect(int index);
 
   TUndo *initSelectionUndo(int strokeIndex, bool clearSelection = true);
+
+  void holdSelection();
+  void restoreSelection();
 
   void deleteControlPoints();
 


### PR DESCRIPTION
The following changes have been made to the Control Point Editor Tool to bring the modifier keys more in line with other software.

- `SHIFT` with area selection adds more control points to an already existing selection
- `ALT` with area selection will unselect selected control points in the selection area
- `CTRL`+click on a control point has been replaced with `SHIFT`+click to select/deselect specific control points
- Double-click on a line segment now adds control points also.
