### PR TITLE
Fix actions that shouldn't happen while autosaving

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1030,6 +1030,10 @@ Room *MainWindow::getCurrentRoom() const {
 //-----------------------------------------------------------------------------
 
 void MainWindow::onUndo() {
+  // Must wait for current save to finish, just in case
+  while (TApp::instance()->isSaveInProgress())
+    ;
+
   bool ret = TUndoManager::manager()->undo();
   if (!ret) DVGui::error(QObject::tr("No more Undo operations available."));
 }
@@ -1037,6 +1041,10 @@ void MainWindow::onUndo() {
 //-----------------------------------------------------------------------------
 
 void MainWindow::onRedo() {
+  // Must wait for current save to finish, just in case
+  while (TApp::instance()->isSaveInProgress())
+    ;
+
   bool ret = TUndoManager::manager()->redo();
   if (!ret) DVGui::error(QObject::tr("No more Redo operations available."));
 }

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -115,6 +115,7 @@ TApp::TApp()
     , m_mainWindow(0)
     , m_autosaveTimer(0)
     , m_autosaveSuspended(false)
+    , m_saveInProgress(false)
     , m_isStarting(false)
     , m_isPenCloseToTablet(false)
     , m_canHideTitleBars(CanHideTitleBarsWhenLocked == 1 ? true : false)
@@ -752,6 +753,8 @@ void TApp::autosave() {
     return;
   } else
     m_autosaveSuspended = false;
+
+  if (m_saveInProgress) return;
 
   // DVGui::ProgressDialog pb(
   //    "Autosaving scene..." + toQString(scene->getScenePath()), 0, 0, 1);

--- a/toonz/sources/toonz/tapp.h
+++ b/toonz/sources/toonz/tapp.h
@@ -87,6 +87,7 @@ class TApp final : public QObject,
 
   int m_autosavePeriod;  // minutes
   bool m_autosaveSuspended;
+  bool m_saveInProgress;
   QTimer *m_autosaveTimer;
   StatusBar *m_statusBar;
   TApp();
@@ -217,6 +218,9 @@ public:
   void setStatusBarFrameInfo(QString text);
 
   void refreshStatusBar() override;
+
+  bool isSaveInProgress() { return m_saveInProgress; }
+  void setSaveInProgress(bool inProgress) { m_saveInProgress = inProgress; }
 
 protected:
   bool eventFilter(QObject *obj, QEvent *event) override;


### PR DESCRIPTION
While reviewing #1332, I noticed there is a potential for overlapping save operations under certain scenarios which could potentially result in file corruption.  Additionally, #1332 suggests an undo operation was performed while an autosave was in progress.  This could cause a crash when it tries to access something that may no longer exist.

I've added logic to internally flag when a save is in progress so that any additional calls to save while actively saving will wait until the flag is cleared.

Scenarios that should be covered by this fix
- Timed autosave + suspended autosave due to active drawing or something
- Timed autosave + manual save by user
- Timed autosave + Undo/Redo

NOTE: It's hard to duplicate overlapping saving issues naturally.  I mostly regression tested for normal saving and autosaving operations as well as a simple saving error (file locked) and ensuring T2D didn't completely freeze up.