### PR TITLE
Add Flatpak bin directory and fix ffmpeg & rhubarb detection

### DIFF
--- a/toonz/sources/toonzlib/thirdparty.cpp
+++ b/toonz/sources/toonzlib/thirdparty.cpp
@@ -110,6 +110,7 @@ QString autodetectFFmpeg() {
 #endif
 
 #ifndef _WIN32
+  folderList.append("/app/bin");
   folderList.append("/usr/local/bin");
   folderList.append("/usr/bin");
   folderList.append("/bin");
@@ -282,6 +283,7 @@ QString autodetectRhubarb() {
 #endif
 
 #ifndef _WIN32
+  folderList.append("/app/bin");
   folderList.append("/usr/local/bin");
   folderList.append("/usr/bin");
   folderList.append("/bin");

--- a/toonz/sources/toonzlib/thirdparty.cpp
+++ b/toonz/sources/toonzlib/thirdparty.cpp
@@ -75,10 +75,10 @@ bool findFFmpeg(QString dir) {
 
 bool checkFFmpeg() {
   // Path in preferences
-  bool found = findFFmpeg(Preferences::instance()->getFfmpegPath());
-  if (found) return true;
+  QString path = Preferences::instance()->getFfmpegPath();
+  if (!path.isEmpty() && findFFmpeg(path)) return true;
 
-  QString path = autodetectFFmpeg();
+  path = autodetectFFmpeg();
   if (path.isEmpty()) return false;
 
   setFFmpegDir(path);
@@ -90,7 +90,7 @@ bool checkFFmpeg() {
 
 QString autodetectFFmpeg() {
   QString dir = Preferences::instance()->getFfmpegPath();
-  if (findFFmpeg(dir)) return dir;
+  if (!dir.isEmpty() && findFFmpeg(dir)) return dir;
 
   // Let's try and autodetect the exe included with release
   QStringList folderList;
@@ -249,10 +249,10 @@ bool findRhubarb(QString dir) {
 
 bool checkRhubarb() {
   // Path in preferences
-  bool found = findRhubarb(Preferences::instance()->getRhubarbPath());
-  if (found) return true;
+  QString path = Preferences::instance()->getRhubarbPath();
+  if (!path.isEmpty() && findRhubarb(path)) return true;
 
-  QString path = autodetectRhubarb();
+  path = autodetectRhubarb();
   if (path.isEmpty()) return false;
 
   setRhubarbDir(path);
@@ -263,7 +263,7 @@ bool checkRhubarb() {
 
 QString autodetectRhubarb() {
   QString dir = Preferences::instance()->getRhubarbPath();
-  if (findRhubarb(dir)) return dir;
+  if (!dir.isEmpty() && findRhubarb(dir)) return dir;
 
   // Let's try and autodetect the exe included with release
   QStringList folderList;


### PR DESCRIPTION
I'm working on adding Tahoma2D to Flathub (a Linux App store). Due to how flatpaks work, I'm adding the `/app/bin` directory to the search paths for ffmpeg and rhubarb. 

This additionally fixes an issue with autodetection of ffmpeg/rhubarb primarily for Linux builds, but the change can impact Windows/macOS