### PR TITLE
OCA Import

### DIFF
--- a/toonz/sources/tnztools/controlpointselection.cpp
+++ b/toonz/sources/tnztools/controlpointselection.cpp
@@ -1031,7 +1031,7 @@ void ControlPointSelection::addMenuItems(QMenu *menu) {
   menu->addAction(CommandManager::instance()->getAction("MI_SetLinearControlPoint"));
   menu->addAction(CommandManager::instance()->getAction("MI_SetNonLinearControlPoint"));
   menu->addSeparator();
-  //assert(ret); makes debug build fail
+  //assert(ret);
 }
 
 //---------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1891,6 +1891,10 @@ void MainWindow::defineActions() {
       QT_TRANSLATE_NOOP("MainWindow", "Export Open Cel Animation (OCA)"), "",
       "export_oca");
   createMenuFileAction(
+      MI_ImportOCA,
+      QT_TRANSLATE_NOOP("MainWindow", "Import Open Cel Animation (OCA)"), "",
+      "import_oca");
+  createMenuFileAction(
       MI_ExportTvpJson,
       QT_TRANSLATE_NOOP("MainWindow", "Export TVPaint JSON File"), "",
       "export_tvpaint");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -339,7 +339,10 @@ void TopBar::loadMenubar() {
   }
   fileMenu->addSeparator();
   QMenu *importMenu = fileMenu->addMenu(tr("Import"));
-  { addMenuItem(importMenu, MI_ImportMagpieFile); }
+  { 
+    addMenuItem(importMenu, MI_ImportMagpieFile); 
+    addMenuItem(importMenu, MI_ImportOCA);
+  }
   QMenu *exportMenu = fileMenu->addMenu(tr("Export"));
   {
     addMenuItem(exportMenu, MI_ExportCurrentScene);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -491,6 +491,7 @@
 
 #define MI_ExportXDTS "MI_ExportXDTS"
 #define MI_ExportOCA "MI_ExportOCA"
+#define MI_ImportOCA "MI_ImportOCA"
 #define MI_ExportTvpJson "MI_ExportTvpJson"
 #define MI_ExportXsheetPDF "MI_ExportXsheetPDF"
 #define MI_ExportCameraTrack "MI_ExportCameraTrack"

--- a/toonz/sources/toonz/ocaio.cpp
+++ b/toonz/sources/toonz/ocaio.cpp
@@ -15,9 +15,11 @@
 #include "toonz/txsheethandle.h"
 #include "toonz/tscenehandle.h"
 #include "toonz/preferences.h"
+#include "toonz/preferencesitemids.h"
 #include "toonz/sceneproperties.h"
 #include "toonz/tstageobject.h"
 #include "toutputproperties.h"
+#include "toonz/txshlevelcolumn.h"
 
 #include "toonzqt/menubarcommand.h"
 #include "toonzqt/gutil.h"
@@ -537,15 +539,7 @@ void ExportOCACommand::execute() {
   }
 }
 
