### PR TITLE
Fix Fx not working with Implicit Holds

### DIFF
--- a/toonz/sources/common/tfx/tfx.cpp
+++ b/toonz/sources/common/tfx/tfx.cpp
@@ -612,7 +612,7 @@ TFxTimeRegion TFx::getTimeRegion(bool ignoreImplicit) const {
     if (port && port->isConnected() && !port->isaControlPort()) {
       TFx *fx = port->getFx();
       std::wstring fxName = fx->getName();
-      tr += fx->getTimeRegion((fx->getFxType() == "Toonz_columnFx" ? true : ignoreImplicit));
+      tr += fx->getTimeRegion(ignoreImplicit);
     }
   }
 

--- a/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
+++ b/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
@@ -36,7 +36,7 @@ void Iwa_FlowPaintBrushFx::getBrushRasters(std::vector<TRasterP> &brushRasters,
                                            const TRenderSettings &ri) {
   // ブラシテクスチャ情報
   TPointD b_offset;
-  const TFxTimeRegion &tr = m_brush->getTimeRegion();
+  const TFxTimeRegion &tr = m_brush->getTimeRegion(true);
   lastFrame               = tr.getLastFrame() + 1;
   TLevelP partLevel       = new TLevel();
   partLevel->setName(m_brush->getAlias(0, ri));

--- a/toonz/sources/stdfx/iwa_particlesfx.cpp
+++ b/toonz/sources/stdfx/iwa_particlesfx.cpp
@@ -484,7 +484,7 @@ void Iwa_TiledParticlesFx::doCompute(TTile &tile, double frame,
     TRectD bbox;
 
     for (unsigned int i = 0; i < (int)part_ports.size(); ++i) {
-      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion();
+      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion(true);
 
       lastframe.push_back(tr.getLastFrame() + 1);
       partLevel.push_back(new TLevel());

--- a/toonz/sources/stdfx/particlesfx.cpp
+++ b/toonz/sources/stdfx/particlesfx.cpp
@@ -423,7 +423,7 @@ void ParticlesFx::doCompute(TTile &tile, double frame,
     TRectD bbox;
 
     for (unsigned int i = 0; i < (int)part_ports.size(); ++i) {
-      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion();
+      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion(true);
 
       lastframe.push_back(tr.getLastFrame() + 1);
       partLevel.push_back(new TLevel());


### PR DESCRIPTION
This fixes an issue with some Fx not working in Preview mode/Render when using Implicit Holds. The workaround used to require adding Stop Hold Frames for all levels at the end of the scene.  This fix should eliminate the need for that workaround.

I had previously added logic for handling a preview/rendering performance issue with Particle Fx when Implicit Holds were used. When determining what textures to use, it needed to ignore implicit holds otherwise it would try to use them as additional textures. That logic had impacted some fx where implicit holds needed to be factored in.

Modified the logic to constrain the previously added logic to any `Particles` Fx, `Tiled Particles Iwa` and the `Flow Paint Brush Iwa` fx; essentially any fx where an image was being used as a texture but extended exposure didn't matter.

I did go through all stock Fx and they seemed to be working fine without any workarounds.  There were a few whose performance was slow, but they were also slow in OT. Additional feedback would be great.