### PR TITLE
Shift and Trace - Hide original position

### DIFF
--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -108,6 +108,7 @@ since underlying onion-skinned drawings must be visible.
   }
 
   bool isShiftTraceEnabled() const { return m_shiftTraceStatus != DISABLED; }
+  bool isEditingShift() const { return m_shiftTraceStatus == EDITING_GHOST; }
 
   bool getLightTableStatus() const { return m_LightTableStatus; }
   void setLightTableStatus(bool status) { m_LightTableStatus = status; }

--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -107,6 +107,10 @@ since underlying onion-skinned drawings must be visible.
     m_shiftTraceStatus = status;
   }
 
+  bool isShowShiftOrigin() const { return m_showShiftOrigin; }
+  void setShowShiftOrigin(bool showShiftOrigin) {
+    m_showShiftOrigin = showShiftOrigin;
+  }
   bool isShiftTraceEnabled() const { return m_shiftTraceStatus != DISABLED; }
   bool isEditingShift() const { return m_shiftTraceStatus == EDITING_GHOST; }
 
@@ -148,6 +152,7 @@ private:
   bool m_everyFrame;              //!< Whether the OS renders every frame or only on new exposures.
 
   ShiftTraceStatus m_shiftTraceStatus;
+  bool m_showShiftOrigin;
   TAffine m_ghostAff[2];
   TPointD m_ghostCenter[2];
   int m_ghostFrame[2];         // relative frame position of the ghosts

