### PR TITLE
Timeline/Xsheet Folders

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2362,9 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #7692a1;
   qproperty-SoundColumnHlColor: #34FE5E;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
-  qproperty-FolderColumnColor: #e7c9a9;
-  qproperty-FolderColumnBorderColor: #dcb081;
-  qproperty-SelectedFolderColumnColor: #fbcdbe;
+  qproperty-FolderColumnColor: #c4a972;
+  qproperty-FolderColumnBorderColor: #b5934e;
+  qproperty-SelectedFolderColumnColor: #dbaf8b;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2362,6 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #7692a1;
   qproperty-SoundColumnHlColor: #34FE5E;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
+  qproperty-FolderColumnColor: #e7c9a9;
+  qproperty-FolderColumnBorderColor: #dcb081;
+  qproperty-SelectedFolderColumnColor: #fbcdbe;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -2362,9 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #7692a1;
   qproperty-SoundColumnHlColor: #34FE5E;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
-  qproperty-FolderColumnColor: #e7c9a9;
-  qproperty-FolderColumnBorderColor: #dcb081;
-  qproperty-SelectedFolderColumnColor: #fbcdbe;
+  qproperty-FolderColumnColor: #c4a972;
+  qproperty-FolderColumnBorderColor: #b5934e;
+  qproperty-SelectedFolderColumnColor: #dbaf8b;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -2362,6 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #7692a1;
   qproperty-SoundColumnHlColor: #34FE5E;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
+  qproperty-FolderColumnColor: #e7c9a9;
+  qproperty-FolderColumnBorderColor: #dcb081;
+  qproperty-SelectedFolderColumnColor: #fbcdbe;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2362,6 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #a8b2c0;
   qproperty-SoundColumnHlColor: #f5ffe6;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
+  qproperty-FolderColumnColor: #e7c9a9;
+  qproperty-FolderColumnBorderColor: #cfa375;
+  qproperty-SelectedFolderColumnColor: #d2a9a1;
   qproperty-ActiveCameraColor: #79b5ee;
   qproperty-SelectedActiveCameraColor: #869bd1;
   qproperty-OtherCameraColor: #6eb7c2;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -2362,9 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #7692a1;
   qproperty-SoundColumnHlColor: #34FE5E;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
-  qproperty-FolderColumnColor: #e7c9a9;
-  qproperty-FolderColumnBorderColor: #dcb081;
-  qproperty-SelectedFolderColumnColor: #fbcdbe;
+  qproperty-FolderColumnColor: #c4a972;
+  qproperty-FolderColumnBorderColor: #b5934e;
+  qproperty-SelectedFolderColumnColor: #dbaf8b;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -2362,6 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #7692a1;
   qproperty-SoundColumnHlColor: #34FE5E;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
+  qproperty-FolderColumnColor: #e7c9a9;
+  qproperty-FolderColumnBorderColor: #dcb081;
+  qproperty-SelectedFolderColumnColor: #fbcdbe;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Medium/less/Medium.less
+++ b/stuff/config/qss/Medium/less/Medium.less
@@ -461,7 +461,7 @@
 @xsheet-SoundColumnHL-color:                #34FE5E;
 @xsheet-SoundColumnTrack-color:             rgba(0,0,0,0.8);
 @xsheet-SoundPreviewTool-color:             darken(@xsheet-SoundColumnTrack-color, 20);
-@xsheet-FolderColumn-color:                 #e7c9a9;
+@xsheet-FolderColumn-color:                 #c4a972;
 @xsheet-ActiveCamera-color:                 #4073a3;
 @xsheet-OtherCamera-color:                  #5e9aa3;
 

--- a/stuff/config/qss/Medium/less/Medium.less
+++ b/stuff/config/qss/Medium/less/Medium.less
@@ -461,6 +461,7 @@
 @xsheet-SoundColumnHL-color:                #34FE5E;
 @xsheet-SoundColumnTrack-color:             rgba(0,0,0,0.8);
 @xsheet-SoundPreviewTool-color:             darken(@xsheet-SoundColumnTrack-color, 20);
+@xsheet-FolderColumn-color:                 #e7c9a9;
 @xsheet-ActiveCamera-color:                 #4073a3;
 @xsheet-OtherCamera-color:                  #5e9aa3;
 

