### PR TITLE
Fix position of parent dropdown menu

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2798,6 +2798,8 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
         if (column && !column->getSoundTextColumn() &&
             !column->getSoundColumn()) {
           int y = Preferences::instance()->isShowQuickToolbarEnabled() ? 30 : 0;
+          y += Preferences::instance()->isShowXsheetBreadcrumbsEnabled() ? 30
+                                                                         : 0;
           TStageObjectId columnId = m_viewer->getObjectId(m_col);
           bool isColumn = xsh->getStageObject(columnId)->getParent().isColumn();
           bool clickChangeParent =


### PR DESCRIPTION
This fixes the position of the Xsheet column's parent dropdown menu when both the Quick Toolbar and the Sub-Scene Navigation bar are both visible.