### PR TITLE
Add missing exception catch-all

### DIFF
--- a/toonz/sources/common/tapptools/tcli.cpp
+++ b/toonz/sources/common/tapptools/tcli.cpp
@@ -724,6 +724,10 @@ bool Usage::parse(int argc, char *argv[], std::ostream &err) {
     err << "Usage error: " << e.getError() << endl;
     m_imp->printUsageLines(err);
     return false;
+  } catch (...) {
+    err << "Usage error: Unhandled exception encountered" << endl;
+    m_imp->printUsageLines(err);
+    return false;
   }
 }
 

--- a/toonz/sources/common/tfx/tfx.cpp
+++ b/toonz/sources/common/tfx/tfx.cpp
@@ -934,7 +934,8 @@ void TFx::loadPreset(TIStream &is) {
             TParamP param = getParams()->getParam(paramName);
             param->loadData(is);
           } catch (TException &) { /*skip*/
-          }                        // il parametro non e' presente
+          } catch (...) {          // il parametro non e' presente
+          }
           is.closeChild();
         }
       }

--- a/toonz/sources/common/timage_io/timage_io.cpp
+++ b/toonz/sources/common/timage_io/timage_io.cpp
@@ -136,6 +136,8 @@ void TImageReader::open() {
       if (msg == QString("Old 4.1 Palette")) throw e;
     } catch (std::string str) {
       if (str == "Tiff file closed") m_file = NULL;
+    } catch (...) {
+      close();
     }
   }
 }

--- a/toonz/sources/common/timage_io/tlevel_io.cpp
+++ b/toonz/sources/common/timage_io/tlevel_io.cpp
@@ -134,6 +134,11 @@ TLevelP TLevelReader::loadInfo() {
             tmfe.getMessage() + L": " +
             QObject::tr("Skipping frame.").toStdWString()));
         continue;
+      } catch (...) {
+        DVGui::warning(QString::fromStdWString(
+            QObject::tr("Unhandled exception encountered: Skipping frame.")
+                .toStdWString()));
+        continue;
       }
     }
   }

--- a/toonz/sources/common/tparam/tnotanimatableparam.cpp
+++ b/toonz/sources/common/tparam/tnotanimatableparam.cpp
@@ -239,6 +239,8 @@ void TEnumParam::loadData(TIStream &is) {
     setValue(value, false);
   } catch (TException &) {
     TNotAnimatableParam<int>::reset();
+  } catch (...) {
+    TNotAnimatableParam<int>::reset();
   }
 }
 

--- a/toonz/sources/common/tunit/tunit.cpp
+++ b/toonz/sources/common/tunit/tunit.cpp
@@ -489,6 +489,8 @@ bool TMeasuredValue::setValue(std::wstring s, int *pErr) {
       return false;
     } catch (const std::out_of_range &) {
       return false;
+    } catch (...) {
+      return false;
     }
 
     valueFlag = true;

--- a/toonz/sources/common/tvectorimage/outlineApproximation.cpp
+++ b/toonz/sources/common/tvectorimage/outlineApproximation.cpp
@@ -246,6 +246,10 @@ void makeOutline(/*std::ofstream& cout,*/
     delete edge.first;
     delete edge.second;
     return;
+  } catch (...) {
+    delete edge.first;
+    delete edge.second;
+    return;
   }
 
   const TQuadratic *q_up     = edge.first;

--- a/toonz/sources/image/pli/pli_io.cpp
+++ b/toonz/sources/image/pli/pli_io.cpp
@@ -185,6 +185,8 @@ void MyIfstream::open(const TFilePath &filename) {
     m_fp = fopen(filename, "rb");
   } catch (TException &) {
     throw TImageException(filename, "File not found");
+  } catch (...) {
+    throw TImageException(filename, "Unhandled exception encountered");
   }
 }
 

--- a/toonz/sources/tconverter/tconverter.cpp
+++ b/toonz/sources/tconverter/tconverter.cpp
@@ -460,6 +460,9 @@ int main(int argc, char *argv[]) {
     msg = "Untrapped exception: " + ::to_string(e.getMessage());
     cout << msg << endl;
     return -1;
+  } catch (...) {
+    cout << "Unhandled exception" << endl;
+    return -1;
   }
   msg = "Conversion terminated!";
   cout << endl << msg << endl;

--- a/toonz/sources/tnzext/StrokeParametricDeformer.cpp
+++ b/toonz/sources/tnzext/StrokeParametricDeformer.cpp
@@ -30,6 +30,8 @@ ToonzExt::StrokeParametricDeformer::StrokeParametricDeformer(
     ref_copy_ = new TStroke(*s);
   } catch (std::bad_alloc &) {
     throw std::invalid_argument("Not possible to have a copy of stroke!!!");
+  } catch (...) {
+    throw std::invalid_argument("Unhandled exception encountered");
   }
 
   assert(0.0 <= startParameter_ && startParameter_ <= 1.0);

--- a/toonz/sources/tnztools/pinchtool.cpp
+++ b/toonz/sources/tnztools/pinchtool.cpp
@@ -273,6 +273,9 @@ void PinchTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     } catch (TDoubleProperty::RangeError &) {
       m_toolRange.setValue((prop_range.first + prop_range.second) * 0.5);
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
+    } catch (...) {
+      m_toolRange.setValue((prop_range.first + prop_range.second) * 0.5);
+      TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
     m_selector.setLength(m_toolRange.getValue());

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -564,6 +564,8 @@ void TypeTool::loadFonts() {
   } catch (TFontLibraryLoadingError &) {
     m_validFonts = false;
     //    TMessage::error(toString(e.getMessage()));
+  } catch (...) {
+    m_validFonts = false;
   }
 
   if (!m_validFonts) return;
@@ -641,6 +643,9 @@ void TypeTool::setFont(std::wstring family) {
     //    TMessage::error(toString(e.getMessage()));
     assert(m_fontFamily == instance->getCurrentFamily());
     m_fontFamilyMenu.setValue(m_fontFamily);
+  } catch (...) {
+    assert(m_fontFamily == instance->getCurrentFamily());
+    m_fontFamilyMenu.setValue(m_fontFamily);
   }
 }
 