-/// <summary>
-///  OCA importer
-/// Roadmap:
-/// - test the case of child layer, add progress bar
-/// - add the option to update the current scene from OCA, importing only the missing layers 
-/// (example : import a krita paint layer, but keep the tlv with their palette as smart rasters...)
-/// - keyframe animation transfert for camera, pegs, etc...
-/// that would be another tool and another open file format (ascii (json or xml?) or binary (faster for huge scenes?) ?).
-/// </summary>
+//-------------------------------------------------
 
 class ImportOCACommand final : public MenuItemHandler {
 public:
@@ -554,12 +548,14 @@ public:
 } ImportOCACommand;
 
 void ImportOCACommand::execute() {
-  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
-  TXsheet *xsheet   = TApp::instance()->getCurrentXsheet()->getXsheet();
-  TFilePath fp      = scene->getScenePath().withType("oca");
+  bool importEnabled = false;
+  ToonzScene *scene  = TApp::instance()->getCurrentScene()->getScene();
+  TXsheet *xsheet    = TApp::instance()->getCurrentXsheet()->getXsheet();
+  TFilePath fp       = scene->getScenePath().withType("oca");
   static GenericLoadFilePopup *loadPopup = 0;
   if (!loadPopup) {
-    loadPopup             = new GenericLoadFilePopup( QObject::tr("Import Open Cel Animation (OCA)") );
+    loadPopup = new GenericLoadFilePopup(
+        QObject::tr("Import Open Cel Animation (OCA)"));
     loadPopup->addFilterType("oca");
   }
   if (!scene->isUntitled())
@@ -571,23 +567,38 @@ void ImportOCACommand::execute() {
   loadPopup->setFilename(fp.withoutParentDir());
   fp = loadPopup->getPath();
   if (fp.isEmpty()) {
-    DVGui::info(QObject::tr("Open OCA file cancelled : empty filepath."));
+    DVGui::info(QObject::tr("OCA Import cancelled : empty filepath."));
     return;
   } else {
-    DVGui::info(QObject::tr("Open OCA file : ") + fp.getQString());
+    DVGui::info(QObject::tr("OCA Import file : %1").arg(fp.getQString()));
+
+    QString label = QObject::tr(
+        "Do you want to import or load image files from their original "
+        "location?");
+    QStringList buttons;
+    buttons << QObject::tr("Import") << QObject::tr("Load")
+            << QObject::tr("Cancel");
+    DVGui::Dialog *importDialog =
+        DVGui::createMsgBox(DVGui::QUESTION, label, buttons, 0);
+    int ret = importDialog->exec();
+    importDialog->deleteLater();
+
+    if (ret == 0 || ret == 3) return;
+
+    importEnabled = (ret == 1);
   }
 
-  QString ocafile = fp.getQString();
-  OCAInputData ocaInputData = OCAInputData(0, true, false);
+  QString ocafile           = fp.getQString();
+  OCAInputData ocaInputData = OCAInputData(0, false, false);
   QJsonObject ocaObject;
-  if (!ocaInputData.load(ocafile, ocaObject)) {
-    DVGui::warning(QObject::tr("Failed to load OCA file: ") +
-                   fp.getQString());
+  if (!ocaInputData.read(ocafile, ocaObject)) {
+    DVGui::warning(
+        QObject::tr("Failed to load OCA file: %1").arg(fp.getQString()));
     return;
   }
-  ocaInputData.getSceneData();   // gather default values
-  ocaInputData.read(ocaObject); // parser
-  ocaInputData.setSceneData();  // set scene/xsheet values
+  ocaInputData.getSceneData();                  // gather default values
+  ocaInputData.load(ocaObject, importEnabled);  // load resources
+  ocaInputData.setSceneData();                  // set scene/xsheet values
   // TApp::instance()->getCurrentLevel()->notifyLevelChange(); > importOcaLayer
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->notifyCastChange();
@@ -595,18 +606,20 @@ void ImportOCACommand::execute() {
 }
 
 OCAIo::OCAInputData::OCAInputData(float antialiasSoftness, bool whiteTransp,
-                                  bool doPremultiply) {
-  m_antialiasSoftness = antialiasSoftness;
-  m_whiteTransp       = whiteTransp;
-  m_doPremultiply     = doPremultiply;
-  m_scene             = TApp::instance()->getCurrentScene()->getScene();
-  m_xsheet            = TApp::instance()->getCurrentXsheet()->getXsheet();
-  m_oprop             = m_scene->getProperties()->getOutputProperties();
+                                  bool doPremultiply)
+    : m_antialiasSoftness(antialiasSoftness)
+    , m_whiteTransp(whiteTransp)
+    , m_doPremultiply(doPremultiply)
+    , m_supressImportMessages(false) {
+  m_scene  = TApp::instance()->getCurrentScene()->getScene();
+  m_xsheet = TApp::instance()->getCurrentXsheet()->getXsheet();
+  m_oprop  = m_scene->getProperties()->getOutputProperties();
+  m_dpi    = Preferences::instance()->getDefLevelDpi();
 }
 
-bool OCAIo::OCAInputData::load(QString path, QJsonObject &json) { 
-  //see XdtsIo::loadXdtsScene
-  m_path = path;
+bool OCAIo::OCAInputData::read(QString path, QJsonObject &json) {
+  // see XdtsIo::loadXdtsScene
+  m_path      = path;
   m_parentDir = TFilePath(m_path).getParentDir();
   // 1. Open the QFile, read it in a byteArray and close the file
   QFile file;
@@ -615,13 +628,14 @@ bool OCAIo::OCAInputData::load(QString path, QJsonObject &json) {
     DVGui::error(QObject::tr("Unable to open OCA file for loading."));
     return false;
   } else {
-    DVGui::info(QObject::tr("Loading : ") + path);
+    DVGui::info(QObject::tr("Reading OCA file: %1").arg(path));
   }
   QByteArray byteArray;
   byteArray = file.readAll();
   file.close();
 
-  // 2. Format the content of the byteArray as QJsonDocument and check on parse Errors
+  // 2. Format the content of the byteArray as QJsonDocument and check on parse
+  // Errors
   QJsonParseError parseError;
   QJsonDocument jsonDoc;
   jsonDoc = QJsonDocument::fromJson(byteArray, &parseError);
@@ -634,10 +648,6 @@ bool OCAIo::OCAInputData::load(QString path, QJsonObject &json) {
   return true;
 }
 
-/// <summary>
-/// Gather default values from current scene, 
-/// just in case they are missing in the oca file...
-/// </summary>
 void OCAIo::OCAInputData::getSceneData() {
   m_framerate = m_oprop->getFrameRate();
   int from, to, step;
@@ -650,25 +660,22 @@ void OCAIo::OCAInputData::getSceneData() {
     m_endTime   = m_xsheet->getFrameCount() - 1;
   }
   if (m_endTime < 0) m_endTime = 0;
+
   m_width  = m_scene->getCurrentCamera()->getRes().lx;
   m_height = m_scene->getCurrentCamera()->getRes().ly;
 }
 
-/// <summary>
-/// json OCA parser, getting global properties and import the layers
-/// </summary>
-/// <param name="json"></param>
-void OCAIo::OCAInputData::read(const QJsonObject &json) {
-  m_originApp        = json.value("originApp").toString();
-  m_originAppVersion = json.value("originAppVersion").toString();
-  m_ocaVersion       = json.value("ocaVersion").toString();
-  m_name             = json.value("name").toString();
-  m_framerate  = json.value("frameRate").toInt(m_framerate);
-  m_width      = json.value("width").toInt(m_width);
-  m_height     = json.value("height").toInt(m_height);
-  m_startTime  = json.value("startTime").toInt(m_startTime);
-  m_endTime    = json.value("endTime").toInt(m_endTime);
-  m_colorDepth = json.value("colorDepth").toString();
+void OCAIo::OCAInputData::load(const QJsonObject &json, bool importFiles) {
+  m_originApp             = json.value("originApp").toString();
+  m_originAppVersion      = json.value("originAppVersion").toString();
+  m_ocaVersion            = json.value("ocaVersion").toString();
+  m_name                  = json.value("name").toString();
+  m_framerate             = json.value("frameRate").toInt(m_framerate);
+  m_width                 = json.value("width").toInt(m_width);
+  m_height                = json.value("height").toInt(m_height);
+  m_startTime             = json.value("startTime").toInt(m_startTime);
+  m_endTime               = json.value("endTime").toInt(m_endTime);
+  m_colorDepth            = json.value("colorDepth").toString();
   QJsonArray bgColorArray = json["backgroundColor"].toArray();
   m_bgRed                 = bgColorArray[0].toDouble();
   m_bgGreen               = bgColorArray[1].toDouble();
@@ -676,41 +683,36 @@ void OCAIo::OCAInputData::read(const QJsonObject &json) {
   m_bgAlpha               = bgColorArray[3].toDouble();
   m_layers                = json.value("layers").toArray();
   for (auto jsonLayer : m_layers) {
-    importOcaLayer(jsonLayer.toObject());
+    importOcaLayer(jsonLayer.toObject(), importFiles);
   }
 }
 
-/// <summary>
-/// Updates global scene properties.
-/// </summary>
 void OCAIo::OCAInputData::setSceneData() {
-  m_scene->setSceneName(m_name.toStdWString());
+  // Only set scene data if this is an untitled scene
+  if (!m_scene->isUntitled()) return;
+
+  // Never set scene name
+  // m_scene->setSceneName(m_name.toStdWString());
   m_oprop->setFrameRate(m_framerate);
   auto resolution = TDimension(m_width, m_height);
-  m_scene->getCurrentCamera()->setRes(resolution);
   if (m_dpi > 0) {
     TDimensionD size(0, 0);
     size.lx = resolution.lx / m_dpi;
     size.ly = resolution.ly / m_dpi;
     m_scene->getCurrentCamera()->setSize(size, false, false);
   }
-  //else {
-  //  TDimensionD size(16, 9);
-  //  m_scene->getCurrentCamera()->setSize(size, false, false);
-  //}
+  m_scene->getCurrentCamera()->setRes(resolution);
+
   m_xsheet->updateFrameCount();
   m_oprop->setRange(m_startTime, m_endTime, 1);
-  TPixel32 color = TPixel32(m_bgRed * 255.0, m_bgGreen * 255.0,
-                            m_bgBlue * 255.0, m_bgAlpha * 255.0);
-  m_scene->getProperties()->setBgColor(color);
-  // anyway touching rendersettings here doesn't make sense
-  // m_colorDepth (json["colorDepth"]) doesn't tell if the image is linear or
-  // not... (a 32 bit tif could very well be non-linear, or a linear exr could
-  // be 16 bit only, usually probalby half float 16 bit ...)
-  // TRenderSettings renderSettings = m_scene->getProperties()->getOutputProperties()->getRenderSettings(); // incomplete type ?
-  // renderSettings.m_bpp...
-  // https://github.com/RxLaboratory/OCA/blob/master/src-docs/docs/specs/color-depth.md
-  // only raises nonlinearBpp, never make it lower than it is... (the levels could be 8 bit but comp output higher)
+
+  // If background is all 0s, use our default Bg color
+  if (m_bgRed || m_bgGreen || m_bgBlue || m_bgAlpha) {
+    TPixel32 color = TPixel32(m_bgRed * 255.0, m_bgGreen * 255.0,
+                              m_bgBlue * 255.0, m_bgAlpha * 255.0);
+    m_scene->getProperties()->setBgColor(color);
+  }
+
   int nonlinearBpp = m_oprop->getNonlinearBpp();
   if (m_colorDepth == "U8" && nonlinearBpp < 32)
     m_oprop->setNonlinearBpp(32);
@@ -722,61 +724,73 @@ void OCAIo::OCAInputData::setSceneData() {
     m_oprop->setNonlinearBpp(128);
 }
 
-/// <summary>
-/// creates level from OCA layer, and exposes it in the xsheet
-/// see OCA layer specs https://github.com/RxLaboratory/OCA/blob/master/src-docs/docs/specs/layer.md?plain=1
-/// - only raster levels are supported
-/// - whiteTransp / doPremultiply / colorSpaceGamma / antialiasSoftness / dpi are hardcoded
-/// - blendingMode / animated are not used
-/// - OCA doesn't support frame tags (NavigationTags) 
-/// this would be very usefull to mark keys / breakdowns / inbetweens / etc drawing ... 
-/// for the onion skining and fliping
-/// - recursive layers (layer groups) have not neen tested 
-/// (not sure if and how it could translate in toonz ? see CHILD_XSHLEVEL ?)
-/// 
-/// TODO :
-/// - while TZP_XSHLEVEL is for toonz levels (smart rasters with palette)
-/// For roundtrip / scene sharing between softwares,
-/// Smart raster TZP_XSHLEVEL cannot be recreated from raster OVL_XSHLEVEL,
-/// without palette loss. I would thus implement a dialog to let the user load
-/// only missing layers in the scene (in order to keep smart raster levels
-/// intact...)
-/// </summary>
-/// <param name="jsonLayer"></param>
-void OCAIo::OCAInputData::importOcaLayer(const QJsonObject &jsonLayer) {
-  if (jsonLayer["type"] == "paintlayer") {
+void OCAIo::OCAInputData::importOcaLayer(const QJsonObject &jsonLayer,
+                                         bool importFiles) {
+  if (jsonLayer["type"] == "paintlayer" || jsonLayer["type"] == "vectorlayer") {
     if (jsonLayer["blendingMode"].toString() != "normal") {
-      DVGui::warning(QObject::tr("importOcaLayer : blending modes not implemented ") +
-                  jsonLayer["name"].toString());
+      showImportMessage(
+          DVGui::WARNING,
+          QObject::tr("Blending mode '%1' not implemented for %2 '%3'")
+              .arg(jsonLayer["blendingMode"].toString())
+              .arg(jsonLayer["type"].toString())
+              .arg(jsonLayer["name"].toString()));
     }
-    DVGui::info(QObject::tr("importOcaLayer : ") +
-                jsonLayer["name"].toString());
-    auto levelType   = OVL_XSHLEVEL; // OVL_XSHLEVEL is for raster images,
 
-    //  I am using my own preference m_dpi / m_antialiasSoftness / m_whiteTransp / m_doPremultiply
-    auto resolution  = TDimension(m_width, m_height);
-    TXshLevel *level = m_scene->createNewLevel(
-        levelType, jsonLayer["name"].toString().toStdWString(), resolution,
-        m_dpi);
+    //
+    // Create level from image files
+    //
+    IoCmd::LoadResourceArguments args;
+    args.expose       = false;
+    args.importPolicy = importFiles
+                            ? IoCmd::LoadResourceArguments::ImportPolicy::IMPORT
+                            : IoCmd::LoadResourceArguments::ImportPolicy::LOAD;
+
+    auto frames = jsonLayer["frames"].toArray();
+    for (int i = 0; i < frames.size(); i++) {
+      auto jsonFrame = frames[i].toObject();
+      if (jsonFrame["fileName"].toString() == "") continue;
+      TFilePath fp = m_parentDir + TFilePath(jsonFrame["fileName"].toString());
+      fp           = fp.getParentDir() + fp.getLevelName();
+      args.resourceDatas.push_back(fp);
+      break;
+    }
+
+    // Do not create levels without images!
+    if (args.resourceDatas.empty()) {
+      showImportMessage(DVGui::WARNING,
+                        QObject::tr("Skipped %1 '%2'. No image file indicated.")
+                            .arg(jsonLayer["type"].toString())
+                            .arg(jsonLayer["name"].toString()));
+      return;
+    }
+
+    IoCmd::loadResources(args);
+
+    if (args.loadedLevels.empty()) {
+      showImportMessage(DVGui::CRITICAL,
+                        QObject::tr("Unable to load images for %1 '%2'.")
+                            .arg(jsonLayer["type"].toString())
+                            .arg(jsonLayer["name"].toString()));
+      return;
+    }
+
+    //
+    // Set level properties
+    //
+    TXshLevel *level = *args.loadedLevels.begin();
+    if (!level) return;
 
     TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(level);
-    // TXshLevel *ToonzScene::createNewLevel(int type, std::wstring levelName, const TDimension &dim, double dpi, TFilePath fp) 
-    // ignores the resolution argument !
+    if (!sl) return;
+
+    auto resolution = TDimension(m_width, m_height);
     sl->getProperties()->setImageRes(resolution);
 
-    // lookup the first frame to eventually load image format loading preferences which is based on frame extention
-    // seeTXshLevel *ToonzScene::loadLevel
-    // the problem is tahomastuff/profiles/users/[username]/preferences.ini doesn't add new image fomats to the list...
-    auto frames = jsonLayer["frames"].toArray();
     bool formatSpecified = false;
     LevelProperties *lp  = sl->getProperties();
     if (frames.size() > 0) {
-      auto jsonFrame      = frames[0].toObject();
-      auto levelPath = TFilePath(m_parentDir.getQString() + "/" +
-                            jsonFrame["fileName"].toString());
-
       const Preferences &prefs = *Preferences::instance();
-      int formatIdx            = prefs.matchLevelFormat(levelPath);
+      int formatIdx = prefs.matchLevelFormat(TFilePath(level->getPath()));
       if (formatIdx >= 0) {
         lp->options()   = prefs.levelFormat(formatIdx).m_options;
         formatSpecified = true;
@@ -800,183 +814,91 @@ void OCAIo::OCAInputData::importOcaLayer(const QJsonObject &jsonLayer) {
       sl->getProperties()->setDpiPolicy(LevelProperties::DP_CustomDpi);
     }
 
-    // float colorSpaceGamma   = 2.2;
-    // we don't need to touch this...
-    // display gamma 2.2 is only valid for srgb color space, and for rec709 is
-    // grading on a computer monitor...but... gamma for rec709 should be 2.4 if
-    // you have a rec709 grading monitor set for HDTV, gamma for rec2020 should
-    // be 2.6 if you have a rec2020 grading monitor, gamma for DCI-P3 should
-    // be 2.4 if you have a DCI-P3 grading theatre !? linear images colorDepth
-    // could be could be F16 or F32 (but the channel
-    // width preference is locked to 32 bit if checking linear color space...) 
-    //if (sl->getPath().getType() == "exr")
-    //    sl->getProperties()->setColorSpaceGamma(colorSpaceGamma); 
-    // Why is colorSpaceGamma disabled in the level settings ui ??
-    // see render>output settings> color settings
+    //
+    // Load level into xsheet
+    //
+    int col = m_xsheet->getFirstFreeColumnIndex();
 
-    sl->setName(jsonLayer["name"].toString().toStdWString());
-    std::vector<TFrameId> fids;
-    for (auto frame : jsonLayer["frames"].toArray()) {
-      importOcaFrame(frame.toObject(), sl);
-      TFrameId fid(frame.toObject()["frameNumber"].toInt());
-      fids.push_back(fid);
-    }
-    
-    // Shouldn't api provide a simple method to expose the level using fids in xsheet timing ?
-    int emptyColumnIndex = m_xsheet->getFirstFreeColumnIndex();
-    int frameOffset = 0;
-    if (m_startTime < 1) { // prevent crash if startTime is less than 1 : offset the timing...
-      frameOffset = -m_startTime + 1;
-    }
-    for (auto fid : fids) {
-      if (fid.getNumber() <= 0) {
-        DVGui::warning(
-            QObject::tr("importOcaLayer : skipping frame -1! ") +
-            jsonLayer["name"].toString());
-        continue;
-      }
-      // -1 converts framenumber to index, frameOffset moves the frame range above 0...
-      m_xsheet->setCell(fid.getNumber() - 1 + frameOffset, emptyColumnIndex,
-                        TXshCell(sl, fid));
-    }
+    TXshLevelColumn *column = new TXshLevelColumn();
+    m_xsheet->insertColumn(col, column);
 
-    // Note about drawing numbering : I personally frame number as drawing number,
-    // following richard william's animator's survival kit ("The best numbering system", page 76)
-    // In toonz, this means : preference>Drawing>Numbering system = Animation sheet (isAnimationSheetEnabled ==  true) 
-    // + Autorenumber
-    // That way, I can define the timing on paper while numbering drawings
-    // (i write barsheets with music and avoid the computer as much as i can)
-    // column properties
-    auto column = m_xsheet->getColumn(emptyColumnIndex);
     TStageObject *stageColumn =
-        m_xsheet->getStageObject(TStageObjectId::ColumnId(emptyColumnIndex));
+        m_xsheet->getStageObject(TStageObjectId::ColumnId(col));
     stageColumn->setName(jsonLayer["name"].toString().toStdString());
-    //std::string str = m_columnName.toStdString();
     column->setOpacity(byteFromFloat(
         jsonLayer["opacity"].toDouble() *
         255.0));  // not sure if byteFromFloat is really necessary...
-    // confusing but preview is render visibility
     column->setPreviewVisible(!jsonLayer["reference"].toBool());
-    // and Camstand is viewport visibility
     column->setCamstandVisible(jsonLayer["visible"].toBool());
-    // jsonLayer["label"]
-    // https://github.com/RxLaboratory/OCA/blob/master/src-docs/docs/specs/layer-labels.md
-    // Most drawing and animation applications are able to
-    // label the layers. These labels are often just different colors to display
-    // the layers and used to differentiate them. OCA stores a simple number to
-    // identify these labels. If this number is less than 0, it means the layer
-    // is not labelled.
-    // We use column filters...
     column->setColorFilterId(jsonLayer["label"].toInt());
-    // column->setColorTag(jsonLayer["label"].toInt()); what is the difference
-    // between ColorTag and  ColorFilterId ??
 
+    int frameOffset                  = 0;
+    if (m_startTime < 1) frameOffset = -m_startTime + 1;
 
-    ////// unused OCA properties:
-    // - jsonLayer["animated"] Whether this layer is a single frame or not.
-    // - jsonLayer["fileType"] The file extension, without the initial dot.
-    // - Blending Modes
-    // jsonLayer["blendingMode"] This could be supported with the fx schematic
-    // (that wouldn't help while animating)
-    // side note about blending mode :
-    // I think blending modes should be implemented as realtime shaders in the viewport (fbo pingpong + glsl)
-    // exposed in the ui as an easy to use column property in the column header (like opacity etc...)
-    // the taoist RGB white japanese method of dealing with transparency based on white level,
-    // or "RGBM" as it's called,
-    // make it very paintfull to not have blending mode while animating... 
-    // (ex : shoot paper drawings and they are opaque rasters, so onion skin doesn' work.
-    // Ok you can set white level in the capture setting image ajust,
-    // and check White As Transparent in the raster level settings,
-    // The level premult option doesn't make onion skin work, if white level is too low...
-    // but that's destructive.
-    // And the level premult option doesn't make onion skin work, if white level is too low...
-    // I would even add a realtime shader for chromakey and lumakey in the column header 
-    // (even though i agree that it would be painfull to have all necessary keying parameters exposed column header in the ui)
-    // - Frame tags
-    // NavigationTags (frame tags) should be supported by OCA
-    // NavigationTags *navTags = xsh->getNavigationTags();
-    // this could be a great base to implement an onion skin filter... (like TVPaint has)
-    // (ex : onion skin displays only 1 prev + 1 next key drawing, etc...)
-    // Unfortunately, OCA doesn't support that.
+    int lastFrame = 0;
+    for (auto frame : jsonLayer["frames"].toArray()) {
+      TXshCell cell;
+      if (frame.toObject()["name"].toString() == "_blank" ||
+          frame.toObject()["fileName"].toString() == "") {
+        cell = TXshCell(0, TFrameId::EMPTY_FRAME);
+      } else {
+        TFilePath fp(frame.toObject()["fileName"].toString());
+        TFrameId fid = fp.getFrame();
+        if (fp.getDots() != "..")
+          fid = jsonLayer["type"] == "vectorlayer" ? 65534 : TFrameId::NO_FRAME;
+        cell  = TXshCell(sl, fid);
+      }
 
-    // recursion for sublayers : nothing special to do ?
-    // see CHILD_XSHLEVEL ?
-    for (auto layer : jsonLayer["childLayers"].toArray()) {
-      // I guess we dont need to deal with jsonLayer["passThrough"] ?
-      // when passThrough is false, the group content *must* be merged in rendering, 
-      // else the group is only used as a way to group the layers in the UI of the application
-      importOcaLayer(layer.toObject());
+      int row = frame.toObject()["frameNumber"].toInt();
+
+      // -1 converts framenumber to index, frameOffset moves the frame range
+      // above 0...
+      row = row - 1 + frameOffset;
+
+      int duration = frame.toObject()["duration"].toInt();
+      lastFrame += duration;
+      if (Preferences::instance()->isImplicitHoldEnabled()) duration = 1;
+
+      for (int i = 0; i < duration; i++) m_xsheet->setCell(row + i, col, cell);
     }
+    if (Preferences::instance()->isImplicitHoldEnabled())
+      m_xsheet->setCell(lastFrame, col, TXshCell(sl, TFrameId::STOP_FRAME));
 
     TApp::instance()->getCurrentLevel()->setLevel(
         level->getSimpleLevel());  // selects the last created level
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
     TApp::instance()->getCurrentScene()->notifyCastChange();
+  } else if (jsonLayer["type"] == "grouplayer") {
+    showImportMessage(
+        DVGui::WARNING,
+        QObject::tr(
+            "Sub-layers in grouplayer '%1' will be imported without grouping.")
+            .arg(jsonLayer["name"].toString()));
 
+    // For now, import the child layers without grouping information
+    for (auto layer : jsonLayer["childLayers"].toArray()) {
+      importOcaLayer(layer.toObject(), importFiles);
+    }
   } else {
-    DVGui::warning(QObject::tr("importOcaLayer skipping unimplemented layer type : ") +
-        jsonLayer["type"].toString() + " : " + jsonLayer["name"].toString()
-    );
+    showImportMessage(DVGui::WARNING,
+                      QObject::tr("Skipping unimplemented %1 '%2'")
+                          .arg(jsonLayer["type"].toString())
+                          .arg(jsonLayer["name"].toString()));
   }
 }
 
-/// <summary>
-/// creates frame from OCA frame
-/// see OCA frame specs
-/// https://github.com/RxLaboratory/OCA/blob/master/src-docs/docs/specs/frame.md
-/// UNUSED properties :
-/// - meta: metadata...
-/// - opacity: per frame opacity isn't used.
-/// - position: transforms handled in a separate file ? (keyframe animation transfert for camera, pegs, etc...) 
-/// And what about scale/rotation ?
-/// - name: could be used to create empty frames (named "_blank")
-/// </summary>
-/// <param name="jsonLayer"></param>
+void OCAIo::OCAInputData::showImportMessage(DVGui::MsgType msgType,
+                                            QString msg) {
+  if (m_supressImportMessages) return;
 
-void OCAIo::OCAInputData::importOcaFrame(const QJsonObject &jsonFrame,
-                                         TXshSimpleLevel *sl) {
-  // doesExists (QFileInfo.exists()) should skip empty frames ! but...
-  TFrameId fid(jsonFrame["frameNumber"].toInt());
-  if (jsonFrame["name"].toString() == "_blank" ||
-      jsonFrame["fileName"].toString() == "") {
-    TImageP img = sl->createEmptyFrame();
-    sl->setFrame(fid, img);
-    return;
-  }
-  auto path       = TFilePath(m_parentDir.getQString() + "/" +
-                        jsonFrame["fileName"].toString());
-  bool fileExists = TFileStatus(path).doesExist();
-  TImageP img;
-  if (fileExists) {
-    auto imageReader = TImageReaderP(path);
-    try {
-      img = imageReader->load();
-      if (img.getPointer() == 0) img = sl->createEmptyFrame();
-    } catch (const std::string &msg)
-    {
-      DVGui::error(QObject::tr("importOcaFrame load failed : ") +
-                   path.getQString());
-      img = sl->createEmptyFrame();
-      throw TException(msg);
-    }
-    if (img->getType() != TImage::RASTER) {
-      DVGui::warning(
-          QObject::tr("importOcaFrame skipping unimplemented image type : ") +
-          jsonFrame["name"].toString());
-    }
-    auto info = imageReader->getImageInfo();
-    DVGui::info(QObject::tr("importOcaFrame : ") + path.getQString() +
-                " width: " + QString::number(info->m_lx) +
-                " height: " + QString::number(info->m_ly) 
-                + " bits: " + QString::number(info->m_bitsPerSample) );
+  QString checkBoxLabel = QObject::tr("Ignore all future warnings and errors.");
+  QStringList buttons;
+  buttons << QObject::tr("Ok");
+  DVGui::MessageAndCheckboxDialog *importDialog = DVGui::createMsgandCheckbox(
+      msgType, msg, checkBoxLabel, buttons, 0, Qt::Unchecked);
+  int ret     = importDialog->exec();
+  int checked = importDialog->getChecked();
+  importDialog->deleteLater();
 
-  } else {
-    DVGui::error(QObject::tr("importOcaFrame file not found! : ") + path.getQString());
-    img = sl->createEmptyFrame();
-  }
-  sl->setFrame(fid, img);
-  if (!Preferences::instance()->isImplicitHoldEnabled()) {
-      //do something with the image duration ?
-  }
+  if (checked > 0) m_supressImportMessages = true;
 }
-

--- a/toonz/sources/toonz/ocaio.h
+++ b/toonz/sources/toonz/ocaio.h
@@ -75,24 +75,26 @@ class OCAInputData : public OCAData {
   QString m_originAppVersion;
   QString m_ocaVersion;
   // toonz objects
-  ToonzScene * m_scene;
+  ToonzScene *m_scene;
   TXsheet *m_xsheet;
   TOutputProperties *m_oprop;
   TFilePath m_parentDir;
-  // hardcoded...
-  int m_dpi                 = 120; // this should match default m_dpi set in startuppopup.cpp@588 !?
-  float m_antialiasSoftness = 0.0;
-  bool m_whiteTransp        = true;
-  bool m_doPremultiply      = false;
+  int m_dpi;
+  float m_antialiasSoftness;
+  bool m_whiteTransp, m_doPremultiply;
+
+  bool m_supressImportMessages;
 
 public:
-  OCAInputData(float antialiasSoftness, bool whiteTransp, bool doPremultiply);
-  bool load(QString path, QJsonObject &json);
+  OCAInputData(float antialiasSoftness = (float)0.0, bool whiteTransp = true,
+               bool doPremultiply = false);
+  bool read(QString path, QJsonObject &json);
   void getSceneData();
-  void read(const QJsonObject &json);
+  void load(const QJsonObject &json, bool importFiles = true);
   void setSceneData();
-  void importOcaLayer(const QJsonObject &jsonLayer);
-  void importOcaFrame(const QJsonObject &jsonFrame, TXshSimpleLevel *sl);
+  void importOcaLayer(const QJsonObject &jsonLayer, bool importFiles);
+
+  void showImportMessage(DVGui::MsgType type, QString msg);
 };
 }  // namespace OCAIo
 

--- a/toonz/sources/toonz/ocaio.h
+++ b/toonz/sources/toonz/ocaio.h
@@ -79,9 +79,14 @@ class OCAInputData : public OCAData {
   TXsheet *m_xsheet;
   TOutputProperties *m_oprop;
   TFilePath m_parentDir;
+  // hardcoded...
+  int m_dpi                 = 0;
+  float m_antialiasSoftness = 0.0;
+  bool m_whiteTransp        = true;
+  bool m_doPremultiply      = false;
 
 public:
-  OCAInputData(ToonzScene *scene, TXsheet *xsheet);
+  OCAInputData();
   bool load(QString path, QJsonObject &json);
   void getSceneData();
   void read(const QJsonObject &json);

--- a/toonz/sources/toonz/ocaio.h
+++ b/toonz/sources/toonz/ocaio.h
@@ -80,13 +80,13 @@ class OCAInputData : public OCAData {
   TOutputProperties *m_oprop;
   TFilePath m_parentDir;
   // hardcoded...
-  int m_dpi                 = 0;
+  int m_dpi                 = 120; // this should match default m_dpi set in startuppopup.cpp@588 !?
   float m_antialiasSoftness = 0.0;
   bool m_whiteTransp        = true;
   bool m_doPremultiply      = false;
 
 public:
-  OCAInputData();
+  OCAInputData(float antialiasSoftness, bool whiteTransp, bool doPremultiply);
   bool load(QString path, QJsonObject &json);
   void getSceneData();
   void read(const QJsonObject &json);

--- a/toonz/sources/toonz/ocaio.h
+++ b/toonz/sources/toonz/ocaio.h
@@ -3,6 +3,8 @@
 #define OCAIO_H
 
 #include "toonzqt/dvdialog.h"
+#include "tfilepath.h"
+#include "toonz/txshlevelhandle.h"
 
 #include <QString>
 #include <QList>
@@ -15,8 +17,11 @@
 class ToonzScene;
 class TXshCellColumn;
 class TXsheet;
-
+class TXshSimpleLevel;
 class TFrameId;
+class TFilePath;
+class TOutputProperties;
+class TXshLevelHandle;
 
 namespace OCAIo {
 
@@ -28,6 +33,7 @@ struct OCAAsset {
 };
 
 class OCAData {
+protected:
   QString m_path;
   QString m_name;
   double m_framerate;
@@ -62,6 +68,27 @@ public:
   bool isEmpty() { return m_layers.isEmpty(); }
 };
 
+class OCAInputData : public OCAData {
+  // json objects
+  QString m_colorDepth;
+  QString m_originApp;
+  QString m_originAppVersion;
+  QString m_ocaVersion;
+  // toonz objects
+  ToonzScene * m_scene;
+  TXsheet *m_xsheet;
+  TOutputProperties *m_oprop;
+  TFilePath m_parentDir;
+
+public:
+  OCAInputData(ToonzScene *scene, TXsheet *xsheet);
+  void load(QString path, QJsonObject &json);
+  void getSceneData();
+  void read(QJsonObject &json);
+  void setSceneData();
+  void importOcaLayer(QJsonObject &jsonLayer);
+  void importOcaFrame(QJsonObject &jsonFrame, TXshSimpleLevel *sl);
+};
 }  // namespace OCAIo
 
 #endif

--- a/toonz/sources/toonz/ocaio.h
+++ b/toonz/sources/toonz/ocaio.h
@@ -82,12 +82,12 @@ class OCAInputData : public OCAData {
 
 public:
   OCAInputData(ToonzScene *scene, TXsheet *xsheet);
-  void load(QString path, QJsonObject &json);
+  bool load(QString path, QJsonObject &json);
   void getSceneData();
-  void read(QJsonObject &json);
+  void read(const QJsonObject &json);
   void setSceneData();
-  void importOcaLayer(QJsonObject &jsonLayer);
-  void importOcaFrame(QJsonObject &jsonFrame, TXshSimpleLevel *sl);
+  void importOcaLayer(const QJsonObject &jsonLayer);
+  void importOcaFrame(const QJsonObject &jsonFrame, TXshSimpleLevel *sl);
 };
 }  // namespace OCAIo
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2108,8 +2108,9 @@ QWidget* PreferencesPopup::createDrawingPage() {
     getUI<MeasuredDoubleLineEdit*>(DefLevelHeight)->setDecimals(0);
   }
 
-  bool ret = ret && connect(frameFormatBtn, SIGNAL(clicked()), this,
-                            SLOT(onFrameFormatButton()));
+  //bool ret = ret && connect(frameFormatBtn, SIGNAL(clicked()), this,
+  //                          SLOT(onFrameFormatButton()));
+  connect(frameFormatBtn, SIGNAL(clicked()), this, SLOT(onFrameFormatButton()));
 
   return widget;
 }

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -92,8 +92,7 @@ inline bool formatLess(const Preferences::LevelFormat &a,
 //=================================================================
 
 void getDefaultLevelFormats(LevelFormatVector &lfv) {
-  //lfv.resize(2);
-  lfv.resize(5);
+  lfv.resize(2);
   {
     LevelFormat &lf = lfv[0];
 
@@ -112,27 +111,6 @@ void getDefaultLevelFormats(LevelFormatVector &lfv) {
     // lfv[2].m_name                  = Preferences::tr("PNG");
     // lfv[2].m_pathFormat            = QRegExp("..*\\.png",
     // Qt::CaseInsensitive); lfv[2].m_options.m_premultiply = true;
-
-    // for all PNG files, set premultiply by default
-    lfv[2].m_name                  = Preferences::tr("PNG");
-    lfv[2].m_pathFormat            = QRegExp("..*\\.png", Qt::CaseInsensitive);
-    lfv[2].m_options.m_premultiply = true;
-    lfv[2].m_options.m_whiteTransp = true;
-    //lfv[2].m_options.m_antialias   = 70;
-
-    // for all TIF files, set premultiply by default
-    lfv[3].m_name                  = Preferences::tr("TIF");
-    lfv[3].m_pathFormat            = QRegExp("..*\\.tif", Qt::CaseInsensitive);
-    lfv[3].m_options.m_premultiply = true;
-    lfv[3].m_options.m_whiteTransp = true;
-    //lfv[3].m_options.m_antialias   = 70;
-
-    // for all EXR files, set premultiply by default
-    lfv[4].m_name                  = Preferences::tr("EXR");
-    lfv[4].m_pathFormat            = QRegExp("..*\\.exr", Qt::CaseInsensitive);
-    lfv[4].m_options.m_premultiply = true;
-    lfv[4].m_options.m_whiteTransp = true;
-    //lfv[4].m_options.m_antialias   = 70;
   }
 }
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -92,7 +92,8 @@ inline bool formatLess(const Preferences::LevelFormat &a,
 //=================================================================
 
 void getDefaultLevelFormats(LevelFormatVector &lfv) {
-  lfv.resize(2);
+  //lfv.resize(2);
+  lfv.resize(5);
   {
     LevelFormat &lf = lfv[0];
 
@@ -111,6 +112,27 @@ void getDefaultLevelFormats(LevelFormatVector &lfv) {
     // lfv[2].m_name                  = Preferences::tr("PNG");
     // lfv[2].m_pathFormat            = QRegExp("..*\\.png",
     // Qt::CaseInsensitive); lfv[2].m_options.m_premultiply = true;
+
+    // for all PNG files, set premultiply by default
+    lfv[2].m_name                  = Preferences::tr("PNG");
+    lfv[2].m_pathFormat            = QRegExp("..*\\.png", Qt::CaseInsensitive);
+    lfv[2].m_options.m_premultiply = true;
+    lfv[2].m_options.m_whiteTransp = true;
+    //lfv[2].m_options.m_antialias   = 70;
+
+    // for all TIF files, set premultiply by default
+    lfv[3].m_name                  = Preferences::tr("TIF");
+    lfv[3].m_pathFormat            = QRegExp("..*\\.tif", Qt::CaseInsensitive);
+    lfv[3].m_options.m_premultiply = true;
+    lfv[3].m_options.m_whiteTransp = true;
+    //lfv[3].m_options.m_antialias   = 70;
+
+    // for all EXR files, set premultiply by default
+    lfv[4].m_name                  = Preferences::tr("EXR");
+    lfv[4].m_pathFormat            = QRegExp("..*\\.exr", Qt::CaseInsensitive);
+    lfv[4].m_options.m_premultiply = true;
+    lfv[4].m_options.m_whiteTransp = true;
+    //lfv[4].m_options.m_antialias   = 70;
   }
 }
 


### PR DESCRIPTION
This OCA Import PR is based on the early commits of @janimatic's OCA Import PR #1371

This is a cleaned up and simplified version of the OCA Import logic that was being introduced.  I had to revise it for various reasons and chose to undertake it myself due to the complexity of trying to explain how image files needed to be loaded and handled in T2D.  Additional corrections were made.

OCA Import notes:
- OCA Layer Types
  - `paintlayer` - Supported, except for `blendingModes`.
  - `vectorlayer` - Supported via automatic conversion of SVG to PLI format
  - `grouplayer` - sub-layers will be imported without grouping
    - This will change in a separate PR after Timeline/Xsheet Folders (PR #1385) is merged.
- User will be prompted to `Import` or `Load`
  - Importing places PNG files in `+extras` and SVG files in `+drawings`
  - Loading (instead of Importing) vector layers will create the PLI file in the source directory.
- Layers without image files will not be imported.
- When importing, if the level already exists, user will be prompted to either keep, overwrite or rename.
- In case of import issues, warnings and errors will be displayed as it imports each layer
  - User can opt to ignore all future warnings and errors to speed up loading.
