### PR TITLE
Update Github Actions for Node 20

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -16,12 +16,12 @@ jobs:
             cc: clang
             cxx: clang++
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           ci-scripts/linux/tahoma-install.sh
           sudo apt-get install ccache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             /home/runner/.ccache

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -6,7 +6,7 @@ jobs:
   macOS:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install Dependencies
@@ -14,7 +14,7 @@ jobs:
           ci-scripts/osx/tahoma-install.sh
           brew install ccache
           mkdir /Users/runner/.ccache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             /Users/runner/.ccache

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -6,7 +6,7 @@ jobs:
   Windows:
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install Dependencies
@@ -15,7 +15,7 @@ jobs:
           choco install ccache
           copy C:\ProgramData\chocolatey\lib\ccache\tools\ccache*\ccache.exe C:\ProgramData\chocolatey\bin\cl.exe
           mkdir %LOCALAPPDATA%\ccache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/AppData/Local/ccache
@@ -33,7 +33,7 @@ jobs:
         run: |
           ci-scripts\windows\tahoma-get3rdpartyapps.bat
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build Tahoma2D
         run: |
           ci-scripts\windows\tahoma-build.bat


### PR DESCRIPTION
This fixes the following Github Actions warning on all platform builds:

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3, microsoft/setup-msbuild@v1.1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`