@@ -656,6 +661,9 @@ void TypeTool::setTypeface(std::wstring typeface) {
     invalidate();
   } catch (TFontCreationError &) {
     //    TMessage::error(toString(e.getMessage()));
+    assert(m_typeface == instance->getCurrentTypeface());
+    m_typeFaceMenu.setValue(m_typeface);
+  } catch (...) {
     assert(m_typeface == instance->getCurrentTypeface());
     m_typeFaceMenu.setValue(m_typeface);
   }

--- a/toonz/sources/toonz/batches.cpp
+++ b/toonz/sources/toonz/batches.cpp
@@ -321,6 +321,7 @@ void BatchesController::addCleanupTask(const TFilePath &taskFilePath) {
   try {
     BatchesController::instance()->addTask(id, taskGroup);
   } catch (TException &) {
+  } catch (...) {
   }
 }
 
@@ -332,6 +333,7 @@ void BatchesController::addComposerTask(const TFilePath &_taskFilePath) {
   try {
     taskFilePath = TSystem::toUNC(_taskFilePath);
   } catch (TException &) {
+  } catch (...) {
   }
 
   ToonzScene scene;
@@ -394,6 +396,7 @@ void BatchesController::addComposerTask(const TFilePath &_taskFilePath) {
     BatchesController::instance()->addTask(id, taskGroup);
   } catch (TException &) {
     // TMessage::error(toString(e.getMessage()));
+  } catch (...) {
   }
   // m_data->m_scene.setProject( mainprogramProj);
   // TModalPopup::closePopup();
@@ -1000,6 +1003,9 @@ void BatchesController::update() {
         }
       }
     } catch (TException &e) {
+      ControllerFailureMsg(e).send();
+    } catch (...) {
+      TException e("Unhandled exception encountered");
       ControllerFailureMsg(e).send();
     }
   }

--- a/toonz/sources/toonz/batchserversviewer.cpp
+++ b/toonz/sources/toonz/batchserversviewer.cpp
@@ -52,6 +52,8 @@ void FarmServerListView::update() {
     }
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
   }
 }
 
@@ -68,6 +70,8 @@ void FarmServerListView::activate() {
     static_cast<BatchServersViewer *>(parentWidget())->updateSelected();
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
   }
 }
 
@@ -84,6 +88,8 @@ void FarmServerListView::deactivate() {
     static_cast<BatchServersViewer *>(parentWidget())->updateSelected();
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
   }
 }
 //-----------------------------------------------------------------------------
@@ -100,6 +106,9 @@ void FarmServerListView::openContextMenu(const QPoint &p) {
     state = controller->queryServerState2(item->m_id);
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+    return;
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
     return;
   }
 
@@ -170,6 +179,8 @@ void BatchServersViewer::updateServerInfo(const QString &id) {
     controller->queryServerInfo(id, info);
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
   }
 
   switch (info.m_state) {
@@ -212,6 +223,9 @@ void BatchServersViewer::updateServerInfo(const QString &id) {
     } catch (TException &e) {
       m_tasks->setText("");
       DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+    } catch (...) {
+      m_tasks->setText("");
+      DVGui::warning("Unhandled exception encountered");
     }
   }
 
@@ -344,6 +358,10 @@ void BatchServersViewer::onProcessWith(int index) {
     return;
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+    m_processWith->setCurrentIndex(0);
+    return;
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
     m_processWith->setCurrentIndex(0);
     return;
   }

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -345,6 +345,11 @@ you want to do?";*/
                           "included in the rendered clip.")
                            .arg(QString::fromStdWString(fp.getLevelNameW()));
         DVGui::warning(text);
+      } catch (...) {
+        QString text =
+            tr("Unhandled exception encountered.\nThe audio file will not be "
+               "included in the rendered clip.");
+        DVGui::warning(text);
       }
     }
 

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -609,6 +609,10 @@ void FileBrowser::refreshCurrentFolderItems() {
             tmfe.getMessage() + L": " +
             QObject::tr("Skipping frame.").toStdWString()));
         continue;
+      } catch (...) {
+        DVGui::warning(QString::fromStdWString(
+            QObject::tr("Unhandled exception encountered: Skipping frame.").toStdWString()));
+        continue;
       }
 
       TFilePath levelName(it->getLevelName());

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -562,6 +562,10 @@ static int importScene(TFilePath scenePath) {
     DVGui::error(QObject::tr("There was an error saving the %1 scene.")
                      .arg(toQString(scenePath)));
     return 0;
+  } catch (...) {
+    DVGui::error(QObject::tr("There was an error saving the %1 scene.")
+                     .arg(toQString(scenePath)));
+    return 0;
   }
 
   DvDirModel::instance()->refreshFolder(

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -1505,8 +1505,12 @@ void FlipBook::playAudioFrame(int frame) {
         } catch (TSoundDeviceException &ex) {
           throw TException(ex.getMessage());
           return;
+        } catch (...) {
+          throw TException("Unhandled exception encountered");
+          return;
         }
       }
+    } catch (...) {
     }
   }
 }

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -265,6 +265,14 @@ public:
 
       errorDialog->exec();
       errorDialog->deleteLater();
+    } catch (...) {
+      DVGui::Dialog *errorDialog = DVGui::createMsgBox(
+          DVGui::WARNING,
+          "Can't copy resources: Unhandled exception encountered",
+          QStringList("OK"), 0);
+
+      errorDialog->exec();
+      errorDialog->deleteLater();
     }
     // notify
     FileBrowser::refreshFolder(actualDstPath.getParentDir());
