### PR TITLE
Fix insert column crash without a column selected

### DIFF
--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -773,6 +773,7 @@ void InsertEmptyColumnsUndo::undo() const {
 
 void ColumnCmd::insertEmptyColumns(const std::set<int> &indices,
                                    bool insertAfter) {
+  if (indices.empty()) return;
   // Filter out all less than 0 indices (in particular, the 'camera' column
   // in the Toonz derivative product "Tab")
   std::vector<int> positiveIndices(indices.begin(), indices.end());

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -21,6 +21,7 @@
 #include "orientation.h"
 #include "toonz/preferences.h"
 #include "toonz/txshchildlevel.h"
+#include "toonz/tcolumnhandle.h"
 
 // TnzCore includes
 #include "tvectorimage.h"
@@ -190,12 +191,21 @@ void TColumnSelection::cutColumns() {
 //-----------------------------------------------------------------------------
 
 void TColumnSelection::insertColumnsBelow() {
+  if (m_indices.empty()) {
+    int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
+    if (col < 0) return;
+    selectColumn(col, true);
+  }
   ColumnCmd::insertEmptyColumns(m_indices);
 }
 
 //-----------------------------------------------------------------------------
 
 void TColumnSelection::insertColumns() {
+  if (m_indices.empty()) {
+    int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
+    selectColumn(col, true);
+  }
   ColumnCmd::insertEmptyColumns(m_indices, true);
 }
 


### PR DESCRIPTION
This PR fixes #1319 

Some column operations like `Fold Column` and `Delete` cause the selected column list to be cleared.  When you attempt an `Insert` column without a selected column, the logic didn't account for this and crashed.

Added logic to find the current column focus, outlined in cyan, and use that as the insert point.  Still added logic to ignore the insert action if for some reason a current column still could not be found.