### PR TITLE
UHD capture camera + "save scene as" updates levels path

### DIFF
--- a/toonz/sources/stopmotion/webcam.cpp
+++ b/toonz/sources/stopmotion/webcam.cpp
@@ -220,6 +220,7 @@ void Webcam::refreshWebcamResolutions() {
     m_webcamResolutions.push_back(QSize(1600, 896));
     m_webcamResolutions.push_back(QSize(1600, 900));
     m_webcamResolutions.push_back(QSize(1920, 1080));
+    m_webcamResolutions.push_back(QSize(3840, 2160));
   }
 }
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -644,8 +644,15 @@ bool SaveSceneAsPopup::execute() {
   if (isSpaceString(QString::fromStdString(
           fp.getName())))  // Lol. Cmon! Really necessary?
     return false;
-
+#ifdef DEBUG_saveSceneAs
+  bool result = IoCmd::saveScene(fp, 0);
+  if (result)
+      return IoCmd::saveAll(0);
+  else
+    return false;
+#else
   return IoCmd::saveScene(fp, 0);
+#endif
 }
 
 void SaveSceneAsPopup::initFolder() {

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -18,6 +18,7 @@
 #include "cellselection.h"
 
 #define DEBUG_saveSceneAs
+#define FEATURE_copyLevelsOnSaveSceneAs
 
 //========================================================
 

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -17,6 +17,8 @@
 // Tnz6 includes
 #include "cellselection.h"
 
+#define DEBUG_saveSceneAs
+
 //========================================================
 
 //    Forward declaration


### PR DESCRIPTION
Hello,
this is my first Pull Request.
I guess it would be better to split in 2 PRs but i am new to it, forgive me, 'ill try to make seprate PR per commit in the future.

1 - UHD capture camera
A single line change adds UHD camera support for capture
It's a workaround because i guess the resolutions should not be hardcoded.

2 - "save scene as" updates levels path
this works fine, but i am open to suggestions as i am new to toonz code (I am exploring the existing code logic).
I'll remove the ifdefs once you review my code and give me your feedback.
In addition, "Save all" is called on "save scene as" to make sure no changes are lost.

Potential problems:
* using a search/replace logic with old / new scene name to create a correct level path could fail if the levels where not using scene subfolder already... I'd rather use the path formated when getUseSubScenePath option is on, but i couldn't find the correct method for that...

Thank you !
Happy 2d animating...

Julien
