### PR TITLE
Fix fillable regions after SVG import

### DIFF
--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2256,6 +2256,7 @@ TImageP TImageReaderSvg::load() {
                            paintIndex, true, true, false);
         vimage->exitGroup();
       }
+      vimage->findRegions();
     }
     if (startStrokeIndex == vimage->getStrokeCount()) continue;
 


### PR DESCRIPTION
This is a follow-up to #1395.

It is a semi-workaround to an issue with how fill regions were calculated with or without grouping when using SVG import.

In the old SVG import, every individual stroke was grouped.  In order to fill areas, you had to ungroup everything.  The ungrouping of strokes would look for new fillable regions as each stroke was ungrouped.

In new SVG import, individual strokes were not grouped so the calculation of fillable regions is done at the end. The results were different than before and were often wrong or incomplete.

This ultimately is due to our intersection/fill region detection logic which appears to do better when there are fewer strokes and intersections being used to calculate regions as in the case of ungrouping. It appears to be worse if there are too many available intersections to consider at once.

In order to find more accurate fill regions, this change will now calculate fillable regions as each stroke in the SVG is imported, rather than wait until the end.