### PR TITLE
Fix Vector Stroke Group/Ungroup issues

### DIFF
--- a/toonz/sources/tnztools/imagegrouping.cpp
+++ b/toonz/sources/tnztools/imagegrouping.cpp
@@ -61,7 +61,7 @@ void groupWithoutUndo(TVectorImage *vimg, StrokeSelection *selection) {
 
 void ungroupWithoutUndo(TVectorImage *vimg, StrokeSelection *selection) {
   for (int i = 0; i < (int)vimg->getStrokeCount();)
-    if (selection->isSelected(i)) {
+    if (vimg->isEnteredGroupStroke(i) && selection->isSelected(i)) {
       if (!vimg->isStrokeGrouped(i)) {
         i++;
         continue;
@@ -402,6 +402,7 @@ if (i == vimg->getStrokeCount())
         if (!m_sel->isSelected(j) && vimg->sameSubGroup(i, j)) break;
       if (j < vimg->getStrokeCount()) continue;
       ungroupingMakesSense = true;
+      break;
     }
   }
   if (ungroupingMakesSense) mask |= UNGROUP;
@@ -423,9 +424,11 @@ if (i == vimg->getStrokeCount())
           groupingMakesSense = true;  // gli storke selezionati non sono gia'
                                       // tutti dello stesso gruppo
         for (j = 0; j < vimg->getStrokeCount(); j++)
-          if (!m_sel->isSelected(j) && vimg->sameGroup(i, j)) return mask;
+          if (!m_sel->isSelected(j) && vimg->sameGroup(i, j))
+            groupingMakesSense = true;
       } else
         groupingMakesSense = true;
+      if (groupingMakesSense) break;
     }
 
   if (groupingMakesSense) mask |= GROUP;

--- a/toonz/sources/tnztools/imagegrouping.cpp
+++ b/toonz/sources/tnztools/imagegrouping.cpp
@@ -342,15 +342,17 @@ if (i == vimg->getStrokeCount())
   // PER l'UNGROUP: si ungruppa solo se tutti gli stroke selezionati stanno nel
   // gruppo (anche piu' gruppi insieme)
 
+  bool ungroupingMakesSense = false;
   for (i = 0; i < vimg->getStrokeCount(); i++) {
     if (m_sel->isSelected(i)) {
-      if (!vimg->isStrokeGrouped(i)) break;
+      if (!vimg->isStrokeGrouped(i)) continue;
       for (j = 0; j < vimg->getStrokeCount(); j++)
         if (!m_sel->isSelected(j) && vimg->sameSubGroup(i, j)) break;
-      if (j < vimg->getStrokeCount()) break;
+      if (j < vimg->getStrokeCount()) continue;
+      ungroupingMakesSense = true;
     }
   }
-  if (i == vimg->getStrokeCount()) mask |= UNGROUP;
+  if (ungroupingMakesSense) mask |= UNGROUP;
 
   // PER il GROUP: si raggruppa solo  se:
   // //almeno una delle  stroke selezionate non fa parte di gruppi o e' di un

--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -638,6 +638,7 @@ void StrokeSelection::selectAll() {
   int sCount = int(m_vi->getStrokeCount());
 
   for (int s = 0; s < sCount; ++s) {
+    if (!m_vi->isEnteredGroupStroke(s)) continue;
     m_indexes.push_back(s);
   }
 

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -1174,6 +1174,7 @@ public:
     TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
   }
   int getSize() const override { return sizeof(*this); }
+  QString getHistoryString() override { return QObject::tr("Enter Group"); }
 };
 
 //=============================================================================
@@ -1197,6 +1198,8 @@ public:
   }
 
   int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override { return QObject::tr("Exit Group"); }
 };
 
 }  // namespace


### PR DESCRIPTION
This will fix the following vector stroke group/ungroup issues:

- Ungroup now works even if the selection includes an ungrouped stroke.
- When inside a group, `Select All` will only select strokes inside the group.
- `Enter Group` and `Exit Group` actions are now properly recorded in History
- Corrected issues when using group/ungroup while inside a group.
- Fixed group undo/redo actions working on incorrect strokes caused by group reordering strokes