### PR TITLE
Fix sub-scene navigation bar issues

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2256,7 +2256,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #111111;
 }

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -2256,7 +2256,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #060606;
 }

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2256,7 +2256,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #a8a8a8;
 }

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -2256,7 +2256,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #2c2c2c;
 }

--- a/stuff/config/qss/Medium/less/layouts/xsheet.less
+++ b/stuff/config/qss/Medium/less/layouts/xsheet.less
@@ -41,7 +41,7 @@
 }
 
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid @accent;
   &::separator:horizontal {

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2256,7 +2256,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #5a5a5a;
 }

--- a/toonz/sources/toonz/xshbreadcrumbs.cpp
+++ b/toonz/sources/toonz/xshbreadcrumbs.cpp
@@ -83,7 +83,8 @@ void Breadcrumb::onButtonClicked() {
 
     app->getCurrentColumn()->setColumnIndex(m_col);
     app->getCurrentFrame()->setFrameIndex(r);
-    app->getCurrentSelection()->getSelection()->selectNone();
+    if (app->getCurrentSelection()->getSelection())
+      app->getCurrentSelection()->getSelection()->selectNone();
 
     QAction *openChildAction =
         CommandManager::instance()->getAction(MI_OpenChild);
@@ -123,7 +124,8 @@ void Breadcrumb::onComboBoxIndexChanged(int index) {
 
   app->getCurrentColumn()->setColumnIndex(col);
   app->getCurrentFrame()->setFrameIndex(r);
-  app->getCurrentSelection()->getSelection()->selectNone();
+  if (app->getCurrentSelection()->getSelection())
+    app->getCurrentSelection()->getSelection()->selectNone();
 
   QAction *openChildAction =
       CommandManager::instance()->getAction(MI_OpenChild);

--- a/toonz/sources/toonz/xshbreadcrumbs.cpp
+++ b/toonz/sources/toonz/xshbreadcrumbs.cpp
@@ -304,7 +304,7 @@ void BreadcrumbArea::updateBreadcrumbs() {
   m_breadcrumbLayout->setSpacing(0);
   {
     if (!m_viewer->orientation()->isVerticalTimeline())
-      m_breadcrumbLayout->addSpacing(220);
+      m_breadcrumbLayout->addSpacing(215);
     m_breadcrumbLayout->addWidget(new QLabel(tr("Scene Depth:"), this), 0,
                                   Qt::AlignCenter);
     m_breadcrumbLayout->addSpacing(5);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -445,6 +445,7 @@ void XsheetViewer::positionSections() {
                                          XsheetGUI::BREADCRUMB_HEIGHT);
       bodyLayer = bodyLayer.adjusted(XsheetGUI::BREADCRUMB_HEIGHT, 0);
     }
+    m_breadcrumbArea->updateBreadcrumbs();
   } else {
     m_breadcrumbArea->showBreadcrumbs(false);
     m_breadcrumbScrollArea->setGeometry(0, 0, 0, 0);


### PR DESCRIPTION
This fixes the following issues related to sub-scene navigation bar:
- A crash when navigating using Sub-Scene Navigation Bar after switching to certain tools.
- The position of the breadcrumbs doesn't adjust when the orientation of timeline/xsheet is changed
- Left padding for breadcrumbs on Xsheet only