--- a/toonz/sources/tnztools/shifttracetool.cpp
+++ b/toonz/sources/tnztools/shifttracetool.cpp
@@ -354,6 +354,8 @@ void ShiftTraceTool::onDeactivate() {
   if (!shiftTrace->isChecked()) return;
   QAction *action = CommandManager::instance()->getAction("MI_EditShift");
   action->setChecked(false);
+  action = CommandManager::instance()->getAction("MI_ShowShiftOrigin");
+  action->setChecked(false);
 }
 
 ShiftTraceTool::GadgetId ShiftTraceTool::getGadget(const TPointD &p) {

--- a/toonz/sources/tnztools/shifttracetool.cpp
+++ b/toonz/sources/tnztools/shifttracetool.cpp
@@ -354,8 +354,15 @@ void ShiftTraceTool::onDeactivate() {
   if (!shiftTrace->isChecked()) return;
   QAction *action = CommandManager::instance()->getAction("MI_EditShift");
   action->setChecked(false);
-  action = CommandManager::instance()->getAction("MI_ShowShiftOrigin");
-  action->setChecked(false);
+  action = CommandManager::instance()->getAction("MI_NoShift");
+  action->setEnabled(true);
+
+  TApplication *app = TTool::getApplication();
+  OnionSkinMask osm = app->getCurrentOnionSkin()->getOnionSkinMask();
+  if (osm.isEditingShift()) {
+    osm.setShiftTraceStatus(OnionSkinMask::ENABLED);
+    TTool::getApplication()->getCurrentOnionSkin()->setOnionSkinMask(osm);
+  }
 }
 
 ShiftTraceTool::GadgetId ShiftTraceTool::getGadget(const TPointD &p) {

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -83,6 +83,7 @@ TEnv::IntVar ShowStatusBarAction("ShowStatusBarAction", 1);
 // TEnv::IntVar DockingCheckToggleAction("DockingCheckToggleAction", 1);
 TEnv::IntVar ShiftTraceToggleAction("ShiftTraceToggleAction", 0);
 TEnv::IntVar EditShiftToggleAction("EditShiftToggleAction", 0);
+TEnv::IntVar ShowShiftOriginToggleAction("ShowShiftOriginToggleAction", 0);
 TEnv::IntVar NoShiftToggleAction("NoShiftToggleAction", 0);
 TEnv::IntVar TouchGestureControl("TouchGestureControl", 0);
 TEnv::IntVar TransparencySliderValue("TransparencySliderValue", 50);
@@ -1057,6 +1058,7 @@ void MainWindow::onNewScene() {
   cm->setChecked(MI_ShiftTrace, false);
   cm->setChecked(MI_EditShift, false);
   cm->setChecked(MI_NoShift, false);
+  cm->setChecked(MI_ShowShiftOrigin, false);
   cm->setChecked(MI_VectorGuidedDrawing, false);
 }
 
@@ -1329,6 +1331,8 @@ void MainWindow::onMenuCheckboxChanged() {
     EditShiftToggleAction = isChecked;
   else if (cm->getAction(MI_NoShift) == action)
     NoShiftToggleAction = isChecked;
+  else if (cm->getAction(MI_ShowShiftOrigin) == action)
+    ShowShiftOriginToggleAction = isChecked;
   else if (cm->getAction(MI_TouchGestureControl) == action)
     TouchGestureControl = isChecked;
 }
@@ -2357,8 +2361,11 @@ void MainWindow::defineActions() {
                MenuViewCommandType, "shift_and_trace_edit");
   createToggle(MI_NoShift, QT_TR_NOOP("No Shift"), "", false,
                MenuViewCommandType, "shift_and_trace_no_shift");
+  createToggle(MI_ShowShiftOrigin, QT_TR_NOOP("Show Shift Origin"), "", false,
+               MenuViewCommandType, "");
   CommandManager::instance()->enable(MI_EditShift, false);
   CommandManager::instance()->enable(MI_NoShift, false);
+  CommandManager::instance()->enable(MI_ShowShiftOrigin, false);
   createAction(MI_ResetShift, QT_TR_NOOP("Reset Shift"), "", "",
                MenuViewCommandType, "shift_and_trace_reset");
   createToggle(MI_VectorGuidedDrawing, QT_TR_NOOP("Vector Guided Tweening"), "",

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -615,6 +615,7 @@ void TopBar::loadMenubar() {
   viewMenu->addSeparator();
   addMenuItem(viewMenu, MI_ToggleLightTable);
   addMenuItem(viewMenu, MI_ShiftTrace);
+  addMenuItem(viewMenu, MI_ShowShiftOrigin);
   addMenuItem(viewMenu, MI_EditShift);
   addMenuItem(viewMenu, MI_NoShift);
   addMenuItem(viewMenu, MI_ResetShift);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -206,6 +206,7 @@
 #define MI_EditShift "MI_EditShift"
 #define MI_NoShift "MI_NoShift"
 #define MI_ResetShift "MI_ResetShift"
+#define MI_ShowShiftOrigin "MI_ShowShiftOrigin"
 #define MI_Histogram "MI_Histogram"
 #define MI_ViewerHistogram "MI_ViewerHistogram"
 #define MI_FxParamEditor "MI_FxParamEditor"

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -427,6 +427,7 @@ public:
     if (std::string(m_cmdId) == MI_ShiftTrace) {
       cm->enable(MI_EditShift, checked);
       cm->enable(MI_NoShift, checked);
+      cm->enable(MI_ShowShiftOrigin, checked);
       if (checked) {
         OnioniSkinMaskGUI::resetShiftTraceFrameOffset();
         // activate edit shift
@@ -472,6 +473,7 @@ public:
     OnionSkinMask osm =
         TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
     osm.setShiftTraceStatus(status);
+    osm.setShowShiftOrigin(isChecked(MI_ShowShiftOrigin));
     osm.clearGhostFlipKey();
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
     TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
@@ -479,7 +481,8 @@ public:
 };
 
 TShiftTraceToggleCommand shiftTraceToggleCommand(MI_ShiftTrace),
-    editShiftToggleCommand(MI_EditShift), noShiftToggleCommand(MI_NoShift);
+    editShiftToggleCommand(MI_EditShift), noShiftToggleCommand(MI_NoShift),
+    showShiftOriginCommand(MI_ShowShiftOrigin);
 
 class TResetShiftTraceCommand final : public MenuItemHandler {
 public:

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1410,6 +1410,7 @@ void RowArea::contextMenuEvent(QContextMenuEvent *event) {
   menu->addSeparator();
   menu->addAction(cmdManager->getAction(MI_ToggleLightTable));
   menu->addAction(cmdManager->getAction(MI_ShiftTrace));
+  menu->addAction(cmdManager->getAction(MI_ShowShiftOrigin));
   menu->addAction(cmdManager->getAction(MI_EditShift));
   menu->addAction(cmdManager->getAction(MI_NoShift));
   menu->addAction(cmdManager->getAction(MI_ResetShift));

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -184,6 +184,7 @@ public:
 
   ShiftTraceGhostId m_shiftTraceGhostId;
   bool m_editingShift;
+  bool m_showShiftOrigin;
 
   bool m_camera3d;
   OnionSkinMask m_onionSkinMask;
@@ -276,6 +277,7 @@ StageBuilder::StageBuilder()
     , m_fade(0)
     , m_shiftTraceGhostId(NO_GHOST)
     , m_editingShift(false)
+    , m_showShiftOrigin(false)
     , m_currentXsheetLevel(0)
     , m_xsheetLevel(0)
     , m_currentDrawingOnTop(false) {
@@ -461,7 +463,7 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         if (m_onionSkinMask.getShiftTraceStatus() !=
             OnionSkinMask::ENABLED_WITHOUT_GHOST_MOVEMENTS) {
           if (m_shiftTraceGhostId == FIRST_GHOST) {
-            if (m_editingShift) {
+            if (m_editingShift || m_showShiftOrigin) {
               player.m_opacity = 30;
               players.push_back(player);
             }
@@ -470,7 +472,7 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
             player.m_placement =
                 m_onionSkinMask.getShiftTraceGhostAff(0) * player.m_placement;
           } else if (m_shiftTraceGhostId == SECOND_GHOST) {
-            if (m_editingShift) {
+            if (m_editingShift || m_showShiftOrigin) {
               player.m_opacity = 30;
               players.push_back(player);
             }
@@ -581,7 +583,8 @@ void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
   };  // locals
 
   if (m_onionSkinMask.isShiftTraceEnabled()) {
-    m_editingShift = m_onionSkinMask.isEditingShift();
+    m_editingShift    = m_onionSkinMask.isEditingShift();
+    m_showShiftOrigin = m_onionSkinMask.isShowShiftOrigin();
 
     // when visiting the subxsheet, valuate the subxsheet column index
     bool isCurrent = (subSheetColIndex >= 0)

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -183,6 +183,7 @@ public:
   double m_fade;
 
   ShiftTraceGhostId m_shiftTraceGhostId;
+  bool m_editingShift;
 
   bool m_camera3d;
   OnionSkinMask m_onionSkinMask;
@@ -274,6 +275,7 @@ StageBuilder::StageBuilder()
     , m_ancestorColumnIndex(-1)
     , m_fade(0)
     , m_shiftTraceGhostId(NO_GHOST)
+    , m_editingShift(false)
     , m_currentXsheetLevel(0)
     , m_xsheetLevel(0)
     , m_currentDrawingOnTop(false) {
@@ -459,15 +461,19 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         if (m_onionSkinMask.getShiftTraceStatus() !=
             OnionSkinMask::ENABLED_WITHOUT_GHOST_MOVEMENTS) {
           if (m_shiftTraceGhostId == FIRST_GHOST) {
-            player.m_opacity = 30;
-            players.push_back(player);
+            if (m_editingShift) {
+              player.m_opacity = 30;
+              players.push_back(player);
+            }
             player.m_opacity           = opacity;
             player.m_onionSkinDistance = -1;
             player.m_placement =
                 m_onionSkinMask.getShiftTraceGhostAff(0) * player.m_placement;
           } else if (m_shiftTraceGhostId == SECOND_GHOST) {
-            player.m_opacity = 30;
-            players.push_back(player);
+            if (m_editingShift) {
+              player.m_opacity = 30;
+              players.push_back(player);
+            }
             player.m_opacity           = opacity;
             player.m_onionSkinDistance = 1;
             player.m_placement =
@@ -575,6 +581,8 @@ void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
   };  // locals
 
   if (m_onionSkinMask.isShiftTraceEnabled()) {
+    m_editingShift = m_onionSkinMask.isEditingShift();
+
     // when visiting the subxsheet, valuate the subxsheet column index
     bool isCurrent = (subSheetColIndex >= 0)
                          ? (subSheetColIndex == m_currentColumnIndex)


### PR DESCRIPTION
When using Shift and Trace, the original position is now only shown when you `Edit Shift`.

For those that still want to see the original position, a new `View` -> `Show Shift Origin` option is available.

![image](https://github.com/tahoma2d/tahoma2d/assets/19245851/0bf04f65-62cc-4c67-a58d-600134fe3315)

