### PR TITLE
Feature copy levels on save scene as

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -163,6 +163,7 @@ public:
     return getBoolValue(rasterOptimizedMemory);
   }
   bool isAutosaveEnabled() const { return getBoolValue(autosaveEnabled); }
+  bool isSaveLevelsOnSaveSceneEnabled() const { return getBoolValue(saveLevelsOnSaveSceneEnabled); }
   int getAutosavePeriod() const {
     return getIntValue(autosavePeriod);
   }  // minutes

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -75,6 +75,7 @@ enum PreferencesItemId {
   defaultProjectPath,
   recordFileHistory,
   recordAsUsername,
+  saveLevelsOnSaveSceneEnabled,
 
   //----------
   // Import / Export

--- a/toonz/sources/stopmotion/webcam.cpp
+++ b/toonz/sources/stopmotion/webcam.cpp
@@ -220,6 +220,7 @@ void Webcam::refreshWebcamResolutions() {
     m_webcamResolutions.push_back(QSize(1600, 896));
     m_webcamResolutions.push_back(QSize(1600, 900));
     m_webcamResolutions.push_back(QSize(1920, 1080));
+    m_webcamResolutions.push_back(QSize(3840, 2160));
   }
 }
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -666,7 +666,8 @@ bool SaveSceneAsPopup::execute() {
                   << pathQString.toStdString() << std::endl;
         auto newPath = TFilePath(pathQString);
         // 1 - Save level to a folder using new scene name
-        IoCmd::saveLevel(newPath, lvl->getSimpleLevel(), true);
+        if (Preferences::instance()->isSaveLevelsOnSaveSceneEnabled())
+          IoCmd::saveLevel(newPath, lvl->getSimpleLevel(), true);
         // 2 - Update level's path property
         lvl->getSimpleLevel()->setPath(newPath);
       } else {
@@ -683,8 +684,13 @@ bool SaveSceneAsPopup::execute() {
 #ifdef DEBUG_saveSceneAs
   bool result = IoCmd::saveScene(fp, 0);
   // automatic "save all" (otherwize, unsaved level changes would be lost)
-  if (result)
+  if (result) {
+    // 1 - Save level to a folder using new scene name
+    if (Preferences::instance()->isSaveLevelsOnSaveSceneEnabled())
       return IoCmd::saveAll(0);
+    else
+      return result;
+  }
   else
     return false;
 #else

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -644,8 +644,15 @@ bool SaveSceneAsPopup::execute() {
   if (isSpaceString(QString::fromStdString(
           fp.getName())))  // Lol. Cmon! Really necessary?
     return false;
-
+#ifdef DEBUG_saveSceneAs
+  bool result = IoCmd::saveScene(fp, 0);
+  if (result)
+      return IoCmd::saveAll(0);
+  else
+    return false;
+#else
   return IoCmd::saveScene(fp, 0);
+#endif
 }
 
 void SaveSceneAsPopup::initFolder() {

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -645,7 +645,6 @@ bool SaveSceneAsPopup::execute() {
           fp.getName())))  // Lol. Cmon! Really necessary?
     return false;
 
-#ifdef FEATURE_copyLevelsOnSaveSceneAs
   // copy and replace all levels if project option "Separate assets into scene sub-folders" is checked
   TProjectP project = TProjectManager::instance()->getCurrentProject();
   if (project->getUseSubScenePath()) {
@@ -680,8 +679,6 @@ bool SaveSceneAsPopup::execute() {
     TApp::instance()->getCurrentScene()->notifyCastChange();
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
-#endif
-#ifdef DEBUG_saveSceneAs
   bool result = IoCmd::saveScene(fp, 0);
   // automatic "save all" (otherwize, unsaved level changes would be lost)
   if (result) {
@@ -693,9 +690,6 @@ bool SaveSceneAsPopup::execute() {
   }
   else
     return false;
-#else
-  return IoCmd::saveScene(fp, 0);
-#endif
 }
 
 void SaveSceneAsPopup::initFolder() {

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -18,6 +18,7 @@
 #include "cellselection.h"
 
 #define DEBUG_saveSceneAs
+#define FEATURE_copyLevelsOnSaveSceneAs
 
 //========================================================
 

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -17,8 +17,6 @@
 // Tnz6 includes
 #include "cellselection.h"
 
-#define DEBUG_saveSceneAs
-#define FEATURE_copyLevelsOnSaveSceneAs
 
 //========================================================
 

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -17,6 +17,8 @@
 // Tnz6 includes
 #include "cellselection.h"
 
+#define DEBUG_saveSceneAs
+
 //========================================================
 
 //    Forward declaration

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1327,6 +1327,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {defaultProjectPath, tr("Default Project Path:")},
       {recordFileHistory, tr("Record File History* (tnz, pli, hst)")},
       {recordAsUsername, tr("History Username*:")},
+      {saveLevelsOnSaveSceneEnabled, tr("Automatically Save Levels On 'Save Scene As'")},
 
       // Import / Export
       {ffmpegPath, tr("Executable Directory:")},
@@ -1980,6 +1981,7 @@ QWidget* PreferencesPopup::createSavingPage() {
   insertUI(rasterBackgroundColor, lay);
   insertUI(resetUndoOnSavingLevel, lay);
   insertUI(doNotShowPopupSaveScene, lay);
+  insertUI(saveLevelsOnSaveSceneEnabled, lay);
 
   insertUI(fastRenderPath, lay);
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -499,6 +499,8 @@ void Preferences::definePreferenceItems() {
   QString userName = TSystem::getUserName();
   define(recordAsUsername, "recordAsUsername", QMetaType::QString, userName);
 
+  define(saveLevelsOnSaveSceneEnabled, "saveLevelsOnSaveSceneEnabled", QMetaType::Bool, false);
+
   // Import / Export
   define(ffmpegPath, "ffmpegPath", QMetaType::QString, "");
   define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, 0, 0,


### PR DESCRIPTION
* "save scene as" updates levels path
In addition, "Save all" is called on "save scene as" to make sure no changes are lost.

Potential problems:
using a search/replace logic with old / new scene name to create a correct level path could fail if the levels where not using scene subfolder already... I'd rather use the path formated when getUseSubScenePath option is on, but i couldn't find the correct method for that...

* - preference 
Saving/Automatically Save Levels On 'Save Scene As'
(it defaults to false, but i turn it on, to avoid red drawings on scene save as)
There might be reasons the user wishes to save just the scene file as a different name and not save level changes.

* - UHD capture camera
A single line change adds UHD camera support for capture
It's a workaround because i guess the resolutions should not be hardcoded.

