### PR TITLE
Show Symmetry and Perspective Grids commands and buttons

### DIFF
--- a/toonz/sources/tnztools/perspectivetool.cpp
+++ b/toonz/sources/tnztools/perspectivetool.cpp
@@ -512,7 +512,8 @@ PerspectiveTool::PerspectiveTool()
     , m_selecting(false)
     , m_selectingRect(TRectD())
     , m_firstTime(false)
-    , m_undo(0) {
+    , m_undo(0)
+    , m_guideEnabled(false) {
   bind(TTool::AllTargets);
 
   m_prop.bind(m_type);

--- a/toonz/sources/tnztools/perspectivetool.h
+++ b/toonz/sources/tnztools/perspectivetool.h
@@ -444,6 +444,8 @@ public:
 
   void setPerspectiveObjects(std::vector<PerspectiveObject *> objs);
   std::vector<PerspectiveObject *> getPerspectiveObjects() {
+    if (!m_guideEnabled) return std::vector<PerspectiveObject *>();
+
     return m_perspectiveObjs;
   }
 
@@ -462,6 +464,10 @@ public:
 
   void onEnter() override;
   void onDeactivate() override;
+
+  void setGuideEnabled(bool enabled) { m_guideEnabled = enabled; }
+  void toggleGuideEnabled() { m_guideEnabled = !m_guideEnabled; }
+  bool isGuideEnabled() { return m_guideEnabled; }
 
   void initPresets();
   void loadPreset();
@@ -524,6 +530,8 @@ protected:
   PerspectivePresetManager m_presetsManager;
 
   PerspectiveObjectUndo *m_undo;
+
+  bool m_guideEnabled;
 };
 
 #endif

--- a/toonz/sources/tnztools/symmetrytool.h
+++ b/toonz/sources/tnztools/symmetrytool.h
@@ -257,9 +257,6 @@ public:
   void setGuideEnabled(bool enabled) { m_guideEnabled = enabled; }
   void toggleGuideEnabled() { m_guideEnabled = !m_guideEnabled; }
   bool isGuideEnabled() {
-    if (!CommandManager::instance()->getAction(MI_FieldGuide)->isChecked())
-      return false;
-
     return m_guideEnabled;
   }
 

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -142,6 +142,10 @@ void ComboViewerPanel::addShowHideContextMenu(QMenu *menu) {
   showHideMenu->addSeparator();
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_ViewCamera));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_ViewTable));
+  showHideMenu->addAction(
+      CommandManager::instance()->getAction(MI_ShowSymmetryGuide));
+  showHideMenu->addAction(
+      CommandManager::instance()->getAction(MI_ShowPerspectiveGrids));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_FieldGuide));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_SafeArea));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_ViewBBox));

--- a/toonz/sources/toonz/icons/dark/actions/20/pane_perspective.svg
+++ b/toonz/sources/toonz/icons/dark/actions/20/pane_perspective.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100%"
+   height="100%"
+   viewBox="0 0 20 20"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg8"
+   sodipodi:docname="pane_perspective.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs12" /><sodipodi:namedview
+   id="namedview10"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:zoom="35.95"
+   inkscape:cx="11.696801"
+   inkscape:cy="11.515994"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg8"
+   inkscape:snap-global="false"><inkscape:grid
+     type="xygrid"
+     id="grid841" /></sodipodi:namedview>
+    
+    
+    <g
+   id="g10931"><rect
+     x="3"
+     y="3"
+     width="14"
+     height="14"
+     style="fill-opacity:0;stroke-width:0.7"
+     id="rect2" /><path
+     d="m 12.5,6.5 -9,-2 v 11 l 9,-5 z"
+     style="fill-opacity:0.2;stroke-width:0.707107"
+     id="path4" /><path
+     d="M 3,4.6998912 V 15.719991 C 3,16.106391 3.3446154,16.5 3.7692308,16.5 H 17.231 c 0.212308,0 0.384385,-0.3068 0.384385,-0.5 0,-0.0931 -0.04077,-0.2122 -0.112308,-0.278 -0.07231,-0.0651 -0.170003,-0.12116 -0.272308,-0.122 L 5.25,15.5 l 1.5,-1 h 9.711538 c 0.102309,0 0.2,-0.1169 0.272308,-0.182 0.07154,-0.0658 0.112308,-0.2249 0.112308,-0.318 0,-0.0931 -0.04077,-0.3122 -0.112308,-0.378 -0.07231,-0.0651 -0.17,-0.122 -0.272308,-0.122 H 8.4 l 1.6,-1 h 5.692308 c 0.212307,0 0.384615,-0.3068 0.384615,-0.5 0,-0.1932 -0.172308,-0.5 -0.384615,-0.5 H 11.5 L 12.3,11 h 2.623077 c 0.10231,0 0.2,-0.1169 0.272308,-0.182 0.07154,-0.0658 0.112307,-0.2249 0.112307,-0.318 0,-0.0931 -0.04077,-0.3122 -0.112307,-0.378 C 15.123075,10.0569 15.025385,10 14.923077,10 H 13 V 6.4771912 c 0,-0.3262 -0.246923,-0.609 -0.596154,-0.6825 -1.673846,-0.3514 -6.4276922,-1.3496 -8.4615383,-1.7766 -0.2284615,-0.0483 -0.4684615,0.0014 -0.6523077,0.1337 -0.1830769,0.133 -0.29,0.3346 -0.29,0.5481 z M 7,13.244 V 9.675 l -3,0.567 v 4.924991 z M 8,9.558 v 3.056 l 2,-1.29255 V 9.2085501 Z M 12,8.8581001 11,9.092 v 1.598 l 1,-0.661 z M 4,9.142 7,8.675 V 5.657 L 4,5.011 Z M 8,8.458 10,8.2081 V 6.304 L 8,5.819 Z M 11,6.465 V 7.992 L 12,7.8581 V 6.689 Z"
+     id="path6"
+     style="stroke-width:0.733799"
+     sodipodi:nodetypes="ssssscsccscscsccsssccscscscscccscccccccccccccccccccccccccccccc" /></g>
+</svg>

