### PR TITLE
Fix Minimum Xsheet layout UI issues

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -835,6 +835,7 @@ QPushButton,
 #CustomPanelButton,
 .ComboBox,
 #enableBlankFrameButton,
+#ColumnLockButton,
 QComboBox {
   background-color: #4c4c4c;
   border-color: #303030;
@@ -850,7 +851,8 @@ QPushButton:hover,
 #CustomPanelButton:hover,
 #ViewerFpsSlider::sub-line:horizontal:hover,
 #ViewerFpsSlider::add-line:horizontal:hover,
-#enableBlankFrameButton:hover {
+#enableBlankFrameButton:hover,
+#ColumnLockButton:hover {
   background-color: #595959;
   border-color: #303030;
   color: #f3f3f3;
@@ -860,7 +862,8 @@ QPushButton:pressed,
 #CustomPanelButton:pressed,
 #ViewerFpsSlider::sub-line:horizontal:pressed,
 #ViewerFpsSlider::add-line:horizontal:pressed,
-#enableBlankFrameButton:pressed {
+#enableBlankFrameButton:pressed,
+#ColumnLockButton:pressed {
   background-color: #141414;
   border-color: #0f0f0f;
   color: #f3f3f3;
@@ -868,7 +871,8 @@ QPushButton:pressed,
 .Button:checked,
 QPushButton:checked,
 #CustomPanelButton:checked,
-#enableBlankFrameButton:checked {
+#enableBlankFrameButton:checked,
+#ColumnLockButton:checked {
   background-color: #141414;
   border-color: #0f0f0f;
   color: #f3f3f3;
@@ -876,14 +880,16 @@ QPushButton:checked,
 .Button:checked:hover,
 QPushButton:checked:hover,
 #CustomPanelButton:checked:hover,
-#enableBlankFrameButton:checked:hover {
+#enableBlankFrameButton:checked:hover,
+#ColumnLockButton:checked:hover {
   background-color: #282828;
   border-color: #1c1c1c;
 }
 .Button:checked:hover:pressed,
 QPushButton:checked:hover:pressed,
 #CustomPanelButton:checked:hover:pressed,
-#enableBlankFrameButton:checked:hover:pressed {
+#enableBlankFrameButton:checked:hover:pressed,
+#ColumnLockButton:checked:hover:pressed {
   background: #1c1c1c;
 }
 .Button:disabled,
@@ -893,6 +899,7 @@ QPushButton:disabled,
 #ViewerFpsSlider::sub-line:horizontal:disabled,
 #ViewerFpsSlider::add-line:horizontal:disabled,
 #enableBlankFrameButton:disabled,
