### PR TITLE
Fixes to SVG Import and Export

### DIFF
--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -171,4 +171,4 @@ elseif(BUILD_ENV_UNIXLIKE)
     endif()
 endif()
 
-target_link_libraries(image Qt5::Core Qt5::Gui Qt5::Network ${Z_LIB} ${GLUT_LIB} ${GL_LIB} ${JPEG_LIB} ${TIFF_LIB} ${PNG_LIB} ${EXTRA_LIBS})
+target_link_libraries(image Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Network ${Z_LIB} ${GLUT_LIB} ${GL_LIB} ${JPEG_LIB} ${TIFF_LIB} ${PNG_LIB} ${EXTRA_LIBS})

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -900,6 +900,7 @@ int nsvg__parseAttr(struct NSVGParser *p, const char *name, const char *value) {
       attr->fillColor = nsvg__parseColor(value);
     }
   } else if (strcmp(name, "fill-opacity") == 0) {
+    attr->hasFill = 1;
     attr->fillOpacity = nsvg__parseFloat(value);
   } else if (strcmp(name, "stroke") == 0) {
     if (strcmp(value, "none") == 0) {

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include <QApplication>
+#include <QDesktopWidget>
 #include <QTextStream>
 #include <QFile>
 
@@ -2107,6 +2109,8 @@ TStroke *buildStroke(NSVGpath *path, float width, float scale) {
 //-----------------------------------------------------------------------------
 
 TImageP TImageReaderSvg::load() {
+  static int devPixRatio = QApplication::desktop()->devicePixelRatio();
+
   NSVGimage *svgImg =
       nsvgParseFromFile(m_path.getQString().toStdString().c_str());
   if (!svgImg) return TImageP();
@@ -2135,8 +2139,9 @@ TImageP TImageReaderSvg::load() {
     // vapp->setPalette(plt.getPointer());
     int startStrokeIndex = vimage->getStrokeCount();
     for (; path; path = path->next) {
-      TStroke *s = buildStroke(path, shape->hasStroke ? shape->strokeWidth : 0,
-                               shape->scale);
+      TStroke *s = buildStroke(
+          path, shape->hasStroke ? shape->strokeWidth / devPixRatio : 0,
+          shape->scale);
       if (!s) continue;
       s->setStyle(inkIndex);
       vimage->addStroke(s);

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -1637,11 +1637,30 @@ void nsvg__parseSVG(struct NSVGParser *p, const char **attr) {
   for (i = 0; attr[i]; i += 2) {
     if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
       if (strcmp(attr[i], "width") == 0) {
+        float w;
+        char units[8];
+        units[0]            = '\0';
         p->image->wunits[0] = '\0';
-        sscanf(attr[i + 1], "%f%s", &p->image->width, p->image->wunits);
+        sscanf(attr[i + 1], "%f%s", &w, units);
+        if (strcmp(units, "%") != 0) {
+          p->image->width = w;
+          strcpy(p->image->wunits, units);
+        }
       } else if (strcmp(attr[i], "height") == 0) {
+        float h;
+        char units[8];
+        units[0]            = '\0';
         p->image->hunits[0] = '\0';
-        sscanf(attr[i + 1], "%f%s", &p->image->height, p->image->hunits);
+        sscanf(attr[i + 1], "%f%s", &h, units);
+        if (strcmp(units, "%") != 0) {
+          p->image->height = h;
+          strcpy(p->image->hunits, units);
+        }
+      } else if (strcmp(attr[i], "viewBox") == 0) {
+        float x, y, w, h;
+        sscanf(attr[i + 1], "%f %f %f %f", &x, &y, &w, &h);
+        if (p->image->width <= 0) p->image->width = w;
+        if (p->image->height <= 0) p->image->height = h;
       }
     }
   }
@@ -2169,6 +2188,11 @@ indexes[i] = vimage->getStrokeCount()+i;
 vimage->insertImage(vapp, indexes);*/
     // delete appPlt;
   }
+  double dx =
+      (svgImg->width > 0 ? svgImg->width : vimage->getBBox().getLx()) * 0.5;
+  double dy =
+      (svgImg->height > 0 ? svgImg->height : vimage->getBBox().getLy()) * 0.5;
+  vimage->transform(TTranslation(-dx, dy));
 
   nsvgDelete(svgImg);
   // if (m_level)

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2124,23 +2124,20 @@ TImageP TImageReaderSvg::load() {
     // TPalette* appPlt = new TPalette();
     // vapp->setPalette(appPlt);
 
-    TPixel color(shape->fillColor & 0xFF, (shape->fillColor >> 8) & 0xFF,
-                 shape->fillColor >> 16, shape->fillColor >> 24);
-    if (!shape->hasFill) {
-      assert(color == TPixel::Black);
+    inkIndex   = shape->hasStroke ? findColor(plt, shape->strokeColor) : 1;
+    paintIndex = shape->hasFill ? findColor(plt, shape->fillColor) : 1;
+    if (!shape->hasFill && (!shape->hasStroke || !shape->strokeWidth)) {
       shape->hasFill = true;
     }
-    if (shape->hasStroke) inkIndex = findColor(plt, shape->strokeColor);
-
-    if (shape->hasFill) paintIndex = findColor(plt, shape->fillColor);
 
     // vapp->setPalette(plt.getPointer());
     int startStrokeIndex = vimage->getStrokeCount();
     for (; path; path = path->next) {
       TStroke *s = buildStroke(path, shape->hasStroke ? shape->strokeWidth : 0);
       if (!s) continue;
-      s->setStyle(shape->hasStroke ? inkIndex : 0);
+      s->setStyle(inkIndex);
       vimage->addStroke(s);
+      if (s->isSelfLoop() && !shape->hasFill) shape->hasFill = true;
     }
     if (startStrokeIndex == vimage->getStrokeCount()) continue;
 

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -201,6 +201,7 @@ struct NSVGAttrib {
   char hasFillColor;
   unsigned int strokeColor;
   char hasStrokeColor;
+  float opacity;
   float fillOpacity;
   float strokeOpacity;
   float strokeWidth;
@@ -324,6 +325,7 @@ struct NSVGParser *nsvg__createParser() {
   p->attr[0].hasFillColor   = 1;
   p->attr[0].strokeColor    = 0;
   p->attr[0].hasStrokeColor = 1;
+  p->attr[0].opacity        = 1;
   p->attr[0].fillOpacity    = 1;
   p->attr[0].strokeOpacity  = 1;
   p->attr[0].strokeWidth    = 1;
@@ -444,12 +446,14 @@ void nsvg__addShape(struct NSVGParser *p) {
   shape->fillColor    = attr->fillColor;
   shape->hasFillColor = attr->hasFillColor;
   if (shape->hasFillColor)
-    shape->fillColor |= (unsigned int)(attr->fillOpacity * 255) << 24;
+    shape->fillColor |= (unsigned int)(attr->opacity * attr->fillOpacity * 255)
+                        << 24;
 
   shape->strokeColor    = attr->strokeColor;
   shape->hasStrokeColor = attr->hasStrokeColor;
   if (shape->hasStrokeColor)
-    shape->strokeColor |= (unsigned int)(attr->strokeOpacity * 255) << 24;
+    shape->strokeColor |=
+        (unsigned int)(attr->opacity * attr->strokeOpacity * 255) << 24;
 
   shape->paths = p->plist;
   p->plist     = NULL;
@@ -909,6 +913,8 @@ int nsvg__parseAttr(struct NSVGParser *p, const char *name, const char *value) {
       attr->visible = 0;
     else
       attr->visible = 1;
+  } else if (strcmp(name, "opacity") == 0) {
+    attr->opacity = nsvg__parseFloat(value);
   } else if (strcmp(name, "fill") == 0) {
     attr->hasFillInfo = 1;
     if (strcmp(value, "none") == 0) {

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -1927,7 +1927,7 @@ static void writeRegion(TRegion *r, TPalette *plt, QTextStream &out,
     out << "Q " << quadsOutline[i]->getP1().x << ","
         << ly - quadsOutline[i]->getP1().y << "," << quadsOutline[i]->getP2().x
         << "," << ly - quadsOutline[i]->getP2().y << "\n";
-  out << " \" /> \n";
+  out << "Z \" /> \n";
   for (int i = 0; i < (int)r->getSubregionCount(); i++)
     writeRegion(r->getSubregion(i), plt, out, ly);
 }
@@ -1955,7 +1955,7 @@ static void writeOutlineStroke(TStroke *s, TPalette *plt, QTextStream &out,
     out << "Q " << quadsOutline[i]->getP1().x << ","
         << ly - quadsOutline[i]->getP1().y << "," << quadsOutline[i]->getP2().x
         << "," << ly - quadsOutline[i]->getP2().y << "\n";
-  out << " \" /> \n";
+  out << "Z \" /> \n";
 }
 
 //----------------------------------------------------------
@@ -2027,7 +2027,10 @@ static void writeCenterlineStroke(TStroke *s, TPalette *plt, QTextStream &out,
     out << "Q " << s->getChunk(i)->getP1().x << ","
         << ly - s->getChunk(i)->getP1().y << "," << s->getChunk(i)->getP2().x
         << "," << ly - s->getChunk(i)->getP2().y << "\n";
-  out << " \" /> \n";
+  if (s->isSelfLoop())
+    out << "Z \" /> \n";
+  else
+    out << " \" /> \n";
 }
 
 //----------------------------------------------------------

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2228,6 +2228,16 @@ TImageP TImageReaderSvg::load() {
       s->setStyle(inkIndex);
       vimage->addStroke(s);
       if (s->isSelfLoop() && shape->hasFillColor) applyFill = true;
+      if (!s->isSelfLoop() && shape->hasFillColor) {
+        // Create a connecting line for fill
+        std::vector<TPointD> pts;
+        pts.push_back(s->getControlPoint(0));
+        pts.push_back(s->getControlPoint(s->getControlPointCount()));
+        s = new TStroke(pts);
+        s->setStyle(0);
+        vimage->addStroke(s);
+        applyFill = true;
+      }
     }
     if (startStrokeIndex == vimage->getStrokeCount()) continue;
 

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2156,7 +2156,11 @@ TStroke *buildStroke(NSVGpath *path, float width, float scale) {
   if (points.empty()) return 0;
 
   if (path->closed) {
-    if (points.back() != points.front()) {
+    // Compare front and back points. We'll adjust to compare to 2 decimal
+    // places only due to precision difference between absolute and relative
+    // calculations
+    if (((int)(points.back().x * 100) != (int)(points.front().x * 100)) ||
+        (int)(points.back().y * 100) != (int)(points.front().y * 100)) {
       points.push_back(0.5 * (points.back() + points.front()));
       points.push_back(points.front());
     } else {

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2143,13 +2143,14 @@ TImageP TImageReaderSvg::load() {
     }
     if (startStrokeIndex == vimage->getStrokeCount()) continue;
 
-    vimage->group(startStrokeIndex,
-                  vimage->getStrokeCount() - startStrokeIndex);
     if (shape->hasFill) {
+      vimage->group(startStrokeIndex,
+                    vimage->getStrokeCount() - startStrokeIndex);
       vimage->enterGroup(startStrokeIndex);
       vimage->selectFill(TRectD(-9999999, -9999999, 9999999, 9999999), 0,
                          paintIndex, true, true, false);
       vimage->exitGroup();
+      vimage->ungroup(startStrokeIndex);
     }
 
     /* vapp->findRegions();

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2032,7 +2032,7 @@ void TImageWriterSvg::save(const TImageP &img) {
 
 namespace {
 int addColorToPalette(TPalette *plt, unsigned int _color) {
-  TPixel color(_color & 0xFF, (_color >> 8) & 0xFF, _color >> 16);
+  TPixel color(_color & 0xFF, (_color >> 8) & 0xFF, _color >> 16, _color >> 24);
   for (int i = 0; i < plt->getStyleCount(); i++)
     if (plt->getStyle(i)->getMainColor() == color) return i;
   TPalette::Page *page = plt->getPage(0);
@@ -2041,7 +2041,7 @@ int addColorToPalette(TPalette *plt, unsigned int _color) {
 }
 
 int findColor(TPalette *plt, unsigned int _color) {
-  TPixel color(_color & 0xFF, (_color >> 8) & 0xFF, _color >> 16);
+  TPixel color(_color & 0xFF, (_color >> 8) & 0xFF, _color >> 16, _color >> 24);
   for (int i = 0; i < plt->getStyleCount(); i++)
     if (plt->getStyle(i)->getMainColor() == color) return i;
   assert(false);
@@ -2125,7 +2125,7 @@ TImageP TImageReaderSvg::load() {
     // vapp->setPalette(appPlt);
 
     TPixel color(shape->fillColor & 0xFF, (shape->fillColor >> 8) & 0xFF,
-                 shape->fillColor >> 16);
+                 shape->fillColor >> 16, shape->fillColor >> 24);
     if (!shape->hasFill) {
       assert(color == TPixel::Black);
       shape->hasFill = true;

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -16,6 +16,7 @@
 #include "tregion.h"
 #include "tcurves.h"
 #include "tpalette.h"
+#include "tstroke.h"
 
 //=------------------------------------------------------------------------------------------------------------------------------
 //=------------------------------------------------------------------------------------------------------------------------------
@@ -1895,7 +1896,7 @@ static void writeRegion(TRegion *r, TPalette *plt, QTextStream &out,
   if (col == TPixel::Transparent) col = TPixel::White;
 
   out << "style=\"fill:rgb(" << col.r << "," << col.g << "," << col.b
-      << ")\" \n";
+      << ");fill-opacity:" << (col.m / 255.0) << "\" \n";
   out << "d=\"M " << quadsOutline[0]->getP0().x << " "
       << ly - quadsOutline[0]->getP0().y << "\n";
 
@@ -1923,7 +1924,7 @@ static void writeOutlineStroke(TStroke *s, TPalette *plt, QTextStream &out,
   TPixel32 col = plt->getStyle(s->getStyle())->getMainColor();
 
   out << "style=\"fill:rgb(" << col.r << "," << col.g << "," << col.b
-      << ")\" \n";
+      << ");fill-opacity:" << (col.m / 255.0) << "\" \n";
   out << "d=\"M " << quadsOutline[0]->getP0().x << " "
       << ly - quadsOutline[0]->getP0().y << "\n";
 
@@ -1962,8 +1963,40 @@ static void writeCenterlineStroke(TStroke *s, TPalette *plt, QTextStream &out,
   out << "<path  \n";
   TPixel32 col = plt->getStyle(s->getStyle())->getMainColor();
 
+  int capStyle    = s->outlineOptions().m_capStyle;
+  QString lineCap = "";
+  switch (capStyle) {
+  case TStroke::OutlineOptions::PROJECTING_CAP:
+    lineCap = "square";
+    break;
+  case TStroke::OutlineOptions::ROUND_CAP:
+    lineCap = "round";
+    break;
+  default:
+  case TStroke::OutlineOptions::BUTT_CAP:
+    lineCap = "butt";
+    break;
+  }
+  int joinStyle    = s->outlineOptions().m_joinStyle;
+  QString lineJoin = "";
+  switch (joinStyle) {
+  case TStroke::OutlineOptions::BEVEL_JOIN:
+    lineJoin = "bevel";
+    break;
+  case TStroke::OutlineOptions::ROUND_JOIN:
+    lineJoin = "round";
+    break;
+  default:
+  case TStroke::OutlineOptions::MITER_JOIN:
+    lineJoin = "miter";
+    break;
+  }
+
   out << "style=\"stroke:rgb(" << col.r << "," << col.g << "," << col.b
-      << ")\" stroke-width=\"" << thick << " \"  \n";
+      << ");stroke-width:" << thick << ";stroke-linecap:" << lineCap
+      << ";stroke-linejoin:" << lineJoin
+      << ";stroke-miterlimit:" << s->outlineOptions().m_miterUpper
+      << ";stroke-opacity:" << (col.m / 255.0) << "\"  \n";
   out << "d=\"M " << s->getChunk(0)->getP0().x << " "
       << ly - s->getChunk(0)->getP0().y << "\n";
 

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -1360,6 +1360,8 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
       cpy        = 0;
       closedFlag = 0;
       nargs      = 0;
+      prev_m_cpx = 0;
+      prev_m_cpy = 0;
       prev_m_exists = false;
 
       while (*s) {
@@ -1373,7 +1375,7 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
             case 'M':
 			 
               // If moveto is relative it relative to previous moveto point
-              if (cmd == 'm' && prev_m_exists) {
+              if (cmd == 'm' && !prev_m_exists) {
                 cpx = prev_m_cpx;
                 cpy = prev_m_cpy;
               }
@@ -1382,7 +1384,7 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
               
               prev_m_cpx = cpx;
               prev_m_cpy = cpy;
-              prev_m_exists = true;
+              if (cmd == 'M') prev_m_exists = true;
 
               // Moveto can be followed by multiple coordinate pairs,
               // which should be treated as linetos.

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2137,7 +2137,8 @@ TStroke *buildStroke(NSVGpath *path, float width, float scale) {
 
   points.push_back(p0);
 
-  for (int i = 1; i < path->npts; i += 3) {
+  int npts = path->npts + (path->closed ? -3 : 0);
+  for (int i = 1; i < npts; i += 3) {
     std::vector<TThickQuadratic *> chunkArray;
 
     computeQuadraticsFromCubic(

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2202,13 +2202,18 @@ TImageP TImageReaderSvg::load() {
     if (startStrokeIndex == vimage->getStrokeCount()) continue;
 
     if (shape->hasFill) {
-      vimage->group(startStrokeIndex,
-                    vimage->getStrokeCount() - startStrokeIndex);
+      int c = vimage->getStrokeCount() - startStrokeIndex;
+      vimage->group(startStrokeIndex, c);
       vimage->enterGroup(startStrokeIndex);
-      vimage->selectFill(TRectD(-9999999, -9999999, 9999999, 9999999), 0,
-                         paintIndex, true, true, false);
+      if (c > 1) {
+        TStroke *s = vimage->getStroke(vimage->getStrokeCount() - 1);
+        for (int i = 0; i < s->getControlPointCount(); i++)
+          vimage->fill(s->getControlPoint(i), paintIndex, true);
+      } else
+        vimage->selectFill(TRectD(-9999999, -9999999, 9999999, 9999999), 0,
+                           paintIndex, true, true, false);
       vimage->exitGroup();
-      vimage->ungroup(startStrokeIndex);
+      if (c == 1) vimage->ungroup(startStrokeIndex);
     }
 
     /* vapp->findRegions();


### PR DESCRIPTION
I'm sure there are a number of issues surrounding SVG Import, and to a degree SVG Export.  This PR fixes only some of the more common issues people have run into.

### **SVG Import (SVG -> PLI converison)**
- Fixes fill and stroke opacity not being applied
  - Opacity was being read in but was not making palette entries for them, resulting in default fills, usually black, being used
- Default fill and stroke color to black when not specified
  - In some cases, fill/stroke information was provided but not color so it used whatever style it successfully used before. It now defaults to Style 1, which is usually black.
  - Forces default fill if there is no stroke information or stroke width = 0.  It is likely a fill-shape
  - Forces default fill if it's a closed shape without fill information
- Fixes incorrect application of stroke scaling information
  - Was applying scale information to stroke width incorrectly.
  - The scaling is now applied to the overall stroke for proper placement and sizing
- Fixes unnecessary grouping of every stroke.
  - If there is a fill associated with a stroke (i.e. closed shapes), the stroke is grouped and filled
  - If a fill is applied on a single stroke, the stroke will be ungrouped. 
  - If a fill is applied on a multi-stroke shape, the strokes will remain grouped.
  - If no fill is associated with the stroke, no grouping is performed.
- Fixes an issue where there was minimal fill information (i.e just opacity), but nothing else.
  - This now applies the default fill with the information provided
- Fixes stroke width importing wider than indicated in the file
  - This is likely an issue where device pixel ratio > 1 (usually 2) but the information in the file only assumes 1, causing stroke width to be doubled.
  - When building the stroke, it now adjusts for device pixel ratio > 1 to maintain proper stroke width
- Fixes imported SVG image displaying in the lower-right area of the canvas
  - Now centers the image on the canvas if width/height or viewBox information is provided
  - If none of the above is found, it will use the bounding box of all the strokes in the image to center
- Fixes importing filled shapes with cutouts
  - These shapes are multi-stroke shapes.  Added some logic to handle these properly
  - Subject to how the write records the outer path as well as our sometimes problematic fill process.
- Fixed closed shapes having an extra point causing circles to be deformed.
- Fixed moveTo logic not properly moving relative after moving absolute
- Fixed missing fills on shapes made by single strokes. (strokes with fills).
  - Added 0 width stroke to connect endpoints so fill can take place.

### **SVG Export (PLI -> SVG conversion)**
- Corrects how it writes `stroke-width` information to the file so it can be read by Inkscape.
- Now writes out `fill-opacity`, `stroke-linecap`, `stroke-linejoin`, `stroke-miterlimit` and `stroke-opacity`
- For closed shapes, now writes out the 'Z' in the path instruction

----
If you run into issues testing, please provide SVG file.  It would be helpful to know what generated the SVG as well.