--- a/toonz/sources/toonz/icons/dark/actions/20/pane_symmetry.svg
+++ b/toonz/sources/toonz/icons/dark/actions/20/pane_symmetry.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100%"
+   height="100%"
+   viewBox="0 0 20 20"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg8"
+   sodipodi:docname="pane_symmetry.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs12" /><sodipodi:namedview
+   id="namedview10"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:snap-grids="true"
+   inkscape:snap-to-guides="true"
+   inkscape:zoom="25.420489"
+   inkscape:cx="18.980752"
+   inkscape:cy="12.784963"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g14"><inkscape:grid
+     type="xygrid"
+     id="grid829" /></sodipodi:namedview>
+    <rect
+   x="0"
+   y="0"
+   width="20"
+   height="20"
+   style="fill-opacity:0;"
+   id="rect2" />
+    
+    
+<g
+   transform="translate(-170,-126)"
+   id="g14"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"><g
+     id="g2147"><g
+       id="bg"
+       transform="matrix(0.08130691,0,0,0.09202497,161.04789,116.5421)"><rect
+         x="147"
+         y="156"
+         width="145"
+         height="132"
+         style="fill:#878787;fill-opacity:0"
+         id="rect2-6" /></g><path
+       d="m 173,140.5 5,-4.5 -5,-4.5 z m 1,-2.25 2.5,-2.25 -2.5,-2.25 z"
+       id="path9-1"
+       sodipodi:nodetypes="cccccccc"
+       style="clip-rule:evenodd;fill-rule:evenodd;stroke-width:0.792173;stroke-linejoin:round;stroke-miterlimit:2" /><path
+       d="m 187,140.5 -5,-4.5 5,-4.5 z m -1,-2.25 -2.5,-2.25 2.5,-2.25 z"
+       id="path9-1-0"
+       sodipodi:nodetypes="cccccccc"
+       style="clip-rule:evenodd;fill-rule:evenodd;stroke-width:0.792173;stroke-linejoin:round;stroke-miterlimit:2" /><path
+       style="fill:none;stroke:#000000;stroke-width:1.03192;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:2;stroke-dasharray:4.12767, 2.06384;stroke-dashoffset:1.65107;stroke-opacity:1"
+       d="M 180.01596,129.51596 V 142.4511"
+       id="path5853"
+       sodipodi:nodetypes="cc" /></g></g></svg>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -87,6 +87,8 @@ TEnv::IntVar ShowShiftOriginToggleAction("ShowShiftOriginToggleAction", 0);
 TEnv::IntVar NoShiftToggleAction("NoShiftToggleAction", 0);
 TEnv::IntVar TouchGestureControl("TouchGestureControl", 0);
 TEnv::IntVar TransparencySliderValue("TransparencySliderValue", 50);