@@ -991,6 +999,10 @@ TXshLevel *loadLevel(ToonzScene *scene,
       else
         error(QString::fromStdWString(e.getMessage()));
 
+      return 0;
+    } catch (...) {
+      if (convertingPopup->isVisible()) convertingPopup->hide();
+      error("Unhandled exception encountered");
       return 0;
     }
 
@@ -2287,6 +2299,8 @@ static int createSubXSheetFromPSDFolder(IoCmd::LoadResourceArguments &args,
                             col1, false);
       } catch (TException &e) {
         error(QString::fromStdWString(e.getMessage()));
+      } catch (...) {
+        error("Unhandled exception encountered");
       }
       if (xl) {
         // lo importo nell'xsheet
@@ -2356,6 +2370,8 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
                             col1, !popup->subxsheet());
       } catch (TException &e) {
         error(QString::fromStdWString(e.getMessage()));
+      } catch (...) {
+        error("Unhandled exception encountered");
       }
       if (xl) {
         // lo importo nell'xsheet
@@ -2595,6 +2611,9 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
       } catch (std::string msg) {
         error(QString::fromStdString(msg));
         continue;
+      } catch (...) {
+        error("Unhandled exception encountered");
+        continue;
       }
 
       if (importDialog.aborted()) break;
@@ -2638,6 +2657,8 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
         }
       } catch (TException &e) {
         error(QString::fromStdWString(e.getMessage()));
+      } catch (...) {
+        error("Unhandled exception encountered");
       }
       // if load success
       if (xl) {
@@ -3039,6 +3060,9 @@ public:
       TProjectManager::instance()->saveTemplate(scene);
     } catch (TSystemException se) {
       DVGui::warning(QString::fromStdWString(se.getMessage()));
+      return;
+    } catch (...) {
+      DVGui::warning("Unhandled exception encountered");
       return;
     }
   }

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -611,6 +611,8 @@ int main(int argc, char *argv[]) {
           TSystem::mkDir(localPath);
         } catch (TException &e) {
           fatalError(QString::fromStdWString(e.getMessage()));
+        } catch (...) {
+          fatalError("Unhandled exception encountered");
         }
       }
       projectManager->addSVNProjectsRoot(localPath);
@@ -840,6 +842,8 @@ int main(int argc, char *argv[]) {
     isItalic   = fontMgr->isItalic(fontName, fontStyle);
     hasKerning = fontMgr->hasKerning();
   } catch (TFontCreationError &) {
+    // Do nothing. A default font should load
+  } catch (...) {
     // Do nothing. A default font should load
   }
 

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -2162,6 +2162,7 @@ void OutputSettingsPopup::onPresetSelected(const QString &str) {
               try {
                 enumProp->setValue(enumAppProp->getValue());
               } catch (TProperty::RangeError &) {
+              } catch (...) {
               }
             } else
               throw TException();

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -452,6 +452,9 @@ QList<ComboBoxItem> PreferencesPopup::buildFontStyleList() const {
   } catch (TFontCreationError&) {
     it = typefaces.begin();
     typefaces.insert(it, style.toStdWString());
+  } catch (...) {
+    it = typefaces.begin();
+    typefaces.insert(it, style.toStdWString());
   }
   QList<ComboBoxItem> styleList;
   for (it = typefaces.begin(); it != typefaces.end(); ++it)

--- a/toonz/sources/toonz/previewer.cpp
+++ b/toonz/sources/toonz/previewer.cpp
@@ -921,6 +921,9 @@ bool Previewer::Imp::doSaveRenderedFrames(TFilePath fp) {
   } catch (TImageException &e) {
     error(QString::fromStdString(::to_string(e.getMessage())));
     return false;
+  } catch (...) {
+    error("Unhandled exception encountered");
+    return false;
   }
 
   m_lw->setFrameRate(outputSettings->getFrameRate());

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -493,6 +493,9 @@ void ProjectSettingsPopup::onSomethingChanged() {
   } catch (TSystemException se) {
     DVGui::warning(QString::fromStdWString(se.getMessage()));
     return;
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
+    return;
   }
   DvDirModel::instance()->refreshFolder(project->getProjectFolder());
 }
@@ -610,6 +613,9 @@ void ProjectCreatePopup::createProject() {
                        .arg(toQString(projectPath)));
   } catch (TSystemException se) {
     DVGui::warning(QString::fromStdWString(se.getMessage()));
+    return;
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
     return;
   }
   pm->setCurrentProjectPath(projectPath);

--- a/toonz/sources/toonz/psdsettingspopup.cpp
+++ b/toonz/sources/toonz/psdsettingspopup.cpp
@@ -102,6 +102,9 @@ static void doPSDInfo(TFilePath psdpath, QTreeWidget *psdTree) {
   } catch (TImageException &e) {
     error(QString::fromStdString(::to_string(e.getMessage())));
     return;
+  } catch (...) {
+    error("Unhandled exception encountered");
+    return;
   }
 }
 
@@ -374,6 +377,9 @@ void PsdSettingsPopup::doPsdParser() {
     }
   } catch (TImageException &e) {
     error(QString::fromStdString(::to_string(e.getMessage())));
+    return;
+  } catch (...) {
+    error("Unhandled exception encountered");
     return;
   }
 }

--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -1275,6 +1275,8 @@ void TaskTreeModel::start(bool) {
       }
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
   }
 
   emit layoutChanged();
@@ -1305,6 +1307,8 @@ void TaskTreeModel::stop(bool) {
       }
   } catch (TException &e) {
     DVGui::warning(QString::fromStdString(::to_string(e.getMessage())));
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
   }
 
   emit layoutChanged();

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -1515,6 +1515,8 @@ void VectorizerPopup::saveParameters() {
       locals.saveParams(fileName);
     } catch (const TException &e) {
       DVGui::error(QString::fromStdWString(e.getMessage()));
+    } catch (...) {
+      DVGui::error("Unhandled exception encountered");
     }
   }
 }
