### PR TITLE
Clipping Mask Column (Raster/Smart Raster)

### DIFF
--- a/toonz/sources/common/tfx/tfxcachemanager.cpp
+++ b/toonz/sources/common/tfx/tfxcachemanager.cpp
@@ -271,6 +271,8 @@ ResourceData TFxCacheManager::getResource(const std::string &alias,
                                           const TRenderSettings &rs) {
   TCacheResourceP result, temp;
 
+  if (rs.m_applyMask) return ResourceData(0, result);
+
   // Seek the associated infos
   Imp::ResourceInstanceDataMap::iterator jt =
       m_imp->m_resourcesData.find(alias);

--- a/toonz/sources/include/tgl.h
+++ b/toonz/sources/include/tgl.h
@@ -240,6 +240,8 @@ void DVAPI tglDraw(const TRectD &rect, const std::vector<TRaster32P> &textures,
 void DVAPI tglDraw(const TRectD &rect, const TRaster32P &tex,
                    bool blending = true);
 
+void DVAPI tglDrawMask(const TRectD &rect, const TRaster32P &mask);
+
 void DVAPI tglBuildMipmaps(std::vector<TRaster32P> &rasters,
                            const TFilePath &filepath);
 

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -159,6 +159,23 @@ bool containsVectorLevel(int col) {
   return false;
 }
 
+bool canUseAsMask(int col) {
+  TXshColumn *column =
+      TApp::instance()->getCurrentXsheet()->getXsheet()->getColumn(col);
+  TXshColumn::ColumnType type = column->getColumnType();
+  if (type != TXshColumn::eLevelType) return false;
+
+  const QSet<TXshLevel *> levels = getLevels(column);
+  QSet<TXshLevel *>::const_iterator it2;
+  for (it2 = levels.begin(); it2 != levels.end(); it2++) {
+    TXshLevel *lvl = *it2;
+    int type       = lvl->getType();
+    if (type == PLI_XSHLEVEL || type == TZP_XSHLEVEL || type == OVL_XSHLEVEL)
+      return true;
+  }
+  return false;
+}
+
 QIcon createLockIcon(XsheetViewer *viewer) {
   const Orientation *o = viewer->orientation();
   QColor bgColor;
@@ -202,7 +219,7 @@ public:
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) return;
 
-    if (containsVectorLevel(m_col)) {
+    if (canUseAsMask(m_col)) {
       column->setIsMask(!m_isMask);
       TApp::instance()->getCurrentScene()->notifySceneChanged();
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -216,7 +233,7 @@ public:
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) return;
 
-    if (containsVectorLevel(m_col)) {
+    if (canUseAsMask(m_col)) {
       column->setIsMask(m_isMask);
       TApp::instance()->getCurrentScene()->notifySceneChanged();
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -248,7 +265,7 @@ public:
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) return;
 
-    if (containsVectorLevel(m_col)) {
+    if (canUseAsMask(m_col)) {
       column->setInvertedMask(!m_invertMask);
       TApp::instance()->getCurrentScene()->notifySceneChanged();
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -262,7 +279,7 @@ public:
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) return;
 
-    if (containsVectorLevel(m_col)) {
+    if (canUseAsMask(m_col)) {
       column->setInvertedMask(m_invertMask);
       TApp::instance()->getCurrentScene()->notifySceneChanged();
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -294,7 +311,7 @@ public:
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) return;
 
-    if (containsVectorLevel(m_col)) {
+    if (canUseAsMask(m_col)) {
       column->setCanRenderMask(!m_renderMask);
       TApp::instance()->getCurrentScene()->notifySceneChanged();
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -308,7 +325,7 @@ public:
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) return;
 
-    if (containsVectorLevel(m_col)) {
+    if (canUseAsMask(m_col)) {
       column->setCanRenderMask(m_renderMask);
       TApp::instance()->getCurrentScene()->notifySceneChanged();
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -2720,7 +2737,7 @@ void ColumnTransparencyPopup::setColumn(TXshColumn *column) {
   m_maskGroupBox->blockSignals(true);
   m_invertMask->blockSignals(true);
   m_renderMask->blockSignals(true);
-  if (containsVectorLevel(m_column->getIndex())) {
+  if (canUseAsMask(m_column->getIndex())) {
     m_maskGroupBox->setVisible(true);
     m_maskGroupBox->setChecked(m_column->isMask());
     m_maskGroupBox->setEnabled(true);

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -630,6 +630,16 @@ void RasterPainter::flushRasterImages() {
     TRop::quickPut(ras2, ras, TAffine());
   }
 
+  if (m_maskLevel > 0) {
+    TRaster32P mask = ras2->clone();
+
+    tglDrawMask(TRectD(rect.x0, rect.y0, rect.x1, rect.y0), ras2);
+
+    ras->unlock();
+    m_nodes.clear();
+    return;
+  }
+
   // Now, output the raster buffer on top of the OpenGL buffer
   glPushAttrib(GL_COLOR_BUFFER_BIT);  // Preserve blending and stuff
 
@@ -1075,6 +1085,8 @@ void RasterPainter::onRasterImage(TRasterImage *ri,
                          player.m_frame, player.m_isCurrentColumn, onionMode,
                          doPremultiply, whiteTransp, ignoreAlpha,
                          player.m_filterColor));
+
+  if (m_maskLevel > 0) flushRasterImages();
 }
 
 //-----------------------------------------------------------------------------
@@ -1131,6 +1143,8 @@ void RasterPainter::onToonzImage(TToonzImage *ti, const Stage::Player &player) {
   m_nodes.push_back(Node(r, ti->getPalette(), alpha, aff, ti->getSavebox(),
                          bbox, player.m_frame, player.m_isCurrentColumn,
                          onionMode, false, false, false, player.m_filterColor));
+
+  if (m_maskLevel > 0) flushRasterImages();
 }
 
 //**********************************************************************************************

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -847,6 +847,11 @@ bool TLevelColumnFx::canHandle(const TRenderSettings &info, double frame) {
   TXshSimpleLevel *sl = cell.m_level->getSimpleLevel();
   if (!sl) return true;
 
+  // For non-Vector masks, must return true so it is not cached
+  if (sl->getType() != PLI_XSHLEVEL && m_levelColumn->isMask() &&
+      info.m_applyMask)
+    return true;
+
   return (sl->getType() == PLI_XSHLEVEL &&
           !vectorMustApplyCmappedFx(info.m_data));
 }
@@ -1246,6 +1251,8 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
       TRenderSettings infoAux(info);
       assert(info.m_affine.isTranslation());
       infoAux.m_data.clear();
+      if (infoAux.m_applyMask)
+        infoAux.m_invertedMask = m_levelColumn->isInvertedMask();
 
       // Place the output rect in the image's reference
       tileRectD += TPointD(lx_2 - info.m_affine.a13, ly_2 - info.m_affine.a23);


### PR DESCRIPTION
This extends the Clipping Mask Column feature to Raster and Smart Raster levels.

- You can mix and match masks of different level types.
- When using the `Selection Tool` to manipulate the mask, you cannot see the outline of the mask like you can with Vector masks.

-----

Known issues:
- Drawings clipped by Raster/Smart Raster masks do not show in 3D view.
- When using Selection Tool on the mask, the selected area shows the original mask image while it is being moved or manipulated. (Not planning to fix)

