### PR TITLE
Fix undo selection paste into new frame + undo renumbering

### DIFF
--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -55,6 +55,10 @@ class DVAPI RasterSelection final : public TSelection {
   bool m_isPastedSelection;
   bool m_noAntialiasing;
 
+  bool m_createdFrame;
+  bool m_createdLevel;
+  bool m_renumberedLevel;
+
 private:
   bool pasteSelection(const RasterImageData *data);
 
@@ -99,6 +103,10 @@ public:
   void setNoAntialiasing(bool value) { m_noAntialiasing = value; }
 
   bool isPastedSelection() const { return m_isPastedSelection; }
+
+  bool wasFrameCreated() const { return m_createdFrame; }
+  bool wasLevelCreated() const { return m_createdLevel; }
+  bool wasLevelRenumbered() const { return m_renumberedLevel; }
 
   /*! Returns strokes bounding box.*/
   TRectD getStrokesBound(std::vector<TStroke> strokes) const;

--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -171,7 +171,8 @@ protected:
 public:
   TToolUndo(TXshSimpleLevel *level, const TFrameId &frameId,
             bool createdFrame = false, bool createdLevel = false,
-            const TPaletteP &oldPalette = 0);
+            const TPaletteP &oldPalette = 0,
+            bool renumberedLevel        = TTool::m_isLevelRenumbererd);
   ~TToolUndo();
 
   virtual QString getToolName() { return QString("Tool"); }

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -451,7 +451,8 @@ TStroke *ToolUtils::merge(const ArrayOfStroke &a) {
 
 ToolUtils::TToolUndo::TToolUndo(TXshSimpleLevel *level, const TFrameId &frameId,
                                 bool createdFrame, bool createdLevel,
-                                const TPaletteP &oldPalette)
+                                const TPaletteP &oldPalette,
+                                bool renumberedLevel)
     : TUndo()
     , m_level(level)
     , m_frameId(frameId)
@@ -461,7 +462,7 @@ ToolUtils::TToolUndo::TToolUndo(TXshSimpleLevel *level, const TFrameId &frameId,
     , m_isEditingLevel(false)
     , m_createdFrame(createdFrame)
     , m_createdLevel(createdLevel)
-    , m_renumberedLevel(TTool::m_isLevelRenumbererd)
+    , m_renumberedLevel(renumberedLevel)
     , m_imageId("") {
   TTool::Application *app = TTool::getApplication();
   m_isEditingLevel        = app->getCurrentFrame()->isEditingLevel();
@@ -552,7 +553,6 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
         app->getCurrentScene()->notifyCastChange();
       }
     }
-    app->getCurrentLevel()->notifyLevelChange();
   }
   if (m_oldPalette.getPointer()) {
     m_level->getPalette()->assign(m_oldPalette->clone());
@@ -568,6 +568,8 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
     m_level->renumber(m_oldFids);
     app->getCurrentXsheet()->notifyXsheetChanged();
   }
+  if (m_createdFrame || m_createdLevel)
+    app->getCurrentLevel()->notifyLevelChange();
 }
 
 //------------------------------------------------------------------------------------------


### PR DESCRIPTION
While trying to reproduce the crash mentioned in #1313, I found an issue with Undo when selecting part of a Raster/Smart Raster level and then pasting into a held frame w/ `Creation In Hold Cells` toggled `On`. A new blank frame is created with the paste, but an Undo doesn't remove the newly created frame.  There after, the undo history becomes messed up.

Corrected the logic to record the creation of the blank frame as part of the paste so it is undone correctly.

Also fixed an issue with undo and cell renumbering. After removing the newly created frame as part of the undo, an update to the level was triggered. This reset the old frame ids list which can cause the renumber to crash if the list was empty.  This may be why the crash occurred in #1313, but I could not duplicate the original issue to confirm.  Modified the logic to update the level after the renumber is complete.