+#ColumnLockButton:disabled,
 QComboBox:disabled {
   background-color: #3d3d3d;
   border-color: #303030;
@@ -2223,6 +2230,15 @@ Ruler {
 }
 #enableBlankFrameButton:checked {
   border-width: 2px;
+}
+#ColumnLockButton {
+  border-radius: 0;
+  background-color: transparent;
+  border-color: transparent;
+}
+#ColumnLockButton:checked {
+  background-color: transparent;
+  border-color: transparent;
 }
 /* -----------------------------------------------------------------------------
    XSheet Viewer

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -835,6 +835,7 @@ QPushButton,
 #CustomPanelButton,
 .ComboBox,
 #enableBlankFrameButton,
+#ColumnLockButton,
 QComboBox {
   background-color: #3c3c3c;
   border-color: #202020;
@@ -850,7 +851,8 @@ QPushButton:hover,
 #CustomPanelButton:hover,
 #ViewerFpsSlider::sub-line:horizontal:hover,
 #ViewerFpsSlider::add-line:horizontal:hover,
-#enableBlankFrameButton:hover {
+#enableBlankFrameButton:hover,
+#ColumnLockButton:hover {
   background-color: #494949;
   border-color: #202020;
   color: #f3f3f3;
@@ -860,7 +862,8 @@ QPushButton:pressed,
 #CustomPanelButton:pressed,
 #ViewerFpsSlider::sub-line:horizontal:pressed,
 #ViewerFpsSlider::add-line:horizontal:pressed,
-#enableBlankFrameButton:pressed {
+#enableBlankFrameButton:pressed,
+#ColumnLockButton:pressed {
   background-color: #040404;
   border-color: #000000;
   color: #f3f3f3;
@@ -868,7 +871,8 @@ QPushButton:pressed,
 .Button:checked,
 QPushButton:checked,
 #CustomPanelButton:checked,
-#enableBlankFrameButton:checked {
+#enableBlankFrameButton:checked,
+#ColumnLockButton:checked {
   background-color: #040404;
   border-color: #000000;
   color: #f3f3f3;
@@ -876,14 +880,16 @@ QPushButton:checked,
 .Button:checked:hover,
 QPushButton:checked:hover,
 #CustomPanelButton:checked:hover,
-#enableBlankFrameButton:checked:hover {
+#enableBlankFrameButton:checked:hover,
+#ColumnLockButton:checked:hover {
   background-color: #181818;
   border-color: #0c0c0c;
 }
 .Button:checked:hover:pressed,
 QPushButton:checked:hover:pressed,
 #CustomPanelButton:checked:hover:pressed,
-#enableBlankFrameButton:checked:hover:pressed {
+#enableBlankFrameButton:checked:hover:pressed,
+#ColumnLockButton:checked:hover:pressed {
   background: #0c0c0c;
 }
 .Button:disabled,
@@ -893,6 +899,7 @@ QPushButton:disabled,
 #ViewerFpsSlider::sub-line:horizontal:disabled,
 #ViewerFpsSlider::add-line:horizontal:disabled,
 #enableBlankFrameButton:disabled,
+#ColumnLockButton:disabled,
 QComboBox:disabled {
   background-color: #2d2d2d;
   border-color: #202020;
@@ -2223,6 +2230,15 @@ Ruler {
 }
 #enableBlankFrameButton:checked {
   border-width: 2px;
+}
+#ColumnLockButton {
+  border-radius: 0;
+  background-color: transparent;
+  border-color: transparent;
+}
+#ColumnLockButton:checked {
+  background-color: transparent;
+  border-color: transparent;
 }
 /* -----------------------------------------------------------------------------
    XSheet Viewer

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -835,6 +835,7 @@ QPushButton,
 #CustomPanelButton,
 .ComboBox,
 #enableBlankFrameButton,
+#ColumnLockButton,
 QComboBox {
   background-color: #c7c7c7;
   border-color: #a0a0a0;
@@ -850,7 +851,8 @@ QPushButton:hover,
 #CustomPanelButton:hover,
 #ViewerFpsSlider::sub-line:horizontal:hover,
 #ViewerFpsSlider::add-line:horizontal:hover,
-#enableBlankFrameButton:hover {
+#enableBlankFrameButton:hover,
+#ColumnLockButton:hover {
   background-color: #d3d3d3;
   border-color: #a0a0a0;
   color: #0d0d0d;
@@ -860,7 +862,8 @@ QPushButton:pressed,
 #CustomPanelButton:pressed,
 #ViewerFpsSlider::sub-line:horizontal:pressed,
 #ViewerFpsSlider::add-line:horizontal:pressed,
-#enableBlankFrameButton:pressed {
+#enableBlankFrameButton:pressed,
+#ColumnLockButton:pressed {
   background-color: #8f8f8f;
   border-color: #7a7a7a;
   color: #0d0d0d;
@@ -868,7 +871,8 @@ QPushButton:pressed,
 .Button:checked,
 QPushButton:checked,
 #CustomPanelButton:checked,
-#enableBlankFrameButton:checked {
+#enableBlankFrameButton:checked,
+#ColumnLockButton:checked {
   background-color: #b5b5b5;
   border-color: #8e8e8e;
   color: #000;
@@ -876,14 +880,16 @@ QPushButton:checked,
 .Button:checked:hover,
 QPushButton:checked:hover,
 #CustomPanelButton:checked:hover,
-#enableBlankFrameButton:checked:hover {
+#enableBlankFrameButton:checked:hover,
+#ColumnLockButton:checked:hover {
   background-color: #c9c9c9;
   border-color: #bcbcbc;
 }
 .Button:checked:hover:pressed,
 QPushButton:checked:hover:pressed,
 #CustomPanelButton:checked:hover:pressed,
-#enableBlankFrameButton:checked:hover:pressed {
+#enableBlankFrameButton:checked:hover:pressed,
+#ColumnLockButton:checked:hover:pressed {
   background: #bcbcbc;
 }
 .Button:disabled,
@@ -893,6 +899,7 @@ QPushButton:disabled,
 #ViewerFpsSlider::sub-line:horizontal:disabled,
 #ViewerFpsSlider::add-line:horizontal:disabled,
 #enableBlankFrameButton:disabled,
+#ColumnLockButton:disabled,
 QComboBox:disabled {
   background-color: #d1d1d1;
   border-color: #b7b7b7;
@@ -2223,6 +2230,15 @@ Ruler {
 }
 #enableBlankFrameButton:checked {
   border-width: 2px;
+}
+#ColumnLockButton {
+  border-radius: 0;
+  background-color: transparent;
+  border-color: transparent;
+}
+#ColumnLockButton:checked {
+  background-color: transparent;
+  border-color: transparent;
 }
 /* -----------------------------------------------------------------------------
    XSheet Viewer

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -835,6 +835,7 @@ QPushButton,
 #CustomPanelButton,
 .ComboBox,
 #enableBlankFrameButton,
+#ColumnLockButton,
 QComboBox {
   background-color: #646464;
   border-color: #484848;
@@ -850,7 +851,8 @@ QPushButton:hover,
 #CustomPanelButton:hover,
 #ViewerFpsSlider::sub-line:horizontal:hover,
 #ViewerFpsSlider::add-line:horizontal:hover,
-#enableBlankFrameButton:hover {
+#enableBlankFrameButton:hover,
+#ColumnLockButton:hover {
   background-color: #717171;
   border-color: #484848;
   color: #f3f3f3;
@@ -860,7 +862,8 @@ QPushButton:pressed,
 #CustomPanelButton:pressed,
 #ViewerFpsSlider::sub-line:horizontal:pressed,
 #ViewerFpsSlider::add-line:horizontal:pressed,
-#enableBlankFrameButton:pressed {
+#enableBlankFrameButton:pressed,
+#ColumnLockButton:pressed {
   background-color: #2c2c2c;
   border-color: #272727;
   color: #f3f3f3;
@@ -868,7 +871,8 @@ QPushButton:pressed,
 .Button:checked,
 QPushButton:checked,
 #CustomPanelButton:checked,
-#enableBlankFrameButton:checked {
+#enableBlankFrameButton:checked,
+#ColumnLockButton:checked {
   background-color: #2c2c2c;
   border-color: #272727;
   color: #f3f3f3;
@@ -876,14 +880,16 @@ QPushButton:checked,
 .Button:checked:hover,
 QPushButton:checked:hover,
 #CustomPanelButton:checked:hover,
-#enableBlankFrameButton:checked:hover {
+#enableBlankFrameButton:checked:hover,
+#ColumnLockButton:checked:hover {
   background-color: #404040;
   border-color: #343434;
 }
 .Button:checked:hover:pressed,
 QPushButton:checked:hover:pressed,
 #CustomPanelButton:checked:hover:pressed,
-#enableBlankFrameButton:checked:hover:pressed {
+#enableBlankFrameButton:checked:hover:pressed,
+#ColumnLockButton:checked:hover:pressed {
   background: #343434;
 }
 .Button:disabled,
@@ -893,6 +899,7 @@ QPushButton:disabled,
 #ViewerFpsSlider::sub-line:horizontal:disabled,
 #ViewerFpsSlider::add-line:horizontal:disabled,
 #enableBlankFrameButton:disabled,
+#ColumnLockButton:disabled,
 QComboBox:disabled {
   background-color: #555555;
   border-color: #484848;
@@ -2223,6 +2230,15 @@ Ruler {
 }
 #enableBlankFrameButton:checked {
   border-width: 2px;
+}
+#ColumnLockButton {
+  border-radius: 0;
+  background-color: transparent;
+  border-color: transparent;
+}
+#ColumnLockButton:checked {
+  background-color: transparent;
+  border-color: transparent;
 }
 /* -----------------------------------------------------------------------------
    XSheet Viewer

--- a/stuff/config/qss/Medium/less/layouts/viewer.less
+++ b/stuff/config/qss/Medium/less/layouts/viewer.less
@@ -191,3 +191,14 @@ Ruler {
     border-width: 2px;
   }
 }
+
+#ColumnLockButton {
+  &:extend(.Button all);
+  border-radius: 0;
+  background-color: transparent;
+  border-color: transparent;
+  &:checked {
+    background-color: transparent;
+    border-color: transparent;
+  }
+}

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -835,6 +835,7 @@ QPushButton,
 #CustomPanelButton,
 .ComboBox,
 #enableBlankFrameButton,
+#ColumnLockButton,
 QComboBox {
   background-color: #9f9f9f;
   border-color: #616161;
@@ -850,7 +851,8 @@ QPushButton:hover,
 #CustomPanelButton:hover,
 #ViewerFpsSlider::sub-line:horizontal:hover,
 #ViewerFpsSlider::add-line:horizontal:hover,
-#enableBlankFrameButton:hover {
+#enableBlankFrameButton:hover,
+#ColumnLockButton:hover {
   background-color: #b3b3b3;
   border-color: #616161;
   color: #0d0d0d;
@@ -860,7 +862,8 @@ QPushButton:pressed,
 #CustomPanelButton:pressed,
 #ViewerFpsSlider::sub-line:horizontal:pressed,
 #ViewerFpsSlider::add-line:horizontal:pressed,
-#enableBlankFrameButton:pressed {
+#enableBlankFrameButton:pressed,
+#ColumnLockButton:pressed {
   background-color: #676767;
   border-color: #525252;
   color: #0d0d0d;
@@ -868,7 +871,8 @@ QPushButton:pressed,
 .Button:checked,
 QPushButton:checked,
 #CustomPanelButton:checked,
-#enableBlankFrameButton:checked {
+#enableBlankFrameButton:checked,
+#ColumnLockButton:checked {
   background-color: #5a5a5a;
   border-color: #404040;
   color: rgba(255, 255, 255, 0.917);
@@ -876,14 +880,16 @@ QPushButton:checked,
 .Button:checked:hover,
 QPushButton:checked:hover,
 #CustomPanelButton:checked:hover,
-#enableBlankFrameButton:checked:hover {
+#enableBlankFrameButton:checked:hover,
+#ColumnLockButton:checked:hover {
   background-color: #6e6e6e;
   border-color: #616161;
 }
 .Button:checked:hover:pressed,
 QPushButton:checked:hover:pressed,
 #CustomPanelButton:checked:hover:pressed,
-#enableBlankFrameButton:checked:hover:pressed {
+#enableBlankFrameButton:checked:hover:pressed,
+#ColumnLockButton:checked:hover:pressed {
   background: #616161;
 }
 .Button:disabled,
@@ -893,6 +899,7 @@ QPushButton:disabled,
 #ViewerFpsSlider::sub-line:horizontal:disabled,
 #ViewerFpsSlider::add-line:horizontal:disabled,
 #enableBlankFrameButton:disabled,
+#ColumnLockButton:disabled,
 QComboBox:disabled {
   background-color: #8d8d8d;
   border-color: #737373;
@@ -2223,6 +2230,15 @@ Ruler {
 }
 #enableBlankFrameButton:checked {
   border-width: 2px;
+}
+#ColumnLockButton {
+  border-radius: 0;
+  background-color: transparent;
+  border-color: transparent;
+}
+#ColumnLockButton:checked {
+  background-color: transparent;
+  border-color: transparent;
 }
 /* -----------------------------------------------------------------------------
    XSheet Viewer

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2179,12 +2179,11 @@ m_value->setFont(font);*/
   m_maskGroupBox->setLayout(maskLay);
 
   // Lock button is moved in the popup for Minimum layout