@@ -1571,6 +1573,8 @@ void VectorizerPopup::loadParameters() {
       refreshPopup();  // Update GUI to reflect changes
     } catch (const TException &e) {
       DVGui::error(QString::fromStdWString(e.getMessage()));
+    } catch (...) {
+      DVGui::error("Unhandled exception encountered");
     }
   }
 }

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -851,6 +851,8 @@ bool BaseViewerPanel::hasSoundtrack() {
     } else {
       throw TSoundDeviceException(e.getType(), e.getMessage());
     }
+  } catch (...) {
+    std::cout << "Unhandled exception encountered" << std::endl;
   }
   if (m_sound == NULL) {
     m_hasSoundtrack = false;

--- a/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
@@ -531,6 +531,7 @@ QString TFarmTask::getCommandLineArguments() const {
     try {
       outputPath = TSystem::toUNC(m_outputPath);
     } catch (TException &) {
+    } catch (...) {
     }
 
     cmdline +=
@@ -587,6 +588,7 @@ QStringList TFarmTask::getCommandLineArgumentsList() const {
     try {
       outputPath = TSystem::toUNC(m_outputPath);
     } catch (TException &) {
+    } catch (...) {
     }
 
     ret << "-o" << QString::fromStdWString(outputPath.getWideString());
@@ -691,6 +693,7 @@ bool TFarmTaskGroup::changeChunkSize(int chunksize) {
         addTask(subTask);
       } catch (TException &) {
         // TMessage::error(toString(e.getMessage()));
+      } catch (...) {
       }
 
       ra = rb + 1;
@@ -737,6 +740,7 @@ TFarmTaskGroup::TFarmTaskGroup(
         addTask(subTask);
       } catch (TException &) {
         // TMessage::error(toString(e.getMessage()));
+      } catch (...) {
       }
 
       ra = rb + 1;

--- a/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
+++ b/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
@@ -736,6 +736,7 @@ void FarmController::loadServersData(const TFilePath &globalRoot) {
         try {
           server->attachController(m_hostName, m_addr, m_port);
         } catch (TException &) {
+        } catch (...) {
         }
       }
     }
@@ -1124,6 +1125,8 @@ void FarmController::startTask(CtrlFarmTask *task, FarmServerProxy *server) {
     server->addTask(taskToBeSubmitted);
   } catch (TException &e) {
     throw e;
+  } catch (...) {
+    throw;
   }
 
   if (rc == 0) {
@@ -1287,6 +1290,8 @@ bool FarmController::tryToStartTask(CtrlFarmTask *task) {
               startTask(task, server);
             } catch (TException & /*e*/) {
               continue;
+            } catch (...) {
+              continue;
             }
 
             return true;
@@ -1303,6 +1308,8 @@ bool FarmController::tryToStartTask(CtrlFarmTask *task) {
         try {
           startTask(task, server);
         } catch (TException & /*e*/) {
+          continue;
+        } catch (...) {
           continue;
         }
       }
@@ -1366,6 +1373,8 @@ public:
       m_server->queryHwInfo(hwInfo);
     } catch (TException & /*e*/) {
       return;
+    } catch (...) {
+      return;
     }
 
     m_server->m_attached = true;
@@ -1383,6 +1392,10 @@ void FarmController::initServer(FarmServerProxy *server) {
   try {
     server->queryHwInfo(hwInfo);
   } catch (TException & /*e*/) {
+    TThread::Executor exec;
+    exec.addTask(new ServerInitializer(server));
+    return;
+  } catch (...) {
     TThread::Executor exec;
     exec.addTask(new ServerInitializer(server));
     return;
@@ -1807,6 +1820,8 @@ void FarmController::taskSubmissionError(const QString &taskId, int errCode) {
           startTask(task, server);
         } catch (TException & /*e*/) {
           continue;
+        } catch (...) {
+          continue;
         }
 
         break;
@@ -1988,6 +2003,7 @@ void FarmController::taskCompleted(const QString &taskId, int exitCode) {
         } else
           startTask(task, server);
       } catch (TException & /*e*/) {
+      } catch (...) {
       }
     }
   }
@@ -2072,6 +2088,7 @@ void FarmController::activateServer(const QString &id) {
           } else
             startTask(task, server);
         } catch (TException & /*e*/) {
+        } catch (...) {
         }
       }
     }
@@ -2196,6 +2213,7 @@ void FarmController::activateReadyServers() {
             } else
               startTask(task, server);
           } catch (TException & /*e*/) {
+          } catch (...) {
           }
         }
       }

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -854,6 +854,12 @@ void FarmServerService::onStart(int argc, char *argv[]) {
     errMsg += ::to_string(e.getMessage());
     addToMessageLog(errMsg);
     setStatus(TService::Stopped, NO_ERROR, 0);  // exit the program
+  } catch (...) {
+    std::string errMsg("Unable to start the Server");
+    errMsg += "\n";
+    errMsg += "Unhandled exception encountered";
+    addToMessageLog(errMsg);
+    setStatus(TService::Stopped, NO_ERROR, 0);  // exit the program
   }
 
   if (isRunningAsConsoleApp()) {
@@ -900,6 +906,7 @@ void FarmServerService::onStart(int argc, char *argv[]) {
     m_farmServer->getController()->attachServer(TSystem::getHostName(), m_addr,
                                                 m_port);
   } catch (TException const &) {
+  } catch (...) {
   }
 
 #ifdef _WIN32
@@ -976,6 +983,7 @@ void FarmServerService::onStop() {
     m_farmServer->getController()->detachServer(TSystem::getHostName(), m_addr,
                                                 m_port);
   } catch (TException & /*e*/) {
+  } catch (...) {
   }
 
 // i dischi vengono montati al primo task di tipo "runcasm"

--- a/toonz/sources/toonzlib/autoclose.cpp
+++ b/toonz/sources/toonzlib/autoclose.cpp
@@ -292,6 +292,10 @@ void TAutocloser::Imp::compute(std::vector<Segment> &closingSegmentArray) {
   catch (TException &e) {
     throw e;
   }
+
+  catch (...) {
+    throw;
+  }
 }
 
 /*------------------------------------------------------------------------*/

--- a/toonz/sources/toonzlib/captureparameters.cpp
+++ b/toonz/sources/toonzlib/captureparameters.cpp
@@ -139,6 +139,7 @@ void CaptureParameters::loadData(TIStream &is) {
               try {
                 enumProp->setValue(enumAppProp->getValue());
               } catch (TProperty::RangeError &) {
+              } catch (...) {
               }
             } else
               throw TException();

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -67,6 +67,8 @@ bool ImageLoader::getInfo(TImageInfo &info, int imFlags, void *extData) {
     if (msg == QString("Old 4.1 Palette")) throw;
 
     return false;
+  } catch (...) {
+    return false;
   }
 }
 

