### PR TITLE
saveLevelsOnSaveAs + UHD capture cam + clean debug asserts

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -163,6 +163,7 @@ public:
     return getBoolValue(rasterOptimizedMemory);
   }
   bool isAutosaveEnabled() const { return getBoolValue(autosaveEnabled); }
+  bool isSaveLevelsOnSaveSceneEnabled() const { return getBoolValue(saveLevelsOnSaveSceneEnabled); }
   int getAutosavePeriod() const {
     return getIntValue(autosavePeriod);
   }  // minutes

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -75,6 +75,7 @@ enum PreferencesItemId {
   defaultProjectPath,
   recordFileHistory,
   recordAsUsername,
+  saveLevelsOnSaveSceneEnabled,
 
   //----------
   // Import / Export

--- a/toonz/sources/stopmotion/webcam.cpp
+++ b/toonz/sources/stopmotion/webcam.cpp
@@ -220,6 +220,7 @@ void Webcam::refreshWebcamResolutions() {
     m_webcamResolutions.push_back(QSize(1600, 896));
     m_webcamResolutions.push_back(QSize(1600, 900));
     m_webcamResolutions.push_back(QSize(1920, 1080));
+    m_webcamResolutions.push_back(QSize(3840, 2160));
   }
 }
 

--- a/toonz/sources/tnztools/controlpointselection.cpp
+++ b/toonz/sources/tnztools/controlpointselection.cpp
@@ -1031,7 +1031,7 @@ void ControlPointSelection::addMenuItems(QMenu *menu) {
   menu->addAction(CommandManager::instance()->getAction("MI_SetLinearControlPoint"));
   menu->addAction(CommandManager::instance()->getAction("MI_SetNonLinearControlPoint"));
   menu->addSeparator();
-  assert(ret);
+  //assert(ret); makes debug build fail
 }
 
 //---------------------------------------------------------------------------

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -645,64 +645,7 @@ bool SaveSceneAsPopup::execute() {
           fp.getName())))  // Lol. Cmon! Really necessary?
     return false;
 