-  QPushButton *lockExtraBtn = nullptr;
   if (m_viewer->getXsheetLayout() == "Minimum") {
     m_lockBtn = new QPushButton(tr("Lock Column"), this);
     m_lockBtn->setCheckable(true);
     m_lockBtn->setIcon(createLockIcon(m_viewer));
-    lockExtraBtn = new QPushButton(this);
+    m_lockExtraBtn = new QPushButton(this);
     QMenu *menu  = new QMenu();
     menu->setObjectName("xsheetColumnAreaMenu_Lock");
     CommandManager *cmdManager = CommandManager::instance();
@@ -2194,8 +2193,8 @@ m_value->setFont(font);*/
     menu->addAction(cmdManager->getAction("MI_UnlockSelectedColumns"));
     menu->addAction(cmdManager->getAction("MI_UnlockAllColumns"));
     menu->addAction(cmdManager->getAction("MI_ToggleColumnLocks"));
-    lockExtraBtn->setMenu(menu);
-    lockExtraBtn->setFixedSize(20, 20);
+    m_lockExtraBtn->setMenu(menu);
+    m_lockExtraBtn->setFixedSize(20, 20);
   }
 
   QGridLayout *mainLayout = new QGridLayout();
@@ -2228,7 +2227,7 @@ m_value->setFont(font);*/
       lockLay->setSpacing(3);
       {
         lockLay->addWidget(m_lockBtn, 0);
-        lockLay->addWidget(lockExtraBtn, 0);
+        lockLay->addWidget(m_lockExtraBtn, 0);
       }
       mainLayout->addLayout(lockLay, 3, 1, Qt::AlignLeft | Qt::AlignVCenter);
     }