--- a/toonz/sources/toonzlib/sandor_fxs/BlurMatrix.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/BlurMatrix.cpp
@@ -42,6 +42,8 @@ CBlurMatrix::CBlurMatrix(const CBlurMatrix &m)
     for (int i = 0; i < NBRS; i++) m_m[i] = m.m_m[i];
   } catch (exception) {
     throw SBlurMatrixError();
+  } catch (...) {
+    throw SBlurMatrixError();
   }
 }
 
@@ -62,6 +64,8 @@ CBlurMatrix::CBlurMatrix(const double d, const int nb, const bool isSAC,
 
     if (m_isSAC) addPath();
   } catch (SBlurMatrixError) {
+    throw;
+  } catch (...) {
     throw;
   }
 }
@@ -114,6 +118,8 @@ void CBlurMatrix::createRandom(const double d, const int nb)
       }
     }
   } catch (exception) {
+    throw SBlurMatrixError();
+  } catch (...) {
     throw SBlurMatrixError();
   }
 }
@@ -182,6 +188,8 @@ void CBlurMatrix::createEqual(const double d, const int nb)
     }
   } catch (exception) {
     throw SBlurMatrixError();
+  } catch (...) {
+    throw SBlurMatrixError();
   }
 }
 
@@ -206,6 +214,8 @@ void CBlurMatrix::addPath(vector<BLURSECTION>::iterator pBS)
     }
   } catch (exception) {
     throw;
+  } catch (...) {
+    throw;
   }
 }
 
@@ -219,6 +229,8 @@ void CBlurMatrix::addPath()  // throw(SBlurMatrixError)
       }
     }
   } catch (exception) {
+    throw SBlurMatrixError();
+  } catch (...) {
     throw SBlurMatrixError();
   }
 }

--- a/toonz/sources/toonzlib/sandor_fxs/CallCircle.h
+++ b/toonz/sources/toonzlib/sandor_fxs/CallCircle.h
@@ -136,6 +136,8 @@ public:
       }
     } catch (SMemAllocError) {
       throw;
+    } catch (...) {
+      throw;
     }
   }
 };

--- a/toonz/sources/toonzlib/sandor_fxs/Pattern.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/Pattern.cpp
@@ -38,6 +38,8 @@ CPattern::CPattern(RASTER *imgContour) : m_lX(0), m_lY(0) {
     optimalizeSize();
   } catch (SMemAllocError) {
     throw;
+  } catch (...) {
+    throw;
   }
 }
 
@@ -262,6 +264,8 @@ void CPattern::rotate(const double angle) {
   try {
     optimalizeSize();
   } catch (SMemAllocError) {
+    throw;
+  } catch (...) {
     throw;
   }
 }

--- a/toonz/sources/toonzlib/sandor_fxs/PatternMapParam.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/PatternMapParam.cpp
@@ -53,6 +53,8 @@ CPatternMapParam::CPatternMapParam(const int argc, const char *argv[],
     }
   } catch (SError) {
     throw;
+  } catch (...) {
+    throw;
   }
 }
 

--- a/toonz/sources/toonzlib/sandor_fxs/PatternPosition.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/PatternPosition.cpp
@@ -59,6 +59,10 @@ void CPatternPosition::makeRandomPositions(const int nbPat, const int nbPixel,
     char s[50];
     snprintf(s, sizeof(s), "in Pattern Position Generation");
     throw SMemAllocError(s);
+  } catch (...) {
+    char s[50];
+    snprintf(s, sizeof(s), "Unhandled exception encountered");
+    throw SMemAllocError(s);
   }
 }
 
@@ -159,6 +163,10 @@ void CPatternPosition::prepareCircle(vector<SPOINT> &v, const double r) {
     char s[50];
     snprintf(s, sizeof(s), "Position Generation");
     throw SMemAllocError(s);
+  } catch (...) {
+    char s[50];
+    snprintf(s, sizeof(s), "Unhandled exception encountered");
+    throw SMemAllocError(s);
   }
 }
 
@@ -182,6 +190,8 @@ void CPatternPosition::makeDDPositions(const int lX, const int lY, UCHAR *sel,
         prepareCircle(ddc[i], dist);
     }
   } catch (SMemAllocError) {
+    throw;
+  } catch (...) {
     throw;
   }
   // Preparing local selection
@@ -210,6 +220,10 @@ void CPatternPosition::makeDDPositions(const int lX, const int lY, UCHAR *sel,
   } catch (exception) {
     char s[50];
     snprintf(s, sizeof(s), "in Pattern Position Generation");
+    throw SMemAllocError(s);
+  } catch (...) {
+    char s[50];
+    snprintf(s, sizeof(s), "Unhandled exception encountered");
     throw SMemAllocError(s);
   }
   //	memcpy(sel,lSel,lX*lY);

