### PR TITLE
OCA Import/Export folder information

### DIFF
--- a/toonz/sources/toonz/ocaio.h
+++ b/toonz/sources/toonz/ocaio.h
@@ -91,7 +91,8 @@ public:
   void getSceneData();
   void load(const QJsonObject &json, bool importFiles = true);
   void setSceneData();
-  void importOcaLayer(const QJsonObject &jsonLayer, bool importFiles);
+  void importOcaLayer(const QJsonObject &jsonLayer, bool importFiles,
+                      QStack<int> folderIds);
 
   void showImportMessage(DVGui::MsgType type, QString msg);
 };

--- a/toonz/sources/toonz/ocaio.h
+++ b/toonz/sources/toonz/ocaio.h
@@ -18,6 +18,7 @@ class ToonzScene;
 class TXshCellColumn;
 class TXsheet;
 class TXshSimpleLevel;
+class TXshFolderColumn;
 class TFrameId;
 class TFilePath;
 class TOutputProperties;
@@ -55,9 +56,12 @@ public:
   bool saveCell(TXshCellColumn *column, int row, const QString &cellname,
                 OCAAsset &out);
   int frameLen(TXshCellColumn *column, const QList<int> &rows, int index);
-  bool isGroup(TXshCellColumn *column);
-  bool buildGroup(QJsonObject &json, const QList<int> &rows,
-                  TXshCellColumn *column, bool exportReferences);
+  bool isSubSceneGroup(TXshCellColumn *column);
+  bool buildSubSceneGroup(QJsonObject &json, const QList<int> &rows,
+                          TXshCellColumn *column, bool exportReferences);
+  bool buildFolderGroup(QJsonObject &json, const QList<int> &rows,
+                        int columnIndex, int folderId, TXshCellColumn *column,
+                        bool exportReferences);
   bool buildLayer(QJsonObject &json, const QList<int> &rows,
                   TXshCellColumn *column);
 


### PR DESCRIPTION
This is a follow-up to #1392, adding support for importing `grouplayer` information as Folders as well as exporting Folders as `grouplayer` like sub-scenes.