### PR TITLE
Fix loading unexpected image filetype

### DIFF
--- a/toonz/sources/common/timage_io/timage_io.cpp
+++ b/toonz/sources/common/timage_io/timage_io.cpp
@@ -130,6 +130,7 @@ void TImageReader::open() {
         else
           throw TImageException(m_path, "Image format not supported");
       }
+/*
     } catch (TException &e) {
       close();  // close() chiude il file e setta m_file a NULL.
 //      QString msg = QString::fromStdWString(e.getMessage());
@@ -137,6 +138,7 @@ void TImageReader::open() {
       throw e;
 //    } catch (std::string str) {
 //      if (str == "Tiff file closed") m_file = NULL;
+*/
     } catch (...) {
       close();
       throw;
@@ -748,16 +750,20 @@ TImageWriterP::TImageWriterP(const TFilePath &path) {
 
 bool TImageReader::load(const TFilePath &path, TRasterP &raster) {
   raster = TRasterP();
-  TImageReaderP ir(path);
-  if (!ir) return false;
-  TImageP img = ir->load();
-  if (!img) return false;
+  try {
+    TImageReaderP ir(path);
+    if (!ir) return false;
+    TImageP img = ir->load();
+    if (!img) return false;
 
-  TRasterImageP ri(img);
-  if (!ri) return false;
+    TRasterImageP ri(img);
+    if (!ri) return false;
 
-  raster = ri->getRaster();
-  return true;
+    raster = ri->getRaster();
+    return true;
+  } catch (...) {
+    return false;
+  }
 }
 
 //-----------------------------------------------------------


### PR DESCRIPTION
This fixes a crash loading Textures that was indirectly caused by changes made in PR #1306.

When Textures are loaded into the Style Editor, there is no filter for valid image types.  In the case of this crash, there was a .ZIP file in the `tahomastuff\library\textures` folder. T2D failed to load the file as an image and threw an exception.  This particular exception was not caught by any logic and would cause an immediate crash w/o a crash log.

Rather than apply a file filter for valid texture files, I modified the procedure that loads image files to handle the exception because there were a number of other places where the procedure was being used and could crash if it loaded an invalid file type.