### PR TITLE
Fix UI issues with no-drag bar layouts

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1899,12 +1899,15 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
   bool showDragBars = Preferences::instance()->isShowDragBarsEnabled();
   bool isMinimumLayout =
       Preferences::instance()->getTimelineLayoutPreference() == "NoDragMinimum";
+  bool isRoomyLayout =
+      Preferences::instance()->getTimelineLayoutPreference() == "Roomy";
 
   if (isKeyFrame) {
     if (!m_viewer->orientation()->isVerticalTimeline()) {
-      int adjust = (isCamera && showDragBars)
-                       ? -3
-                       : ((!showDragBars && isMinimumLayout) ? 1 : 0);
+      int adjust =
+          (isCamera && showDragBars) || (!showDragBars && isRoomyLayout)
+              ? -3
+              : ((!showDragBars && isMinimumLayout) ? 1 : 0);
       dotRect.adjust(0, adjust, 0, adjust);
     }
 
@@ -1916,7 +1919,10 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
                                  dotRect.adjusted(1, 1, 1, 1).center(), color,
                                  outlineColor);
   } else {
-    int adjust = (!isCamera && !showDragBars && isMinimumLayout) ? 1 : 0;
+    int adjust =
+        (!isCamera && !showDragBars && isMinimumLayout)
+            ? 1
+            : ((!isCamera && !showDragBars && isRoomyLayout) ? -2 : 0);
     dotRect.adjust(0, adjust, 0, adjust);
 
     // move to column center
@@ -2235,6 +2241,13 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
   }
 
   nameRect.adjust(0, 0, -frameAdj.x(), -frameAdj.y());
+
+  if (!Preferences::instance()->isShowDragBarsEnabled()) {
+    if (o->isVerticalTimeline())
+      nameRect.adjust(-3, 0, 0, 0);
+    else if (Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
+      nameRect.adjust(0, -3, -0, -3);
+  }
 
   // draw text in red if the file does not exist
   bool isRed          = false;
@@ -2564,6 +2577,14 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
                 (!m_viewer->orientation()->isVerticalTimeline() && r == 0 ? -1
                                                                           : 0),
                 0, -frameAdj.x(), -frameAdj.y());
+
+    if (!Preferences::instance()->isShowDragBarsEnabled()) {
+      if (o->isVerticalTimeline())
+        ret.nameRect.adjust(-3, 0, 0, 0);
+      else if (Preferences::instance()->getTimelineLayoutPreference() ==
+               "Roomy")
+        ret.nameRect.adjust(0, -3, -0, -3);
+    }
 
     return ret;
   };
@@ -3008,6 +3029,14 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
 
     nameRect.adjust(0, 0, -frameAdj.x(), -frameAdj.y());
 
+    if (!Preferences::instance()->isShowDragBarsEnabled()) {
+      if (o->isVerticalTimeline())
+        nameRect.adjust(-3, 0, 0, 0);
+      else if (Preferences::instance()->getTimelineLayoutPreference() ==
+               "Roomy")
+        nameRect.adjust(0, -3, -0, -3);
+    }
+
     QColor penColor = isRed ? QColor(m_viewer->getErrorTextColor())
                             : m_viewer->getTextColor();
     p.setPen(penColor);
@@ -3103,6 +3132,9 @@ void CellArea::drawKeyframe(QPainter &p, const QRect toBeUpdated) {
       if (Preferences::instance()->getTimelineLayoutPreference() ==
           "NoDragMinimum")
         adjust++;
+      else if (Preferences::instance()->getTimelineLayoutPreference() ==
+               "Roomy")
+        adjust -= 3;
       tmpKeyRect.adjust(0, adjust, 0, adjust);
     }
 
@@ -3271,6 +3303,9 @@ void CellArea::drawKeyframeLine(QPainter &p, int col,
     if (Preferences::instance()->getTimelineLayoutPreference() ==
         "NoDragMinimum")
       adjust++;
+    else if (Preferences::instance()->getTimelineLayoutPreference() ==
+             "Roomy")
+      adjust -= 3;
     begin.setY(begin.y() + adjust);
     end.setY(end.y() + adjust);
   }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1678,7 +1678,8 @@ void CellArea::drawSoundCell(QPainter &p, int row, int col, bool isReference) {
     drawEndOfDragHandle(p, isLastRow, xy, cellColor);
     dottedLineColor = cellColor;
   } else