--- a/toonz/sources/toonzlib/sandor_fxs/PatternPosition.h
+++ b/toonz/sources/toonzlib/sandor_fxs/PatternPosition.h
@@ -55,6 +55,8 @@ public:
       }
     } catch (SMemAllocError) {
       throw;
+    } catch (...) {
+      throw;
     }
   }
 

--- a/toonz/sources/toonzlib/sandor_fxs/SDirection.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/SDirection.cpp
@@ -38,6 +38,8 @@ CSDirection::CSDirection(const int lX, const int lY, const UCHAR *sel,
     }
   } catch (SMemAllocError) {
     throw;
+  } catch (...) {
+    throw;
   }
 }
 
@@ -59,6 +61,8 @@ CSDirection::CSDirection(const int lX, const int lY, const UCHAR *sel,
       makeDirFilter(sens);
     }
   } catch (SMemAllocError) {
+    throw;
+  } catch (...) {
     throw;
   }
 }
@@ -382,6 +386,8 @@ void CSDirection::doRadius(const double rH, const double rLR, const double rV,
 
     if (dBlur > 0) blurRadius(dBlur);
   } catch (SMemAllocError) {
+    throw;
+  } catch (...) {
     throw;
   }
 }

--- a/toonz/sources/toonzlib/sandor_fxs/STColSelPic.h
+++ b/toonz/sources/toonzlib/sandor_fxs/STColSelPic.h
@@ -79,6 +79,8 @@ public:
       }
     } catch (SMemAllocError) {
       throw;
+    } catch (...) {
+      throw;
     }
     return (*this);
   }
@@ -612,6 +614,8 @@ void expand(const int border) throw(SMemAllocError)
           m_sel=nSel;
   }
   catch (SMemAllocError) {
+          throw;
+  catch (...) {
           throw;
   }
 }

--- a/toonz/sources/toonzlib/sandor_fxs/STPic.h
+++ b/toonz/sources/toonzlib/sandor_fxs/STPic.h
@@ -97,6 +97,9 @@ public:
     } catch (SMemAllocError) {
       null();
       throw;
+    } catch (...) {
+      null();
+      throw;
     }
   }
 
@@ -110,6 +113,9 @@ public:
       initPic();
       copyPic(sp);
     } catch (SMemAllocError) {
+      null();
+      throw;
+    } catch (...) {
       null();
       throw;
     }
@@ -479,6 +485,9 @@ public:
     } catch (SMemAllocError) {
       null();
       throw;
+    } catch (...) {
+      null();
+      throw;
     }
   }
 
@@ -492,6 +501,9 @@ public:
       initPic();
       copyPic(sp);
     } catch (SMemAllocError) {
+      null();
+      throw;
+    } catch (...) {
       null();
       throw;
     }

--- a/toonz/sources/toonzlib/sandor_fxs/calligraph.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/calligraph.cpp
@@ -88,6 +88,7 @@ static void calligraphUC(
     //	SMemAllocError();
   } catch (SWriteRasterError) {
     // SWriteRasterError();
+  } catch (...) {
   }
 }
 
@@ -139,6 +140,7 @@ static void calligraphUS(
     // SMemAllocError();
   } catch (SWriteRasterError) {
     // SWriteRasterError();
+  } catch (...) {
   }
 }
 
@@ -171,6 +173,9 @@ int calligraph(const RASTER *inr, RASTER *outr, const int border, int argc,
     return 0;
   } catch (SWriteRasterError e) {
     e.debug_print();
+    COPY_RASTER(inr, outr, border);
+    return 0;
+  } catch (...) {
     COPY_RASTER(inr, outr, border);
     return 0;
   }

--- a/toonz/sources/toonzlib/sandor_fxs/patternmap.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/patternmap.cpp
@@ -118,6 +118,7 @@ static void patternmapUC(
     //	SWriteRasterError();
   } catch (SFileReadError) {
     //	SFileReadError();
+  } catch (...) {
   }
 }
 
@@ -198,6 +199,7 @@ static void patternmapUS(
     //	SWriteRasterError();
   } catch (SFileReadError) {
     //	SFileReadError();
+  } catch (...) {
   }
 }
 
@@ -234,6 +236,9 @@ int patternmap(const RASTER *iras, RASTER *oras, const int border, int argc,
     return 0;
   } catch (SFileReadError e) {
     e.debug_print();
+    COPY_RASTER(iras, oras, border);
+    return 0;
+  } catch (...) {
     COPY_RASTER(iras, oras, border);
     return 0;
   }

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -763,6 +763,7 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
                       try {
                         enumProp->setValue(enumAppProp->getValue());
                       } catch (TProperty::RangeError &) {
+                      } catch (...) {
                       }
                     } else
                       throw TException();

--- a/toonz/sources/toonzlib/scriptbinding_level.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_level.cpp
@@ -208,6 +208,8 @@ QScriptValue Level::save(const QScriptValue &fpArg) {
     return context()->throwError(
         tr("Exception writing %1")
             .arg(QString::fromStdWString(se.getMessage())));
+  } catch (...) {
+    return context()->throwError(tr("Unhandled exception encountered"));
   }
   return context()->thisObject();
 }

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1121,6 +1121,7 @@ bool ToonzScene::convertLevelIfNeeded(TFilePath &levelPath) {
           TSystem::removeFileOrLevel(levelPath);
         throw e;
       }
+    } catch (...) {
     }
     lw = TLevelWriterP();  // bisogna liberare prima lw di outLevel,
     // altrimenti la paletta che lw vuole scrivere e' gia' stata
@@ -1165,6 +1166,9 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     {
       throw TException(msg);
     }  // from load, and rethrowing... curious!
+    catch (...) {
+      throw;
+    }
 
     m_levelSet->insertLevel(sl);
     return sl;
@@ -1185,6 +1189,8 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
         xl->load();
     } catch (const std::string &msg) {
       throw TException(msg);
+    } catch (...) {
+      throw;
     }
 
     if (ltype.m_oldLevelFlag)

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -1656,6 +1656,7 @@ void TXsheet::scrub(int frame, bool isPreview) {
     } else {
       throw TSoundDeviceException(e.getType(), e.getMessage());
     }