@@ -2412,7 +2411,12 @@ void ColumnTransparencyPopup::setColumn(TXshColumn *column) {
   m_invertMask->blockSignals(false);
   m_renderMask->blockSignals(false);
 
-  if (m_lockBtn) m_lockBtn->setChecked(m_column->isLocked());
+  if (m_lockBtn) {
+    m_lockBtn->setChecked(m_column->isLocked());
+    bool isVertical = m_viewer->orientation()->isVerticalTimeline();
+    m_lockBtn->setVisible(isVertical);
+    m_lockExtraBtn->setVisible(isVertical);
+  }
 }
 
 /*void ColumnTransparencyPopup::mouseMoveEvent ( QMouseEvent * e )
@@ -2594,7 +2598,8 @@ void ColumnArea::openCameraColumnPopup(QPoint pos) {
     menu.addAction(action);
   }
   // Lock button is moved in this menu for Minimum layout
-  if (m_viewer->getXsheetLayout() == "Minimum") {
+  if (m_viewer->getXsheetLayout() == "Minimum" &&
+      m_viewer->orientation()->isVerticalTimeline()) {
     menu.addSeparator();
     bool isLocked = m_viewer->getXsheet()->getColumn(-1)->isLocked();
     QAction *lockAction =

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -159,15 +159,20 @@ bool containsVectorLevel(int col) {
 }
 
 QIcon createLockIcon(XsheetViewer *viewer) {
-  QColor bgColor_on, bgColor_off;
+  const Orientation *o = viewer->orientation();
+  QColor bgColor;
+  QString svgFilePath;
 
-  QString svgFilePath_on  = viewer->getXsheetLockButtonOnImage();
-  QString svgFilePath_off = viewer->getXsheetLockButtonOffImage();
+  viewer->getButton(LOCK_ON_XSHBUTTON, bgColor, svgFilePath,
+                    !o->isVerticalTimeline());
+  QPixmap pm_on =
+      svgToPixmap(svgFilePath, QSize(16, 16), Qt::KeepAspectRatio, bgColor);
 
-  QPixmap pm_on  = svgToPixmap(svgFilePath_on, QSize(16, 16),
-                               Qt::KeepAspectRatio, bgColor_on);
-  QPixmap pm_off = svgToPixmap(svgFilePath_off, QSize(16, 16),
-                               Qt::KeepAspectRatio, bgColor_off);
+  viewer->getButton(LOCK_OFF_XSHBUTTON, bgColor, svgFilePath,
+                    !o->isVerticalTimeline());
+  QPixmap pm_off =
+      svgToPixmap(svgFilePath, QSize(16, 16), Qt::KeepAspectRatio, bgColor);
+
   QIcon lockIcon;
   lockIcon.addPixmap(pm_off);
   lockIcon.addPixmap(pm_on, QIcon::Normal, QIcon::On);
@@ -2181,6 +2186,7 @@ m_value->setFont(font);*/
   // Lock button is moved in the popup for Minimum layout
   if (m_viewer->getXsheetLayout() == "Minimum") {
     m_lockBtn = new QPushButton(tr("Lock Column"), this);
+    m_lockBtn->setObjectName("ColumnLockButton");
     m_lockBtn->setCheckable(true);
     m_lockBtn->setIcon(createLockIcon(m_viewer));
     m_lockExtraBtn = new QPushButton(this);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1256,7 +1256,8 @@ void ColumnArea::DrawHeader::drawColumnName() const {
       if (column->isPreviewVisible() && !column->getSoundTextColumn() &&
           !column->getPaletteColumn() && col >= 0)
         nameBacklit = true;
-    } else if (Preferences::instance()->isShowColumnNumbersEnabled()) {
+    } else if (Preferences::instance()->isShowColumnNumbersEnabled() &&
+               o->flag(PredefinedFlag::LAYER_NUMBER_VISIBLE)) {
       if (o->isVerticalTimeline())
         rightadj = -20;
       else

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -222,7 +222,7 @@ class ColumnTransparencyPopup final : public QWidget {
   QComboBox *m_filterColorCombo;
 
   XsheetViewer *m_viewer;
-  QPushButton *m_lockBtn;
+  QPushButton *m_lockBtn, *m_lockExtraBtn;
 
   QGroupBox *m_maskGroupBox;
   QCheckBox *m_invertMask;


### PR DESCRIPTION
This is a minor UI fix to the `Minimum` xsheet layout.

1. Column numbers are purposefully hidden in this layout, however the space is made for it when `Show Column Numbers in Column Headers` is enabled. Added a check to not adjust for column number spacing if it isn't supposed to be shown.
2. Fixed the issue with the missing lock button icon in the context menu
3. Fixed styling issues with the lock button in the context menu