-    dottedLineColor = Qt::black;
+    dottedLineColor = sideColor;
+
 
   drawLockedDottedLine(p, soundColumn->isLocked(), isFirstRow, isLastRow, xy,
                        dottedLineColor);
@@ -1841,7 +1842,9 @@ void CellArea::drawLockedDottedLine(QPainter &p, bool isLocked, bool isStart,
       adjEndY = isLastRow ? -2 : -1;
   }
 
-  p.setPen(QPen(cellColor, 2, Qt::DotLine));
+  int dashWidth = !Preferences::instance()->isShowDragBarsEnabled() ? 3 : 2;
+
+  p.setPen(QPen(cellColor, dashWidth, Qt::DotLine));
   QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
   QLine dottedLine =
       m_viewer->orientation()->line(PredefinedLine::LOCKED).translated(lxy);
@@ -2223,7 +2226,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
       drawEndOfDragHandle(p, isLastRow, xy, cellColor);
       dottedLineColor = cellColor;
     } else
-      dottedLineColor = Qt::black;
+      dottedLineColor = sideColor;
 
     drawLockedDottedLine(p, xsh->getColumn(col)->isLocked(), isStart, isLastRow,
                          xy, dottedLineColor);
@@ -2479,7 +2482,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
     drawEndOfDragHandle(p, isLastRow, xy, cellColor);
     dottedLineColor = cellColor;
   } else
-    dottedLineColor = Qt::black;
+    dottedLineColor = sideColor;
 
   drawLockedDottedLine(p, xsh->getColumn(col)->isLocked(), isStart, isLastRow,
 xy,
@@ -2712,7 +2715,7 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
         drawEndOfDragHandle(p, info.isEndOfRange, info.xy, tmpCellColor);
         dottedLineColor = tmpCellColor;
       } else
-        dottedLineColor = Qt::black;
+        dottedLineColor = sideColor;
 
       drawLockedDottedLine(p, xsh->getColumn(col)->isLocked(), isStart,
                            info.isEndOfRange, info.xy, dottedLineColor);
@@ -2983,7 +2986,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
       drawEndOfDragHandle(p, isLastRow, xy, cellColor);
       dottedLineColor = cellColor;
     } else