--- a/stuff/config/qss/Medium/less/layouts/xsheet.less
+++ b/stuff/config/qss/Medium/less/layouts/xsheet.less
@@ -155,6 +155,10 @@ XsheetViewer {
   qproperty-SoundColumnHlColor: @xsheet-SoundColumnHL-color;
   qproperty-SoundColumnTrackColor: @xsheet-SoundColumnTrack-color;
 
+  qproperty-FolderColumnColor: @xsheet-FolderColumn-color;
+  qproperty-FolderColumnBorderColor: desaturate(darken(@xsheet-FolderColumn-color, @columnBorderDarkness), @columnBorderDesaturation);
+  qproperty-SelectedFolderColumnColor: mix(shade(@xsheet-FolderColumn-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);
+ 
   qproperty-ActiveCameraColor: @xsheet-ActiveCamera-color;
   qproperty-SelectedActiveCameraColor: mix(shade(@xsheet-ActiveCamera-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);
   qproperty-OtherCameraColor: @xsheet-OtherCamera-color;

--- a/stuff/config/qss/Medium/less/themes/Light.less
+++ b/stuff/config/qss/Medium/less/themes/Light.less
@@ -211,6 +211,7 @@
 @xsheet-MeshColumn-color:                   #b8a2cf;
 @xsheet-SoundColumn-color:                  #aad6d6;
 @xsheet-SoundTextColumn-color:              #c2c2c2;
+@xsheet-FolderColumn-color:                 #e7c9a9;
 @xsheet-ActiveCamera-color:                 #79b5ee;
 @xsheet-OtherCamera-color:                  #6eb7c2;
 

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2362,9 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #98a8b5;
   qproperty-SoundColumnHlColor: #f5ffe6;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
-  qproperty-FolderColumnColor: #e7c9a9;
-  qproperty-FolderColumnBorderColor: #d6a36d;
-  qproperty-SelectedFolderColumnColor: #ffd0bf;
+  qproperty-FolderColumnColor: #c4a972;
+  qproperty-FolderColumnBorderColor: #a58545;
+  qproperty-SelectedFolderColumnColor: #e1b28d;
   qproperty-ActiveCameraColor: #6491be;
   qproperty-SelectedActiveCameraColor: #899cd3;
   qproperty-OtherCameraColor: #8f9c9e;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2362,6 +2362,9 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #98a8b5;
   qproperty-SoundColumnHlColor: #f5ffe6;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
+  qproperty-FolderColumnColor: #e7c9a9;
+  qproperty-FolderColumnBorderColor: #d6a36d;
+  qproperty-SelectedFolderColumnColor: #ffd0bf;
   qproperty-ActiveCameraColor: #6491be;
   qproperty-SelectedActiveCameraColor: #899cd3;
   qproperty-OtherCameraColor: #8f9c9e;

--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -141,7 +141,10 @@ enum class PredefinedRect {
   FOOTER_NOTE_OBJ_AREA,
   FOOTER_NOTE_AREA,
   NAVIGATION_TAG_AREA,
-  CLIPPING_MASK_AREA
+  CLIPPING_MASK_AREA,
+  FOLDER_INDICATOR_AREA,
+  FOLDER_TOGGLE_ICON,
+  BUTTONS_AREA
 };
 enum class PredefinedLine {
   LOCKED,              //! dotted vertical line when cell is locked

--- a/toonz/sources/include/toonz/columnfan.h
+++ b/toonz/sources/include/toonz/columnfan.h
@@ -36,7 +36,8 @@ class DVAPI ColumnFan {
   public:
     bool m_active;
     int m_pos;
-    Column() : m_active(true), m_pos(0) {}
+    bool m_visible;
+    Column() : m_active(true), m_pos(0), m_visible(true) {}
   };
   std::vector<Column> m_columns;
   std::map<int, int> m_table;
@@ -93,9 +94,17 @@ of column identified by \b col.
 
   void saveData(TOStream &os);
   void loadData(TIStream &is);
+  void saveVisibilityData(TOStream &os);
+  void loadVisibilityData(TIStream &is);
 
   void rollLeftFoldedState(int index, int count);
   void rollRightFoldedState(int index, int count);
+
+  void hide(int col);
+  void show(int col);
+  bool isVisible(int col) const;
+
+  void initializeCol(int col);
 };
 
 #endif

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -164,7 +164,7 @@ Return true if camera stand is transparent.notice: this value is not relevant if
 camerastandVisible is off.
 \sa setCamstandTransparent()
 */
-  UCHAR getOpacity() const { return m_opacity; }
+  UCHAR getOpacity() const;
   /*!
 Set column status camera stand transparent to \b on. notice: this value is not
 relevant if camerastandVisible is off.
@@ -269,7 +269,7 @@ Set column color tag to \b colorTag.
     m_colorTag = colorTag;
   }  // Usato solo in tabkids
 
-  int getColorFilterId() const { return m_colorFilterId; }
+  int getColorFilterId() const;
   void setColorFilterId(int id) { m_colorFilterId = id; }
   void resetColumnProperties();
 
@@ -290,6 +290,8 @@ Set column color tag to \b colorTag.
   bool isFolderCamstandVisible() const;
   bool isFolderPreviewVisible() const;
   bool isFolderLocked() const;
+  UCHAR getFolderOpacity() const;
+  int getFolderColorFilterId() const;
 
   bool loadFolderInfo(std::string tagName, TIStream &is);
   void saveFolderInfo(TOStream &os);

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -276,7 +276,7 @@ Set column color tag to \b colorTag.
   // Folder management
   int setFolderId(int value);
   void setFolderId(int value, int position);
-  int getFolderId() const;
+  int getFolderId(int position = -1) const;
   QStack<int> getFolderIdStack() const { return m_folderId; }
   void setFolderIdStack(QStack<int> folderIdStack);
   void removeFolderId(int position);

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -276,7 +276,7 @@ Set column color tag to \b colorTag.
   // Folder management
   int setFolderId(int value);
   void setFolderId(int value, int position);
-  int getFolderId();
+  int getFolderId() const;
   QStack<int> getFolderIdStack() const { return m_folderId; }
   void setFolderIdStack(QStack<int> folderIdStack);
   void removeFolderId(int position);
@@ -285,6 +285,11 @@ Set column color tag to \b colorTag.
   bool isContainedInFolder(int folderId);
   void removeFromAllFolders();
   int folderDepth();
+
+  TXshColumn *getFolderColumn() const;
+  bool isFolderCamstandVisible() const;
+  bool isFolderPreviewVisible() const;
+  bool isFolderLocked() const;
 
   bool loadFolderInfo(std::string tagName, TIStream &is);
   void saveFolderInfo(TOStream &os);

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -10,6 +10,7 @@
 #include <QPair>
 #include <QString>
 #include <QMap>
+#include <QStack>
 
 #undef DVAPI
 #undef DVVAR
@@ -30,6 +31,7 @@ class TXshCellColumn;
 class TXshPaletteColumn;
 class TXshZeraryFxColumn;
 class TXshMeshColumn;
+class TXshFolderColumn;
 class TXsheet;
 class TXshCell;
 class TFx;
@@ -67,6 +69,9 @@ class DVAPI TXshColumn : public TColumnHeader, public TPersist {
   TXsheet *m_xsheet;
   int m_colorTag;  // Usato solo in tabkids
   UCHAR m_opacity;
+
+  QStack<int> m_folderId;
+  int m_folderSelector;
 
 public:
 private:
@@ -106,6 +111,7 @@ Constructs a TXshColumn with default value.
       , m_colorTag(0)
       , m_opacity(255)
       , m_colorFilterId(0)  // None
+      , m_folderSelector(-1)
   {}
 
   enum ColumnType {
@@ -114,7 +120,8 @@ Constructs a TXshColumn with default value.
     eSoundTextType,
     eZeraryFxType,
     ePaletteType,
-    eMeshType
+    eMeshType,
+    eFolderType
   };
 
   virtual ColumnType getColumnType() const = 0;
@@ -135,6 +142,7 @@ Constructs a TXshColumn with default value.
   virtual TXshPaletteColumn *getPaletteColumn() { return 0; }
   virtual TXshZeraryFxColumn *getZeraryFxColumn() { return 0; }
   virtual TXshMeshColumn *getMeshColumn() { return 0; }
+  virtual TXshFolderColumn *getFolderColumn() { return 0; }
 
   virtual int getMaxFrame(bool ignoreLastStop = false) const = 0;
 
@@ -264,6 +272,22 @@ Set column color tag to \b colorTag.
   int getColorFilterId() const { return m_colorFilterId; }
   void setColorFilterId(int id) { m_colorFilterId = id; }
   void resetColumnProperties();
+
+  // Folder management
+  int setFolderId(int value);
+  void setFolderId(int value, int position);
+  int getFolderId();
+  QStack<int> getFolderIdStack() const { return m_folderId; }
+  void setFolderIdStack(QStack<int> folderIdStack);
+  void removeFolderId(int position);
+  int removeFolderId();
+  bool isInFolder();
+  bool isContainedInFolder(int folderId);
+  void removeFromAllFolders();
+  int folderDepth();
+
+  bool loadFolderInfo(std::string tagName, TIStream &is);
+  void saveFolderInfo(TOStream &os);
 };
 
 #ifdef _WIN32

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -604,6 +604,10 @@ in TXsheetImp.
   bool isCurrentDrawingOnTop() { return m_currentDrawingOnTop; }
   void setCurrentDrawingOnTop(bool onTop) { m_currentDrawingOnTop = onTop; }
 
+  int getNewFolderId();
+  bool isFolderColumn(int col);
+  void openCloseFolder(int folderCol, bool openFolder);
+
 protected:
   bool checkCircularReferences(TXsheet *childCandidate);
 

--- a/toonz/sources/include/toonz/txshfoldercolumn.h
+++ b/toonz/sources/include/toonz/txshfoldercolumn.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#ifndef TXSHFOLDERCOLUMN_INCLUDED
+#define TXSHFOLDERCOLUMN_INCLUDED
+
+#include "toonz/txshcolumn.h"
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZLIB_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+
+//=============================================================================
+//! The TXshFolderColumn class provides a folder column in xsheet and allows
+//! its management through cell concept.
+/*!Inherits \b TXshCellColumn. */
+//=============================================================================
+
+class DVAPI TXshFolderColumn final : public TXshCellColumn {
+  PERSIST_DECLARATION(TXshFolderColumn)
+
+  int m_folderColumnFolderId;
+  bool m_expanded;
+
+public:
+  TXshFolderColumn();
+  ~TXshFolderColumn();
+
+  TXshColumn::ColumnType getColumnType() const override;
+  TXshFolderColumn *getFolderColumn() override { return this; }
+
+  // Technically level folder columns are always empty but needs to be regarded
+  // as not
+  bool isEmpty() const override { return false; }
+
+  bool canSetCell(const TXshCell &cell) const override;
+
+  TXshColumn *clone() const override;
+
+  void loadData(TIStream &is) override;
+  void saveData(TOStream &os) override;
+
+  bool isExpanded() { return m_expanded; }
+  void setExpanded(bool expanded) { m_expanded = expanded; }
+
+  int getFolderColumnFolderId() { return m_folderColumnFolderId; }
+  void setFolderColumnFolderId(int folderId) {
+    m_folderColumnFolderId = folderId;
+  }
+};
+
+#ifdef _WIN32
+template class DV_EXPORT_API TSmartPointerT<TXshFolderColumn>;
+#endif
+typedef TSmartPointerT<TXshFolderColumn> TXshFolderColumnP;
+
+#endif  // TXSHFOLDERCOLUMN_INCLUDED

--- a/toonz/sources/include/toonz/txshleveltypes.h
+++ b/toonz/sources/include/toonz/txshleveltypes.h
@@ -27,7 +27,8 @@ enum TXshLevelType {
   PLT_XSHLEVEL      = 2 << 7,
   SND_XSHLEVEL      = 3 << 7,
   SND_TXT_XSHLEVEL  = 4 << 7,
-  MESH_XSHLEVEL     = 5 << 7
+  MESH_XSHLEVEL     = 5 << 7,
+  FOLDER_XSHLEVEL   = 6 << 7
 };
 
 #endif

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -785,7 +785,8 @@ bool EditTool::doesApply() const {
       TTool::getApplication()->getCurrentObject()->getObjectId();
   if (objId.isColumn()) {
     TXshColumn *column = xsh->getColumn(objId.getIndex());
-    if (column && column->getSoundColumn()) return false;
+    if (column && (column->getSoundColumn() || column->getFolderColumn()))
+      return false;
   }
   return true;
 }
@@ -1714,6 +1715,11 @@ QString EditTool::updateEnabled(int rowIndex, int columnIndex) {
     return (enable(false),
             QObject::tr(
                 "Note columns can only be edited in the xsheet or timeline."));
+
+  else if (column->getFolderColumn())
+    return (enable(false),
+            QObject::tr("It is not possible to edit the folder column."));
+
 
   // Enable to control Fx gadgets even on the locked or hidden columns
   if (m_fxGadgetController && m_fxGadgetController->hasGadget())

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -306,7 +306,8 @@ bool SkeletonTool::doesApply() const {
   TStageObjectId objId = app->getCurrentObject()->getObjectId();
   if (objId.isColumn()) {
     TXshColumn *column = xsh->getColumn(objId.getIndex());
-    if (column && column->getSoundColumn()) return false;
+    if (column && (column->getSoundColumn() || column->getFolderColumn()))
+      return false;
   }
   return true;
 }

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -917,12 +917,13 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
   // find the nearest level before it
   if (levelType == NO_XSHLEVEL &&
       !m_application->getCurrentFrame()->isEditingLevel()) {
-      if (!column || (column && !column->getSoundColumn())) {
-          TXshCell cell = xsh->getCell(rowIndex, columnIndex);
-          xl = cell.isEmpty() ? 0 : (TXshLevel*)(&cell.m_level);
-          sl = cell.isEmpty() ? 0 : cell.getSimpleLevel();
-          levelType = cell.isEmpty() ? NO_XSHLEVEL : cell.m_level->getType();
-      }
+    if (!column ||
+        (column && !column->getSoundColumn() && !column->getFolderColumn())) {
+      TXshCell cell = xsh->getCell(rowIndex, columnIndex);
+      xl            = cell.isEmpty() ? 0 : (TXshLevel *)(&cell.m_level);
+      sl            = cell.isEmpty() ? 0 : cell.getSimpleLevel();
+      levelType     = cell.isEmpty() ? NO_XSHLEVEL : cell.m_level->getType();
+    }
   }
 
   bool spline = m_application->getCurrentObject()->isSpline();
@@ -939,7 +940,8 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
     // find the nearest level before it
     if (levelType == NO_XSHLEVEL &&
         !m_application->getCurrentFrame()->isEditingLevel()) {
-        if (!column || (column && !column->getSoundColumn())) {
+      if (!column ||
+          (column && !column->getSoundColumn() && !column->getFolderColumn())) {
             int r0, r1;
             xsh->getCellRange(columnIndex, r0, r1);
             for (int r = std::min(r1, rowIndex); r > r0; r--) {
@@ -1016,6 +1018,10 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
           enable(false),
           QObject::tr(
               "Note columns can only be edited in the xsheet or timeline."));
+
+    else if (column->getFolderColumn())
+      return (enable(false),
+              QObject::tr("It is not possible to edit the folder column."));
 
     if (toolType == TTool::ColumnTool) {
       // Check column target

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -985,7 +985,8 @@ void ArrowToolOptionsBox::updateStageObjectComboItems() {
     if (id == xsh->getStageObjectTree()->getMotionPathViewerId()) continue;
     if (id.isColumn()) {
       int columnIndex = id.getIndex();
-      if (xsh->isColumnEmpty(columnIndex)) continue;
+      if (xsh->isColumnEmpty(columnIndex) || xsh->isFolderColumn(columnIndex))
+        continue;
     }
     TStageObject *pegbar = xsh->getStageObject(id);
     QString itemName     = (id.isTable())

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2389,7 +2389,7 @@ void TCellSelection::pasteDuplicateCells() {
         int levelType = level->getType();
         if (levelType == ZERARYFX_XSHLEVEL || levelType == PLT_XSHLEVEL ||
             levelType == SND_XSHLEVEL || levelType == SND_TXT_XSHLEVEL ||
-            levelType == MESH_XSHLEVEL) {
+            levelType == MESH_XSHLEVEL || levelType == FOLDER_XSHLEVEL) {
           DVGui::warning(
               QObject::tr("Cannot duplicate a drawing in the current column"));
           return;
@@ -2862,7 +2862,7 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
     int levelType = level->getType();
     if (levelType == ZERARYFX_XSHLEVEL || levelType == PLT_XSHLEVEL ||
         levelType == SND_XSHLEVEL || levelType == SND_TXT_XSHLEVEL ||
-        levelType == MESH_XSHLEVEL) {
+        levelType == MESH_XSHLEVEL || levelType == FOLDER_XSHLEVEL) {
       if (!multiple)
         DVGui::warning(
             QObject::tr("Cannot create a blank drawing on the current column"));
@@ -3033,7 +3033,8 @@ void TCellSelection::stopFrameHold(int row, int col, bool multiple) {
   }
   if (level) {
     int levelType = level->getType();
-    if (levelType == SND_XSHLEVEL || levelType == SND_TXT_XSHLEVEL) {
+    if (levelType == SND_XSHLEVEL || levelType == SND_TXT_XSHLEVEL ||
+        levelType == FOLDER_XSHLEVEL) {
       if (!multiple)
         DVGui::warning(QObject::tr(
             "Cannot create a stop frame hold on the current column"));
@@ -3127,7 +3128,7 @@ void TCellSelection::duplicateFrame(int row, int col, bool multiple) {
     int levelType = level->getType();
     if (levelType == ZERARYFX_XSHLEVEL || levelType == PLT_XSHLEVEL ||
         levelType == SND_XSHLEVEL || levelType == SND_TXT_XSHLEVEL ||
-        levelType == MESH_XSHLEVEL) {
+        levelType == MESH_XSHLEVEL || levelType == FOLDER_XSHLEVEL) {
       if (!multiple)
         DVGui::warning(
             QObject::tr("Cannot duplicate a drawing in the current column"));
@@ -4299,7 +4300,7 @@ void TCellSelection::fillEmptyCell() {
   for (c = c0; c <= c1; c++) {
     TXshColumn *column = xsh->getColumn(c);
     if (!column || column->isEmpty() || column->isLocked() ||
-        column->getSoundColumn())
+        column->getSoundColumn() || column->getFolderColumn())
       continue;
 
     for (r = r1; r >= r0; r--) {

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1462,6 +1462,8 @@ void TCellSelection::setKeyframes() {
 
   int row = m_range.m_r0, col = m_range.m_c0;
 
+  if (xsh->getColumn(col) && xsh->getColumn(col)->getFolderColumn()) return;
+
   const TXshCell &cell = xsh->getCell(row, col);
   if (cell.getSoundLevel() || cell.getSoundTextLevel()) return;
 

--- a/toonz/sources/toonz/columncommand.h
+++ b/toonz/sources/toonz/columncommand.h
@@ -54,6 +54,8 @@ bool checkExpressionReferences(const std::set<int> &indices,
 // checkInvert is always true for collapsing in stage schematic
 bool checkExpressionReferences(const QList<TStageObjectId> &objects);
 
+void groupColumns(const std::set<int> &indices);
+void ungroupColumns(const std::set<int> &indices);
 }  // namespace ColumnCmd
 
 #endif

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -98,6 +98,8 @@ void TColumnSelection::enableCommands() {
   enableCommand(this, MI_ReframeWithEmptyInbetweens,
                 &TColumnSelection::reframeWithEmptyInbetweens);
   enableCommand(this, MI_Autorenumber, &TColumnSelection::renumberColumns);
+  enableCommand(this, MI_Group, &TColumnSelection::groupColumns);
+  enableCommand(this, MI_Ungroup, &TColumnSelection::ungroupColumns);
 }
 //-----------------------------------------------------------------------------
 
@@ -207,6 +209,18 @@ void TColumnSelection::insertColumns() {
     selectColumn(col, true);
   }
   ColumnCmd::insertEmptyColumns(m_indices, true);
+}
+
+//-----------------------------------------------------------------------------
+
+void TColumnSelection::groupColumns() {
+  ColumnCmd::groupColumns(m_indices);
+}
+
+//-----------------------------------------------------------------------------
+
+void TColumnSelection::ungroupColumns() {
+  ColumnCmd::ungroupColumns(m_indices);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/columnselection.h
+++ b/toonz/sources/toonz/columnselection.h
@@ -39,6 +39,8 @@ public:
   void cutColumns();
   void insertColumns();
   void insertColumnsBelow();
+  void groupColumns();
+  void ungroupColumns();
 
   void collapse();
   void explodeChild();

--- a/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_down.svg
+++ b/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_down.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40px"
+   height="30px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg7"
+   sodipodi:docname="folder_arrow_v.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs11">
+        
+        
+    </defs><sodipodi:namedview
+   id="namedview9"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:zoom="23.966667"
+   inkscape:cx="20.006954"
+   inkscape:cy="14.979137"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg7"><inkscape:grid
+     type="xygrid"
+     id="grid828" /></sodipodi:namedview>
+    <rect
+   id="rect4"
+   x="0"
+   y="0"
+   width="40"
+   height="30"
+   style="fill-opacity:0" />
+<g
+   id="g6"
+   style="clip-rule:evenodd;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#010101;stroke-linejoin:round;stroke-miterlimit:2;stroke-opacity:1"
+   transform="matrix(0,-1,-1,0,34.499942,29.499999)"><path
+     id="path10"
+     d="M 8,14.979138 21,26 V 3 Z"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#010101;stroke-opacity:1"
+     sodipodi:nodetypes="cccc" /></g></svg>

--- a/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_left.svg
+++ b/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_left.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40px"
+   height="30px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg7"
+   sodipodi:docname="folder_arrow_left.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs11">
+        
+        
+    </defs><sodipodi:namedview
+   id="namedview9"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:zoom="23.966667"
+   inkscape:cx="20.006954"
+   inkscape:cy="14.979137"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg7"><inkscape:grid
+     type="xygrid"
+     id="grid1910" /></sodipodi:namedview>
+    <rect
+   id="rect4"
+   x="0"
+   y="0"
+   width="40"
+   height="30"
+   style="fill-opacity:0" /><g
+   id="g6"
+   style="fill:#ffffff;fill-opacity:1;stroke:#010101;stroke-opacity:1"
+   transform="translate(5.3388213,0.49993597)">
+            <path
+   id="path10"
+   d="M 8,14.979138 21,26 V 3 Z"
+   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#010101;stroke-opacity:1"
+   sodipodi:nodetypes="cccc" />
+        </g>
+</svg>

--- a/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_right.svg
+++ b/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_right.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40px"
+   height="30px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg7"
+   sodipodi:docname="folder_arrow_h.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs11">
+        
+        
+    </defs><sodipodi:namedview
+   id="namedview9"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:zoom="23.966667"
+   inkscape:cx="20.006954"
+   inkscape:cy="14.979137"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg7"><inkscape:grid
+     type="xygrid"
+     id="grid1910" /></sodipodi:namedview>
+    <rect
+   id="rect4"
+   x="0"
+   y="0"
+   width="40"
+   height="30"
+   style="fill-opacity:0" /><g
+   id="g6"
+   style="fill:#ffffff;fill-opacity:1;stroke:#010101;stroke-opacity:1"
+   transform="matrix(-1,0,0,1,34.5,0.49993597)">
+            <path
+   id="path10"
+   d="M 8,14.979138 21,26 V 3 Z"
+   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#010101;stroke-opacity:1"
+   sodipodi:nodetypes="cccc" />
+        </g>
+</svg>

--- a/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_up.svg
+++ b/toonz/sources/toonz/icons/dark/actions/30/folder_arrow_up.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40px"
+   height="30px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg7"
+   sodipodi:docname="folder_arrow_up.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs11">
+        
+        
+    </defs><sodipodi:namedview
+   id="namedview9"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:zoom="23.966667"
+   inkscape:cx="20.006954"
+   inkscape:cy="14.979137"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg7"><inkscape:grid
+     type="xygrid"
+     id="grid828" /></sodipodi:namedview>
+    <rect
+   id="rect4"
+   x="0"
+   y="0"
+   width="40"
+   height="30"
+   style="fill-opacity:0" />
+<g
+   id="g6"
+   style="clip-rule:evenodd;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#010101;stroke-linejoin:round;stroke-miterlimit:2;stroke-opacity:1"
+   transform="rotate(90,16.999984,17.499958)"><path
+     id="path10"
+     d="M 8,14.979138 21,26 V 3 Z"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#010101;stroke-opacity:1"
+     sodipodi:nodetypes="cccc" /></g></svg>

--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -115,7 +115,8 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
     int col      = c0 + pos.second;
     positions.insert(std::make_pair(row, col));
     TXshColumn *column = xsh->getColumn(col);
-    if (column && column->getSoundColumn()) continue;
+    if (column && (column->getSoundColumn() || column->getFolderColumn()))
+      continue;
     TStageObject *pegbar = xsh->getStageObject(
         col >= 0 ? TStageObjectId::ColumnId(col) : cameraId);
     if (xsh->getColumn(col) && xsh->getColumn(col)->isLocked()) continue;

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2104,6 +2104,9 @@ void MainWindow::defineActions() {
           tr("Motion paths can be used as animation guides, or you can animate "
              "objects along a motion path."));
 
+  createMenuLevelAction(MI_NewFolder, QT_TR_NOOP("New Folder"), "",
+                        "");
+
   // Menu - Scene
 
   createMenuXsheetAction(MI_SceneSettings, QT_TR_NOOP("&Scene Settings..."), "",

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2545,6 +2545,8 @@ void MainWindow::defineActions() {
                              "toggle_sub_nav");
   createRightClickMenuAction(MI_ToggleXsheetCameraColumn,
                              QT_TR_NOOP("Show/Hide Camera Column"), "");
+  createRightClickMenuAction(MI_ToggleOpenCloseFolder,
+                             QT_TR_NOOP("Open/Close Folder"), "");
   createRightClickMenuAction(MI_SetKeyframes, QT_TR_NOOP("&Set Key"), "Z",
                              "set_key");
   createRightClickMenuAction(MI_ShiftKeyframesDown,

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -455,6 +455,8 @@ void TopBar::loadMenubar() {
     addMenuItem(newMenu, MI_NewToonzRasterLevel);
     addMenuItem(newMenu, MI_NewVectorLevel);
     addMenuItem(newMenu, MI_NewNoteLevel);
+    newMenu->addSeparator();
+    addMenuItem(newMenu, MI_NewFolder);
   }
   addMenuItem(levelMenu, MI_LoadLevel);
   addMenuItem(levelMenu, MI_SaveLevel);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -336,6 +336,7 @@
 #define MI_FoldColumns "MI_FoldColumns"
 #define MI_ToggleXsheetCameraColumn "MI_ToggleXsheetCameraColumn"
 #define MI_ToggleCurrentTimeIndicator "MI_ToggleCurrentTimeIndicator"
+#define MI_ToggleOpenCloseFolder "MI_ToggleOpenCloseFolder"
 
 #define MI_LoadIntoCurrentPalette "MI_LoadIntoCurrentPalette"
 #define MI_AdjustCurrentLevelToPalette "MI_AdjustCurrentLevelToPalette"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -522,4 +522,6 @@
 
 #define MI_OpenAlignmentPanel "MI_OpenAlignmentPanel"
 
+#define MI_NewFolder "MI_NewFolder"
+
 #endif

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -398,7 +398,12 @@
 		<file>icons/dark/actions/30/sound_header_on.svg</file>
 		<file>icons/dark/actions/74/notelevel.svg</file>
 
-		<file>icons/dark/actions/16/connect.svg</file>
+		<file>icons/dark/actions/30/folder_arrow_left.svg</file>
+		<file>icons/dark/actions/30/folder_arrow_right.svg</file>
+		<file>icons/dark/actions/30/folder_arrow_up.svg</file>
+		<file>icons/dark/actions/30/folder_arrow_down.svg</file>
+
+ 		<file>icons/dark/actions/16/connect.svg</file>
 		<file>icons/dark/actions/16/disconnect.svg</file>
 		<file>icons/dark/actions/16/xsheet_connect.svg</file>
 		<file>icons/dark/actions/16/xsheet_disconnect.svg</file>

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -124,6 +124,7 @@ class CellArea final : public QWidget {
   void drawSoundCell(QPainter &p, int row, int col, bool isReference = false);
   void drawSoundTextColumn(QPainter &p, int r0, int r1, int col);
   void drawPaletteCell(QPainter &p, int row, int col, bool isReference = false);
+  void drawFolderColumn(QPainter &p, int r0, int r1, int col);
 
   void drawKeyframe(QPainter &p, const QRect toBeUpdated);
   void drawKeyframeLine(QPainter &p, int col, const NumberRange &rows) const;

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3549,7 +3549,8 @@ void ColumnArea::mouseMoveEvent(QMouseEvent *event) {
                  .adjusted(0, indicatorYAdj, 0, indicatorYAdj)
                  .contains(mouseInCell)) {
     if (o->isVerticalTimeline()) {
-      if (column && column->getFolderColumn())
+      if (column && column->getFolderColumn() &&
+          Preferences::instance()->getXsheetLayoutPreference() == "Minimum")
         m_tooltip =
             tr("Click to select column, drag to move it, double-click to edit, "
                "long press to open/close");

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1348,8 +1348,7 @@ void ColumnArea::DrawHeader::drawColumnName() const {
   QRect indicatorRect = o->rect(PredefinedRect::FOLDER_INDICATOR_AREA);
   if (column && column->folderDepth()) {
     if (!o->isVerticalTimeline())
-      columnName.adjust(indicatorRect.width() * column->folderDepth(), 0,
-                        indicatorRect.width() * column->folderDepth(), 0);
+      columnName.adjust(indicatorRect.width() * column->folderDepth(), 0, 0, 0);
     else
       columnName.adjust(0, indicatorRect.height() * column->folderDepth(), 0,
                         indicatorRect.height() * column->folderDepth());

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -976,7 +976,7 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
                                  : PredefinedRect::LAYER_HEADER)
                    .translated(orig);
   if (!o->isVerticalTimeline())
-    rect.adjust(73, 0, m_viewer->getTimelineBodyOffset(), 0);
+    rect.adjust(isEmpty ? 0 : 73, 0, m_viewer->getTimelineBodyOffset(), 0);
   else
     rect.adjust(0, 0, 0, m_viewer->getXsheetBodyOffset());
   // Adjust for folder indicator
@@ -985,7 +985,8 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
   if (column && column->folderDepth() && !o->isVerticalTimeline()) {
     folderDepth = column->folderDepth();
     rect.adjust(indicatorRect.width() * folderDepth, 0, 0, 0);
-  } else if (col >= 0 && (!column || column->isEmpty()))
+  } else if (col >= 0 && o->isVerticalTimeline() &&
+             (!column || column->isEmpty()))
     rect.adjust(0, 0, 0, m_viewer->getXsheetBodyOffset());
 
   int x0 = rect.left();

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -978,8 +978,13 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
   if (!o->isVerticalTimeline()) rect.adjust(73, 0, 0, 0);
   // Adjust for folder indicator
   QRect indicatorRect = o->rect(PredefinedRect::FOLDER_INDICATOR_AREA);
-  if (column && column->folderDepth() && !o->isVerticalTimeline())
-    rect.adjust(indicatorRect.width() * column->folderDepth(), 0, 0, 0);
+  if (column && column->folderDepth()) {
+    if (!o->isVerticalTimeline())
+      rect.adjust(indicatorRect.width() * column->folderDepth(), 0, 0, 0);
+    else if (Preferences::instance()->getXsheetLayoutPreference() ==
+             QString("Minimum"))
+      rect.adjust(0, 0, 0, indicatorRect.height() * column->folderDepth());
+  }
 
   int x0 = rect.left();
   int x1 = rect.right();

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1006,10 +1006,11 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
         o->flag(PredefinedFlag::DRAG_LAYER_VISIBLE)) {
       // column handle
       QRect sideBar =
-          o->rect(PredefinedRect::DRAG_LAYER)
-              .translated(x0 - 73 - (indicatorRect.width() * folderDepth), y0);
+          o->rect(PredefinedRect::DRAG_LAYER).translated(x0 - 73, y0);
       if (!o->isVerticalTimeline())
-        sideBar.adjust(0, 0, m_viewer->getTimelineBodyOffset(), 0);
+        sideBar.adjust(0, 0, m_viewer->getTimelineBodyOffset() -
+                                 (indicatorRect.width() * folderDepth),
+                       0);
 
       if (o->flag(PredefinedFlag::DRAG_LAYER_BORDER)) {
         p.setPen(m_viewer->getVerticalLineColor());

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -978,12 +978,14 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
   if (!o->isVerticalTimeline()) rect.adjust(73, 0, 0, 0);
   // Adjust for folder indicator
   QRect indicatorRect = o->rect(PredefinedRect::FOLDER_INDICATOR_AREA);
+  int folderDepth     = 0;
   if (column && column->folderDepth()) {
+    folderDepth = column->folderDepth();
     if (!o->isVerticalTimeline())
-      rect.adjust(indicatorRect.width() * column->folderDepth(), 0, 0, 0);
+      rect.adjust(indicatorRect.width() * folderDepth, 0, 0, 0);
     else if (Preferences::instance()->getXsheetLayoutPreference() ==
              QString("Minimum"))
-      rect.adjust(0, 0, 0, indicatorRect.height() * column->folderDepth());
+      rect.adjust(0, 0, 0, indicatorRect.height() * folderDepth);
   }
 
   int x0 = rect.left();
@@ -1003,7 +1005,9 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
     if (Preferences::instance()->isShowDragBarsEnabled() &&
         o->flag(PredefinedFlag::DRAG_LAYER_VISIBLE)) {
       // column handle
-      QRect sideBar = o->rect(PredefinedRect::DRAG_LAYER).translated(x0 - 80, y0);
+      QRect sideBar =
+          o->rect(PredefinedRect::DRAG_LAYER)
+              .translated(x0 - 73 - (indicatorRect.width() * folderDepth), y0);
 
       if (o->flag(PredefinedFlag::DRAG_LAYER_BORDER)) {
         p.setPen(m_viewer->getVerticalLineColor());

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -975,7 +975,7 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
   QRect rect = o->rect((col < 0) ? PredefinedRect::CAMERA_LAYER_HEADER
                                  : PredefinedRect::LAYER_HEADER)
                    .translated(orig);
-  if (!o->isVerticalTimeline()) rect.adjust(80, 0, 0, 0);
+  if (!o->isVerticalTimeline()) rect.adjust(73, 0, 0, 0);
   // Adjust for folder indicator
   QRect indicatorRect = o->rect(PredefinedRect::FOLDER_INDICATOR_AREA);
   if (column && column->folderDepth() && !o->isVerticalTimeline())

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3493,9 +3493,15 @@ void ColumnArea::mouseMoveEvent(QMouseEvent *event) {
       indicatorYAdj = indicatorRect.height() * column->folderDepth();
   }
 
-  if (col < 0)
-    m_tooltip = tr("Click to select camera");
-  else if (o->rect(PredefinedRect::DRAG_LAYER)
+  m_tooltip = "";
+  if (col < 0) {
+    if (o->rect(PredefinedRect::CAMERA_LOCK_AREA).contains(mouseInCell)) {
+      m_tooltip = tr("Lock Toggle");
+    } else if (o->rect(PredefinedRect::CAMERA_CONFIG_AREA)
+                   .contains(mouseInCell)) {
+      m_tooltip = tr("Click to select camera");
+    } 
+  } else if (o->rect(PredefinedRect::DRAG_LAYER)
                .adjusted(
                    0, indicatorYAdj,
                    (!o->isVerticalTimeline() ? m_viewer->getTimelineBodyOffset()
@@ -3570,8 +3576,6 @@ void ColumnArea::mouseMoveEvent(QMouseEvent *event) {
     } else if (Preferences::instance()->getColumnIconLoadingPolicy() ==
                Preferences::LoadOnDemand)
       m_tooltip = tr("Alt + Click to Toggle Thumbnail");
-    else
-      m_tooltip = tr("");
   }
   update();
 }

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3912,6 +3912,21 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       }
       menu.addSeparator();
     }
+
+    if (xsh->isFolderColumn(m_menuCol)) {
+      QAction *folderToggle =
+          cmdManager->getAction(MI_ToggleOpenCloseFolder);
+
+      bool isOpen = column->getFolderColumn()->isExpanded();
+      bool cameraVisible =
+          Preferences::instance()->isXsheetCameraColumnVisible();
+      if (isOpen)
+        folderToggle->setText(tr("Close Folder"));
+      else
+        folderToggle->setText(tr("Open Folder"));
+      menu.addAction(folderToggle);
+    }
+
     menu.addAction(cmdManager->getAction(MI_FoldColumns));
     if (Preferences::instance()->isShowKeyframesOnXsheetCellAreaEnabled()) {
       QAction *cameraToggle =

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3449,6 +3449,7 @@ void ColumnArea::mouseMoveEvent(QMouseEvent *event) {
     m_pos                        = event->pos();
     m_viewer->setTimelineBodyOffset(newOffset);
     m_viewer->positionSections();
+    m_viewer->refreshContentSize(0, 0);
     return;
   }
 

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -359,6 +359,7 @@ class ColumnArea final : public QWidget {
     void drawPreviewToggle(int opacity) const;
     void drawLock() const;
     void drawConfig() const;
+    void drawFolderIndicator() const;
     void drawColumnNumber() const;
     void drawColumnName() const;
     void drawThumbnail(QPixmap &iconPixmap) const;
@@ -369,6 +370,7 @@ class ColumnArea final : public QWidget {
 
     void drawSoundIcon(bool isPlaying) const;
     void drawVolumeControl(double volume) const;
+    void drawFolderStatusIcon(bool isOpen) const;
   };
 
 public:
@@ -383,6 +385,7 @@ public:
   void drawSoundColumnHead(QPainter &p, int col);
   void drawPaletteColumnHead(QPainter &p, int col);
   void drawSoundTextColumnHead(QPainter &p, int col);
+  void drawFolderColumnHead(QPainter &p, int col);
   void drawCurrentColumnFocus(QPainter &p, int col);
 
   QPixmap getColumnIcon(int columnIndex);
@@ -393,7 +396,15 @@ public:
   public:
     static const QPixmap &sound();
     static const QPixmap &soundPlaying();
+    static const QPixmap &folder_arrow_left();
+    static const QPixmap &folder_arrow_right();
+    static const QPixmap &folder_arrow_up();
+    static const QPixmap &folder_arrow_down();
   };
+
+  void toggleFolderStatus(TXshColumn *column);
+  bool getFolderStatus(int folderItemCol, int statusIndex);
+  void syncFolderColumnStatus(int folderCol, int statusIndex, bool statusValue);
 
 protected:
   void select(int columnIndex, QMouseEvent *event);

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -312,6 +312,8 @@ class ColumnArea final : public QWidget {
   QPoint m_pos;
   QString m_tooltip;
 
+  bool m_resizingHeader;
+
   RenameColumnField *m_renameColumnField;
 #ifndef LINETEST
   ChangeObjectParent *m_changeObjectParent;

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -299,6 +299,7 @@ class ColumnArea final : public QWidget {
   ColumnTransparencyPopup *m_columnTransparencyPopup;
   SoundColumnPopup *m_soundColumnPopup;
   QTimer *m_transparencyPopupTimer;
+  QTimer *m_openCloseFolderTimer;
   int m_doOnRelease;
   XsheetViewer *m_viewer;
   int m_col;
@@ -428,6 +429,7 @@ protected slots:
   void onXsheetCameraChange(int);
   void onMenuAboutToHide();
   void onResetContextMenuTarget();
+  void autoOpenCloseFolder();
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -403,8 +403,6 @@ public:
   };
 
   void toggleFolderStatus(TXshColumn *column);
-  bool getFolderStatus(int folderItemCol, int statusIndex);
-  void syncFolderColumnStatus(int folderCol, int statusIndex, bool statusValue);
 
 protected:
   void select(int columnIndex, QMouseEvent *event);

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -44,6 +44,7 @@
 #include "toonz/preferences.h"
 #include "toonz/txshlevelcolumn.h"
 #include "toonz/navigationtags.h"
+#include "toonz/txshfoldercolumn.h"
 
 // TnzQt includes
 #include "toonzqt/tselectionhandle.h"
@@ -453,7 +454,7 @@ void GlobalKeyframeUndo::doInsertGlobalKeyframes(
     TStageObjectId objectId;
 
     TXshColumn *column = xsh->getColumn(c);
-    if (column && column->getSoundColumn()) continue;
+    if (column && (column->getSoundColumn() || column->getFolderColumn())) continue;
 
     if (c == -1)
       objectId = TStageObjectId::CameraId(xsh->getCameraColumnIndex());
@@ -480,7 +481,7 @@ void GlobalKeyframeUndo::doRemoveGlobalKeyframes(
     TStageObjectId objectId;
 
     TXshColumn *column = xsh->getColumn(c);
-    if (column && column->getSoundColumn()) continue;
+    if (column && (column->getSoundColumn() || column->getFolderColumn())) continue;
 
     if (c == -1)
       objectId = TStageObjectId::CameraId(xsh->getCameraColumnIndex());
@@ -705,8 +706,8 @@ SetGlobalStopframeUndo::SetGlobalStopframeUndo(int frame,
 
     TXshColumn *xshColumn = xsh->getColumn(c);
     if (!xshColumn || xshColumn->getSoundColumn() ||
-        xshColumn->getSoundTextColumn() || xshColumn->isLocked() ||
-        xshColumn->isEmpty())
+        xshColumn->getSoundTextColumn() || xshColumn->getFolderColumn() ||
+        xshColumn->isLocked() || xshColumn->isEmpty())
       continue;
 
     TXshCellColumn *cellColumn = xshColumn->getCellColumn();
@@ -729,8 +730,8 @@ void SetGlobalStopframeUndo::redo() const {
 
     TXshColumn *xshColumn = xsh->getColumn(c);
     if (!xshColumn || xshColumn->getSoundColumn() ||
-        xshColumn->getSoundTextColumn() || xshColumn->isLocked() ||
-        xshColumn->isEmpty())
+        xshColumn->getSoundTextColumn() || xshColumn->getFolderColumn() ||
+        xshColumn->isLocked() || xshColumn->isEmpty())
       continue;
 
     TXshCellColumn *cellColumn = xshColumn->getCellColumn();
@@ -839,8 +840,8 @@ RemoveGlobalStopframeUndo::RemoveGlobalStopframeUndo(
 
     TXshColumn *xshColumn = xsh->getColumn(c);
     if (!xshColumn || xshColumn->getSoundColumn() ||
-        xshColumn->getSoundTextColumn() || xshColumn->isLocked() ||
-        xshColumn->isEmpty())
+        xshColumn->getSoundTextColumn() || xshColumn->getFolderColumn() ||
+        xshColumn->isLocked() || xshColumn->isEmpty())
       continue;
 
     TXshCellColumn *cellColumn = xshColumn->getCellColumn();
@@ -863,8 +864,8 @@ void RemoveGlobalStopframeUndo::redo() const {
 
     TXshColumn *xshColumn = xsh->getColumn(c);
     if (!xshColumn || xshColumn->getSoundColumn() ||
-        xshColumn->getSoundTextColumn() || xshColumn->isLocked() ||
-        xshColumn->isEmpty())
+        xshColumn->getSoundTextColumn() || xshColumn->getFolderColumn() ||
+        xshColumn->isLocked() || xshColumn->isEmpty())
       continue;
 
     TXshCellColumn *cellColumn = xshColumn->getCellColumn();
@@ -1396,6 +1397,79 @@ public:
   NewNoteLevelCommand() : MenuItemHandler(MI_NewNoteLevel) {}
   void execute() override { XshCmd::newNoteLevel(); }
 } NewNoteLevelCommand;
+
+//============================================================
+
+class NewFolderUndo final : public TUndo {
+  TXshFolderColumnP m_folderColumn;
+  int m_col;
+  QString m_columnName;
+
+public:
+  NewFolderUndo(TXshFolderColumn *folderColumn, int col,
+                   QString columnName)
+      : m_folderColumn(folderColumn)
+      , m_col(col)
+      , m_columnName(columnName) {}
+
+  void undo() const override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    xsh->removeColumn(m_col);
+    app->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  void redo() const override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    xsh->insertColumn(m_col, m_folderColumn.getPointer());
+
+    TStageObject *obj = xsh->getStageObject(TStageObjectId::ColumnId(m_col));
+    std::string str   = m_columnName.toStdString();
+    obj->setName(str);
+
+    app->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override { return QObject::tr("New Level Folder"); }
+
+  int getHistoryType() override { return HistoryType::Xsheet; }
+};
+
+//============================================================
+
+static void newFolder() {
+  TTool::Application *app = TTool::getApplication();
+  TXsheet *xsh            = app->getCurrentScene()->getScene()->getXsheet();
+  int col = TTool::getApplication()->getCurrentColumn()->getColumnIndex();
+  if (col < 0)
+    col = 0;  // Normally insert before. In case of camera, insert after
+  TXshFolderColumn *folderCol = new TXshFolderColumn();
+  int folderId                = xsh->getNewFolderId();
+
+  folderCol->setXsheet(xsh);
+  folderCol->setFolderColumnFolderId(folderId);
+  xsh->insertColumn(col, folderCol);
+
+  TStageObject *obj = xsh->getStageObject(TStageObjectId::ColumnId(col));
+  QString str       = "Folder" + QString::number(folderId);
+  obj->setName(str.toStdString());
+
+  TUndoManager::manager()->add(new NewFolderUndo(folderCol, col, str));
+
+  TXsheetHandle *xshHandle = app->getCurrentXsheet();
+  xshHandle->notifyXsheetChanged();
+}
+
+//============================================================
+
+class NewFolderCommand final : public MenuItemHandler {
+public:
+  NewFolderCommand() : MenuItemHandler(MI_NewFolder) {}
+  void execute() override { XshCmd::newFolder(); }
+} NewFolderCommand;
 
 //============================================================
 

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2630,6 +2630,19 @@ public:
 
 //-----------------------------------------------------------------------------
 
+class ToggleXsheetOpenCloseFolderCommand final : public MenuItemHandler {
+public:
+  ToggleXsheetOpenCloseFolderCommand()
+      : MenuItemHandler(MI_ToggleOpenCloseFolder) {}
+
+  void execute() override {
+    TApp::instance()->getCurrentXsheetViewer()->toggleCurrentFolderOpenClose();
+  }
+
+} ToggleXsheetOpenCloseFolderCommand;
+
+//-----------------------------------------------------------------------------
+
 class SetCellMarkCommand final : public MenuItemHandler {
   int m_markId;
 

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1443,7 +1443,8 @@ public:
 static void newFolder() {
   TTool::Application *app = TTool::getApplication();
   TXsheet *xsh            = app->getCurrentScene()->getScene()->getXsheet();
-  int col = TTool::getApplication()->getCurrentColumn()->getColumnIndex() + 1;
+  int col = TTool::getApplication()->getCurrentColumn()->getColumnIndex();
+  if (!xsh->isColumnEmpty(col)) col++;
   TXshFolderColumn *folderCol = new TXshFolderColumn();
   int folderId                = xsh->getNewFolderId();
 

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1443,9 +1443,7 @@ public:
 static void newFolder() {
   TTool::Application *app = TTool::getApplication();
   TXsheet *xsh            = app->getCurrentScene()->getScene()->getXsheet();
-  int col = TTool::getApplication()->getCurrentColumn()->getColumnIndex();
-  if (col < 0)
-    col = 0;  // Normally insert before. In case of camera, insert after
+  int col = TTool::getApplication()->getCurrentColumn()->getColumnIndex() + 1;
   TXshFolderColumn *folderCol = new TXshFolderColumn();
   int folderId                = xsh->getNewFolderId();
 

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -2011,6 +2011,8 @@ public:
                      .translated(orig);
     if (!o->isVerticalTimeline())
       rect.adjust(0, 0, getViewer()->getTimelineBodyOffset(), 0);
+    else
+      rect.adjust(0, 0, 0, getViewer()->getXsheetBodyOffset());
 
     if (!o->isVerticalTimeline()) {
       QRect buttonsRect =

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1772,8 +1772,6 @@ public:
     TColumnSelection *selection = getViewer()->getColumnSelection();
     if (!selection || selection->isEmpty()) return false;
 
-    if (getViewer()->orientation()->isVerticalTimeline()) return true;
-
     std::set<int> indices = selection->getIndices();
     if (indices.find(col) != indices.end()) return false;
 

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1579,7 +1579,7 @@ public:
         TXshColumn *column = getViewer()->getXsheet()->getColumn(col);
         if (column && column->getColumnType() == TXshColumn::eFolderType) {
           int folderId = column->getFolderColumn()->getFolderColumnFolderId();
-          for (int c = col - 1; c > 0; c--) {
+          for (int c = col - 1; c >= 0; c--) {
             TXshColumn *folderItemCol = getViewer()->getXsheet()->getColumn(c);
             if (!folderItemCol || !folderItemCol->isContainedInFolder(folderId))
               break;
@@ -1614,7 +1614,7 @@ public:
       if (!column || column->getColumnType() != TXshColumn::eFolderType)
         continue;
       int folderId = column->getFolderColumn()->getFolderColumnFolderId();
-      for (int c = (*it) - 1; c > 0; c--) {
+      for (int c = (*it) - 1; c >= 0; c--) {
         TXshColumn *folderItemCol = getViewer()->getXsheet()->getColumn(c);
         if (!folderItemCol || !folderItemCol->isContainedInFolder(folderId))
           break;
@@ -1818,7 +1818,7 @@ public:
       if (!column || column->getColumnType() != TXshColumn::eFolderType)
         continue;
       int folderId = column->getFolderColumn()->getFolderColumnFolderId();
-      for (int c = (*it) - 1; c > 0; c--) {
+      for (int c = (*it) - 1; c >= 0; c--) {
         TXshColumn *folderItemCol = getViewer()->getXsheet()->getColumn(c);
         if (!folderItemCol || !folderItemCol->isContainedInFolder(folderId))
           break;

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1860,6 +1860,8 @@ public:
                      ->orientation()
                      ->rect(PredefinedRect::LAYER_HEADER)
                      .translated(orig);
+    if (!o->isVerticalTimeline())
+      rect.adjust(0, 0, getViewer()->getTimelineBodyOffset(), 0);
 
     TXshFolderColumn *folderColumn = column ? column->getFolderColumn() : 0;
     int folderAdj = folderColumn && folderColumn->isExpanded() ? 5 : 0;
@@ -2007,6 +2009,8 @@ public:
                      ->orientation()
                      ->rect(PredefinedRect::LAYER_HEADER)
                      .translated(orig);
+    if (!o->isVerticalTimeline())
+      rect.adjust(0, 0, getViewer()->getTimelineBodyOffset(), 0);
 
     if (!o->isVerticalTimeline()) {
       QRect buttonsRect =

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1938,6 +1938,8 @@ public:
         newCol--;
       }
 
+      if (newCol < 0) return;
+
       std::vector<int>::reverse_iterator it;
       int i = 0;
       int subfolder = -1;

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1771,6 +1771,8 @@ public:
     TColumnSelection *selection = getViewer()->getColumnSelection();
     if (!selection || selection->isEmpty()) return false;
 
+    if (getViewer()->orientation()->isVerticalTimeline()) return true;
+
     std::set<int> indices = selection->getIndices();
     if (indices.find(col) != indices.end()) return false;
 
@@ -1845,11 +1847,11 @@ public:
 
     if (!canDrop(CellPosition(0, col))) return;
 
-    TXsheet *xsh           = getViewer()->getXsheet();
-    TXshColumn *column     = xsh->getColumn(col);
-    if (!column) return;
-
     const Orientation *o = getViewer()->orientation();
+    TXsheet *xsh         = getViewer()->getXsheet();
+    TXshColumn *column   = xsh->getColumn(col);
+    if (!o->isVerticalTimeline() && !column) return;
+
     QPoint orig          = getViewer()->positionToXY(pos);
     int dPos = o->isVerticalTimeline() ? m_curPos.x() - m_firstPos.x()
                                        : m_firstPos.y() - m_curPos.y();
@@ -1859,7 +1861,7 @@ public:
                      ->rect(PredefinedRect::LAYER_HEADER)
                      .translated(orig);
 
-    TXshFolderColumn *folderColumn = column->getFolderColumn();
+    TXshFolderColumn *folderColumn = column ? column->getFolderColumn() : 0;
     int folderAdj = folderColumn && folderColumn->isExpanded() ? 5 : 0;
 
     // See if we're on top of a folder column
@@ -1997,7 +1999,7 @@ public:
 
     TStageObjectId columnId = getViewer()->getObjectId(m_targetCol);
     TXshColumn *column      = xsh->getColumn(m_targetCol);
-    if (!column) return;
+    if (!o->isVerticalTimeline() && !column) return;
 
     QRect rect = getViewer()
                      ->orientation()
@@ -2015,7 +2017,7 @@ public:
 
     int topCol = *indices.rbegin();
 
-    int columnDepth = origColumn->folderDepth();
+    int columnDepth = origColumn ? origColumn->folderDepth() : 0;
     QRect indicatorRect =
         o->rect(PredefinedRect::FOLDER_INDICATOR_AREA).translated(orig);
     if (o->isVerticalTimeline())

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -51,6 +51,7 @@
 #include "toonz/preferences.h"
 #include "toonz/columnfan.h"
 #include "toonz/navigationtags.h"
+#include "toonz/txshfoldercolumn.h"
 
 // TnzBase includes
 #include "tfx.h"
@@ -400,6 +401,7 @@ public:
     int r1       = m_row + m_rowCount - 1;
     for (int c = 0; c < m_colCount; c++) {
       TXshColumn *column = xsh->getColumn(c);
+      if (column && column->getFolderColumn()) continue;
       bool isSoundColumn = (column && column->getSoundColumn());
       int col = m_col + c;
       xsh->insertCells(r0, col, count);
@@ -446,6 +448,7 @@ public:
     }
     for (int c = 0; c < m_colCount; c++) {
       TXshColumn *column = xsh->getColumn(c);
+      if (column && column->getFolderColumn()) continue;
       bool isSoundColumn = (column && column->getSoundColumn());
       int col = m_col + c;
       for (int r = r0; r <= r1; r++) {
@@ -780,6 +783,7 @@ public:
 
       for (int c = 0; c < m_colCount; c++) {
         TXshColumn *column = xsh->getColumn(m_c0 + c);
+        if (column && column->getFolderColumn()) continue;
         bool isSoundColumn = (column && column->getSoundColumn());
         if (m_insert) xsh->insertCells(m_r1 + 1, m_c0 + c, dr);
         for (int r = m_r1 + 1; r <= r1; r++)
@@ -839,6 +843,7 @@ public:
     else {
       for (int c = 0; c < m_colCount; c++) {
         TXshColumn *column = xsh->getColumn(m_c0 + c);
+        if (column && column->getFolderColumn()) continue;
         bool isSoundColumn = (column && column->getSoundColumn());
         for (int r = r0; r <= m_r0 - 1; r++) {
           if (isSoundColumn)
@@ -1569,7 +1574,21 @@ public:
     if (event->modifiers() & Qt::ControlModifier) {
       selection->selectColumn(col, !isSelected);
       m_enabled = true;
-      m_colSet  = selection->getIndices();
+
+      if (isSelected) {
+        TXshColumn *column = getViewer()->getXsheet()->getColumn(col);
+        if (column && column->getColumnType() == TXshColumn::eFolderType) {
+          int folderId = column->getFolderColumn()->getFolderColumnFolderId();
+          for (int c = col - 1; c > 0; c--) {
+            TXshColumn *folderItemCol = getViewer()->getXsheet()->getColumn(c);
+            if (!folderItemCol || !folderItemCol->isContainedInFolder(folderId))
+              break;
+            selection->selectColumn(c, !isSelected);
+          }
+        }
+      }
+
+      m_colSet = selection->getIndices();
     } else if (event->modifiers() & Qt::ShiftModifier) {
       // m_enabled = true;
       if (isSelected) return;
@@ -1586,6 +1605,23 @@ public:
       selection->selectNone();
       selection->selectColumn(col, true);
     }
+
+    // Look for folders and add contents to folder list if not already included
+    std::set<int> orig = selection->getIndices();
+    std::set<int>::iterator it;
+    for (it = orig.begin(); it != orig.end(); it++) {
+      TXshColumn *column = getViewer()->getXsheet()->getColumn(*it);
+      if (!column || column->getColumnType() != TXshColumn::eFolderType)
+        continue;
+      int folderId = column->getFolderColumn()->getFolderColumnFolderId();
+      for (int c = (*it) - 1; c > 0; c--) {
+        TXshColumn *folderItemCol = getViewer()->getXsheet()->getColumn(c);
+        if (!folderItemCol || !folderItemCol->isContainedInFolder(folderId))
+          break;
+        selection->selectColumn(c, true);
+      }
+    }
+
     selection->makeCurrent();
     getViewer()->update();
   }
@@ -1632,64 +1668,81 @@ XsheetGUI::DragTool *XsheetGUI::DragTool::makeColumnSelectionTool(
 // Column Movement
 //-----------------------------------------------------------------------------
 
-static void moveColumns(const std::set<int> &indices, int delta) {
-  if (indices.empty()) return;
-  if (delta < 0 && *indices.begin() + delta < 0) delta = -*indices.begin();
-  if (delta == 0) return;
+static void moveColumns(const std::set<int> &oldIndices,
+                        const std::set<int> &newIndices,
+                        const std::vector<QStack<int>> &newFolders) {
+  if (oldIndices.empty() || newIndices.empty() || oldIndices.size() != newIndices.size()) return;
 
   TApp *app    = TApp::instance();
   TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-  std::vector<int> ii;
-  if (delta > 0)
-    ii.assign(indices.rbegin(), indices.rend());
-  else
-    ii.assign(indices.begin(), indices.end());
-  int i, m = ii.size();
-  for (i = 0; i < m; i++) {
-    int a = ii[i];
-    int b = a + delta;
-    xsh->moveColumn(a, b);
+  std::vector<int> oldSet;
+  std::vector<int> newSet;
+  std::vector<QStack<int>> newFolderSet;
+  if ((*newIndices.begin() - *oldIndices.begin()) > 0) {
+    oldSet.assign(oldIndices.rbegin(), oldIndices.rend());
+    newSet.assign(newIndices.rbegin(), newIndices.rend());
+    newFolderSet.assign(newFolders.rbegin(), newFolders.rend());
+  } else {
+    oldSet.assign(oldIndices.begin(), oldIndices.end());
+    newSet.assign(newIndices.begin(), newIndices.end());
+    newFolderSet.assign(newFolders.begin(), newFolders.end());
   }
-  int col = app->getCurrentColumn()->getColumnIndex();
-  if (indices.count(col) > 0)
-    app->getCurrentColumn()->setColumnIndex(col + delta);
-}
 
+  int currentCol = app->getCurrentColumn()->getColumnIndex();
+  int newCurrentCol = currentCol;
+
+  int i, m = oldSet.size();
+  for (i = 0; i < m; i++) {
+    xsh->moveColumn(oldSet[i], newSet[i]);
+
+    TXshColumn *column = xsh->getColumn(newSet[i]);
+    column->setFolderIdStack(newFolderSet[i]);
+
+    if (oldSet[i] == currentCol) newCurrentCol = newSet[i];
+  }
+
+  app->getCurrentColumn()->setColumnIndex(newCurrentCol);
+}
 //-----------------------------------------------------------------------------
 
 class ColumnMoveUndo final : public TUndo {
-  std::set<int> m_indices;
-  int m_delta;
+  std::set<int> m_oldIndices;
+  std::set<int> m_newIndices;
+
+  std::vector<QStack<int>> m_oldFolders, m_newFolders;
 
 public:
   // nota: indices sono gli indici DOPO aver fatto il movimento
-  ColumnMoveUndo(const std::set<int> &indices, int delta)
-      : m_indices(indices), m_delta(delta) {
-    assert(delta != 0);
-    assert(!indices.empty());
-    assert(*indices.begin() >= 0);
-    assert(delta < 0 || *indices.begin() - delta >= 0);
+  ColumnMoveUndo(const std::set<int> &oldIndices,
+                 const std::vector<QStack<int>> oldFolders,
+                 const std::set<int> &newIndices,
+                 const std::vector<QStack<int>> newFolders)
+      : m_oldIndices(oldIndices)
+      , m_newIndices(newIndices)
+      , m_oldFolders(oldFolders)
+      , m_newFolders(newFolders) {
+    assert(!oldIndices.empty());
+    assert(*oldIndices.begin() >= 0);
+    assert(!newIndices.empty());
+    assert(*newIndices.begin() >= 0);
   }
   void undo() const override {
-    moveColumns(m_indices, -m_delta);
+    moveColumns(m_newIndices, m_oldIndices, m_oldFolders);
     TSelection *selection =
         TApp::instance()->getCurrentSelection()->getSelection();
     if (selection) selection->selectNone();
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   }
   void redo() const override {
-    std::set<int> ii;
-    for (std::set<int>::const_iterator it = m_indices.begin();
-         it != m_indices.end(); ++it)
-      ii.insert(*it - m_delta);
-    moveColumns(ii, m_delta);
+    moveColumns(m_oldIndices, m_newIndices, m_newFolders);
     TSelection *selection =
         TApp::instance()->getCurrentSelection()->getSelection();
     if (selection) selection->selectNone();
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   }
   int getSize() const override {
-    return sizeof(*this) + m_indices.size() * sizeof(int);
+    return sizeof(*this) + m_oldIndices.size() * sizeof(int) +
+           m_newIndices.size() * sizeof(int);
   }
 
   QString getHistoryString() override { return QObject::tr("Move Columns"); }
@@ -1699,19 +1752,34 @@ public:
 //-----------------------------------------------------------------------------
 
 class ColumnMoveDragTool final : public XsheetGUI::DragTool {
-  int m_offset, m_firstCol, m_lastCol, m_origOffset;
+  QPoint m_firstPos, m_curPos;
+  int m_firstCol, m_targetCol;
+  bool m_dropOnColumnFolder;
+  QStack<int> m_addToFolder;
 
 public:
   ColumnMoveDragTool(XsheetViewer *viewer)
       : XsheetGUI::DragTool(viewer)
       , m_firstCol(-1)
-      , m_lastCol(-1)
-      , m_offset(0)
-      , m_origOffset(0) {}
+      , m_targetCol(-1)
+      , m_dropOnColumnFolder(false) {}
+
+  bool canDrop(const CellPosition &pos) {
+    int col = pos.layer();
+    if (col < 0) return false;
+
+    TColumnSelection *selection = getViewer()->getColumnSelection();
+    if (!selection || selection->isEmpty()) return false;
+
+    std::set<int> indices = selection->getIndices();
+    if (indices.find(col) != indices.end()) return false;
+
+    return true;
+  }
 
   void onClick(const QMouseEvent *event) override {
-    QPoint xy                   = event->pos();
-    CellPosition pos            = getViewer()->xyToPosition(xy);
+    m_firstPos                   = event->pos();
+    CellPosition pos            = getViewer()->xyToPosition(m_firstPos);
     int col                     = pos.layer();
     TColumnSelection *selection = getViewer()->getColumnSelection();
     if (!selection->isColumnSelected(col)) {
@@ -1734,86 +1802,250 @@ public:
       selection->makeCurrent();
     }
     std::set<int> indices = selection->getIndices();
+    indices.erase(-1);
     if (indices.empty()) return;
-    m_firstCol = m_lastCol = *indices.begin();
+    m_firstCol = *indices.begin(); //col;
+    m_targetCol = -1;
     assert(m_firstCol >= 0);
-    m_origOffset = m_offset = m_firstCol - col;
-    assert(m_lastCol == *indices.begin());
+
+    // Look for folders and add contents to folder list if not already included
+    std::set<int> orig = indices;
+    std::set<int>::iterator it;
+    for (it = orig.begin(); it != orig.end(); it++) {
+      TXshColumn *column = getViewer()->getXsheet()->getColumn(*it);
+      if (!column || column->getColumnType() != TXshColumn::eFolderType)
+        continue;
+      int folderId = column->getFolderColumn()->getFolderColumnFolderId();
+      for (int c = (*it) - 1; c > 0; c--) {
+        TXshColumn *folderItemCol = getViewer()->getXsheet()->getColumn(c);
+        if (!folderItemCol || !folderItemCol->isContainedInFolder(folderId))
+          break;
+        indices.insert(c);
+      }
+    }
+
+    selection->selectNone();
+    for (std::set<int>::iterator it = indices.begin(); it != indices.end();
+         ++it)
+      selection->selectColumn(*it, true);
+
     getViewer()->update();
 
     if (!getViewer()->orientation()->isVerticalTimeline())
       TUndoManager::manager()->beginBlock();
   }
-  void onDrag(const CellPosition &pos) override {
-    int col                     = pos.layer();
-    TColumnSelection *selection = getViewer()->getColumnSelection();
-    TApp *app                   = TApp::instance();
-    TXsheet *xsh                = app->getCurrentXsheet()->getXsheet();
+  void onDrag(const QMouseEvent *e) override {
+    m_curPos             = e->pos();
+    m_targetCol          = -1;
+    m_dropOnColumnFolder = false;
+    m_addToFolder.clear();
 
-    std::set<int> indices = selection->getIndices();
-    indices.erase(-1);  // Ignore camera column
-    if (indices.empty()) return;
+    CellPosition pos = getViewer()->xyToPosition(m_curPos);
+    int col          = pos.layer();
 
-    assert(m_lastCol == *indices.begin());
+    if (!canDrop(CellPosition(0, col))) return;
 
-    int currEnd = xsh->getColumnCount() - 1;
-    int origCol = col;
-    if (col < 0)
-      col = 0;
-    else if (!getViewer()->orientation()->isVerticalTimeline() && col > currEnd)
-      col = currEnd;
-    int dCol = col - (m_lastCol - m_offset);
+    TXsheet *xsh           = getViewer()->getXsheet();
+    TXshColumn *column     = xsh->getColumn(col);
+    if (!column) return;
 
-    // ignore if the cursor moves in the drag-starting column
-    if (dCol == 0) return;
+    const Orientation *o = getViewer()->orientation();
+    QPoint orig          = getViewer()->positionToXY(pos);
+    int dPos = o->isVerticalTimeline() ? m_curPos.x() - m_firstPos.x()
+                                       : m_firstPos.y() - m_curPos.y();
 
-    if (dCol < 0 &&
-        !xsh->getColumnFan(getViewer()->orientation())->isActive(col)) {
-      while (
-          col != 0 &&
-          !xsh->getColumnFan(getViewer()->orientation())->isActive(col - 1)) {
+    QRect rect = getViewer()
+                     ->orientation()
+                     ->rect(PredefinedRect::LAYER_HEADER)
+                     .translated(orig);
+
+    TXshFolderColumn *folderColumn = column->getFolderColumn();
+    int folderAdj = folderColumn && folderColumn->isExpanded() ? 5 : 0;
+
+    // See if we're on top of a folder column
+    if (column && folderColumn &&
+        (o->isVerticalTimeline()
+             ? rect.adjusted(5, 0, -folderAdj, 0).contains(m_curPos)
+             : rect.adjusted(0, 5, 0, -folderAdj).contains(m_curPos))) {
+      m_dropOnColumnFolder = true;
+      int folderId = column->getFolderColumn()->getFolderColumnFolderId();
+      m_addToFolder = column->getFolderColumn()->getFolderIdStack();
+      m_addToFolder.push(folderId);
+    }
+
+    if (!m_dropOnColumnFolder) {
+      int origCol = col;
+
+      // Split rect in 1/2, keeping Top/Right
+      if (o->isVerticalTimeline())
+        rect.adjust(rect.width() / 2, 0, 0, 0);
+      else
+        rect.adjust(0, 0, 0, -rect.height() / 2);
+
+      if (dPos > 0 && !rect.contains(m_curPos))
         col--;
-        dCol--;
+      else if (dPos <= 0 && rect.contains(m_curPos))
+        col++;
+
+      if (col < 0) return;
+
+      // See if we are on the bottom of folder
+      if (column && column->isInFolder() && !column->getFolderColumn() &&
+          ((dPos > 0 && origCol != col) || (dPos < 0 && origCol == col))) {
+        TXshColumn *prev = xsh->getColumn(origCol - 1);
+        if (prev && prev->getFolderId() != column->getFolderId()) {
+          m_addToFolder = column->getFolderIdStack();
+        }
+      }
+
+      if (m_addToFolder.isEmpty()) {
+        TXshColumn *priorColumn =
+            getViewer()->getXsheet()->getColumn(dPos < 0 ? col - 1 : col);
+        if (priorColumn) { 
+          m_addToFolder = priorColumn->getFolderIdStack();
+        }
       }
     }
 
-    int newBegin = *indices.begin() + dCol;
-    int newEnd   = *indices.rbegin() + dCol;
-
-    if (newBegin < 0)
-      dCol -= newBegin;
-    else if (!getViewer()->orientation()->isVerticalTimeline() &&
-             newEnd > currEnd)
-      dCol -= (newEnd - currEnd);
-
-    // ignore if the dragged columns comes up against the end of column stack
-    if (dCol == 0) return;
-
-    m_lastCol += dCol;
-
-    assert(*indices.begin() + dCol >= 0);
-
-    moveColumns(indices, dCol);
-
-    selection->selectNone();
-    for (std::set<int>::iterator it = indices.begin(); it != indices.end();
-         ++it)
-      selection->selectColumn(*it + dCol, true);
+    m_targetCol = col;
   }
   void onRelease(const CellPosition &pos) override {
-    int delta = m_lastCol - m_firstCol;
-    if (delta != 0) {
-      TColumnSelection *selection = getViewer()->getColumnSelection();
-      std::set<int> indices       = selection->getIndices();
-      if (!indices.empty()) {
-        TUndoManager::manager()->add(new ColumnMoveUndo(indices, delta));
-        TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-        TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    int offset = 0;
+
+    TColumnSelection *selection = getViewer()->getColumnSelection();
+    std::set<int> oldIndices    = selection->getIndices();
+    oldIndices.erase(-1);
+
+    if (!oldIndices.empty() && m_targetCol >= 0) {
+      offset = m_targetCol - m_firstCol;
+      if (offset > 0) offset -= (oldIndices.size() - 1);
+    }
+
+    if (offset != 0) {
+      TXsheet *xsh = getViewer()->getXsheet();
+      std::set<int> newIndices;
+      std::vector<int> vOldIndices, vNewIndices;
+      std::vector<QStack<int>> vOldFolders, vNewFolders;
+      vOldIndices.assign(oldIndices.begin(), oldIndices.end());
+      int newCol = m_firstCol + offset;
+
+      // Dropping into folder
+      if (!m_addToFolder.isEmpty() && offset > 0 && xsh->getColumn(m_targetCol)->getFolderColumn() &&
+          xsh->getColumn(m_targetCol)->getFolderColumn()->getFolderColumnFolderId() == m_addToFolder.back()) {
+        xsh->openCloseFolder(m_targetCol, true);
+        newCol--;
       }
+
+      std::vector<int>::reverse_iterator it;
+      int i = 0;
+      int subfolder = -1;
+      QStack<int> folderList = m_addToFolder;
+      for (it = vOldIndices.rbegin(); it != vOldIndices.rend(); it++, i++) {
+        newIndices.insert(newCol + i);
+
+        TXshColumn *column = xsh->getColumn(*it);
+        QStack<int> folderIdStack = column->getFolderIdStack();
+        vOldFolders.insert(vOldFolders.begin(), folderIdStack);
+  
+        if (subfolder >= 0 && !column->isContainedInFolder(subfolder)) {
+          folderList.pop();
+          if (folderList.size())
+            subfolder = folderList.top();
+          else
+            subfolder = -1;
+        }
+
+        vNewFolders.insert(vNewFolders.begin(), folderList);
+
+        if (column->getFolderColumn()) {
+          subfolder = column->getFolderColumn()->getFolderColumnFolderId();
+          folderList.push(subfolder);
+        }
+      }
+
+      moveColumns(oldIndices, newIndices, vNewFolders);
+
+      selection->selectNone();
+      for (std::set<int>::iterator it = newIndices.begin();
+           it != newIndices.end(); ++it)
+        selection->selectColumn(*it, true);
+
+      TUndoManager::manager()->add(new ColumnMoveUndo(
+          oldIndices, vOldFolders, newIndices, vNewFolders));
+      TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+      TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
     }
 
     if (!getViewer()->orientation()->isVerticalTimeline())
       TUndoManager::manager()->endBlock();
+  }
+  void drawColumnsArea(QPainter &p) {
+    if (m_targetCol < 0) return;
+
+    TColumnSelection *selection = getViewer()->getColumnSelection();
+    if (!selection || selection->isEmpty()) return;
+
+    TXsheet *xsh = getViewer()->getXsheet();
+
+    std::set<int> indices  = selection->getIndices();
+    CellPosition pos       = getViewer()->xyToPosition(m_curPos);
+    int origCol            = pos.layer();
+    TXshColumn *origColumn = xsh->getColumn(origCol);
+
+    const Orientation *o = getViewer()->orientation();
+    QPoint orig = getViewer()->positionToXY(CellPosition(0, m_targetCol));
+
+    TStageObjectId columnId = getViewer()->getObjectId(m_targetCol);
+    TXshColumn *column      = xsh->getColumn(m_targetCol);
+    if (!column) return;
+
+    QRect rect = getViewer()
+                     ->orientation()
+                     ->rect(PredefinedRect::LAYER_HEADER)
+                     .translated(orig);
+
+    if (!o->isVerticalTimeline()) {
+      QRect buttonsRect =
+          o->rect(PredefinedRect::BUTTONS_AREA).translated(orig);
+      rect.adjust(buttonsRect.width(), 0, 0, 0);
+    }
+
+    int dPos = o->isVerticalTimeline() ? m_curPos.x() - m_firstPos.x()
+                                       : m_firstPos.y() - m_curPos.y();
+
+    int topCol = *indices.rbegin();
+
+    int columnDepth = origColumn->folderDepth();
+    QRect indicatorRect =
+        o->rect(PredefinedRect::FOLDER_INDICATOR_AREA).translated(orig);
+    if (o->isVerticalTimeline())
+      rect.adjust(0, indicatorRect.height() * columnDepth, 0, 0);
+    else
+      rect.adjust(indicatorRect.width() * columnDepth, 0, 0, 0);
+
+    p.setPen(QColor(190, 220, 255));
+    p.setBrush(Qt::NoBrush);
+    if (m_dropOnColumnFolder) {
+      for (int i = 0; i < 3; i++)  // thick border within name area
+        p.drawRect(QRect(rect.topLeft() + QPoint(i, i),
+                         rect.size() - QSize(2 * i, 2 * i)));
+    } else {
+      if (o->isVerticalTimeline()) {
+        QPoint begin = dPos > 0 ? rect.topRight() : rect.topLeft();
+        QPoint end   = dPos > 0 ? rect.bottomRight() : rect.bottomLeft();
+
+        p.drawLine(begin + QPoint(-1, 0), end + QPoint(-1, 0));
+        p.drawLine(begin, end);
+        p.drawLine(begin + QPoint(1, 0), end + QPoint(1, 0));
+      } else {
+        QPoint begin = dPos > 0 ? rect.topLeft() : rect.bottomLeft();
+        QPoint end   = dPos > 0 ? rect.topRight() : rect.bottomRight();
+
+        p.drawLine(begin + QPoint(0, -1), end + QPoint(0, -1));
+        p.drawLine(begin, end);
+        p.drawLine(begin + QPoint(0, 1), end + QPoint(0, 1));
+      }
+    }
   }
 };
 
@@ -1882,7 +2114,8 @@ public:
       parentId = TStageObjectId::CameraId(
           getViewer()->getXsheet()->getCameraColumnIndex());
     if (getViewer()->getXsheet()->getColumn(m_lastCol) &&
-        getViewer()->getXsheet()->getColumn(m_lastCol)->getSoundColumn())
+        (getViewer()->getXsheet()->getColumn(m_lastCol)->getSoundColumn() ||
+         getViewer()->getXsheet()->getColumn(m_lastCol)->getFolderColumn()))
       return;
 
     if (m_firstCol == m_lastCol && m_firstCol != -1) {

--- a/toonz/sources/toonz/xsheetdragtool.h
+++ b/toonz/sources/toonz/xsheetdragtool.h
@@ -12,6 +12,7 @@ class XsheetViewer;
 class QMouseEvent;
 class QDropEvent;
 class TXshSoundColumn;
+class QPoint;
 
 namespace XsheetGUI {
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1803,6 +1803,17 @@ void XsheetViewer::setCurrentNoteIndex(int currentNoteIndex) {
 
 //-----------------------------------------------------------------------------
 
+void XsheetViewer::toggleCurrentFolderOpenClose() {
+  int col = getCurrentColumn();
+  if (col < 0) return;
+  TXsheet *xsh       = getXsheet();
+  TXshColumn *column = xsh->getColumn(col);
+  if (!column || !column->getFolderColumn()) return;
+  m_columnArea->toggleFolderStatus(column);
+}
+
+//-----------------------------------------------------------------------------
+
 void XsheetViewer::resetXsheetNotes() {
   m_noteArea->updateButtons();
   m_layerFooterPanel->m_noteArea->updateButtons();

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -124,6 +124,11 @@ void XsheetViewer::getCellTypeAndColors(int &ltype, QColor &cellColor,
           (isSelected) ? getSelectedPaletteColumnColor() : getPaletteColumnColor();
       sideColor = getPaletteColumnBorderColor();
       break;
+    case FOLDER_XSHLEVEL:
+      cellColor =
+          (isSelected) ? getSelectedFolderColumnColor() : getFolderColumnColor();
+      sideColor = getFolderColumnBorderColor();
+      break;
     case UNKNOWN_XSHLEVEL:
     case NO_XSHLEVEL:
     default:
@@ -151,8 +156,11 @@ void XsheetViewer::getColumnColor(QColor &color, QColor &sideColor, int index,
       int ltype;
       getCellTypeAndColors(ltype, color, sideColor, cell);
     }
+  } else if (xsh->getColumn(index)->getFolderColumn()) {
+    color     = m_folderColumnColor;
+    sideColor = m_folderColumnBorderColor;
   }
-//  if (xsh->getColumn(index)->isMask()) color = QColor(255, 0, 255);
+  //  if (xsh->getColumn(index)->isMask()) color = QColor(255, 0, 255);
 }
 
 //-----------------------------------------------------------------------------
@@ -1039,6 +1047,23 @@ bool XsheetViewer::areSoundTextCellsSelected() {
       return false;
     }
   return !areCellsSelectedEmpty();
+}
+
+//-----------------------------------------------------------------------------
+
+bool XsheetViewer::areFolderCellsSelected() {
+  int r0, c0, r1, c1;
+  getCellSelection()->getSelectedCells(r0, c0, r1, c1);
+  if (c0 < 0) return false;
+  int i, j;
+  for (j = c0; j <= c1; j++) {
+    TXshColumn *column = getXsheet()->getColumn(j);
+    if (column && (column->isEmpty() ||
+                   column->getColumnType() == TXshColumn::eFolderType))
+      continue;
+    return false;
+  }
+  return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -421,6 +421,9 @@ void XsheetViewer::positionSections() {
   if (!o->isVerticalTimeline()) {
     headerFrame = headerFrame.adjusted(0, m_timelineBodyOffset);
     m_columnArea->setFixedWidth(headerFrame.to());
+  } else {
+    headerFrame = headerFrame.adjusted(0, m_xsheetBodyOffset);
+    m_columnArea->setFixedHeight(headerFrame.to());
   }
 
   NumberRange bodyLayer(headerLayer.to(), allLayer.to());
@@ -804,10 +807,10 @@ bool XsheetViewer::refreshContentSize(int dx, int dy) {
     NumberRange headerLayer = o->range(PredefinedRange::HEADER_LAYER);
     NumberRange headerFrame = o->range(PredefinedRange::HEADER_FRAME);
 
-    if (!o->isVerticalTimeline()) {
+    if (!o->isVerticalTimeline())
       headerFrame = headerFrame.adjusted(0, m_timelineBodyOffset);
-      m_columnArea->setFixedWidth(headerFrame.to());
-    }
+    else
+      headerFrame = headerFrame.adjusted(0, m_xsheetBodyOffset);
 
     m_isComputingSize = true;
     m_noteArea->setFixedSize(o->rect(PredefinedRect::NOTE_AREA).size());
@@ -857,10 +860,10 @@ void XsheetViewer::updateAreeSize() {
   NumberRange headerLayer = o->range(PredefinedRange::HEADER_LAYER);
   NumberRange headerFrame = o->range(PredefinedRange::HEADER_FRAME);
 
-  if (!o->isVerticalTimeline()) {
+  if (!o->isVerticalTimeline())
     headerFrame = headerFrame.adjusted(0, m_timelineBodyOffset);
-    m_columnArea->setFixedWidth(headerFrame.to());
-  }
+  else
+    headerFrame = headerFrame.adjusted(0, m_xsheetBodyOffset);
 
   m_cellArea->setFixedSize(viewArea.size());
   m_rowArea->setFixedSize(o->frameLayerRect(allFrame, headerLayer).size());

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -635,6 +635,9 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
 
   CellPosition m_ctrlSelectRef;
 
+  int m_xsheetBodyOffset;
+  int m_timelineBodyOffset;
+
 public:
   enum FrameDisplayStyle { Frame = 0, SecAndFrame, SixSecSheet, ThreeSecSheet };
 
@@ -1344,6 +1347,11 @@ public:
   void zoomToFramesPerPage(int frames);
 
   int getContextMenuRow() { return m_rowArea->getContextMenuRow(); }
+
+  int getXsheetBodyOffset() const { return m_xsheetBodyOffset; }
+  void setXsheetBodyOffset(int offset) { m_xsheetBodyOffset = offset; };
+  int getTimelineBodyOffset() const { return m_timelineBodyOffset; }
+  void setTimelineBodyOffset(int offset) { m_timelineBodyOffset = offset; };
 
 protected:
   void scrollToColumn(int col);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -358,6 +358,17 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   Q_PROPERTY(QColor SelectedMeshColumnColor READ getSelectedMeshColumnColor
                  WRITE setSelectedMeshColumnColor)
 
+  // Folder column
+  QColor m_folderColumnColor;
+  QColor m_folderColumnBorderColor;
+  QColor m_selectedFolderColumnColor;
+  Q_PROPERTY(
+      QColor FolderColumnColor READ getFolderColumnColor WRITE setFolderColumnColor)
+  Q_PROPERTY(QColor FolderColumnBorderColor READ getFolderColumnBorderColor WRITE
+                 setFolderColumnBorderColor)
+  Q_PROPERTY(QColor SelectedFolderColumnColor READ getSelectedFolderColumnColor
+                 WRITE setSelectedFolderColumnColor)
+
   // Implicit Cell alpha
   int m_implicitCellAlpha;
   Q_PROPERTY(int ImplicitCellAlpha READ getImplicitCellAlpha WRITE
@@ -663,6 +674,7 @@ public:
   /*! Return true if selection contain only sound cell.*/
   bool areSoundCellsSelected();
   bool areSoundTextCellsSelected();
+  bool areFolderCellsSelected();
   bool areCameraCellsSelected();
 
   XsheetGUI::DragTool *getDragTool() const { return m_dragTool; };
@@ -977,6 +989,23 @@ public:
   QColor getMeshColumnBorderColor() const { return m_meshColumnBorderColor; }
   QColor getSelectedMeshColumnColor() const {
     return m_selectedMeshColumnColor;
+  }
+  // Folder column
+  void setFolderColumnColor(const QColor &color) {
+    m_folderColumnColor = color;
+  }
+  void setFolderColumnBorderColor(const QColor &color) {
+    m_folderColumnBorderColor = color;
+  }
+  void setSelectedFolderColumnColor(const QColor &color) {
+    m_selectedFolderColumnColor = color;
+  }
+  QColor getFolderColumnColor() const { return m_folderColumnColor; }
+  QColor getFolderColumnBorderColor() const {
+    return m_folderColumnBorderColor;
+  }
+  QColor getSelectedFolderColumnColor() const {
+    return m_selectedFolderColumnColor;
   }
 
   // Implicit Cell Alpha

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -763,6 +763,8 @@ public:
 
   void setCurrentNoteIndex(int currentNoteIndex);
 
+  void toggleCurrentFolderOpenClose();
+
   // scroll the cell area to make a cell at (row,col) visible
   void scrollTo(int row, int col);
 

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -165,6 +165,7 @@ set(HEADERS
     ../include/toonz/expressionreferencemonitor.h
     ../include/toonz/filepathproperties.h
     ../include/toonz/navigationtags.h
+    ../include/toonz/txshfoldercolumn.h
 )
 
 set(SOURCES
@@ -326,6 +327,7 @@ set(SOURCES
     boardsettings.cpp
     filepathproperties.cpp
     navigationtags.cpp
+    txshfoldercolumn.cpp
 )
 
 if(BUILD_TARGET_WIN)

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -526,10 +526,17 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::CONFIG_AREA, configArea);
     addRect(PredefinedRect::CONFIG,
             iconRect(configArea, ICON_WIDTH - 1, ICON_HEIGHT - 1));
+
     cameraConfigArea = QRect(INDENT, HDRROW2, CAMERA_CELL_WIDTH, HDRROW_HEIGHT);
     addRect(PredefinedRect::CAMERA_CONFIG_AREA, cameraConfigArea);
     addRect(PredefinedRect::CAMERA_CONFIG,
             iconRect(cameraConfigArea, ICON_WIDTH - 1, ICON_HEIGHT - 1));
+
+    addRect(PredefinedRect::BUTTONS_AREA,
+            QRect(INDENT, HDRROW2, INDENT + eyeArea.width() +
+                                       previewArea.width() + configArea.width(),
+                  HDRROW_HEIGHT));
+
     addRect(PredefinedRect::THUMBNAIL_AREA, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::THUMBNAIL, QRect(0, 0, -1, -1));
     cameraIconArea = QRect(INDENT, HDRROW1, CAMERA_CELL_WIDTH, HDRROW_HEIGHT);
@@ -545,6 +552,8 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::VOLUME_AREA, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::PARENT_HANDLE_NAME, QRect(0, 0, -1, -1));
+
+    addRect(PredefinedRect::FOLDER_TOGGLE_ICON, QRect(0, 0, -1, -1));
 
     addFlag(PredefinedFlag::DRAG_LAYER_BORDER, false);
     addFlag(PredefinedFlag::DRAG_LAYER_VISIBLE, false);
@@ -626,6 +635,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::CAMERA_CONFIG,
             iconRect(cameraConfigArea, ICON_WIDTH - 1, ICON_HEIGHT - 1));
 
+    addRect(
+        PredefinedRect::BUTTONS_AREA,
+        QRect(INDENT, HDRROW2, INDENT + eyeArea.width() + previewArea.width() +
+                                   lockArea.width() + configArea.width(),
+              HDRROW_HEIGHT));
+
     thumbnailArea = QRect(INDENT, HDRROW3, CELL_WIDTH, THUMBNAIL_HEIGHT);
     addRect(PredefinedRect::THUMBNAIL_AREA, thumbnailArea);
     thumbnail = thumbnailArea.adjusted(1, 1, 0, 0);
@@ -658,6 +673,13 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(
         PredefinedRect::PARENT_HANDLE_NAME,
         QRect(INDENT + pegbarname.width() - 20, HDRROW4, 20, HDRROW_HEIGHT));
+
+    addRect(PredefinedRect::FOLDER_TOGGLE_ICON,
+            QRect(thumbnailArea.topLeft(), QSize(40, 30))
+                .adjusted((thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2),
+                          (thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2)));
 
     addFlag(PredefinedFlag::DRAG_LAYER_BORDER, false);
     addFlag(PredefinedFlag::DRAG_LAYER_VISIBLE, false);
@@ -740,6 +762,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::CAMERA_CONFIG,
             iconRect(cameraConfigArea, ICON_WIDTH - 1, ICON_HEIGHT - 1));
 
+    addRect(
+        PredefinedRect::BUTTONS_AREA,
+        QRect(INDENT, HDRROW2, INDENT + eyeArea.width() + previewArea.width() +
+                                   lockArea.width() + configArea.width(),
+              HDRROW_HEIGHT));
+
     thumbnailArea = QRect(INDENT, HDRROW4, CELL_WIDTH, THUMBNAIL_HEIGHT);
     addRect(PredefinedRect::THUMBNAIL_AREA, thumbnailArea);
     thumbnail = thumbnailArea.adjusted(1, 1, 0, 0);
@@ -774,6 +802,13 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(
         PredefinedRect::PARENT_HANDLE_NAME,
         QRect(INDENT + pegbarname.width() - 20, HDRROW5, 20, HDRROW_HEIGHT));
+
+    addRect(PredefinedRect::FOLDER_TOGGLE_ICON,
+            QRect(thumbnailArea.topLeft(), QSize(40, 30))
+                .adjusted((thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2),
+                          (thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2)));
 
     addFlag(PredefinedFlag::DRAG_LAYER_BORDER, false);
     addFlag(PredefinedFlag::DRAG_LAYER_VISIBLE, false);
@@ -851,6 +886,11 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::CAMERA_CONFIG,
             iconRect(cameraConfigArea, ICON_WIDTH - 1, ICON_HEIGHT - 1));
 
+    addRect(PredefinedRect::BUTTONS_AREA,
+            QRect(INDENT, HDRROW2, INDENT + eyeArea.width() +
+                                       previewArea.width() + lockArea.width(),
+                  HDRROW_HEIGHT));
+
     thumbnailArea =
         QRect(INDENT - 1, HDRROW3, CELL_WIDTH - INDENT - 1, THUMBNAIL_HEIGHT);
     addRect(PredefinedRect::THUMBNAIL_AREA, thumbnailArea);
@@ -885,6 +925,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
             QRect(INDENT + pegbarname.width() - 20, HDRROW4, 20,
                   HDRROW_HEIGHT - 1));
 
+    addRect(
+        PredefinedRect::FOLDER_TOGGLE_ICON,
+        QRect(thumbnailArea.topLeft(), QSize(40, 30)).adjusted(21, 19, 21, 19));
+
     addFlag(PredefinedFlag::DRAG_LAYER_BORDER, false);
     addFlag(PredefinedFlag::DRAG_LAYER_VISIBLE, true);
     addFlag(PredefinedFlag::LAYER_NAME_BORDER, false);
@@ -912,6 +956,9 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addFlag(PredefinedFlag::VOLUME_AREA_VERTICAL, true);
     addFlag(PredefinedFlag::NOTE_AREA_IN_POPUP, false);
   }
+
+  addRect(PredefinedRect::FOLDER_INDICATOR_AREA,
+          layername.adjusted(-1, -1, 0, -((layername.height() * 5)/ 6)));
 
   if (flag(PredefinedFlag::VOLUME_AREA_VERTICAL)) {
     soundTopLeft = QPoint(volumeArea.left() + 4, volumeArea.top() + 4);
@@ -1368,9 +1415,13 @@ LeftToRightOrientation::LeftToRightOrientation(QString layout) {
   addRect(PredefinedRect::CONFIG_AREA, eyeArea.translated(3 * ICON_OFFSET, 0));
   addRect(PredefinedRect::CONFIG,
           eye.translated(3 * ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
+  addRect(PredefinedRect::BUTTONS_AREA,
+          eye.adjusted(1, 1, (3 * ICON_OFFSET), -1));
+
   addRect(PredefinedRect::CAMERA_CONFIG_AREA,
           rect(PredefinedRect::CONFIG_AREA));
   addRect(PredefinedRect::CAMERA_CONFIG, rect(PredefinedRect::CONFIG));
+
   addRect(PredefinedRect::DRAG_LAYER,
           QRect(ICONS_WIDTH + THUMBNAIL_WIDTH + 1, 0,
                 LAYER_HEADER_WIDTH - ICONS_WIDTH - THUMBNAIL_WIDTH - 3,
@@ -1398,6 +1449,13 @@ LeftToRightOrientation::LeftToRightOrientation(QString layout) {
   addRect(PredefinedRect::PARENT_HANDLE_NAME, QRect(0, 0, -1, -1));  // hide
 
   addRect(PredefinedRect::SOUND_ICON,
+          QRect(thumbnailArea.topLeft(), QSize(27, thumbnailArea.height()))
+              .adjusted((thumbnailArea.width() / 2) - (27 / 2), 0,
+                        (thumbnailArea.width() / 2) - (27 / 2), 0));
+
+  addRect(PredefinedRect::FOLDER_INDICATOR_AREA,
+      QRect(ICONS_WIDTH + 1, 0, ICON_WIDTH/3, CELL_HEIGHT));
+  addRect(PredefinedRect::FOLDER_TOGGLE_ICON,
           QRect(thumbnailArea.topLeft(), QSize(27, thumbnailArea.height()))
               .adjusted((thumbnailArea.width() / 2) - (27 / 2), 0,
                         (thumbnailArea.width() / 2) - (27 / 2), 0));

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -490,8 +490,8 @@ TopToBottomOrientation::TopToBottomOrientation() {
     THUMBNAIL_HEIGHT = -1;
     HDRROW_HEIGHT    = CELL_HEIGHT - 1;
     INDENT           = 0;
-    HDRROW1          = 1;                        // Name, number
-    HDRROW2          = HDRROW1 + HDRROW_HEIGHT;  // eye, preview, config
+    HDRROW2 = use_header_height - HDRROW_HEIGHT - 2;  // pegbar, parent handle
+    HDRROW1 = 1;                                      // Name, number
 
     addRect(PredefinedRect::DRAG_LAYER, QRect(0, 0, -1, -1));
 
@@ -584,10 +584,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
     THUMBNAIL_HEIGHT = 44;
     HDRROW_HEIGHT    = CELL_HEIGHT - 2;
     INDENT           = 0;
-    HDRROW1          = 1;                        // Name, number
-    HDRROW2          = HDRROW1 + HDRROW_HEIGHT;  // eye, preview, lock, config
-    HDRROW3          = HDRROW2 + HDRROW_HEIGHT;  // thumbnail
-    HDRROW4          = HDRROW3 + THUMBNAIL_HEIGHT;  // pegbar, parent handle
+    HDRROW4 = use_header_height - HDRROW_HEIGHT - 2;  // pegbar, parent handle
+    HDRROW3 = HDRROW4 - THUMBNAIL_HEIGHT;             // thumbnail
+    HDRROW2 = HDRROW3 - HDRROW_HEIGHT;  // eye, preview, lock, config
+    HDRROW1 = 1;                        // Name, number
 
     addRect(PredefinedRect::DRAG_LAYER, QRect(0, 0, -1, -1));
 
@@ -710,11 +710,11 @@ TopToBottomOrientation::TopToBottomOrientation() {
     THUMBNAIL_HEIGHT = 44;
     HDRROW_HEIGHT    = CELL_HEIGHT - 2;
     INDENT           = 0;
-    HDRROW1          = 1;                           // Name, number
-    HDRROW2          = HDRROW1 + HDRROW_HEIGHT;     // eye, lock
-    HDRROW3          = HDRROW2 + HDRROW_HEIGHT;     // preview, config
-    HDRROW4          = HDRROW3 + HDRROW_HEIGHT;     // thumbnail
-    HDRROW5          = HDRROW4 + THUMBNAIL_HEIGHT;  // pegbar, parent handle
+    HDRROW5 = use_header_height - HDRROW_HEIGHT - 2;  // pegbar, parent handle
+    HDRROW4 = HDRROW5 - THUMBNAIL_HEIGHT;             // thumbnail
+    HDRROW3 = HDRROW4 - HDRROW_HEIGHT;                // preview, config
+    HDRROW2 = HDRROW3 - HDRROW_HEIGHT;                // eye, lock
+    HDRROW1 = 1;                                      // Name, number
 
     addRect(PredefinedRect::DRAG_LAYER,
             QRect(0, 0, -1, -1));  // hide - Theme/Compact
@@ -839,10 +839,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
     THUMBNAIL_HEIGHT = 43;
     HDRROW_HEIGHT    = CELL_HEIGHT - 2;
     INDENT           = CELL_DRAG_WIDTH + 2;
-    HDRROW1          = 7;                               // Name/eye
-    HDRROW2          = HDRROW1 + CELL_HEIGHT;           // lock, preview
-    HDRROW3          = HDRROW2 + CELL_HEIGHT;           // thumbnail
-    HDRROW4          = HDRROW3 + THUMBNAIL_HEIGHT + 5;  // pegbar, parenthandle
+    HDRROW4 = use_header_height - HDRROW_HEIGHT - 2;  // pegbar, parent handle
+    HDRROW3 = HDRROW4 - THUMBNAIL_HEIGHT - 5;         // thumbnail
+    HDRROW2 = HDRROW3 - CELL_HEIGHT;                  // lock, preview
+    HDRROW1 = 7;                                      // Name, eye
 
     addRect(PredefinedRect::DRAG_LAYER,
             QRect(0, 0, CELL_DRAG_WIDTH, use_header_height - 3));

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -688,7 +688,8 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     }
     TXshColumn *column = xsh->getColumn(c);
     bool isMask        = false;
-    if (column && !column->isEmpty() && !column->getSoundColumn()) {
+    if (column && !column->isEmpty() && !column->getSoundColumn() &&
+        !column->getFolderColumn()) {
       if (!column->isPreviewVisible() && checkPreviewVisibility) {
         if (!isMask && column->getColumnType() != TXshColumn::eMeshType) {
           while (m_masks.size() > maskCount) m_masks.pop_back();

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -713,6 +713,20 @@ void TXshColumn::setCamstandVisible(bool on) {
 
 //-----------------------------------------------------------------------------
 
+UCHAR TXshColumn::getOpacity() const {
+  UCHAR folderOpacity = getFolderOpacity();
+
+  return folderOpacity == 255 ? m_opacity : folderOpacity;
+}
+
+//-----------------------------------------------------------------------------
+
+int TXshColumn::getColorFilterId() const {
+  int folderColorFilterId = getFolderColorFilterId();
+
+  return !folderColorFilterId ? m_colorFilterId : folderColorFilterId;
+}
+
 //-----------------------------------------------------------------------------
 
 bool TXshColumn::isPreviewVisible() const {
@@ -920,6 +934,24 @@ bool TXshColumn::isFolderLocked() const {
   TXshColumn *column = getFolderColumn();
 
   return column ? column->isLocked() : false;
+}
+
+//-----------------------------------------------------------------------------
+
+UCHAR TXshColumn::getFolderOpacity() const {
+  if (m_folderId.isEmpty()) return 255;
+  TXshColumn *column = getFolderColumn();
+
+  return column ? column->getOpacity() : 255;
+}
+
+//-----------------------------------------------------------------------------
+
+int TXshColumn::getFolderColorFilterId() const {
+  if (m_folderId.isEmpty()) return 0;
+  TXshColumn *column = getFolderColumn();
+
+  return column ? column->getColorFilterId() : 0;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -837,11 +837,11 @@ void TXshColumn::setFolderId(int value, int position) {
 
 //-----------------------------------------------------------------------------
 
-int TXshColumn::getFolderId() const {
-  return m_folderId.isEmpty() || m_folderSelector < 0 ||
-                 m_folderSelector >= m_folderId.size()
+int TXshColumn::getFolderId(int position) const {
+  int pos = position < 0 ? m_folderSelector : position;
+  return m_folderId.isEmpty() || pos < 0 || pos >= m_folderId.size()
              ? 0
-             : m_folderId[m_folderSelector];
+             : m_folderId[pos];
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -682,6 +682,7 @@ void TXshColumn::setCamstandNextState() {
 //-----------------------------------------------------------------------------
 
 bool TXshColumn::isCamstandVisible() const {
+  if (!isFolderCamstandVisible()) return false;
   return (m_status & eCamstandVisible) == 0;
 }
 
@@ -715,6 +716,7 @@ void TXshColumn::setCamstandVisible(bool on) {
 //-----------------------------------------------------------------------------
 
 bool TXshColumn::isPreviewVisible() const {
+  if (!isFolderPreviewVisible()) return false;
   return (m_status & ePreviewVisible) == 0;
 }
 
@@ -730,7 +732,10 @@ void TXshColumn::setPreviewVisible(bool on) {
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isLocked() const { return (m_status & eLocked) != 0; }
+bool TXshColumn::isLocked() const {
+  if (isFolderLocked()) return true;
+  return (m_status & eLocked) != 0;
+}
 
 //-----------------------------------------------------------------------------
 
@@ -818,7 +823,7 @@ void TXshColumn::setFolderId(int value, int position) {
 
 //-----------------------------------------------------------------------------
 
-int TXshColumn::getFolderId() {
+int TXshColumn::getFolderId() const {
   return m_folderId.isEmpty() || m_folderSelector < 0 ||
                  m_folderSelector >= m_folderId.size()
              ? 0
@@ -870,6 +875,52 @@ void TXshColumn::removeFromAllFolders() {
 //-----------------------------------------------------------------------------
 
 int TXshColumn::folderDepth() { return m_folderId.size(); }
+
+//-----------------------------------------------------------------------------
+
+TXshColumn *TXshColumn::getFolderColumn() const {
+  TXsheet *xsh = getXsheet();
+  if (!xsh) return 0;
+
+  if (m_folderId.isEmpty()) return 0;
+
+  for (int i = getIndex() + 1; i < xsh->getColumnCount(); i++) {
+    TXshColumn *folderColumn = xsh->getColumn(i);
+    if (folderColumn->getFolderColumn() &&
+        folderColumn->getFolderColumn()->getFolderColumnFolderId() ==
+            getFolderId())
+      return folderColumn;
+    if (!folderColumn->isInFolder()) break;
+  }
+  return 0;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::isFolderCamstandVisible() const {
+  if (m_folderId.isEmpty()) return true;
+  TXshColumn *column = getFolderColumn();
+
+  return column ? column->isCamstandVisible() : true;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::isFolderPreviewVisible() const {
+  if (m_folderId.isEmpty()) return true;
+  TXshColumn *column = getFolderColumn();
+
+  return column ? column->isPreviewVisible() : true;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::isFolderLocked() const {
+  if (m_folderId.isEmpty()) return false;
+  TXshColumn *column = getFolderColumn();
+
+  return column ? column->isLocked() : false;
+}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/txshfoldercolumn.cpp
+++ b/toonz/sources/toonzlib/txshfoldercolumn.cpp
@@ -1,0 +1,89 @@
+
+
+#include "toonz/txshfoldercolumn.h"
+
+// TnzLib includes
+#include "toonz/txshcell.h"
+
+#include "tstream.h"
+
+PERSIST_IDENTIFIER(TXshFolderColumn, "folderColumn")
+
+//=============================================================================
+
+TXshFolderColumn::TXshFolderColumn()
+    : m_expanded(true), m_folderColumnFolderId(0) {}
+
+//-----------------------------------------------------------------------------
+
+TXshFolderColumn::~TXshFolderColumn() {}
+
+//-----------------------------------------------------------------------------
+
+TXshColumn::ColumnType TXshFolderColumn::getColumnType() const {
+  return eFolderType;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshFolderColumn::canSetCell(const TXshCell &cell) const { return false; }
+
+//-----------------------------------------------------------------------------
+
+TXshColumn *TXshFolderColumn::clone() const {
+  TXshFolderColumn *column = new TXshFolderColumn();
+  column->setXsheet(getXsheet());
+  column->setStatusWord(getStatusWord());
+  column->m_cells = m_cells;
+  column->m_first = m_first;
+
+  column->m_expanded = m_expanded;
+  column->m_folderColumnFolderId = m_folderColumnFolderId;
+  column->setFolderIdStack(getFolderIdStack());
+  return column;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshFolderColumn::loadData(TIStream &is) {
+  std::string tagName;
+  while (is.openChild(tagName)) {
+    if (tagName == "status") {
+      int status;
+      is >> status;
+      setStatusWord(status);
+      if (status & eCamstandTransparent43) {
+        setOpacity(128);
+        status = status & ~eCamstandTransparent43;
+      }
+    } else if (tagName == "columnFolderId") {
+      int id;
+      is >> id;
+      setFolderColumnFolderId(id);
+    } else if (tagName == "expanded") {
+      int id;
+      is >> id;
+      setExpanded(id ? true : false);
+    } else if (loadCellMarks(tagName, is)) {
+      // do nothing
+    } else if (loadFolderInfo(tagName, is)) {
+      // do nothing
+    } else
+      throw TException("TXshFolderColumn, unknown tag: " + tagName);
+    is.closeChild();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshFolderColumn::saveData(TOStream &os) {
+  os.child("status") << getStatusWord();
+
+  os.child("columnFolderId") << getFolderColumnFolderId();
+  os.child("expanded") << (isExpanded() ? 1 : 0);
+
+  // cell marks
+  saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
+}

--- a/toonz/sources/toonzlib/txshfoldercolumn.cpp
+++ b/toonz/sources/toonzlib/txshfoldercolumn.cpp
@@ -56,6 +56,14 @@ void TXshFolderColumn::loadData(TIStream &is) {
         setOpacity(128);
         status = status & ~eCamstandTransparent43;
       }
+    } else if (tagName == "camerastand_opacity") {
+      int opacity;
+      is >> opacity;
+      setOpacity((UCHAR)opacity);
+    } else if (tagName == "filter_color_id") {
+      int id;
+      is >> id;
+      setColorFilterId(id);
     } else if (tagName == "columnFolderId") {
       int id;
       is >> id;
@@ -78,6 +86,9 @@ void TXshFolderColumn::loadData(TIStream &is) {
 
 void TXshFolderColumn::saveData(TOStream &os) {
   os.child("status") << getStatusWord();
+  if (getOpacity() < 255) os.child("camerastand_opacity") << (int)getOpacity();
+  if (getColorFilterId() != 0)
+    os.child("filter_color_id") << (int)getColorFilterId();
 
   os.child("columnFolderId") << getFolderColumnFolderId();
   os.child("expanded") << (isExpanded() ? 1 : 0);

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -89,6 +89,7 @@ TXshColumn *TXshLevelColumn::clone() const {
   column->m_first = m_first;
   column->setColorTag(getColorTag());
   column->setColorFilterId(getColorFilterId());
+  column->setFolderIdStack(getFolderIdStack());
 
   // column->updateIcon();
   return column;
@@ -156,6 +157,8 @@ void TXshLevelColumn::loadData(TIStream &is) {
       fxSet.loadData(is);
     } else if (loadCellMarks(tagName, is)) {
       // do nothing
+    } else if (loadFolderInfo(tagName, is)) {
+      // do nothing
     } else
       throw TException("TXshLevelColumn, unknown tag: " + tagName);
     is.closeChild();
@@ -208,6 +211,8 @@ void TXshLevelColumn::saveData(TOStream &os) {
 
   // cell marks
   saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -54,6 +54,7 @@ TXshColumn *TXshMeshColumn::clone() const {
   column->m_first = m_first;
   column->setColorTag(getColorTag());
   column->setColorFilterId(getColorFilterId());
+  column->setFolderIdStack(getFolderIdStack());
 
   return column;
 }
@@ -115,6 +116,8 @@ void TXshMeshColumn::saveData(TOStream &os) {
   }
   // cell marks
   saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
 }
 
 //------------------------------------------------------------------
@@ -173,6 +176,8 @@ void TXshMeshColumn::loadData(TIStream &is) {
 
       is.closeChild();
     } else if (loadCellMarks(tagName, is)) {
+      is.closeChild();
+    } else if (loadFolderInfo(tagName, is)) {
       is.closeChild();
     } else
       is.skipCurrentTag();

--- a/toonz/sources/toonzlib/txshpalettecolumn.cpp
+++ b/toonz/sources/toonzlib/txshpalettecolumn.cpp
@@ -26,6 +26,7 @@ TXshColumn *TXshPaletteColumn::clone() const {
   column->setStatusWord(getStatusWord());
   column->m_cells = m_cells;
   column->m_first = m_first;
+  column->setFolderIdStack(getFolderIdStack());
 
   // column->updateIcon();
   return column;
@@ -75,8 +76,10 @@ void TXshPaletteColumn::loadData(TIStream &is) {
       if (TFx *fx = dynamic_cast<TFx *>(p)) setFx(fx);
     } else if (loadCellMarks(tagName, is)) {
       // do nothing
+    } else if (loadFolderInfo(tagName, is)) {
+      // do nothing
     } else {
-      throw TException("TXshLevelColumn, unknown tag: " + tagName);
+      throw TException("TXshPaletteColumn, unknown tag: " + tagName);
     }
     is.closeChild();
   }
@@ -112,6 +115,8 @@ void TXshPaletteColumn::saveData(TOStream &os) {
 
   // cell marks
   saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
 }
 
 PERSIST_IDENTIFIER(TXshPaletteColumn, "paletteColumn")

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -197,6 +197,7 @@ TXshColumn *TXshSoundColumn::clone() const {
   int i;
   for (i = 0; i < m_levels.size(); i++)
     column->insertColumnLevel(m_levels.at(i)->clone(), i);
+  column->setFolderIdStack(getFolderIdStack());
 
   return column;
 }
@@ -265,8 +266,12 @@ void TXshSoundColumn::loadData(TIStream &is) {
 
   std::string tagName;
   while (is.openChild(tagName)) {
-    if (!loadCellMarks(tagName, is))
-      throw TException("TXshLevelColumn, unknown tag: " + tagName);
+    if (loadCellMarks(tagName, is)) {
+      // do nothing
+    } else if (loadFolderInfo(tagName, is)) {
+      // do nothing
+    } else
+      throw TException("TXshSoundColumn, unknown tag: " + tagName);
     is.closeChild();
   }
 }
@@ -283,6 +288,8 @@ void TXshSoundColumn::saveData(TOStream &os) {
   os << getStatusWord();
   // cell marks
   saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshsoundtextcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundtextcolumn.cpp
@@ -57,6 +57,7 @@ TXshColumn *TXshSoundTextColumn::clone() const {
   column->setStatusWord(getStatusWord());
   column->m_cells = m_cells;
   column->m_first = m_first;
+  column->setFolderIdStack(getFolderIdStack());
   return column;
 }
 
@@ -85,13 +86,15 @@ void TXshSoundTextColumn::loadData(TIStream &is) {
               setCell(r, cell);
           }
         } else
-          throw TException("TXshLevelColumn, unknown tag(2): " + tagName);
+          throw TException("TXshSoundTextColumn, unknown tag(2): " + tagName);
         is.closeChild();
       }
     } else if (loadCellMarks(tagName, is)) {
       // do nothing
+    } else if (loadFolderInfo(tagName, is)) {
+      // do nothing
     } else
-      throw TException("TXshLevelColumn, unknown tag: " + tagName);
+      throw TException("TXshSoundTextColumn, unknown tag: " + tagName);
     is.closeChild();
   }
 }
@@ -143,6 +146,8 @@ void TXshSoundTextColumn::saveData(TOStream &os) {
   }
   // cell marks
   saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
 }
 
 PERSIST_IDENTIFIER(TXshSoundTextColumn, "soundTextColumn")

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -79,7 +79,9 @@ bool TXshZeraryFxColumn::canSetCell(const TXshCell &cell) const {
 //-----------------------------------------------------------------------------
 
 TXshColumn *TXshZeraryFxColumn::clone() const {
-  return new TXshZeraryFxColumn(*this);
+  TXshZeraryFxColumn *column = new TXshZeraryFxColumn(*this);
+  column->setFolderIdStack(getFolderIdStack());
+  return column;
 }
 
 //-----------------------------------------------------------------------------
@@ -179,6 +181,8 @@ void TXshZeraryFxColumn::loadData(TIStream &is) {
       }
     } else if (loadCellMarks(tagName, is)) {
       // do nothing
+    } else if (loadFolderInfo(tagName, is)) {
+      // do nothing
     } else
       throw TException("expected <status> or <cells>");
     is.closeChild();
@@ -231,6 +235,8 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
   }
   // cell marks
   saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/keyframenavigator.cpp
+++ b/toonz/sources/toonzqt/keyframenavigator.cpp
@@ -184,7 +184,8 @@ TStageObject *ViewerKeyframeNavigator::getStageObject() const {
   // Se e' una colonna sound non posso settare chiavi
   if (objectId.isColumn()) {
     TXshColumn *column = xsh->getColumn(objectId.getIndex());
-    if (column && column->getSoundColumn()) return 0;
+    if (column && (column->getSoundColumn() || column->getFolderColumn()))
+      return 0;
   }
   return xsh->getStageObject(objectId);
 }

--- a/toonz/sources/toonzqt/stageobjectsdata.cpp
+++ b/toonz/sources/toonzqt/stageobjectsdata.cpp
@@ -345,7 +345,9 @@ TStageObjectId TColumnDataElement::restoreColumn(TXsheet *xsh, int index,
     if (column->getFx())
       dagPos            = column->getFx()->getAttributes()->getDagNodePos();
     if (doClone) column = column->clone();
+    QStack<int> folderStack = column->getFolderIdStack();
     xsh->insertColumn(index, column);
+    column->setFolderIdStack(folderStack);
   } else
     xsh->insertColumn(index);  // Create a new one otherwise
 

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -642,7 +642,8 @@ StageSchematicNode *StageSchematicScene::createStageSchematicNode(
       return 0;
     } else {
       TXshColumn *column = m_xshHandle->getXsheet()->getColumn(columnIndex);
-      if (!column || column->getSoundColumn() || column->getSoundTextColumn())
+      if (!column || column->getSoundColumn() || column->getSoundTextColumn() ||
+          column->getFolderColumn())
         return 0;
     }
   }


### PR DESCRIPTION
This new feature allows you to group columns into Folders on the timeline/xsheet.

![image](https://github.com/tahoma2d/tahoma2d/assets/19245851/72907a7e-e756-44fc-8035-e40c779939e2)
![image](https://github.com/tahoma2d/tahoma2d/assets/19245851/7d16bec0-a629-4ee3-a19b-10d5f4f490c3)

General Folder information
- Folders are represented as columns and items in folders will follow immediately below it.
- Folders can be nested in other folders.
- Open/close folders by clicking on the triangle in the thumbnail area, using right-click menu option or shortcut (if defined)
  - For `Minimum` x-sheet layout, you can long press the folder to open/close 
- Xsheet folder items appear left of the folder column when open
- The stacking order of columns, in or out of folders, is still important from a rendering standpoint.  Folders have no impact to rendering.
- Toggling a folder's `Preview` off, `Camera Stand` off or, Lock` on  or setting `Opacity` < 100% or set a color `Filter` will override individual folder item settings.
  - When a folder's setting overrides folder item settings the folder item's settings cannot be changed.
  - Folder item's settings will be restored when the folder's settings are set back to normal.
- Folder cells can be Cell Marked.
- Other cells cannot be moved into folder cells.
- Scenes saved with folder information cannot be opened in prior versions of T2D (or OT for that matter).
- When a folder is selected for operations (i.e movement), all items in the folder are automatically selected.

Other changes:
- Movement of columns has changed.
  - Selected columns are no longer moved immediately.
  - An indicator between columns is shown where the selected column(s) can be moved to.
  - When non-contiguous columns are moved, they are moved to be next to each other.
- Can now resize the timeline's header by dragging the layer/cell divider left or right
-----
Creating folders:
1. Use the `New Folder` menu option in the `Level` -> `New`
2. Use the `New Folder` context menu option of column headers in the time timeline/xsheet
3. Select multiple columns and `Group` (Ctrl+G)
   - This will create a folder above the top/left most column.
   - All columns in the selection will be moved to be under the new folder column.

Adding items to folders:
1. Drag and drop columns directly onto a folder column
2. Drag and drop columns between 2 columns already in a folder
3. Create a new column between 2 columns already in a folder
4. Drag columns to the bottom of the last item in the folder. (indicator will change slightly)

Removing items from folders:
1. Drag and drop columns to any place outside the folder
   - If the last item in the folder is moved out, the folder will remain as an empty folder.
2. Select desired column(s) and `Ungroup` (Shift+Ctrl+G).
   - If the ungroup selection includes the folder, the folder will be removed as well
   - In case of nested groups, it will only ungroup the columns from the current folder, not all folders
   - If a specific column is removed from a folder, it will be shifted down below the folder it was in.

Nesting folders:
1. Create folders as above with at least 1 item already in the folder
2. Drag a folder column into another folder, similar to adding items to a folder