+TEnv::IntVar ShowPerspectiveGrids("ShowPerspectiveGrids", 0);
+TEnv::IntVar ShowSymmetryGuide("ShowSymmetryGuide", 0);
 
 TEnv::StringVar SkipVersion("SkipVersion", "0.0");
 
@@ -1295,6 +1297,10 @@ void MainWindow::onMenuCheckboxChanged() {
     EditInPlaceToggleAction = isChecked;
   else if (cm->getAction(MI_ViewBBox) == action)
     ViewBBoxToggleAction = isChecked;
+  else if (cm->getAction(MI_ShowSymmetryGuide) == action)
+    ShowSymmetryGuide = isChecked;
+  else if (cm->getAction(MI_ShowPerspectiveGrids) == action)
+    ShowPerspectiveGrids = isChecked;
   else if (cm->getAction(MI_FieldGuide) == action)
     FieldGuideToggleAction = isChecked;
   else if (cm->getAction(MI_RasterizePli) == action) {
@@ -2333,6 +2339,10 @@ void MainWindow::defineActions() {
                ViewCameraToggleAction ? 1 : 0, MenuViewCommandType);
   createToggle(MI_ViewTable, QT_TR_NOOP("&Table"), "",
                ViewTableToggleAction ? 1 : 0, MenuViewCommandType);
+  createToggle(MI_ShowSymmetryGuide, QT_TR_NOOP("&Symmetry Guide"), "",
+               ShowSymmetryGuide ? 1 : 0, MenuViewCommandType);
+  createToggle(MI_ShowPerspectiveGrids, QT_TR_NOOP("&Perspective Grids"), "",
+               ShowPerspectiveGrids ? 1 : 0, MenuViewCommandType);
   createToggle(MI_FieldGuide, QT_TR_NOOP("&Grids and Overlays"), "Shift+G",
                FieldGuideToggleAction ? 1 : 0, MenuViewCommandType);
   createToggle(MI_ViewBBox, QT_TR_NOOP("&Raster Bounding Box"), "",

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -607,6 +607,8 @@ void TopBar::loadMenubar() {
   addMenuItem(viewMenu, MI_ViewColorcard);
   addMenuItem(viewMenu, MI_ViewBBox);
   viewMenu->addSeparator();
+  addMenuItem(viewMenu, MI_ShowSymmetryGuide);
+  addMenuItem(viewMenu, MI_ShowPerspectiveGrids);
   addMenuItem(viewMenu, MI_SafeArea);
   addMenuItem(viewMenu, MI_FieldGuide);
   addMenuItem(viewMenu, MI_ViewRuler);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -526,4 +526,6 @@
 
 #define MI_NewFolder "MI_NewFolder"
 
+#define MI_ShowSymmetryGuide "MI_ShowSymmetryGuide"
+#define MI_ShowPerspectiveGrids "MI_ShowPerspectiveGrids"
 #endif

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -18,7 +18,6 @@
 #include "toonz/tscenehandle.h"
 
 #include "tools/toolhandle.h"
-#include "../tnztools/symmetrytool.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -51,8 +50,6 @@ extern TEnv::IntVar ShowRuleOfThirds;
 extern TEnv::IntVar ShowGoldenRatio;
 extern TEnv::IntVar ShowFieldGuide;
 extern TEnv::IntVar GuideOpacity;
-extern TEnv::IntVar ShowPerspectiveGrids;
-extern TEnv::IntVar ShowSymmetryGuide;
 extern TEnv::IntVar ShowSceneOverlay;
 //=============================================================================
 // TPanel
@@ -504,23 +501,6 @@ TPanelTitleBarButtonForGrids::TPanelTitleBarButtonForGrids(
     emit updateViewer();
   });
 
-  QCheckBox *perspectiveCheckbox = new QCheckBox(tr("Perspective Grids"), this);
-  perspectiveCheckbox->setChecked(ShowPerspectiveGrids != 0);
-  connect(perspectiveCheckbox, &QCheckBox::stateChanged, [=](int value) {
-    ShowPerspectiveGrids = value > 0 ? 1 : 0;
-    emit updateViewer();
-  });
-
-  QCheckBox *symmetryCheckbox = new QCheckBox(tr("Symmetry Guide"), this);
-  connect(symmetryCheckbox, &QCheckBox::stateChanged, [=](int value) {
-    ShowSymmetryGuide          = value > 0 ? 1 : 0;
-    SymmetryTool *symmetryTool = dynamic_cast<SymmetryTool *>(
-        TTool::getTool("T_Symmetry", TTool::RasterImage));
-    if (symmetryTool) symmetryTool->setGuideEnabled(ShowSymmetryGuide);
-    emit updateViewer();
-  });
-  symmetryCheckbox->setChecked(ShowSymmetryGuide != 0);
-
   QCheckBox *sceneOverlayCheckbox = new QCheckBox(tr("Scene Overlay"), this);
   connect(sceneOverlayCheckbox, &QCheckBox::stateChanged, [=](int value) {
     ShowSceneOverlay = value > 0 ? 1 : 0;
@@ -531,9 +511,7 @@ TPanelTitleBarButtonForGrids::TPanelTitleBarButtonForGrids(
   gridLayout->addWidget(thirdsCheckbox, 0, 0, 1, 2);
   gridLayout->addWidget(goldenRationCheckbox, 1, 0, 1, 2);
   gridLayout->addWidget(fieldGuideCheckbox, 2, 0, 1, 2);
-  gridLayout->addWidget(perspectiveCheckbox, 3, 0, 1, 2);
-  gridLayout->addWidget(symmetryCheckbox, 4, 0, 1, 2);
-  gridLayout->addWidget(sceneOverlayCheckbox, 5, 0, 1, 2);
+  gridLayout->addWidget(sceneOverlayCheckbox, 4, 0, 1, 2);
 
   gridWidget->setLayout(gridLayout);
   gridsAction->setDefaultWidget(gridWidget);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -90,9 +90,10 @@
 
 #include "sceneviewer.h"
 
-TEnv::IntVar ShowPerspectiveGrids("ShowPerspectiveGrids", 1);
-TEnv::IntVar ShowSymmetryGuide("ShowSymmetryGuide", 1);
 TEnv::IntVar ShowSceneOverlay("ShowSceneOverlay", 1);
+
+extern TEnv::IntVar ShowPerspectiveGrids;
+extern TEnv::IntVar ShowSymmetryGuide;
 
 void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
                 double pixelSize);
@@ -296,6 +297,8 @@ ToggleCommandHandler editInPlaceToggle(MI_ToggleEditInPlace, false);
 ToggleCommandHandler fieldGuideToggle(MI_FieldGuide, false);
 ToggleCommandHandler safeAreaToggle(MI_SafeArea, false);
 ToggleCommandHandler rasterizePliToggle(MI_RasterizePli, false);
+ToggleCommandHandler symmetryGuideToggle(MI_ShowSymmetryGuide, false);
+ToggleCommandHandler perspectiveGridsToggle(MI_ShowPerspectiveGrids, false);
 
 ToggleCommandHandler viewClcToggle("MI_ViewColorcard", false);
 ToggleCommandHandler viewCameraToggle("MI_ViewCamera", false);
@@ -1912,8 +1915,7 @@ void SceneViewer::drawOverlay() {
   TTool *perspectiveTool =
       TTool::getTool(T_PerspectiveGrid, TTool::VectorImage);
   if (tool && perspectiveTool &&
-      ((fieldGuideToggle.getStatus() && ShowPerspectiveGrids) ||
-       tool == perspectiveTool)) {
+      (ShowPerspectiveGrids || tool == perspectiveTool)) {
     glPushMatrix();
     if (m_draw3DMode) {
       mult3DMatrix();
@@ -1925,9 +1927,7 @@ void SceneViewer::drawOverlay() {
   }
 
   TTool *symmetryTool = TTool::getTool(T_Symmetry, TTool::VectorImage);
-  if (tool && symmetryTool &&
-      ((fieldGuideToggle.getStatus() && ShowSymmetryGuide) ||
-       tool == symmetryTool)) {
+  if (tool && symmetryTool && (ShowSymmetryGuide || tool == symmetryTool)) {
     glPushMatrix();
     if (m_draw3DMode) {
       mult3DMatrix();

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -539,6 +539,8 @@
 		<file>icons/dark/actions/20/pane_3d.svg</file>
 		<file>icons/dark/actions/20/pane_minimize.svg</file>
 		<file>icons/dark/actions/20/pane_close.svg</file>
+		<file>icons/dark/actions/20/pane_symmetry.svg</file>
+		<file>icons/dark/actions/20/pane_perspective.svg</file>
 
 		<!-- Textstyle -->
 		<file>icons/dark/actions/16/bold.svg</file>

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -35,7 +35,11 @@
 #include "toonzqt/imageutils.h"
 
 // TnzTools includes
+#include "tools/tool.h"
+#include "tools/toolcommandids.h"
 #include "tools/toolhandle.h"
+
+#include "../tnztools/symmetrytool.h"
 
 // Tnz6 includes
 #include "tapp.h"
@@ -69,6 +73,8 @@
 using namespace DVGui;
 
 extern TEnv::IntVar EnvViewerPreviewBehavior;
+extern TEnv::IntVar ShowPerspectiveGrids;
+extern TEnv::IntVar ShowSymmetryGuide;
 
 // this enum is to keep comaptibility with older versions
 enum OldV_Parts {
@@ -232,6 +238,10 @@ void BaseViewerPanel::addShowHideContextMenu(QMenu *menu) {
   showHideMenu->addSeparator();
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_ViewCamera));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_ViewTable));
+  showHideMenu->addAction(
+      CommandManager::instance()->getAction(MI_ShowSymmetryGuide));
+  showHideMenu->addAction(
+      CommandManager::instance()->getAction(MI_ShowPerspectiveGrids));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_FieldGuide));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_SafeArea));
   showHideMenu->addAction(CommandManager::instance()->getAction(MI_ViewBBox));
@@ -355,6 +365,9 @@ void BaseViewerPanel::showEvent(QShowEvent *event) {
 
   ret = ret && connect(app->getCurrentTool(), SIGNAL(toolSwitched()),
                        m_sceneViewer, SLOT(onToolSwitched()));
+  ret = ret && connect(app->getCurrentTool(), SIGNAL(toolSwitched()), this,
+                       SLOT(onToolSwitched()));
+
   ret =
       ret && connect(sceneHandle, SIGNAL(preferenceChanged(const QString &)),
                      m_flipConsole, SLOT(onPreferenceChanged(const QString &)));
@@ -388,14 +401,44 @@ void BaseViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
 
   TPanelTitleBarButtonSet *viewModeButtonSet;
   m_referenceModeBs = viewModeButtonSet = new TPanelTitleBarButtonSet();
-  int x                                 = -272;
+  int x                                 = -311;
   int iconWidth                         = 20;
   TPanelTitleBarButton *button;
+
+  m_symmetryButton =
+      new TPanelTitleBarButton(titleBar, getIconPath("pane_symmetry"));
+  m_symmetryButton->setToolTip(tr("Show Symmetry Guide"));
+  titleBar->add(QPoint(x, 0), m_symmetryButton);
+  ret = ret &&
+        connect(m_symmetryButton, SIGNAL(toggled(bool)),
+                CommandManager::instance()->getAction(MI_ShowSymmetryGuide),
+                SLOT(trigger()));
+  ret = ret &&
+        connect(CommandManager::instance()->getAction(MI_ShowSymmetryGuide),
+                SIGNAL(triggered(bool)), this,
+                SLOT(onSymmetryGuideToggled(bool)));
+  onSymmetryGuideToggled(ShowSymmetryGuide);
+
+  m_perspectiveButton =
+      new TPanelTitleBarButton(titleBar, getIconPath("pane_perspective"));
+  m_perspectiveButton->setToolTip(tr("Show Perspective Grids"));
+  x += 1 + iconWidth;
+  titleBar->add(QPoint(x, 0), m_perspectiveButton);
+  ret = ret &&
+        connect(m_perspectiveButton, SIGNAL(toggled(bool)),
+                CommandManager::instance()->getAction(MI_ShowPerspectiveGrids),
+                SLOT(trigger()));
+  ret = ret &&
+        connect(CommandManager::instance()->getAction(MI_ShowPerspectiveGrids),
+                SIGNAL(triggered(bool)), this,
+                SLOT(onPerspectiveGuideToggled(bool)));
+  onPerspectiveGuideToggled(ShowPerspectiveGrids);
 
   // buttons for show / hide toggle for the field guide and the safe area
   TPanelTitleBarButtonForSafeArea *safeAreaButton =
       new TPanelTitleBarButtonForSafeArea(titleBar, getIconPath("pane_safe"));
   safeAreaButton->setToolTip(tr("Safe Area (Right Click to Select)"));
+  x += 1 + iconWidth;
   titleBar->add(QPoint(x, 0), safeAreaButton);
   ret = ret && connect(safeAreaButton, SIGNAL(toggled(bool)),
                        CommandManager::instance()->getAction(MI_SafeArea),
@@ -490,6 +533,25 @@ void BaseViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
   //                      SLOT(enableSubCameraPreview(bool)));
 
   assert(ret);
+}
+
+//-----------------------------------------------------------------------------
+
+void BaseViewerPanel::onSymmetryGuideToggled(bool value) {
+  ShowSymmetryGuide          = value > 0 ? 1 : 0;
+  SymmetryTool *symmetryTool = dynamic_cast<SymmetryTool *>(
+      TTool::getTool(T_Symmetry, TTool::RasterImage));
+  if (symmetryTool) symmetryTool->setGuideEnabled(ShowSymmetryGuide);
+  m_symmetryButton->setPressed(ShowSymmetryGuide);
+  m_sceneViewer->update();
+}
+
+//-----------------------------------------------------------------------------
+
+void BaseViewerPanel::onPerspectiveGuideToggled(bool value) {
+  ShowPerspectiveGrids = value > 0 ? 1 : 0;
+  m_perspectiveButton->setPressed(ShowPerspectiveGrids);
+  m_sceneViewer->update();
 }
 
 //-----------------------------------------------------------------------------
@@ -1015,6 +1077,22 @@ void BaseViewerPanel::onActiveViewerChanged() {
     m_isActive = false;
   }
   assert(ret);
+}
+
+void BaseViewerPanel::onToolSwitched() {
+  TTool *tool = TApp::instance()->getCurrentTool()->getTool();
+
+  if (tool->getName() == T_Symmetry) {
+    if (!ShowSymmetryGuide) {
+      m_symmetryButton->setPressed(true);
+      m_symmetryButton->toggled(true);
+    }
+  } else if (tool->getName() == T_PerspectiveGrid) {
+    if (!ShowPerspectiveGrids) {
+      m_perspectiveButton->setPressed(true);
+      m_perspectiveButton->toggled(true);
+    }
+  }
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -40,6 +40,7 @@
 #include "tools/toolhandle.h"
 
 #include "../tnztools/symmetrytool.h"
+#include "../tnztools/perspectivetool.h"
 
 // Tnz6 includes
 #include "tapp.h"
@@ -550,6 +551,10 @@ void BaseViewerPanel::onSymmetryGuideToggled(bool value) {
 
 void BaseViewerPanel::onPerspectiveGuideToggled(bool value) {
   ShowPerspectiveGrids = value > 0 ? 1 : 0;
+  PerspectiveTool *perspectiveTool = dynamic_cast<PerspectiveTool *>(
+      TTool::getTool(T_PerspectiveGrid, TTool::RasterImage));
+  if (perspectiveTool)
+    perspectiveTool->setGuideEnabled(ShowPerspectiveGrids);
   m_perspectiveButton->setPressed(ShowPerspectiveGrids);
   m_sceneViewer->update();
 }

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -53,6 +53,7 @@ protected:
   TPanelTitleBarButtonSet *m_referenceModeBs;
   TPanelTitleBarButtonForPreview *m_previewButton;
   TPanelTitleBarButtonForPreview *m_subcameraPreviewButton;
+  TPanelTitleBarButton *m_symmetryButton, *m_perspectiveButton;
   bool m_onionSkinActive = false;
   UINT m_visiblePartsFlag;
   bool m_playSound     = true;
@@ -118,6 +119,8 @@ public slots:
   void enableFullPreview(bool enabled);
   void enableSubCameraPreview(bool enabled);
   void changeSceneFps(int value);
+  void onSymmetryGuideToggled(bool value);
+  void onPerspectiveGuideToggled(bool value);
 
 protected slots:
 
@@ -129,6 +132,7 @@ protected slots:
   void onShowHideActionTriggered(QAction *);
   void onPreviewStatusChanged();
   void onActiveViewerChanged();
+  void onToolSwitched();
 };
  
 class SceneViewerPanel final : public BaseViewerPanel {


### PR DESCRIPTION
In order to make using the Symmetry and Perspective Tools a bit more intuitive, I've made the following changes:

1. Created `Symmetry Guide` and `Perspective Grids` commands
2. Moved the visibility toggles from the `Grid and Overlays` button to dedicated buttons on the viewer titlebar
  ![image](https://github.com/tahoma2d/tahoma2d/assets/19245851/0d6e6571-65a6-4356-b597-273e4dd62c5d)
3. Options to toggle symmetry guides and perspective grids are also shown in the `View` menu.
4. By default the Symmetry/Perspective buttons are `Off`, but will be automatically switched `On` when entering the tool.
5. User defined perspective grids are only enabled when the Perspective Grids button is on.  If not on, the default perspective (Vanishing Point at camera center) is used.