### PR TITLE
Fix system env variables

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -112,7 +112,7 @@ public:
 #else
     TFilePath systemVarPath = getSystemVarPath(varName);
     if (systemVarPath.isEmpty()) {
-      std::cout << "varName:" << varName << " TOONZROOT not set..."
+      std::cout << "varName:" << varName << " TAHOMA2DROOT not set..."
                 << std::endl;
       return "";
     }
@@ -122,13 +122,13 @@ public:
                         if (!value)
                                 {
                                 std::cout << varName << " not set, returning
-   TOONZROOT" << std::endl;
-        //value = getenv("TOONZROOT");
+   TAHOMA2DROOT" << std::endl;
+        //value = getenv("TAHOMA2DROOT");
                         value="";
                         std::cout << "!!!value= "<< value << std::endl;
                         if (!value)
                                         {
-                                        std::cout << varName << "TOONZROOT not
+                                        std::cout << varName << "TAHOMA2DROOT not
    set..." << std::endl;
                                         //exit(-1);
                                         return "";
@@ -642,7 +642,7 @@ void TEnv::loadAllEnvVariables() { VariableSet::instance()->load(); }
 
 bool TEnv::setArgPathValue(std::string key, std::string value) {
   EnvGlobals *eg = EnvGlobals::instance();
-  // in case of "-TOONZROOT" , set the all unregistered paths
+  // in case of "-TAHOMA2DROOT" , set the all unregistered paths
   if (key == getRootVarName()) {
     TFilePath rootPath(value);
     eg->setStuffDir(rootPath);

--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -185,7 +185,7 @@ public:
     // from v1.3, registry root is moved to SOFTWARE\\Tahoma\\Tahoma
     m_registryRoot = TFilePath("SOFTWARE\\Tahoma2D\\") + m_version.getAppName();
 #endif
-    m_systemVarPrefix = m_version.getAppName();
+    m_systemVarPrefix = toUpper(m_version.getAppName());
     updateEnvFile();
   }
 

--- a/toonz/sources/include/tenv.h
+++ b/toonz/sources/include/tenv.h
@@ -138,7 +138,7 @@ DVAPI TFilePath getConfigDir();
 // DVAPI TFilePath getProfilesDir();
 DVAPI TFilePath getWorkingDirectory();
 
-// per l'utilizzo di ToonzLib senza che sia definita una TOONZROOT
+// per l'utilizzo di ToonzLib senza che sia definita una TAHOMA2DROOT
 // bisogna chiamare TEnv::setStuffDir(stuffdir) prima di ogni altra operazione
 DVAPI void setStuffDir(const TFilePath &stuffDir);
 

--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -63,8 +63,8 @@ inline ostream &operator<<(ostream &out, const TFilePath &fp) {
 //------------------------------------------------------------------------
 namespace {
 
-const char *rootVarName     = "TOONZROOT";
-const char *systemVarPrefix = "TOONZ";
+const char *rootVarName     = "TAHOMA2DROOT";
+const char *systemVarPrefix = "TAHOMA2D";
 
 namespace {
 

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -113,8 +113,8 @@ namespace {
 //   (es <systemVarPrefix>PROJECTS etc.)
 //
 
-const char *rootVarName     = "TOONZROOT";
-const char *systemVarPrefix = "TOONZ";
+const char *rootVarName     = "TAHOMA2DROOT";
+const char *systemVarPrefix = "TAHOMA2D";
 
 // TODO: forse anche questo andrebbe in tnzbase
 // ci possono essere altri programmi offline oltre al tcomposer

--- a/toonz/sources/tconverter/tconverter.cpp
+++ b/toonz/sources/tconverter/tconverter.cpp
@@ -41,8 +41,8 @@ typedef QualifierT<TFilePath> FilePathQualifier;
 
 #define RENDER_LICENSE_NOT_FOUND 888
 
-const char *rootVarName     = "TOONZROOT";
-const char *systemVarPrefix = "TOONZ";
+const char *rootVarName     = "TAHOMA2DROOT";
+const char *systemVarPrefix = "TAHOMA2D";
 
 namespace {
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -701,12 +701,29 @@ TAHOMA2DCONFIG=\"\$HOME/.config/Tahoma2D/stuff/config\"
 TAHOMA2DFXPRESETS=\"\$HOME/.config/Tahoma2D/stuff/fxs\"
 TAHOMA2DLIBRARY=\"\$HOME/.config/Tahoma2D/stuff/library\"
 TAHOMA2DPROJECTS=\"$HOME/.config/Tahoma2D/stuff/projects\"
-TAHOMA2DROOT=\"\$HOME/.config/Tahoma2D/stuff\"
 TAHOMA2DSTUDIOPALETTE=\"\$HOME/.config/Tahoma2D/stuff/studiopalette\"
 EOF
 fi
 
 export ${PRELOAD_VARIABLE}=\${TAHOMA2D_BASE}/lib/tahoma2d:\${${PRELOAD_VARIABLE}}
+
+IFS=:
+for LIBPATH in \$LD_LIBRARY_PATH
+do
+  if [ \"\$CAMLIBS\" = \"\" -a -d \$LIBPATH/libgphoto2 ]
+  then
+     export CAMLIBS=`find \$LIBPATH/libgphoto2 -mindepth 1 -type d`
+  fi
+
+  if [ \"\$IOLIBS\" = \"\" -a -d \$LIBPATH/libgphoto2_port ]
+  then
+     export IOLIBS=`find \$LIBPATH/libgphoto2_port -mindepth 1 -type d`
+  fi
+done
+unset IFS
+
+echo \"CAMLIBS: \$CAMLIBS\"
+echo \"IOLIBS: \$IOLIBS\"
 
 exec \$TAHOMA2D_BASE/bin/Tahoma2D \"\$@\"
 ")

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -169,10 +169,10 @@ static void initToonzEnv(QHash<QString, QString> &argPathValues) {
   QCoreApplication::setApplicationName(
       QString::fromStdString(TEnv::getApplicationName()));
 
-  /*-- TOONZROOTのPathの確認 --*/
+  /*-- TAHOMA2DROOTのPathの確認 --*/
   // controllo se la xxxroot e' definita e corrisponde ad un folder esistente
 
-  /*-- ENGLISH: Confirm TOONZROOT Path
+  /*-- ENGLISH: Confirm TAHOMA2DROOT Path
         Check if the xxxroot is defined and corresponds to an existing folder
   --*/
 
@@ -214,7 +214,7 @@ static void initToonzEnv(QHash<QString, QString> &argPathValues) {
   // for (it = projectsRoots.begin(); it != projectsRoots.end(); ++it)
   //  projectManager->addProjectsRoot(*it);
 
-  /*-- もしまだ無ければ、TOONZROOT/sandboxにsandboxプロジェクトを作る --*/
+  /*-- もしまだ無ければ、TAHOMA2DROOT/sandboxにsandboxプロジェクトを作る --*/
   projectManager->createSandboxIfNeeded();
 
   /*


### PR DESCRIPTION
This PR fixes some environment system variables issues, mainly in regards to running non-portable Linux builds

- Fixed a case issue where T2D was looking for system variable `Tahoma2DROOT` when it should be `TAHOMA2DROOT` [^1]
- Replaced `TOONZROOT` and `TOONZ` prefix that were not replaced with `TAHOMA2DROOT` and `TAHOMA2D` prefix [^1]
- Added logic to linux startup script to auto populate system variables `CAMLIBS` and `IOLIBS` needed for libgphoto2 support.

[^1]: Potentially impacts Windows/macOS builds