-      dottedLineColor = Qt::black;
+      dottedLineColor = sideColor;
 
     drawLockedDottedLine(p, xsh->getColumn(col)->isLocked(), isStart, isLastRow,
                          xy, dottedLineColor);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2245,6 +2245,8 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
   if (!Preferences::instance()->isShowDragBarsEnabled()) {
     if (o->isVerticalTimeline())
       nameRect.adjust(-3, 0, 0, 0);
+    else if (Preferences::instance()->getTimelineLayoutPreference() == "NoDragCompact")
+      nameRect.adjust(0, -1, -0, -1);
     else if (Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
       nameRect.adjust(0, -3, -0, -3);
   }
@@ -2581,6 +2583,9 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
     if (!Preferences::instance()->isShowDragBarsEnabled()) {
       if (o->isVerticalTimeline())
         ret.nameRect.adjust(-3, 0, 0, 0);
+      else if (Preferences::instance()->getTimelineLayoutPreference() ==
+               "NoDragCompact")
+        ret.nameRect.adjust(0, -1, -0, -1);
       else if (Preferences::instance()->getTimelineLayoutPreference() ==
                "Roomy")
         ret.nameRect.adjust(0, -3, -0, -3);
@@ -3032,6 +3037,9 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
     if (!Preferences::instance()->isShowDragBarsEnabled()) {
       if (o->isVerticalTimeline())
         nameRect.adjust(-3, 0, 0, 0);
+      else if (Preferences::instance()->getTimelineLayoutPreference() ==
+               "NoDragCompact")
+        nameRect.adjust(0, -1, -0, -1);
       else if (Preferences::instance()->getTimelineLayoutPreference() ==
                "Roomy")
         nameRect.adjust(0, -3, -0, -3);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1991,15 +1991,15 @@ void CellArea::drawCellMarker(QPainter &p, int markId, QRect rect,
   if (hasFrame && Preferences::instance()->isShowDragBarsEnabled()) {
     QRect dragBar = o->rect(PredefinedRect::DRAG_AREA);
     if (!o->isVerticalTimeline())
-      rect.adjust(0, dragBar.height() - 1, 0, 0);
+      rect.adjust(0, dragBar.height(), 0, 0);
     else
-      rect.adjust(dragBar.width() - 1, 0, 0, 0);
+      rect.adjust(dragBar.width(), 0, 0, 0);
   }
   // Adjust right and bottom
   if (!o->isVerticalTimeline())
-    rect.adjust(0, 0, (!isNextEmpty ? -3 : -1), -1);
+    rect.adjust(1, 1, (!isNextEmpty ? -3 : -1), -1);
   else
-    rect.adjust(0, 0, -1, -1);
+    rect.adjust(1, 1, -1, -1);
   p.drawRect(rect);
 
   p.setBrush(origBrush);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1179,6 +1179,10 @@ void ColumnArea::DrawHeader::drawColumnNumber() const {
 
   if (!o->isVerticalTimeline()) {
     pos.adjust(0, -1, 0, -1);
+
+    if (!Preferences::instance()->isShowDragBarsEnabled() &&
+        Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
+      pos.adjust(0, -3, 0, -3);
   }
 
   p.drawText(pos, Qt::AlignHCenter | valign | Qt::TextSingleLine,
@@ -1275,9 +1279,13 @@ void ColumnArea::DrawHeader::drawColumnName() const {
 
   int vertAdj = 0;
 
-  if (!o->isVerticalTimeline())
+  if (!o->isVerticalTimeline()) {
     vertAdj = ((col < 0 || isEmpty) && showDragBars) ? -4 : -1;
 
+    if (!showDragBars &&
+        Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
+      vertAdj -= 3;
+  }
 
   p.drawText(columnName.adjusted(leftadj, vertAdj, rightadj, vertAdj),
              Qt::AlignLeft | valign | Qt::TextSingleLine,

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1180,9 +1180,12 @@ void ColumnArea::DrawHeader::drawColumnNumber() const {
   if (!o->isVerticalTimeline()) {
     pos.adjust(0, -1, 0, -1);
 
-    if (!Preferences::instance()->isShowDragBarsEnabled() &&
-        Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
-      pos.adjust(0, -3, 0, -3);
+    if (!Preferences::instance()->isShowDragBarsEnabled()) {
+      if (Preferences::instance()->getTimelineLayoutPreference() == "NoDragCompact")
+        pos.adjust(0, -1, 0, -1);
+      else if (Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
+        pos.adjust(0, -3, 0, -3);
+    }
   }
 
   p.drawText(pos, Qt::AlignHCenter | valign | Qt::TextSingleLine,
@@ -1282,9 +1285,12 @@ void ColumnArea::DrawHeader::drawColumnName() const {
   if (!o->isVerticalTimeline()) {
     vertAdj = ((col < 0 || isEmpty) && showDragBars) ? -4 : -1;
 
-    if (!showDragBars &&
-        Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
-      vertAdj -= 3;
+    if (!showDragBars) {
+      if (Preferences::instance()->getTimelineLayoutPreference() == "NoDragCompact")
+        vertAdj -= 1;
+      else if (Preferences::instance()->getTimelineLayoutPreference() == "Roomy")
+        vertAdj -= 3;
+    }
   }
 
   p.drawText(columnName.adjusted(leftadj, vertAdj, rightadj, vertAdj),


### PR DESCRIPTION
The following UI issues have been made related to no-dragbar layouts introduced in #1330 

- Level Extender Handles were lowered in `Compact` and `Minimal` layouts
  - They are now centered on the cell.
  - Keyframe Loop button shifted right when level extender handle is present 
- Cell Mark top/left edges were moved down/right to be inside the cell boundaries instead of on it.
- Vertically centered text, markers and key frame elements in `Roomy` and `Compact` layouts.
- Changed locked cell indicator to a thicker line using original drag bar color
