### PR TITLE
Fix Timeline/Xsheet Frame Range processing

### DIFF
--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -44,6 +44,7 @@ private:
   bool m_firstFrameSelected;
   TXshSimpleLevelP m_level;
   TFrameId m_firstFrameId, m_veryFirstFrameId;
+  int m_firstFrameIdx, m_lastFrameIdx;
   TTool *m_parent;
   std::wstring m_colorType;
   std::pair<int, int> m_currCell;


### PR DESCRIPTION
In level edit mode (Level Strip), the `Frame Range` option takes the 1st and last selected frame ids and performs the operation on all frames in between.

In scene edit mode (Timeline/Xsheet) the `Frame Range` option would take the 1st and last selected from, from a Level Strip point of view, and perform the operation as if it was in the Level Strip.  This does not work right if the exposed frames are out of level strip order (i.e 1-3-2, vs 1-2-3), or if only specific frames are exposed between the 1st and last selected frame.

This PR changes the behavior of the `Frame Range` option when working in the timeline/xsheet.  It will move through the scene frames from the 1st to the last selected and only affect the exposed frames in that span as well as affect them in the order it was exposed.

The only `Frame Range` option that worked correctly was the Fill Tool's Normal fill mode. The following were fixed:
- Fill Tool using non-Normal selection mode
- Tape Tool for Smart Raster
- Eraser Tool for all level types

This also fixes a crash caused by using the Vector Segment Eraser on a level sequence that starts with 0000 when used in Scene edit mode.