### PR TITLE
Eraser Tool Pressure and Frame Range Interpolation settings

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -605,7 +605,7 @@ class EraserToolOptionsBox final : public ToolOptionsBox {
   Q_OBJECT
 
   ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode,
-      *m_eraseOnlySavebox;
+      *m_eraseOnlySavebox, *m_pressure;
   ToolOptionCombo *m_toolType, *m_colorMode;
   QLabel *m_hardnessLabel, *m_colorModeLabel;
   ToolOptionSlider *m_hardnessField;

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -67,6 +67,7 @@ using namespace ToolUtils;
 #define POLYLINEERASE L"Polyline"
 #define SEGMENTERASE L"Segment"
 
+TEnv::DoubleVar EraseMinSize("InknpaintEraseMinSize", 1);
 TEnv::DoubleVar EraseSize("InknpaintEraseSize", 10);
 TEnv::StringVar EraseType("InknpaintEraseType", "Normal");
 TEnv::IntVar EraseSelective("InknpaintEraseSelective", 0);
@@ -76,8 +77,17 @@ TEnv::StringVar EraseColorType("InknpaintEraseColorType", "Lines");
 TEnv::DoubleVar EraseHardness("EraseHardness", 100);
 TEnv::IntVar ErasePencil("InknpaintErasePencil", 0);
 TEnv::IntVar EraseOnlySavebox("InknpaintEraseOnlySavebox", 0);
+TEnv::IntVar ErasePressure("InknpaintErasePressure", 1);
 
 namespace {
+
+int computeThickness(double pressure, const TIntPairProperty &property) {
+  double t   = pressure * pressure * pressure;
+  int thick0 = property.getValue().first;
+  int thick1 = property.getValue().second;
+
+  return tround(thick0 + (thick1 - thick0) * t);
+}
 
 //==============================================================================
 //   Undo dei Tools
@@ -743,7 +753,8 @@ private:
   TPropertyGroup m_prop;
 
   TEnumProperty m_eraseType;
-  TIntProperty m_toolSize;
+  TIntPairProperty m_toolSize;
+  TBoolProperty m_pressure;
   TDoubleProperty m_hardness;
   TBoolProperty m_invertOption;
   TBoolProperty m_currentStyle;
@@ -809,7 +820,7 @@ EraserTool inkPaintEraserTool("T_Eraser");
 
 EraserTool::EraserTool(std::string name)
     : TTool(name)
-    , m_toolSize("Size:", 1, 1000, 10, false)  // W_ToolOptions_EraserToolSize
+    , m_toolSize("Size:", 1, 1000, 1, 10, false)  // W_ToolOptions_EraserToolSize
     , m_hardness("Hardness:", 0, 100, 100)
     , m_eraseType("Type:")                // W_ToolOptions_Erasetype
     , m_colorType("Mode:")                // W_ToolOptions_InkOrPaint
@@ -830,7 +841,8 @@ EraserTool::EraserTool(std::string name)
     , m_firstTime(true)
     , m_workingFrameId(TFrameId())
     , m_isLeftButtonPressed(false)
-    , m_eraseOnlySavebox("Savebox", false) {
+    , m_eraseOnlySavebox("Savebox", false)
+    , m_pressure("Pressure", true) {
   bind(TTool::ToonzImage);
 
   m_toolSize.setNonLinearSlider();
@@ -849,12 +861,14 @@ EraserTool::EraserTool(std::string name)
   m_colorType.addValue(ALL);
   m_prop.bind(m_colorType);
 
+  m_prop.bind(m_pressure);
   m_prop.bind(m_currentStyle);
   m_prop.bind(m_invertOption);
   m_prop.bind(m_multi);
   m_prop.bind(m_pencil);
   m_prop.bind(m_eraseOnlySavebox);
 
+  m_pressure.setId("PressureSensitivity");
   m_currentStyle.setId("Selective");
   m_invertOption.setId("Invert");
   m_multi.setId("FrameRange");
@@ -882,6 +896,7 @@ void EraserTool::updateTranslation() {
   m_colorType.setItemUIName(AREAS, tr("Areas"));
   m_colorType.setItemUIName(ALL, tr("Lines & Areas"));
 
+  m_pressure.setQStringName(tr("Pressure"));
   m_currentStyle.setQStringName(tr("Selective"));
   m_invertOption.setQStringName(tr("Invert"));
   m_multi.setQStringName(tr("Frame Range"));
@@ -981,7 +996,10 @@ void EraserTool::draw() {
       glColor3d(0.5, 0.8, 0.8);
     else
       glColor3d(1.0, 0.0, 0.0);
-    drawEmptyCircle(tround(m_cleanerSize), m_brushPos,
+    drawEmptyCircle(tround(m_toolSize.getValue().first), m_brushPos,
+                    (m_pencil.getValue() || m_colorType.getValue() == AREAS),
+                    lx % 2 == 0, ly % 2 == 0);
+    drawEmptyCircle(tround(m_toolSize.getValue().second), m_brushPos,
                     (m_pencil.getValue() || m_colorType.getValue() == AREAS),
                     lx % 2 == 0, ly % 2 == 0);
   }
@@ -1266,21 +1284,23 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
     if (m_eraseType.getValue() == NORMALERASE) {
       TRasterCM32P raster = ti->getRaster();
       TPointD fixedPos    = fixMousePos(pos);
+      int maxThick        = m_toolSize.getValue().second;
+      int thickness       = (m_pressure.getValue() && e.isTablet())
+                          ? computeThickness(e.m_pressure, m_toolSize)
+                          : maxThick;
+
       TThickPoint intPos;
       /*--Areasタイプの時は常にPencilと同じ消し方にする--*/
       if (m_pencil.getValue() || m_colorType.getValue() == AREAS)
-        intPos = TThickPoint(fixedPos + convert(raster->getCenter()),
-                             m_toolSize.getValue());
+        intPos = TThickPoint(fixedPos + convert(raster->getCenter()), thickness);
       else
-        intPos = TThickPoint(fixedPos + convert(raster->getCenter()),
-                             m_toolSize.getValue() - 1);
+        intPos = TThickPoint(fixedPos + convert(raster->getCenter()), thickness - 1);
       int currentStyle = 0;
       if (m_currentStyle.getValue())
         currentStyle = TTool::getApplication()->getCurrentLevelStyleIndex();
       m_tileSet      = new TTileSetCM32(raster->getSize());
       m_tileSaver    = new TTileSaverCM32(raster, m_tileSet);
-      TPointD halfThick(m_toolSize.getValue() * 0.5,
-                        m_toolSize.getValue() * 0.5);
+      TPointD halfThick(maxThick * 0.5, maxThick * 0.5);
       invalidateRect = TRectD(fixedPos - halfThick, fixedPos + halfThick);
       if (m_hardness.getValue() == 100 || m_pencil.getValue() ||
           m_colorType.getValue() == AREAS) {
@@ -1312,10 +1332,9 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
         m_workRas   = TRaster32P(raster->getSize());
         m_workRas->clear();
         TPointD center = raster->getCenterD();
-        TThickPoint point(fixedPos + center, m_toolSize.getValue());
+        TThickPoint point(fixedPos + center, thickness);
         m_points.push_back(point);
-        m_blurredEraser = new RasterBlurredBrush(
-            m_workRas, m_toolSize.getValue(), m_brushPad, false);
+        m_blurredEraser = new RasterBlurredBrush(m_workRas, maxThick, m_brushPad, false);
 
         if (symmetryTool && symmetryTool->isGuideEnabled()) {
           TPointD dpiScale       = getViewer()->getDpiScale();
@@ -1425,6 +1444,11 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     }
     if (m_eraseType.getValue() == NORMALERASE) {
       TPointD fixedPos = fixMousePos(pos);
+      int maxThick     = m_toolSize.getValue().second;
+      int thickness    = (m_pressure.getValue() && e.isTablet())
+                          ? computeThickness(e.m_pressure, m_toolSize)
+                          : maxThick;
+
       if (m_normalEraser &&
           (m_hardness.getValue() == 100 || m_pencil.getValue() ||
            m_colorType.getValue() == AREAS)) {
@@ -1432,10 +1456,10 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
         TThickPoint intPos;
         if (m_pencil.getValue() || m_colorType.getValue() == AREAS)
           intPos = TThickPoint(pp + convert(ti->getRaster()->getCenter()),
-                               m_toolSize.getValue());
+                               thickness);
         else
           intPos = TThickPoint(pp + convert(ti->getRaster()->getCenter()),
-                               m_toolSize.getValue() - 1);
+                               thickness - 1);
 
         m_normalEraser->add(intPos);
         if (ti) {
@@ -1458,7 +1482,7 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
               points.push_back(brushPoints[m - 2]);
             }
           }
-          invalidateRect = ToolUtils::getBounds(points, m_toolSize.getValue());
+          invalidateRect = ToolUtils::getBounds(points, maxThick);
         }
       } else {
         assert(m_workRas.getPointer() && m_backupRas.getPointer());
@@ -1466,7 +1490,6 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
         TThickPoint old = m_points.back();
         if (norm2(fixedPos - old) < 4) return;
 
-        int thickness = m_toolSize.getValue();
         TThickPoint point(fixedPos + rasCenter, thickness);
         TThickPoint mid((old + point) * 0.5, (point.thick + old.thick) * 0.5);
         m_points.push_back(mid);
@@ -1498,10 +1521,10 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
                                     m_currentStyle.getValue(), currentStyle,
                                     m_colorType.getValue());
 
-        invalidateRect = ToolUtils::getBounds(points, thickness);
         std::vector<TThickPoint> symmPts =
             m_blurredEraser->getSymmetryPoints(points);
         points.insert(points.end(), symmPts.begin(), symmPts.end());
+        invalidateRect = ToolUtils::getBounds(points, maxThick);
       }
       invalidate(invalidateRect.enlarge(2) - rasCenter);
     }
@@ -1699,6 +1722,11 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       SymmetryTool *symmetryTool = dynamic_cast<SymmetryTool *>(
           TTool::getTool("T_Symmetry", TTool::RasterImage));
 
+      int maxThick  = m_toolSize.getValue().second;
+      int thickness = (m_pressure.getValue() && e.isTablet())
+                          ? computeThickness(e.m_pressure, m_toolSize)
+                          : maxThick;
+
       if (m_normalEraser &&
           (m_hardness.getValue() == 100 || m_pencil.getValue() ||
            m_colorType.getValue() == AREAS)) {
@@ -1729,7 +1757,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       } else {
         if (m_points.size() != 1) {
           TPointD rasCenter = ti->getRaster()->getCenterD();
-          TThickPoint point(fixedPos + rasCenter, m_toolSize.getValue());
+          TThickPoint point(fixedPos + rasCenter, thickness);
           m_points.push_back(point);
           int m = m_points.size();
           std::vector<TThickPoint> points;
@@ -1748,8 +1776,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
               m_blurredEraser->getSymmetryPoints(points);
           allPts.insert(allPts.end(), symmPts.begin(), symmPts.end());
 
-          TRectD invalidateRect =
-              ToolUtils::getBounds(allPts, m_toolSize.getValue());
+          TRectD invalidateRect = ToolUtils::getBounds(allPts, maxThick);
 
           invalidate(invalidateRect.enlarge(2) - rasCenter);
         }
@@ -1775,7 +1802,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 
         TUndoManager::manager()->add(new RasterBluredEraserUndo(
             m_tileSet, m_points, currentStyle, m_currentStyle.getValue(),
-            simLevel.getPointer(), frameId, m_toolSize.getValue(),
+            simLevel.getPointer(), frameId, maxThick,
             m_hardness.getValue() * 0.01, m_colorType.getValue(), dpiScale,
             symmetryLines, rotation, centerPoint, useLineSymmetry));
       }
@@ -2082,12 +2109,16 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
   }
 
   else if (propertyName == m_toolSize.getName()) {
-    EraseSize     = m_toolSize.getValue();
-    m_cleanerSize = m_toolSize.getValue();
+    EraseMinSize  = m_toolSize.getValue().first;
+    EraseSize     = m_toolSize.getValue().second;
+    m_cleanerSize = m_toolSize.getValue().second;
 
-    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue(),
+    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                         m_hardness.getValue() * 0.01);
   }
+
+  else if (propertyName == m_pressure.getName())
+    ErasePressure = m_pressure.getValue();
 
   else if (propertyName == m_invertOption.getName())
     EraseInvert = m_invertOption.getValue();
@@ -2112,7 +2143,7 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
 
   else if (propertyName == m_hardness.getName()) {
     EraseHardness = m_hardness.getValue();
-    m_brushPad    = ToolUtils::getBrushPad(m_toolSize.getValue(),
+    m_brushPad    = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                         m_hardness.getValue() * 0.01);
   } else if (propertyName == m_eraseOnlySavebox.getName()) {
     EraseOnlySavebox = (int)(m_eraseOnlySavebox.getValue());
@@ -2120,7 +2151,7 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
 
   if (propertyName == m_hardness.getName() ||
       propertyName == m_toolSize.getName()) {
-    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue(),
+    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                         m_hardness.getValue() * 0.01);
     TRectD rect(m_brushPos - TPointD(EraseSize + 2, EraseSize + 2),
                 m_brushPos + TPointD(EraseSize + 2, EraseSize + 2));
@@ -2145,17 +2176,37 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   struct Locals {
     EraserTool *m_this;
 
-    void setValue(TIntProperty &prop, int value) {
+    void setValue(TIntPairProperty &prop,
+                  const TIntPairProperty::Value &value) {
       prop.setValue(value);
 
       m_this->onPropertyChanged(prop.getName());
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
-    void addValue(TIntProperty &prop, double add) {
-      const TIntProperty::Range &range = prop.getRange();
-      setValue(prop,
-               tcrop<double>(prop.getValue() + add, range.first, range.second));
+    void addMinMax(TIntPairProperty &prop, double add) {
+      const TIntPairProperty::Range &range = prop.getRange();
+
+      TIntPairProperty::Value value = prop.getValue();
+      value.second =
+          tcrop<double>(value.second + add, range.first, range.second);
+      value.first = tcrop<double>(value.first + add, range.first, range.second);
+
+      setValue(prop, value);
+    }
+
+    void addMinMaxSeparate(TIntPairProperty &prop, double min, double max) {
+      if (min == 0.0 && max == 0.0) return;
+      const TIntPairProperty::Range &range = prop.getRange();
+
+      TIntPairProperty::Value value = prop.getValue();
+      value.first += min;
+      value.second += max;
+      if (value.first > value.second) value.first = value.second;
+      value.first  = tcrop<double>(value.first, range.first, range.second);
+      value.second = tcrop<double>(value.second, range.first, range.second);
+
+      setValue(prop, value);
     }
 
   } locals = {this};
@@ -2164,9 +2215,10 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
     const TPointD &diff = pos - m_mousePos;
-    double add          = (fabs(diff.x) > fabs(diff.y)) ? diff.x : diff.y;
+    double max          = diff.x / 2;
+    double min          = diff.y / 2;
 
-    locals.addValue(m_toolSize, add);
+    locals.addMinMaxSeparate(m_toolSize, min, max);
     break;
   }
 
@@ -2185,8 +2237,9 @@ void EraserTool::onEnter() {
   TToonzImageP ti(getImage(false));
   if (!ti) return;
   if (m_firstTime) {
-    m_toolSize.setValue(EraseSize);
+    m_toolSize.setValue(TIntPairProperty::Value(EraseMinSize, EraseSize));
     m_eraseType.setValue(::to_wstring(EraseType.getValue()));
+    m_pressure.setValue(ErasePressure ? 1 : 0);
     m_currentStyle.setValue(EraseSelective ? 1 : 0);
     m_invertOption.setValue(EraseInvert ? 1 : 0);
     m_colorType.setValue(::to_wstring(EraseColorType.getValue()));
@@ -2196,7 +2249,7 @@ void EraserTool::onEnter() {
     m_eraseOnlySavebox.setValue(EraseOnlySavebox ? 1 : 0);
     m_firstTime = false;
   }
-  double x = m_toolSize.getValue();
+  double x = m_toolSize.getValue().second;
 
   double minRange = 1;
   double maxRange = 100;
@@ -2208,7 +2261,7 @@ void EraserTool::onEnter() {
       (x - minRange) / (maxRange - minRange) * (maxSize - minSize) + minSize;
 
   //  getApplication()->editImage();
-  m_cleanerSize           = m_toolSize.getValue();
+  m_cleanerSize           = m_toolSize.getValue().second;
   TTool::Application *app = TTool::getApplication();
   m_level                 = app->getCurrentLevel()->getLevel()
                 ? app->getCurrentLevel()->getSimpleLevel()
@@ -2231,7 +2284,7 @@ void EraserTool::onActivate() {
   if (m_eraseType.getValue() == POLYLINEERASE) m_polyline.reset();
 
   onEnter();
-  m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue(),
+  m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                       m_hardness.getValue() * 0.01);
 }
 
@@ -2527,7 +2580,7 @@ void EraserTool::storeUndoAndRefresh() {
                                        ->getLevel()
                                        ->getSimpleLevel(),
         m_workingFrameId.isEmptyFrame() ? getCurrentFid() : m_workingFrameId,
-        m_toolSize.getValue(), m_hardness.getValue() * 0.01,
+        m_toolSize.getValue().second, m_hardness.getValue() * 0.01,
         m_colorType.getValue(), dpiScale, symmetryLines, rotation, centerPoint,
         useLineSymmetry));
   }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2297,6 +2297,7 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
   m_colorMode = dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
   if (m_colorMode)
     m_colorModeLabel = m_labels.value(m_colorMode->propertyName());
+  m_pressure = dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Pressure"));
   m_invertMode = dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Invert"));
   m_multiFrameMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Frame Range"));
@@ -2325,6 +2326,7 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
   if (m_toolType && m_toolType->getProperty()->getValue() == L"Normal") {
     m_invertMode->setEnabled(false);
     m_multiFrameMode->setEnabled(false);
+    m_pressure->setEnabled(true);
   }
 
   if (m_toolType && m_toolType->getProperty()->getValue() == L"Segment") {
@@ -2333,6 +2335,7 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
       m_colorModeLabel->setEnabled(false);
     }
     m_invertMode->setEnabled(false);
+    m_pressure->setEnabled(false);
   }
 
   if (m_eraseOnlySavebox) {
@@ -2378,6 +2381,7 @@ void EraserToolOptionsBox::onToolTypeChanged(int index) {
     m_colorMode->setDisabled(isSegment);
     m_colorModeLabel->setDisabled(isSegment);
   }
+  m_pressure->setEnabled(!value);
   m_invertMode->setEnabled(!isSegment && value);
   if (m_eraseOnlySavebox) m_eraseOnlySavebox->setEnabled(isSegment);
 }

--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -40,6 +40,7 @@
 
 using namespace ToolUtils;
 
+TEnv::DoubleVar EraseVectorMinSize("InknpaintEraseVectorMinSize", 1);
 TEnv::DoubleVar EraseVectorSize("InknpaintEraseVectorSize", 10);
 TEnv::StringVar EraseVectorType("InknpaintEraseVectorType", "Normal");
 TEnv::StringVar EraseVectorInterpolation("InknpaintEraseVectorInterpolation",
@@ -47,6 +48,7 @@ TEnv::StringVar EraseVectorInterpolation("InknpaintEraseVectorInterpolation",
 TEnv::IntVar EraseVectorSelective("InknpaintEraseVectorSelective", 0);
 TEnv::IntVar EraseVectorInvert("InknpaintEraseVectorInvert", 0);
 TEnv::IntVar EraseVectorRange("InknpaintEraseVectorRange", 0);
+TEnv::IntVar EraseVectorPressure("InknpaintEraseVectorPressure", 1);
 
 //=============================================================================
 // Eraser Tool
@@ -64,6 +66,16 @@ namespace {
 #define EASE_IN_INTERPOLATION L"Ease In"
 #define EASE_OUT_INTERPOLATION L"Ease Out"
 #define EASE_IN_OUT_INTERPOLATION L"Ease In/Out"
+
+//-----------------------------------------------------------------------------
+
+double computeThickness(double pressure, const TDoublePairProperty &property) {
+  double t                    = pressure * pressure * pressure;
+  double thick0               = property.getValue().first;
+  double thick1               = property.getValue().second;
+  if (thick1 < 0.0001) thick0 = thick1 = 0.0;
+  return (thick0 + (thick1 - thick0) * t);
+}
 
 //-----------------------------------------------------------------------------
 
@@ -269,6 +281,7 @@ public:
 
   void draw() override;
 
+  void applyPressure(double pressure, bool isTablet);
   void startErase(
       TVectorImageP vi,
       const TPointD &pos);  //, const TImageLocation &imageLocation);
@@ -305,7 +318,8 @@ private:
 
   TEnumProperty m_eraseType;
   TEnumProperty m_interpolation;
-  TDoubleProperty m_toolSize;
+  TDoublePairProperty m_toolSize;
+  TBoolProperty m_pressure;
   TBoolProperty m_selective;
   TBoolProperty m_invertOption;
   TBoolProperty m_multi;
@@ -390,7 +404,7 @@ EraserTool::EraserTool()
     : TTool("T_Eraser")
     , m_eraseType("Type:")  // "W_ToolOptions_Erasetype"
     , m_interpolation("interpolation:")
-    , m_toolSize("Size:", 1, 1000, 10)  // "W_ToolOptions_EraserToolSize"
+    , m_toolSize("Size:", 1, 1000, 1, 10)  // "W_ToolOptions_EraserToolSize"
     , m_selective("Selective", false)   // "W_ToolOptions_Selective"
     , m_invertOption("Invert", false)   // "W_ToolOptions_Invert"
     , m_multi("Frame Range", false)     // "W_ToolOptions_FrameRange"
@@ -400,7 +414,8 @@ EraserTool::EraserTool()
     , m_stroke(0)
     , m_thick(5)
     , m_active(false)
-    , m_firstTime(true) {
+    , m_firstTime(true)
+    , m_pressure("Pressure", true) {
   bind(TTool::VectorImage);
 
   m_toolSize.setNonLinearSlider();
@@ -412,6 +427,7 @@ EraserTool::EraserTool()
   m_eraseType.addValue(FREEHAND_ERASE);
   m_eraseType.addValue(POLYLINE_ERASE);
   m_eraseType.addValue(SEGMENT_ERASE);
+  m_prop.bind(m_pressure);
   m_prop.bind(m_selective);
   m_prop.bind(m_invertOption);
   m_prop.bind(m_multi);
@@ -421,6 +437,7 @@ EraserTool::EraserTool()
   m_interpolation.addValue(EASE_OUT_INTERPOLATION);
   m_interpolation.addValue(EASE_IN_OUT_INTERPOLATION);
 
+  m_pressure.setId("PressureSensitivity");
   m_selective.setId("Selective");
   m_invertOption.setId("Invert");
   m_multi.setId("FrameRange");
@@ -440,6 +457,7 @@ EraserTool::~EraserTool() {
 
 void EraserTool::updateTranslation() {
   m_toolSize.setQStringName(tr("Size:"));
+  m_pressure.setQStringName(tr("Pressure"));
   m_selective.setQStringName(tr("Selective"));
   m_invertOption.setQStringName(tr("Invert"));
   m_multi.setQStringName(tr("Frame Range"));
@@ -495,7 +513,25 @@ void EraserTool::draw() {
       if (!Preferences::instance()->isCursorOutlineEnabled()) return;
 
       tglColor(TPixel32(255, 0, 255));
-      tglDrawCircle(m_brushPos, m_pointSize);
+
+      double minRange = 1;
+      double maxRange = 100;
+
+      double minSize = 2;
+      double maxSize = 100;
+
+      double min = ((m_toolSize.getValue().first - minRange) /
+                        (maxRange - minRange) * (maxSize - minSize) +
+                    minSize) *
+                   0.5;
+
+      double max = ((m_toolSize.getValue().second - minRange) /
+                        (maxRange - minRange) * (maxSize - minSize) +
+                    minSize) *
+                   0.5;
+
+      tglDrawCircle(m_brushPos, min);
+      tglDrawCircle(m_brushPos, max);
     }
     if ((m_eraseType.getValue() == FREEHAND_ERASE ||
          m_eraseType.getValue() == POLYLINE_ERASE ||
@@ -547,6 +583,25 @@ void EraserTool::resetMulti() {
 
 //-----------------------------------------------------------------------------
 
+void EraserTool::applyPressure(double pressure, bool isTablet) {
+  double maxThick  = m_toolSize.getValue().second;
+  double thickness = (m_pressure.getValue() && isTablet)
+                      ? computeThickness(pressure, m_toolSize)
+                      : maxThick;
+  double minRange = 1;
+  double maxRange = 100;
+
+  double minSize = 2;
+  double maxSize = 100;
+
+  m_pointSize =
+      ((thickness - minRange) / (maxRange - minRange) * (maxSize - minSize) +
+       minSize) *
+      0.5;
+}
+
+//-----------------------------------------------------------------------------
+  
 void EraserTool::startErase(
     TVectorImageP vi,
     const TPointD &pos)  //, const TImageLocation &imageLocation)
@@ -871,6 +926,7 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
   SymmetryObject symmObj = symmetryTool->getSymmetryObject();
 
   if (m_eraseType.getValue() == NORMAL_ERASE) {
+    applyPressure(e.m_pressure, e.isTablet());
     if (TVectorImageP vi = image) startErase(vi, pos /*,imageLocation*/);
   } else if (m_eraseType.getValue() == RECT_ERASE) {
     m_selectingRect.x0 = pos.x;
@@ -927,6 +983,7 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     return;
   } else if (m_eraseType.getValue() == NORMAL_ERASE) {
     if (!m_undo) leftButtonDown(pos, e);
+    applyPressure(e.m_pressure, e.isTablet());
     if (TVectorImageP vi = image) doEraseAtPos(vi, pos);
   } else if (m_eraseType.getValue() == FREEHAND_ERASE ||
              m_eraseType.getValue() == SEGMENT_ERASE) {
@@ -1100,6 +1157,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
   if (!vi || !application) return;
   if (m_eraseType.getValue() == NORMAL_ERASE) {
     if (!m_undo) leftButtonDown(pos, e);
+    applyPressure(e.m_pressure, e.isTablet());
     stopErase(vi);
   } else if (m_eraseType.getValue() == RECT_ERASE) {
     if (m_selectingRect.x0 > m_selectingRect.x1)
@@ -1295,16 +1353,37 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   struct Locals {
     EraserTool *m_this;
 
-    void setValue(TDoubleProperty &prop, double value) {
+    void setValue(TDoublePairProperty &prop,
+                  const TDoublePairProperty::Value &value) {
       prop.setValue(value);
 
       m_this->onPropertyChanged(prop.getName());
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
-    void addValue(TDoubleProperty &prop, double add) {
-      const TDoubleProperty::Range &range = prop.getRange();
-      setValue(prop, tcrop(prop.getValue() + add, range.first, range.second));
+    void addMinMax(TDoublePairProperty &prop, double add) {
+      const TDoublePairProperty::Range &range = prop.getRange();
+
+      TDoublePairProperty::Value value = prop.getValue();
+      value.second =
+          tcrop<double>(value.second + add, range.first, range.second);
+      value.first = tcrop<double>(value.first + add, range.first, range.second);
+
+      setValue(prop, value);
+    }
+
+    void addMinMaxSeparate(TDoublePairProperty &prop, double min, double max) {
+      if (min == 0.0 && max == 0.0) return;
+      const TDoublePairProperty::Range &range = prop.getRange();
+
+      TDoublePairProperty::Value value = prop.getValue();
+      value.first += min;
+      value.second += max;
+      if (value.first > value.second) value.first = value.second;
+      value.first  = tcrop<double>(value.first, range.first, range.second);
+      value.second = tcrop<double>(value.second, range.first, range.second);
+
+      setValue(prop, value);
     }
 
   } locals = {this};
@@ -1313,9 +1392,10 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
     const TPointD &diff = pos - m_mousePos;
-    double add          = (fabs(diff.x) > fabs(diff.y)) ? diff.x : diff.y;
+    double max          = diff.x / 2;
+    double min          = diff.y / 2;
 
-    locals.addValue(m_toolSize, add);
+    locals.addMinMaxSeparate(m_toolSize, min, max);
     break;
   }
 
@@ -1333,12 +1413,14 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 bool EraserTool::onPropertyChanged(std::string propertyName) {
   EraseVectorType          = ::to_string(m_eraseType.getValue());
   EraseVectorInterpolation = ::to_string(m_interpolation.getValue());
-  EraseVectorSize          = m_toolSize.getValue();
+  EraseVectorMinSize       = m_toolSize.getValue().first;
+  EraseVectorSize          = m_toolSize.getValue().second;
+  EraseVectorPressure      = m_pressure.getValue();
   EraseVectorSelective     = m_selective.getValue();
   EraseVectorInvert        = m_invertOption.getValue();
   EraseVectorRange         = m_multi.getValue();
 
-  double x = m_toolSize.getValue();
+  double x = m_toolSize.getValue().second;
 
   double minRange = 1;
   double maxRange = 100;
@@ -1358,16 +1440,18 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
 
 void EraserTool::onEnter() {
   if (m_firstTime) {
-    m_toolSize.setValue(EraseVectorSize);
+    m_toolSize.setValue(
+        TDoublePairProperty::Value(EraseVectorMinSize, EraseVectorSize));
     m_eraseType.setValue(::to_wstring(EraseVectorType.getValue()));
     m_interpolation.setValue(::to_wstring(EraseVectorInterpolation.getValue()));
+    m_pressure.setValue(EraseVectorPressure ? 1 : 0);
     m_selective.setValue(EraseVectorSelective ? 1 : 0);
     m_invertOption.setValue(EraseVectorInvert ? 1 : 0);
     m_multi.setValue(EraseVectorRange ? 1 : 0);
     m_firstTime = false;
   }
 
-  double x = m_toolSize.getValue();
+  double x = m_toolSize.getValue().second;
 
   double minRange = 1;
   double maxRange = 100;


### PR DESCRIPTION
This enhances the Eraser Tool by adding 

1. `Pressure` option.

![image](https://github.com/tahoma2d/tahoma2d/assets/19245851/fece3c5f-f955-459a-8d90-b8e018fdd892)

Pressure option is only available for `Normal` erasing mode and is available for all level types.
Similar to their brush counterpart,
- The `Size` slider now has a `Min` and `Max` setting.
- When using a mouse or `Pressure` is disabled, the max size setting will be used.
- Can alter size using ALT as before with the following change: Move vertically to change `Min` and horizontally to change `Max`

2. ` Frame Range` Interpolation option

Frame Range interpolation options (`Linear`, `Ease In`, `Ease Out`, `Ease In/Out`) has been added to Raster and Smart Raster level types

Additional fix:
Fixed an issue with delayed Symmetry erasing on Smart Raster levels when `Hardness` < 100