### PR TITLE
Fix crash entering Level Strip

### DIFF
--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -70,8 +70,7 @@ TImageP Stage::Player::image() const {
     id = id + "_filled";
 
   ImageLoader::BuildExtData extData(
-      m_sl, m_fid, 0, false,
-      m_xsh->getScene()->decodeFilePath(m_sl->getPath()));
+      m_sl, m_fid, 0, false, m_sl->getScene()->decodeFilePath(m_sl->getPath()));
   return ImageManager::instance()->getImage(id, ImageManager::none, &extData);
 }
 


### PR DESCRIPTION
This fixes a crash when clicking on the level strip.

Crash caused by changes made in #1388.