-  // copy and replace all levels if project option "Separate assets into scene sub-folders" is checked
-  TProjectP project = TProjectManager::instance()->getCurrentProject();
-  bool saveTwice = false;
-  if (project->getUseSubScenePath()) {
-    // save scene a first time before updating levels paths just to make getDefaultLevelPath
-    // method happy (and avoid serach repalace old/new scene name)...
-    saveTwice   = true;
-    bool result = IoCmd::saveScene(fp, 0);
-
-    ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
-    TLevelSet *levelSet = scene->getLevelSet();
-    for (int i = 0; i < levelSet->getLevelCount(); i++) {
-      TXshLevel *lvl = levelSet->getLevel(i);
-      auto oldPath = lvl->getPath();
-      auto newPath = scene->getDefaultLevelPath(lvl->getType(), lvl->getName());
-      if (oldPath != newPath) {
-        std::cout << "SaveSceneAsPopup: level oldPath: "
-                  << oldPath.getQString().toStdString()
-                  << " newPath : " << newPath.getQString().toStdString()
-                  << std::endl;
-        if (Preferences::instance()->isSaveLevelsOnSaveSceneEnabled()) {
-          std::cout << "SaveSceneAsPopup: saveLevel to " << newPath.getQString().toStdString() << std::endl;
-          // 1 - Save level to a folder using new scene name
-          IoCmd::saveLevel(newPath, lvl->getSimpleLevel(), true);
-          // 2 - Update level's path property
-          lvl->getSimpleLevel()->setPath(newPath);
-        } else {
-          TFilePath dOldPath = scene->decodeFilePath(oldPath);
-          TFilePath dNewPath = scene->decodeFilePath(newPath);
-          std::cout << "SaveSceneAsPopup: copyFiles from "
-                    << dOldPath.getQString().toStdString() << " to "
-                    << dNewPath.getQString().toStdString() << std::endl;
-          // 1 - Copy level to a folder using new scene name
-          lvl->getSimpleLevel()->copyFiles(dNewPath, dOldPath);
-          // 2 - Update level's path property
-          lvl->getSimpleLevel()->setPath(newPath, true);
-        }
-      } else {
-        std::cout << "SaveSceneAsPopup: level oldPath == newPath, keeping level paths intact "
-                  << std::endl;
-      }
-    }
-    // 3 - Notify xsheet scene and level of this change, of crash sooner or later ?
-    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-    TApp::instance()->getCurrentScene()->notifyCastChange();
-    TApp::instance()->getCurrentLevel()->notifyLevelChange();
-  }
-  bool result = IoCmd::saveScene(fp, saveTwice ? IoCmd::SILENTLY_OVERWRITE : 0);
-  // automatic "save all" (otherwize, unsaved level changes would be lost)
-  if (result) {
-    // 1 - Save level to a folder using new scene name
-    if (Preferences::instance()->isSaveLevelsOnSaveSceneEnabled())
-      return IoCmd::saveAll(0);
-    else
-      return result;
-  }
-  else
-    return false;
+  return IoCmd::saveSceneAs(fp);
 }
 
 void SaveSceneAsPopup::initFolder() {

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -647,33 +647,35 @@ bool SaveSceneAsPopup::execute() {
 
   // copy and replace all levels if project option "Separate assets into scene sub-folders" is checked
   TProjectP project = TProjectManager::instance()->getCurrentProject();
+  bool saveTwice = false;
   if (project->getUseSubScenePath()) {
+    // save scene a first time before updating levels paths just to make getDefaultLevelPath
+    // method happy (and avoid serach repalace old/new scene name)...
+    saveTwice   = true;
+    bool result = IoCmd::saveScene(fp, 0);
+
     ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
     TLevelSet *levelSet = scene->getLevelSet();
     for (int i = 0; i < levelSet->getLevelCount(); i++) {
       TXshLevel *lvl = levelSet->getLevel(i);
-      auto pathQString = lvl->getPath().getQString();
-      QString oldSceneName = QString::fromStdString(scene->getScenePath().getName());
-      QString newSceneName = QString::fromStdString(fp.getName());
-      std::cout << "SaveSceneAsPopup: oldSceneName: " 
-                << oldSceneName.toStdString()
-                << " newSceneName : " << newSceneName.toStdString()
-                << std::endl;
-      if (oldSceneName != newSceneName) {
-        pathQString = pathQString.replace(oldSceneName, newSceneName);
-        auto newPath = TFilePath(pathQString);
+      auto oldPath = lvl->getPath();
+      auto newPath = scene->getDefaultLevelPath(lvl->getType(), lvl->getName());
+      if (oldPath != newPath) {
+        std::cout << "SaveSceneAsPopup: level oldPath: "
+                  << oldPath.getQString().toStdString()
+                  << " newPath : " << newPath.getQString().toStdString()
+                  << std::endl;
         if (Preferences::instance()->isSaveLevelsOnSaveSceneEnabled()) {
-          std::cout << "SaveSceneAsPopup: saveLevel to "
-                    << pathQString.toStdString() << std::endl;
+          std::cout << "SaveSceneAsPopup: saveLevel to " << newPath.getQString().toStdString() << std::endl;
           // 1 - Save level to a folder using new scene name
           IoCmd::saveLevel(newPath, lvl->getSimpleLevel(), true);
           // 2 - Update level's path property
           lvl->getSimpleLevel()->setPath(newPath);
         } else {
-          TFilePath dOldPath = scene->decodeFilePath(lvl->getPath());
-          TFilePath dNewPath = scene->decodeFilePath(TFilePath(pathQString));
+          TFilePath dOldPath = scene->decodeFilePath(oldPath);
+          TFilePath dNewPath = scene->decodeFilePath(newPath);
           std::cout << "SaveSceneAsPopup: copyFiles from "
-                    << dOldPath.getQString().toStdString() << " to " 
+                    << dOldPath.getQString().toStdString() << " to "
                     << dNewPath.getQString().toStdString() << std::endl;
           // 1 - Copy level to a folder using new scene name
           lvl->getSimpleLevel()->copyFiles(dNewPath, dOldPath);
@@ -681,7 +683,7 @@ bool SaveSceneAsPopup::execute() {
           lvl->getSimpleLevel()->setPath(newPath, true);
         }
       } else {
-        std::cout << "SaveSceneAsPopup: oldSceneName == newSceneName, keeping level paths intact "
+        std::cout << "SaveSceneAsPopup: level oldPath == newPath, keeping level paths intact "
                   << std::endl;
       }
     }
@@ -690,7 +692,7 @@ bool SaveSceneAsPopup::execute() {
     TApp::instance()->getCurrentScene()->notifyCastChange();
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
-  bool result = IoCmd::saveScene(fp, 0);
+  bool result = IoCmd::saveScene(fp, saveTwice ? IoCmd::SILENTLY_OVERWRITE : 0);
   // automatic "save all" (otherwize, unsaved level changes would be lost)
   if (result) {
     // 1 - Save level to a folder using new scene name

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2331,13 +2331,10 @@ static void incrementNumberedFilename(std::string &str) {
 }
 
 bool IoCmd::saveSceneVersion() { 
-
-  auto oldScenePath = TApp::instance()
-                          ->getCurrentScene()
-                          ->getScene()
-                          ->getScenePath()
-                          .getQString()
-                          .toStdString();
+  auto scene = TApp::instance()->getCurrentScene()->getScene();
+  if (scene->isUntitled())
+    return saveScene(0);
+  auto oldScenePath = scene->getScenePath().getQString().toStdString();
   auto newScenePath = oldScenePath;
   incrementNumberedFilename(newScenePath);
   return saveSceneAs(TFilePath(newScenePath));

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2234,7 +2234,7 @@ bool IoCmd::saveSceneAs(const TFilePath &fp) {
   bool saveTwice    = false;
   if (project->getUseSubScenePath()) {
     // save scene a first time before updating levels paths just to make
-    // getDefaultLevelPath method happy (and avoid serach repalace old/new scene
+    // getDefaultLevelPath method happy (and avoid search/replace old/new scene
     // name)...
     saveTwice   = true;
     bool result = IoCmd::saveScene(fp, 0);
@@ -2246,13 +2246,7 @@ bool IoCmd::saveSceneAs(const TFilePath &fp) {
       auto oldPath   = lvl->getPath();
       auto newPath = scene->getDefaultLevelPath(lvl->getType(), lvl->getName());
       if (oldPath != newPath) {
-        std::cout << "SaveSceneAsPopup: level oldPath: "
-                  << oldPath.getQString().toStdString()
-                  << " newPath : " << newPath.getQString().toStdString()
-                  << std::endl;
         if (Preferences::instance()->isSaveLevelsOnSaveSceneEnabled()) {
-          std::cout << "SaveSceneAsPopup: saveLevel to "
-                    << newPath.getQString().toStdString() << std::endl;
           // 1 - Save level to a folder using new scene name
           IoCmd::saveLevel(newPath, lvl->getSimpleLevel(), true);
           // 2 - Update level's path property
@@ -2260,18 +2254,11 @@ bool IoCmd::saveSceneAs(const TFilePath &fp) {
         } else {
           TFilePath dOldPath = scene->decodeFilePath(oldPath);
           TFilePath dNewPath = scene->decodeFilePath(newPath);
-          std::cout << "SaveSceneAsPopup: copyFiles from "
-                    << dOldPath.getQString().toStdString() << " to "
-                    << dNewPath.getQString().toStdString() << std::endl;
           // 1 - Copy level to a folder using new scene name
           lvl->getSimpleLevel()->copyFiles(dNewPath, dOldPath);
           // 2 - Update level's path property
           lvl->getSimpleLevel()->setPath(newPath, true);
         }
-      } else {
-        std::cout << "SaveSceneAsPopup: level oldPath == newPath, keeping "
-                     "level paths intact "
-                  << std::endl;
       }
     }
     // 3 - Notify xsheet scene and level of this change, of crash sooner or
@@ -2340,13 +2327,7 @@ static void incrementNumberedFilename(std::string &str) {
       fileExists(makeNumberedFilename(prefix, intValue, extension, padding))) {
     intValue++;
   }
-  std::cout << "incrementStringSuffix input str:: " << str << std::endl;
-  std::cout << "incrementStringSuffix prefix: " << prefix
-            << " intValue: " << intValue << " extension: " << extension
-            << std::endl;
   str = makeNumberedFilename(prefix, intValue, extension, padding);
-  std::cout << "incrementStringSuffix concat [prefix][intValue][extension]: " << str
-            << std::endl;
 }
 
 bool IoCmd::saveSceneVersion() { 
@@ -2359,8 +2340,6 @@ bool IoCmd::saveSceneVersion() {
                           .toStdString();
   auto newScenePath = oldScenePath;
   incrementNumberedFilename(newScenePath);
-  std::cout << "saveSceneVersion oldScenePath: " << oldScenePath
-            << " newScenePath: " << newScenePath << std::endl;
   return saveSceneAs(TFilePath(newScenePath));
 
   //// I couldn't understand how to use existing toonz numbered file naming methods :

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -180,6 +180,8 @@ bool loadScene(ToonzScene &scene, const TFilePath &scenePath, bool import);
 bool loadScene(const TFilePath &scenePath, bool updateRecentFile = true,
                bool checkSaveOldScene = true);
 bool loadScene();
+bool saveSceneAs(const TFilePath &fp);
+bool saveSceneVersion();
 
 bool loadSubScene();
 bool loadSubScene(const TFilePath &scenePath);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -478,6 +478,7 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler("MI_Undo", this, &MainWindow::onUndo);
   setCommandHandler("MI_Redo", this, &MainWindow::onRedo);
   setCommandHandler("MI_NewScene", this, &MainWindow::onNewScene);
+  setCommandHandler("MI_SaveSceneVersion", this, &MainWindow::onSaveSceneVersion);
   setCommandHandler("MI_LoadScene", this, &MainWindow::onLoadScene);
   setCommandHandler("MI_LoadSubSceneFile", this, &MainWindow::onLoadSubScene);
   setCommandHandler("MI_ResetRoomLayout", this, &MainWindow::resetRoomsLayout);
@@ -1063,6 +1064,8 @@ void MainWindow::onNewScene() {
 //-----------------------------------------------------------------------------
 
 void MainWindow::onLoadScene() { IoCmd::loadScene(); }
+
+void MainWindow::onSaveSceneVersion() { IoCmd::saveSceneVersion(); }
 
 //-----------------------------------------------------------------------------
 
@@ -1803,6 +1806,10 @@ void MainWindow::defineActions() {
                        "save_scene_as",
                        tr("Save ONLY the scene with a new name.") + separator +
                            tr("This does NOT save levels or images."));
+  createMenuFileAction(MI_SaveSceneVersion, QT_TR_NOOP("&Save Scene Version..."), "",
+                       "save_scene_version",
+                       tr("Increment scene version.") + separator +
+                           tr("Add a number suffix if necessary."));
   createMenuFileAction(MI_SaveAll, QT_TR_NOOP("&Save All"), "Ctrl+S", "saveall",
                        tr("Save the scene info and the levels and images.") +
                            separator + tr("Saves everything."));

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -84,6 +84,7 @@ public:
   void onRedo();
   void onNewScene();
   void onLoadScene();
+  void onSaveSceneVersion();
   void onLoadSubScene();
   void resetRoomsLayout();
   void maximizePanel();

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -314,6 +314,7 @@ void TopBar::loadMenubar() {
   {
     addMenuItem(saveOtherMenu, MI_SaveScene);
     addMenuItem(saveOtherMenu, MI_SaveSceneAs);
+    addMenuItem(saveOtherMenu, MI_SaveSceneVersion);
   }
   addMenuItem(fileMenu, MI_OpenRecentScene);
   addMenuItem(fileMenu, MI_RevertScene);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -15,6 +15,7 @@
 #define MI_LoadScene "MI_LoadScene"
 #define MI_SaveScene "MI_SaveScene"
 #define MI_SaveSceneAs "MI_SaveSceneAs"
+#define MI_SaveSceneVersion "MI_SaveSceneVersion"
 #define MI_SaveAll "MI_SaveAll"
 #define MI_SaveAllLevels "MI_SaveAllLevels"
 #define MI_RevertScene "MI_RevertScene"

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1327,6 +1327,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {defaultProjectPath, tr("Default Project Path:")},
       {recordFileHistory, tr("Record File History* (tnz, pli, hst)")},
       {recordAsUsername, tr("History Username*:")},
+      {saveLevelsOnSaveSceneEnabled, tr("Automatically Save Levels On 'Save Scene As'")},
 
       // Import / Export
       {ffmpegPath, tr("Executable Directory:")},
@@ -1980,6 +1981,7 @@ QWidget* PreferencesPopup::createSavingPage() {
   insertUI(rasterBackgroundColor, lay);
   insertUI(resetUndoOnSavingLevel, lay);
   insertUI(doNotShowPopupSaveScene, lay);
+  insertUI(saveLevelsOnSaveSceneEnabled, lay);
 
   insertUI(fastRenderPath, lay);
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -320,7 +320,7 @@ XsheetViewer::~XsheetViewer() {
 //-----------------------------------------------------------------------------
 
 void XsheetViewer::setDragTool(XsheetGUI::DragTool *dragTool) {
-  assert(m_dragTool == 0);
+  //assert(m_dragTool == 0);
   m_dragTool = dragTool;
 }
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -280,7 +280,7 @@ void Preferences::load() {
             formatLess);           // enforced
 
   if (m_roomMaps.key(getStringValue(CurrentRoomChoice), -1) == -1) {
-    assert(!m_roomMaps.isEmpty());
+    // assert(!m_roomMaps.isEmpty());
     setValue(CurrentRoomChoice, m_roomMaps[0]);
   }
 
@@ -498,6 +498,8 @@ void Preferences::definePreferenceItems() {
 
   QString userName = TSystem::getUserName();
   define(recordAsUsername, "recordAsUsername", QMetaType::QString, userName);
+
+  define(saveLevelsOnSaveSceneEnabled, "saveLevelsOnSaveSceneEnabled", QMetaType::Bool, false);
 
   // Import / Export
   define(ffmpegPath, "ffmpegPath", QMetaType::QString, "");


### PR DESCRIPTION
* preference Saving/Automatically Save Levels On 'Save Scene As' (it defaults to false : There might be reasons the user wishes to save just the scene file as a different name and not save level changes).

* "save scene as" updates levels path when project settings uses "separate assets into scene subfolders" option
- if preference Saving/Automatically Save Levels On 'Save Scene As' is checked, "Save all" is called on "save scene as"
- otherwise, the user must use SaveAll to write levels changes (prompt before exit).

Potential problems / todo :
using a search/replace logic with old / new scene name to create a correct level path could fail if the levels where not using scene subfolder already... I'd rather use the path formated when getUseSubScenePath option is on, but i couldn't find the correct method for that...

* UHD capture camera A single line change adds UHD camera support for capture It's a workaround because i guess the resolutions should not be hardcoded.

* removed debug asserts