### PR TITLE
Fix targeting timeline keys and ease handles

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3312,7 +3312,8 @@ public:
   int getHistoryType() override { return HistoryType::Xsheet; }
 };
 //----------------------------------------------------------
-bool CellArea::isKeyFrameArea(int col, int row, QPoint mouseInCell) {
+bool CellArea::isKeyFrameArea(int col, int row, QPoint mouseInCell,
+                              bool withFrameLine) {
   if (!Preferences::instance()->isShowKeyframesOnXsheetCellAreaEnabled())
     return false;
 
@@ -3356,7 +3357,7 @@ bool CellArea::isKeyFrameArea(int col, int row, QPoint mouseInCell) {
   int r0, r1;
   double e0, e1;
   if (pegbar->getKeyframeSpan(row, r0, e0, r1, e1)) {
-    if (r1 - r0 > 4) {
+    if (r1 - r0 > 2) {
       int rh0, rh1;
       if (getEaseHandles(r0, r1, e0, e1, rh0, rh1)) {
         if (row == rh0 && easeRect.contains(mouseInCell))
@@ -3367,6 +3368,8 @@ bool CellArea::isKeyFrameArea(int col, int row, QPoint mouseInCell) {
       }
     }
   }
+
+  if (!withFrameLine) return false;
 
   // In the white line area, if zoomed in.. narrow height by using frame marker
   // area since it has a narrower height
@@ -3872,7 +3875,7 @@ void CellArea::contextMenuEvent(QContextMenuEvent *event) {
       Preferences::instance()->isShowKeyframesOnXsheetCellAreaEnabled() &&
       pegbar && pegbar->getKeyframeRange(k0, k1) && k0 <= row && row <= k1 + 1;
 
-  if (isKeyframeFrame && isKeyFrameArea(col, row, mouseInCell)) {
+  if (isKeyframeFrame && isKeyFrameArea(col, row, mouseInCell, true)) {
     TStageObjectId objectId;
     if (col < 0)
       objectId = TStageObjectId::CameraId(xsh->getCameraColumnIndex());

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -143,7 +143,7 @@ class CellArea final : public QWidget {
   // Restistusce true
   bool getEaseHandles(int r0, int r1, double e0, double e1, int &rh0, int &rh1);
 
-  bool isKeyFrameArea(int col, int row, QPoint mouseInCell);
+  bool isKeyFrameArea(int col, int row, QPoint mouseInCell, bool withFrameLine = false);
 
   DragTool *getDragTool() const;
   void setDragTool(DragTool *dragTool);


### PR DESCRIPTION
When clicking on or close to white line area of a cell containing a key or ease in/out handle, you end up selecting the key/ease handle instead of selecting this cell.

When zoomed in in the timeline, this limits where you can target to select just the cell and may cause you to inadvertently move the key/ease handle.

Modified the logic so you now need to be on top of the key/ease handle to select it.
