### PR TITLE
Fix slow preview generation of particle fx

### DIFF
--- a/toonz/sources/common/tfx/tfx.cpp
+++ b/toonz/sources/common/tfx/tfx.cpp
@@ -600,7 +600,7 @@ int TFx::getReferenceColumnIndex() const {
 
 //--------------------------------------------------
 
-TFxTimeRegion TFx::getTimeRegion(bool ignoreImplicit) const {
+TFxTimeRegion TFx::getTimeRegion() const {
   if (m_imp->m_portTable.empty()) return TFxTimeRegion::createUnlimited();
 
   TFxTimeRegion tr((std::numeric_limits<double>::max)(),
@@ -612,7 +612,7 @@ TFxTimeRegion TFx::getTimeRegion(bool ignoreImplicit) const {
     if (port && port->isConnected() && !port->isaControlPort()) {
       TFx *fx = port->getFx();
       std::wstring fxName = fx->getName();
-      tr += fx->getTimeRegion(ignoreImplicit);
+      tr += fx->getTimeRegion();
     }
   }
 

--- a/toonz/sources/common/tfx/tmacrofx.cpp
+++ b/toonz/sources/common/tfx/tmacrofx.cpp
@@ -288,8 +288,8 @@ void TMacroFx::doCompute(TTile &tile, double frame, const TRenderSettings &ri) {
 
 //--------------------------------------------------
 
-TFxTimeRegion TMacroFx::getTimeRegion(bool ignoreImplicit) const {
-  return m_root->getTimeRegion(ignoreImplicit);
+TFxTimeRegion TMacroFx::getTimeRegion() const {
+  return m_root->getTimeRegion();
 }
 
 //--------------------------------------------------

--- a/toonz/sources/include/tfx.h
+++ b/toonz/sources/include/tfx.h
@@ -436,7 +436,7 @@ public:
   int getOutputConnectionCount() const;
   TFxPort *getOutputConnection(int i) const;
 
-  virtual TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const;
+  virtual TFxTimeRegion getTimeRegion() const;
 
   void setActiveTimeRegion(const TFxTimeRegion &tr);
   TFxTimeRegion getActiveTimeRegion() const;

--- a/toonz/sources/include/tmacrofx.h
+++ b/toonz/sources/include/tmacrofx.h
@@ -52,7 +52,7 @@ public:
                     const TRenderSettings &info) override;
   void doCompute(TTile &tile, double frame, const TRenderSettings &ri) override;
 
-  TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const override;
+  TFxTimeRegion getTimeRegion() const override;
 
   std::string getPluginId() const override;
 

--- a/toonz/sources/include/toonz/tcolumnfx.h
+++ b/toonz/sources/include/toonz/tcolumnfx.h
@@ -89,7 +89,7 @@ public:
   TAffine handledAffine(const TRenderSettings &info, double frame) override;
   TAffine getDpiAff(int frame);
 
-  TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const override;
+  TFxTimeRegion getTimeRegion() const override;
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override;
   std::string getAlias(double frame,
@@ -151,7 +151,7 @@ public:
 
   bool canHandle(const TRenderSettings &info, double frame) override;
 
-  TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const override;
+  TFxTimeRegion getTimeRegion() const override;
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override;
   std::string getAlias(double frame,
@@ -196,7 +196,7 @@ public:
     return true;
   }
 
-  TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const override;
+  TFxTimeRegion getTimeRegion() const override;
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override;
   std::string getAlias(double frame,

--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -273,6 +273,8 @@ If \b scene is in +scenes/name.tnz return name,
 
   TLevelColumnFx *getOverlayFx(int row);
 
+  int getPreviewFrameCount();
+
 private:
   TFilePath m_scenePath;  //!< Full path to the scene file (.tnz).
 

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -172,6 +172,8 @@ public:
   bool m_useMaskBox;
   bool m_plasticMask;
 
+  int m_lastFrame;
+
 public:
   TRenderSettings();
   ~TRenderSettings();

--- a/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
+++ b/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
@@ -36,7 +36,7 @@ void Iwa_FlowPaintBrushFx::getBrushRasters(std::vector<TRasterP> &brushRasters,
                                            const TRenderSettings &ri) {
   // ブラシテクスチャ情報
   TPointD b_offset;
-  const TFxTimeRegion &tr = m_brush->getTimeRegion(true);
+  const TFxTimeRegion &tr = m_brush->getTimeRegion();
   lastFrame = (tr.isUnlimited() ? ri.m_lastFrame : tr.getLastFrame()) + 1;
   TLevelP partLevel = new TLevel();
   partLevel->setName(m_brush->getAlias(0, ri));

--- a/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
+++ b/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
@@ -37,8 +37,8 @@ void Iwa_FlowPaintBrushFx::getBrushRasters(std::vector<TRasterP> &brushRasters,
   // ブラシテクスチャ情報
   TPointD b_offset;
   const TFxTimeRegion &tr = m_brush->getTimeRegion(true);
-  lastFrame               = tr.getLastFrame() + 1;
-  TLevelP partLevel       = new TLevel();
+  lastFrame = (tr.isUnlimited() ? ri.m_lastFrame : tr.getLastFrame()) + 1;
+  TLevelP partLevel = new TLevel();
   partLevel->setName(m_brush->getAlias(0, ri));
 
   // The particles offset must be calculated without considering the

--- a/toonz/sources/stdfx/iwa_particlesfx.cpp
+++ b/toonz/sources/stdfx/iwa_particlesfx.cpp
@@ -486,7 +486,9 @@ void Iwa_TiledParticlesFx::doCompute(TTile &tile, double frame,
     for (unsigned int i = 0; i < (int)part_ports.size(); ++i) {
       const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion(true);
 
-      lastframe.push_back(tr.getLastFrame() + 1);
+      int lastFrameId = tr.isUnlimited() ? ri.m_lastFrame : tr.getLastFrame();
+
+      lastframe.push_back(lastFrameId + 1);
       partLevel.push_back(new TLevel());
       partLevel[i]->setName((*part_ports[i])->getAlias(0, ri));
 
@@ -497,7 +499,7 @@ void Iwa_TiledParticlesFx::doCompute(TTile &tile, double frame,
       riZero.m_affine.a13 = riZero.m_affine.a23 = 0;
 
       // Calculate the bboxes union
-      for (int t = 0; t <= tr.getLastFrame(); ++t) {
+      for (int t = 0; t <= lastFrameId; ++t) {
         TRectD inputBox;
         (*part_ports[i])->getBBox(t, inputBox, riZero);
         bbox += inputBox;

--- a/toonz/sources/stdfx/iwa_particlesfx.cpp
+++ b/toonz/sources/stdfx/iwa_particlesfx.cpp
@@ -484,7 +484,7 @@ void Iwa_TiledParticlesFx::doCompute(TTile &tile, double frame,
     TRectD bbox;
 
     for (unsigned int i = 0; i < (int)part_ports.size(); ++i) {
-      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion(true);
+      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion();
 
       int lastFrameId = tr.isUnlimited() ? ri.m_lastFrame : tr.getLastFrame();
 

--- a/toonz/sources/stdfx/iwa_particlesfx.h
+++ b/toonz/sources/stdfx/iwa_particlesfx.h
@@ -155,7 +155,7 @@ public:
                        const TRenderSettings &info) const override;
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override;
-  TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const override {
+  TFxTimeRegion getTimeRegion() const override {
     return TFxTimeRegion::createUnlimited();
   }
 

--- a/toonz/sources/stdfx/particlesfx.cpp
+++ b/toonz/sources/stdfx/particlesfx.cpp
@@ -424,7 +424,7 @@ void ParticlesFx::doCompute(TTile &tile, double frame,
     TRectD bbox;
 
     for (unsigned int i = 0; i < (int)part_ports.size(); ++i) {
-      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion(true);
+      const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion();
 
       int lastFrameId = tr.isUnlimited() ? ri.m_lastFrame : tr.getLastFrame();
 

--- a/toonz/sources/stdfx/particlesfx.cpp
+++ b/toonz/sources/stdfx/particlesfx.cpp
@@ -13,6 +13,7 @@
 // TnzBase includes
 #include "trasterfx.h"
 #include "tparamuiconcept.h"
+#include "trenderer.h"
 
 // TnzLib includes
 #include "toonz/toonzimageutils.h"
@@ -425,7 +426,9 @@ void ParticlesFx::doCompute(TTile &tile, double frame,
     for (unsigned int i = 0; i < (int)part_ports.size(); ++i) {
       const TFxTimeRegion &tr = (*part_ports[i])->getTimeRegion(true);
 
-      lastframe.push_back(tr.getLastFrame() + 1);
+      int lastFrameId = tr.isUnlimited() ? ri.m_lastFrame : tr.getLastFrame();
+
+      lastframe.push_back(lastFrameId + 1);
       partLevel.push_back(new TLevel());
       partLevel[i]->setName((*part_ports[i])->getAlias(0, ri));
 
@@ -436,7 +439,7 @@ void ParticlesFx::doCompute(TTile &tile, double frame,
       riZero.m_affine.a13 = riZero.m_affine.a23 = 0;
 
       // Calculate the bboxes union
-      for (int t = 0; t <= tr.getLastFrame(); ++t) {
+      for (int t = 0; t <= lastFrameId; ++t) {
         TRectD inputBox;
         (*part_ports[i])->getBBox(t, inputBox, riZero);
         bbox += inputBox;

--- a/toonz/sources/stdfx/particlesfx.h
+++ b/toonz/sources/stdfx/particlesfx.h
@@ -127,7 +127,7 @@ public:
                        const TRenderSettings &info) const override;
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override;
-  TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const override {
+  TFxTimeRegion getTimeRegion() const override {
     return TFxTimeRegion::createUnlimited();
   }
 

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -440,7 +440,7 @@ static std::pair<int, int> generateMovie(ToonzScene *scene, const TFilePath &fp,
   r1 = r1 - 1;
 
   if (r0 < 0) r0 = 0;
-  if (r1 < 0 || r1 >= scene->getFrameCount()) r1 = scene->getFrameCount() - 1;
+  if (r1 < 0) r1 = scene->getFrameCount() - 1;
   string msg;
   assert(r1 >= r0);
   TSceneProperties *sprop          = scene->getProperties();
@@ -914,6 +914,11 @@ int main(int argc, char *argv[]) {
       scene_from++;
       scene_to++;
     }
+
+    TRenderSettings rs = outProp->getRenderSettings();
+    rs.m_lastFrame     = scene_to;
+    outProp->setRenderSettings(rs);
+
     if (range.isSelected()) {
       r0 = range.getFrom();
       r1 = range.getTo();

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -1176,7 +1176,8 @@ TRenderSettings::TRenderSettings()
     , m_applyMask(false)
     , m_invertedMask(false)
     , m_useMaskBox(false)
-    , m_plasticMask(false) {}
+    , m_plasticMask(false)
+    , m_lastFrame(0) {}
 
 //------------------------------------------------------------------------------
 
@@ -1223,7 +1224,8 @@ bool TRenderSettings::operator==(const TRenderSettings &rhs) const {
       m_linearColorSpace != rhs.m_linearColorSpace ||
       m_colorSpaceGamma != rhs.m_colorSpaceGamma ||
       m_applyMask != rhs.m_applyMask || m_invertedMask != rhs.m_invertedMask ||
-      m_useMaskBox != rhs.m_useMaskBox || m_plasticMask != rhs.m_plasticMask)
+      m_useMaskBox != rhs.m_useMaskBox || m_plasticMask != rhs.m_plasticMask ||
+      m_lastFrame != rhs.m_lastFrame)
     return false;
 
   return std::equal(m_data.begin(), m_data.end(), rhs.m_data.begin(), areEqual);

--- a/toonz/sources/toonz/batches.cpp
+++ b/toonz/sources/toonz/batches.cpp
@@ -353,7 +353,8 @@ void BatchesController::addComposerTask(const TFilePath &_taskFilePath) {
 
   int sceneFrameCount = scene.getFrameCount();
   if (r0 < 0) r0 = 0;
-  if (r1 >= sceneFrameCount)
+  if (!Preferences::instance()->isImplicitHoldEnabled() &&
+      r1 >= sceneFrameCount)
     r1 = sceneFrameCount - 1;
   else if (r1 < r0)
     r1 = sceneFrameCount - 1;

--- a/toonz/sources/toonz/previewer.cpp
+++ b/toonz/sources/toonz/previewer.cpp
@@ -355,6 +355,12 @@ void Previewer::Imp::updateRenderSettings() {
   else
     renderSettings.m_shrinkY = renderSettings.m_shrinkX = 1;
 
+  int lastFrame = scene->getPreviewFrameCount();
+  if (Preferences::instance()->isImplicitHoldEnabled())
+    lastFrame = std::max(lastFrame,
+                         TApp::instance()->getCurrentFrame()->getFrameIndex());
+  renderSettings.m_lastFrame = lastFrame;
+
   // In case the settings changed, erase all previously cached images
   if (renderSettings != m_renderSettings) {
     m_renderSettings = renderSettings;

--- a/toonz/sources/toonz/previewfxmanager.cpp
+++ b/toonz/sources/toonz/previewfxmanager.cpp
@@ -718,6 +718,12 @@ void PreviewFxInstance::updateRenderSettings() {
 
   TRenderSettings renderSettings = properties->getRenderSettings();
 
+  int lastFrame = scene->getPreviewFrameCount();
+  if (Preferences::instance()->isImplicitHoldEnabled())
+    lastFrame = std::max(lastFrame,
+                         TApp::instance()->getCurrentFrame()->getFrameIndex());
+  renderSettings.m_lastFrame = lastFrame;
+
   if (m_renderSettings != renderSettings) {
     m_renderSettings = renderSettings;
 

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -29,6 +29,7 @@
 #include "toonz/scenefx.h"
 #include "toonz/movierenderer.h"
 #include "toonz/multimediarenderer.h"
+#include "toonz/tframehandle.h"
 #include "toutputproperties.h"
 
 #ifdef _WIN32
@@ -490,6 +491,17 @@ void RenderCommand::rasterRender(bool isPreview) {
       (std::numeric_limits<int>::max)(), TOutputProperties::LargeVal,
       TOutputProperties::MediumVal, TOutputProperties::SmallVal};
   rs.m_maxTileSize = maxTileSizes[index];
+
+  int r0, r1, step;
+  prop->getRange(r0, r1, step);
+  if (r0 > r1) {
+    r0 = 0;
+    r1 = (isPreview ? scene->getPreviewFrameCount() : scene->getFrameCount()) -
+         1;
+  }
+  if (isPreview && Preferences::instance()->isImplicitHoldEnabled())
+    r1 = std::max(r1, TApp::instance()->getCurrentFrame()->getFrameIndex());
+  rs.m_lastFrame = r1;
 
   // Build
 

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -100,7 +100,7 @@ public:
   void setTimeRegion(const TFxTimeRegion &timeRegion) {
     m_timeRegion = timeRegion;
   }
-  TFxTimeRegion getTimeRegion(bool ignoreImplicit = false) const override {
+  TFxTimeRegion getTimeRegion() const override {
     return m_timeRegion;
   }
 

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1529,7 +1529,7 @@ std::string TLevelColumnFx::getPluginId() const { return "Toonz_"; }
 
 //-------------------------------------------------------------------
 
-TFxTimeRegion TLevelColumnFx::getTimeRegion(bool ignoreImplicit) const {
+TFxTimeRegion TLevelColumnFx::getTimeRegion() const {
   if (!m_levelColumn) return TFxTimeRegion();
 
   int first = m_levelColumn->getFirstRow();
@@ -1537,7 +1537,7 @@ TFxTimeRegion TLevelColumnFx::getTimeRegion(bool ignoreImplicit) const {
 
   // For implicit hold, if the last frame is not a stop frame, it's held
   // indefinitely
-  if (Preferences::instance()->isImplicitHoldEnabled() && !ignoreImplicit &&
+  if (Preferences::instance()->isImplicitHoldEnabled() &&
       !m_levelColumn->getCell(last - 1).getFrameId().isStopFrame())
     return TFxTimeRegion(0, (std::numeric_limits<double>::max)());
 
@@ -1757,7 +1757,7 @@ std::string TPaletteColumnFx::getPluginId() const { return "Toonz_"; }
 
 //-------------------------------------------------------------------
 
-TFxTimeRegion TPaletteColumnFx::getTimeRegion(bool ignoreImplicit) const {
+TFxTimeRegion TPaletteColumnFx::getTimeRegion() const {
   int first = 0;
   int last  = 11;
   return TFxTimeRegion(first, last);
@@ -1847,7 +1847,7 @@ std::string TZeraryColumnFx::getPluginId() const { return "Toonz_"; }
 
 //-------------------------------------------------------------------
 
-TFxTimeRegion TZeraryColumnFx::getTimeRegion(bool ignoreImplicit) const {
+TFxTimeRegion TZeraryColumnFx::getTimeRegion() const {
   return TFxTimeRegion(0, (std::numeric_limits<double>::max)());
 }
 


### PR DESCRIPTION
There is an issue with generating the preview of some fx or combinations of fx when they are connected to a Particle Fx as a texture.  The preview generation of 1 frame never completes.

From my investigation, there are some fx that are internally defined as having an unlimited timespan (i.e Zerary Fx; fx that has a column in the timeline/xsheet). The Particle Fx processes every frame of the fx's timespan as a source texture to determine which image to use for that frame. This is obviously problematic for time and resources.

Particle Fx should probably be fixed to do this differently.  For now, I've modified all Particle Fx, `Timed Particles Iwa` and `Flow Paint Brush Iwa` to limit any unlimited timespan based on the last frame of the scene.  This change impacts viewer preview mode, preview-renders, output-renders, task renders.

It will use the following logic to determine the last frame:
- Stop Play Marker, if enabled (preview modes only)
- last exposed drawing/stop frame or last key (if no stop frame); whichever is furthest out

For viewer preview mode only, if using Implicit Holds and you are beyond the last frame identified above, it will use the current frame as the last frame so it can still preivew the frame at that spot.

Warning: Even with this change Particle fx rendering may still be slow per frame, but should still finish.

Additional fix:
- Fixed Task viewer not able to split and render beyond the last exposed frame for scenes using implicit holds