+  } catch (...) {
   }
 }
 
@@ -1676,6 +1677,7 @@ void TXsheet::play(TSoundTrackP soundtrack, int s0, int s1, bool loop) {
     try {
       m_player->play(soundtrack, s0, s1, loop);
     } catch (TSoundDeviceException &) {
+    } catch (...) {
     }
   }
 }

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -786,6 +786,7 @@ void TXshSoundColumn::play(TSoundTrackP soundtrack, int s0, int s1, bool loop) {
       m_timer.start();
 #endif
     } catch (TSoundDeviceException &) {
+    } catch (...) {
     }
   }
 }
@@ -827,6 +828,7 @@ void TXshSoundColumn::play(int currentFrame) {
     } else {
       throw TSoundDeviceException(e.getType(), e.getMessage());
     }
+  } catch (...) {
   }
 }
 
@@ -925,6 +927,7 @@ void TXshSoundColumn::scrub(int fromFrame, int toFrame) {
     } else {
       throw TSoundDeviceException(e.getType(), e.getMessage());
     }
+  } catch (...) {
   }
 }
 
@@ -1043,6 +1046,7 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
   try {
     overallSoundTrack = TSoundTrack::create(format, lsamp);
   } catch (TSoundDeviceException &) {
+  } catch (...) {
   }
 
   // Blank the whole track

--- a/toonz/sources/toonzlib/txshsoundlevel.cpp
+++ b/toonz/sources/toonzlib/txshsoundlevel.cpp
@@ -70,6 +70,8 @@ void TXshSoundLevel::loadSoundTrack() {
     loadSoundTrack(path);
   } catch (TException &e) {
     throw TException(e.getMessage());
+  } catch (...) {
+    throw;
   }
 }
 
@@ -86,6 +88,8 @@ void TXshSoundLevel::loadSoundTrack(const TFilePath &fileName) {
       setSoundTrack(st);
     }
   } catch (TException &) {
+    return;
+  } catch (...) {
     return;
   }
 }

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -907,6 +907,7 @@ void ParamsPageSet::createControls(const TFxP &fx, int index) {
 
       while (!is.matchEndTag()) createPage(is, fx, index);
     } catch (TException const &) {
+    } catch (...) {
     }
   }
   // else createEmptyPage();

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -760,6 +760,12 @@ void convertOldLevel2Tlv(const TFilePath &source, const TFilePath &dest,
     if (TSystem::doesExistFileOrLevel(dest)) TSystem::removeFileOrLevel(dest);
     frameNotifier->notifyError();
     return;
+  } catch (...) {
+    DVGui::warning("Unknown exception encountered");
+    lw = TLevelWriterP();
+    if (TSystem::doesExistFileOrLevel(dest)) TSystem::removeFileOrLevel(dest);
+    frameNotifier->notifyError();
+    return;
   }
   lw = TLevelWriterP();
 }

--- a/toonz/sources/toonzqt/pluginhost.cpp
+++ b/toonz/sources/toonzqt/pluginhost.cpp
@@ -176,6 +176,10 @@ static int create_param_view(toonz_node_handle_t node,
     printf("create_param_view: exception: %s\n", e.what());
     delete p;
     return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
+    printf("create_param_view: Unhandled exception encountered\n");
+    delete p;
+    return TOONZ_ERROR_UNKNOWN;
   }
   return TOONZ_OK;
 }
@@ -190,7 +194,10 @@ static int setup_input_port(toonz_node_handle_t node, const char *name,
       return TOONZ_ERROR_BUSY;
     }
   } catch (const std::exception &e) {
-    printf("setup_putput_port: exception: %s\n", e.what());
+    printf("setup_input_port: exception: %s\n", e.what());
+    return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
+    printf("setup_input_port: Unhandled exception encountered\n");
     return TOONZ_ERROR_UNKNOWN;
   }
   return TOONZ_OK;
@@ -206,7 +213,10 @@ static int setup_output_port(toonz_node_handle_t node, const char *name,
       return TOONZ_ERROR_BUSY;
     }
   } catch (const std::exception &e) {
-    printf("setup_putput_port: exception: %s\n", e.what());
+    printf("setup_output_port: exception: %s\n", e.what());
+    return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
+    printf("setup_output_port: Unhandled exception encountered\n");
     return TOONZ_ERROR_UNKNOWN;
   }
   return TOONZ_OK;
@@ -227,6 +237,9 @@ static int add_input_port(toonz_node_handle_t node, const char *name, int type,
     *port = p.get();
   } catch (const std::exception &e) {
     printf("add_input_port: exception: %s\n", e.what());
+    return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
+    printf("add_input_port: Unhandled exception encountered\n");
     return TOONZ_ERROR_UNKNOWN;
   }
   return TOONZ_OK;
@@ -264,6 +277,9 @@ static int add_output_port(toonz_node_handle_t node, const char *name, int type,
     }
     *port = p;
   } catch (const std::exception &) {
+    delete p;
+    return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
     delete p;
     return TOONZ_ERROR_UNKNOWN;
   }
@@ -314,6 +330,10 @@ static int add_preference(toonz_node_handle_t node, const char *name,
     printf("add_preference: exception: %s\n", e.what());
     delete p;
     return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
+    printf("add_preference: Unhandled exception encountered\n");
+    delete p;
+    return TOONZ_ERROR_UNKNOWN;
   }
   return TOONZ_OK;
 }
@@ -338,6 +358,10 @@ static int add_param(toonz_node_handle_t node, const char *name, int type,
     printf("add_param: exception: %s\n", e.what());
     delete p;
     return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
+    printf("add_param: Unhandled exception encountered\n");
+    delete p;
+    return TOONZ_ERROR_UNKNOWN;
   }
   return TOONZ_OK;
 }
