### PR TITLE
Fix saving files in scene sub-folders

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -163,7 +163,6 @@ public:
     return getBoolValue(rasterOptimizedMemory);
   }
   bool isAutosaveEnabled() const { return getBoolValue(autosaveEnabled); }
-  bool isSaveLevelsOnSaveSceneEnabled() const { return getBoolValue(saveLevelsOnSaveSceneEnabled); }
   int getAutosavePeriod() const {
     return getIntValue(autosavePeriod);
   }  // minutes

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -75,7 +75,6 @@ enum PreferencesItemId {
   defaultProjectPath,
   recordFileHistory,
   recordAsUsername,
-  saveLevelsOnSaveSceneEnabled,
 
   //----------
   // Import / Export

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -645,7 +645,7 @@ bool SaveSceneAsPopup::execute() {
           fp.getName())))  // Lol. Cmon! Really necessary?
     return false;
 
-  return IoCmd::saveSceneAs(fp);
+  return IoCmd::saveScene(fp, 0);
 }
 
 void SaveSceneAsPopup::initFolder() {

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -180,7 +180,6 @@ bool loadScene(ToonzScene &scene, const TFilePath &scenePath, bool import);
 bool loadScene(const TFilePath &scenePath, bool updateRecentFile = true,
                bool checkSaveOldScene = true);
 bool loadScene();
-bool saveSceneAs(const TFilePath &fp);
 bool saveSceneVersion();
 
 bool loadSubScene();
@@ -261,7 +260,7 @@ bool importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
 // open a warning popup notifying that such level will lose link.
 bool takeCareSceneFolderItemsOnSaveSceneAs(
     ToonzScene *scene, const TFilePath &newPath, TXsheet *subxsh,
-    QHash<TXshLevel *, TFilePath> &orgLevelPaths);
+    QHash<TXshLevel *, TFilePath> &orgLevelPaths, bool useSceneSubfolders);
 
 }  // namespace IoCmd
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1327,7 +1327,6 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {defaultProjectPath, tr("Default Project Path:")},
       {recordFileHistory, tr("Record File History* (tnz, pli, hst)")},
       {recordAsUsername, tr("History Username*:")},
-      {saveLevelsOnSaveSceneEnabled, tr("Automatically Save Levels On 'Save Scene As'")},
 
       // Import / Export
       {ffmpegPath, tr("Executable Directory:")},
@@ -1981,7 +1980,6 @@ QWidget* PreferencesPopup::createSavingPage() {
   insertUI(rasterBackgroundColor, lay);
   insertUI(resetUndoOnSavingLevel, lay);
   insertUI(doNotShowPopupSaveScene, lay);
-  insertUI(saveLevelsOnSaveSceneEnabled, lay);
 
   insertUI(fastRenderPath, lay);
 

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -54,6 +54,11 @@ ImageLoader::ImageLoader(const TFilePath &path, const TFrameId &fid)
 //-------------------------------------------------------------------------
 
 bool ImageLoader::getInfo(TImageInfo &info, int imFlags, void *extData) {
+  // Update path if image file location was changed
+  BuildExtData *data = static_cast<BuildExtData *>(extData);
+  if (data && !data->m_fullPath.isEmpty() && m_path != data->m_fullPath)
+    m_path = data->m_fullPath;
+
   try {
     TLevelReaderP lr(m_path);
     TImageReaderP fr = lr->getFrameReader(m_fid);
@@ -90,6 +95,10 @@ TImageP ImageLoader::build(int imFlags, void *extData) {
   BuildExtData *data = static_cast<BuildExtData *>(extData);
 
   int subsampling = buildSubsampling(imFlags, data);
+
+  // Update path if image file location was changed
+  if (!data->m_fullPath.isEmpty() && m_path != data->m_fullPath)
+    m_path = data->m_fullPath;
 
   try {
     // Initialize level reader

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -40,10 +40,16 @@ public:
     //!< m_sl's subsampling property otherwise)
     bool m_icon;  //!< Whether the icon (if any) should be loaded instead
 
+    TFilePath m_fullPath;
+
   public:
     BuildExtData(const TXshSimpleLevel *sl, const TFrameId &fid, int subs = 0,
-                 bool icon = false)
-        : m_sl(sl), m_fid(fid), m_subs(subs), m_icon(icon) {}
+                 bool icon = false, TFilePath fullPath = TFilePath())
+        : m_sl(sl)
+        , m_fid(fid)
+        , m_subs(subs)
+        , m_icon(icon)
+        , m_fullPath(fullPath) {}
   };
 
 public:

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -499,8 +499,6 @@ void Preferences::definePreferenceItems() {
   QString userName = TSystem::getUserName();
   define(recordAsUsername, "recordAsUsername", QMetaType::QString, userName);
 
-  define(saveLevelsOnSaveSceneEnabled, "saveLevelsOnSaveSceneEnabled", QMetaType::Bool, false);
-
   // Import / Export
   define(ffmpegPath, "ffmpegPath", QMetaType::QString, "");
   define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, 0, 0,

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -13,6 +13,8 @@
 
 #include "toonz/stageplayer.h"
 
+#include "toonz/toonzscene.h"
+
 using namespace Stage;
 
 //*****************************************************************************************
@@ -67,7 +69,9 @@ TImageP Stage::Player::image() const {
       (slType == OVL_XSHLEVEL || slType == TZI_XSHLEVEL))
     id = id + "_filled";
 
-  ImageLoader::BuildExtData extData(m_sl, m_fid);
+  ImageLoader::BuildExtData extData(
+      m_sl, m_fid, 0, false,
+      m_xsh->getScene()->decodeFilePath(m_sl->getPath()));
   return ImageManager::instance()->getImage(id, ImageManager::none, &extData);
 }
 


### PR DESCRIPTION
This fixes some saving issues related to saving when `Project Management` -> `Project Settings` -> `Separate assets into scene sub-folders` is enabled.

1. Fixes when importing images into an untitled (unsaved) scene, saving and then reloading resulted in image loss.
2. Fixes an issue when saving images drawn in an untitled scene the files are saved in `Untitledxxx` folders in `+extras` and `+drawings` instead of the scene name.
3. Fixes an issue when saving a scene with `Save As` to give it a new name, prior images are still referenced in the old scene subfolder.  Now it copies files to the new scene subfolder.