@@ -358,6 +382,7 @@ static int get_param(toonz_node_handle_t node, const char *name,
       return TOONZ_ERROR_NOT_FOUND;
     }
   } catch (const std::exception &) {
+  } catch (...) {
   }
   return TOONZ_OK;
 }
@@ -1318,6 +1343,8 @@ static int query_interface(const UUID *uuid, void **interf) {
     return TOONZ_ERROR_OUT_OF_MEMORY;
   } catch (const std::exception &) {
     return TOONZ_ERROR_UNKNOWN;
+  } catch (...) {
+    return TOONZ_ERROR_UNKNOWN;
   }
 
   return TOONZ_OK;
@@ -1504,6 +1531,8 @@ toonz_plugin_info で検索し、なければ toonz_plugin_probe() を呼び出�
             }
           } catch (const std::exception &e) {
             printf("Exception occurred after plugin loading: %s\n", e.what());
+          } catch (...) {
+            printf("Unhandled exception encountered after plugin loading\n");
           }
 
           if (pi->handler_ && pi->handler_->setup) {
@@ -1523,6 +1552,10 @@ toonz_plugin_info で検索し、なければ toonz_plugin_probe() を呼び出�
       }
     } catch (const std::exception &e) {
       printf("Exception occurred while plugin loading: %s\n", e.what());
+      delete pi;
+      pi = NULL;
+    } catch (...) {
+      printf("Unhandled exception occurred while plugin loading\n");
       delete pi;
       pi = NULL;
     }

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -2173,6 +2173,9 @@ void StyleChooserPage::onRemoveStyleSet() {
   } catch (TSystemException se) {
     DVGui::warning(QString::fromStdWString(se.getMessage()));
     return;
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
+    return;
   }
 
   m_editor->removeStyleSet(this);
@@ -2507,6 +2510,9 @@ bool StyleChooserPage::copyFilesToStyleFolder(TFilePathSet srcFiles,
       TSystem::mkDir(destDir);
     } catch (TSystemException se) {
       DVGui::warning(QString::fromStdWString(se.getMessage()));
+      return false;
+    } catch (...) {
+      DVGui::warning("Unhandled exception encountered");
       return false;
     }
 
@@ -3593,6 +3599,9 @@ void SpecialStyleChooserPage::addSelectedStylesToSet(std::vector<int> selection,
       if (!TFileStatus(setPath).doesExist()) TSystem::mkDir(setPath);
     } catch (TSystemException se) {
       DVGui::warning(QString::fromStdWString(se.getMessage()));
+      return;
+    } catch (...) {
+      DVGui::warning("Unhandled exception encountered");
       return;
     }
 
@@ -6874,6 +6883,9 @@ void StyleEditor::createNewStyleSet(StylePageType pageType, TFilePath pagePath,
   } catch (TSystemException se) {
     DVGui::warning(QString::fromStdWString(se.getMessage()));
     return;
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
+    return;
   }
 
   QString filters;
@@ -7085,6 +7097,9 @@ void StyleEditor::renameStyleSet(StyleChooserPage *styleSetPage,
     TSystem::rmDirTree(styleSetPage->getStylesFolder());
   } catch (TSystemException se) {
     DVGui::warning(QString::fromStdWString(se.getMessage()));
+    return;
+  } catch (...) {
+    DVGui::warning("Unhandled exception encountered");
     return;
   }
 


### PR DESCRIPTION
Some change in Apple clang compiler after version 12.0.5 (used in Big Sur builds) appears to have modified the way macOS handles exceptions.

In Big Sur (and Windows and Linux for that matter), the exception handling behaved the same way.  Starting with macos Monterey, which uses Apple clang 14.0.0, exceptions can lead to crashes in T2D when not handled properly.  The crash log typically looks like this:

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	    0x7ff81f060ffe __pthread_kill + 10
1   libsystem_pthread.dylib       	    0x7ff81f0971ff pthread_kill + 263
2   libsystem_c.dylib             	    0x7ff81efe2d14 abort + 123
3   libc++abi.dylib               	    0x7ff81f053082 abort_message + 241
4   libc++abi.dylib               	    0x7ff81f04425d demangling_terminate_handler() + 266
5   libobjc.A.dylib               	    0x7ff81ef41022 _objc_terminate() + 104
6   libc++abi.dylib               	    0x7ff81f0524a7 std::__terminate(void (*)()) + 8
7   libc++abi.dylib               	    0x7ff81f054eeb __cxa_rethrow + 99
8   libobjc.A.dylib               	    0x7ff81ef4ae7d objc_exception_rethrow + 37
9   AppKit                        	    0x7ff821abed22 -[NSApplication run] + 659
10  libqcocoa.dylib               	       0x10e728c93 0x10e6ee000 + 240787
11  QtCore                        	       0x105f754b6 QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 502
12  QtCore                        	       0x105f79482 QCoreApplication::exec() + 130
13  Tahoma2D                      	       0x1016f49a3 main + 17379
14  dyld                          	       0x104e2c52e start + 462
```

The apparent behavior:
- When a custom exception type is thrown and is caught in the same library, if the custom exception is explicitly handled in a `catch(custom exception)` block, it works fine.  However, when it the custom exception is thrown outside the library it was in, it loses the exception type and must be handled by a `catch(...)` block.

   This is  a problem if we are trying to do specific things based on the thrown exception type. If it gets handled by a `catch(...)` block, we cannot tell what type of exception it is and cannot get much information from it.

- If a thrown exception is not caught by any `catch()` block, T2D crashes.

I can't seem to find any way to fix the exception handling outside the library it's thrown from, but I can stop the crashes caused by unhandled exceptions.

I've gone through and found all `try`-`catch()` blocks and added a `catch(...)` block if it was missing one.  This way, if an exception is thrown, it will always be handled by something.  In many cases, it will just say that an `Unhandled exception encountered`.
