### PR TITLE
Dockable Locator panel

### DIFF
--- a/toonz/sources/common/tgl/tgldisplaylistsmanager.cpp
+++ b/toonz/sources/common/tgl/tgldisplaylistsmanager.cpp
@@ -72,7 +72,7 @@ void TGLDisplayListsManager::releaseContext(TGlContext context) {
       static_cast<Observer *>(*ot)->onDisplayListDestroyed(dlSpaceId);
 
     // Then, destroy stuff
-    delete m_proxies[dlSpaceId].m_proxy;
+    if (!m_proxies[dlSpaceId].m_proxy) delete m_proxies[dlSpaceId].m_proxy;
     m_proxies.erase(dlSpaceId);
   }
 

--- a/toonz/sources/toonz/floatingpanelcommand.cpp
+++ b/toonz/sources/toonz/floatingpanelcommand.cpp
@@ -110,11 +110,13 @@ TPanel *OpenFloatingPanel::getOrOpenFloatingPanel(
     TPanel *panel = list.at(i);
 
     // we want floating panel (possibly hidden) with the correct name
-    if (panel->getPanelType() == panelType && panel->isFloating()) {
+    // Locator panels can only exist 1x per room
+    if (panel->getPanelType() == panelType &&
+        (panel->isFloating() || panelType == "Locator")) {
       // if there is already a floating panel and MultipleInstances are
       // not allowed we must use it
       if (!panel->areMultipleInstancesAllowed() && !panel->isHidden()) {
-        activateWidget(panel);
+        if (panel->isFloating()) activateWidget(panel);
         return panel;
       }
 

--- a/toonz/sources/toonz/locatorpopup.cpp
+++ b/toonz/sources/toonz/locatorpopup.cpp
@@ -12,8 +12,8 @@
 
 #include <QVBoxLayout>
 
-LocatorPopup::LocatorPopup(QWidget *parent)
-    : QDialog(parent), m_initialZoom(true) {
+LocatorPopup::LocatorPopup(QWidget *parent, Qt::WindowFlags flags)
+    : QFrame(parent), m_initialZoom(true) {
   m_viewer = new SceneViewer(NULL);
   m_viewer->setParent(parent);
   m_viewer->setIsLocator();
@@ -65,6 +65,8 @@ void LocatorPopup::showEvent(QShowEvent *) {
                        SLOT(changeWindowTitle()));
   assert(ret);
 
+  app->setActiveLocator(this);
+
   changeWindowTitle();
 }
 
@@ -74,6 +76,7 @@ void LocatorPopup::hideEvent(QHideEvent *) {
   TApp *app = TApp::instance();
   disconnect(app->getCurrentLevel());
   disconnect(app->getCurrentFrame());
+  if (app->getActiveLocator() == this) app->setActiveLocator(0);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/locatorpopup.h
+++ b/toonz/sources/toonz/locatorpopup.h
@@ -4,7 +4,17 @@
 #define LOCATORPOPUP_H
 
 #include "tgeometry.h"
-#include <QDialog>
+#include "toonzqt/dvdialog.h"
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZQT_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
 
 class SceneViewer;
 
@@ -12,13 +22,15 @@ class SceneViewer;
 // LoactorPopup
 //-----------------------------------------------------------------------------
 
-class LocatorPopup : public QDialog {
+class LocatorPopup : public QFrame {
   Q_OBJECT
   SceneViewer* m_viewer;
   bool m_initialZoom;
 
 public:
-  LocatorPopup(QWidget* parent = 0);
+  LocatorPopup(QWidget* parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
+  ~LocatorPopup() {}
+
   SceneViewer* viewer() { return m_viewer; }
 
   void onChangeViewAff(const TPointD& curPos);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1211,6 +1211,11 @@ void MainWindow::onCurrentRoomChanged(int newRoomIndex) {
   for (int i = 0; i < paneList.size(); i++) {
     TPanel *pane = paneList.at(i);
     if (pane->isFloating() && !pane->isHidden()) {
+      // Close floating Locator panes
+      if (pane->getPanelType() == "Locator") {
+        pane->close();
+        continue;
+      }
       QRect oldGeometry = pane->geometry();
       // Just setting the new parent is not enough for the new layout manager.
       // Must be removed from the old and added to the new.
@@ -2481,6 +2486,7 @@ void MainWindow::defineActions() {
                    false);
   createMenuWindowsAction(MI_CustomPanelEditor,
                           QT_TR_NOOP("&Custom Panel Editor..."), "", "");
+  createMenuWindowsAction(MI_OpenLocator, QT_TR_NOOP("&Locator"), "", "locator");
 
   // menuAct = createToggle(MI_DockingCheck, QT_TR_NOOP("&Lock Room Panes"), "",
   //                        DockingCheckToggleAction ? 1 : 0,

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -669,6 +669,7 @@ void TopBar::loadMenubar() {
   addMenuItem(windowsMenu, MI_OpenSchematic);
   addMenuItem(windowsMenu, MI_FxParamEditor);
   addMenuItem(windowsMenu, MI_OpenFilmStrip);
+  addMenuItem(windowsMenu, MI_OpenLocator);
   windowsMenu->addSeparator();
   addMenuItem(windowsMenu, MI_OpenFileBrowser);
   addMenuItem(windowsMenu, MI_OpenPreproductionBoard);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -528,4 +528,6 @@
 
 #define MI_ShowSymmetryGuide "MI_ShowSymmetryGuide"
 #define MI_ShowPerspectiveGrids "MI_ShowPerspectiveGrids"
+
+#define MI_OpenLocator "MI_OpenLocator"
 #endif

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -855,7 +855,6 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
     , m_topRasterPos()
     , m_toolDisableReason("")
     , m_editPreviewSubCamera(false)
-    , m_locator(NULL)
     , m_isLocator(false)
     , m_isBusyOnTabletMove(false)
     , m_mousePanning(0)
@@ -1250,9 +1249,6 @@ void SceneViewer::hideEvent(QHideEvent *) {
     disconnect(m_stopMotion, SIGNAL(liveViewStopped()), this,
                SLOT(onStopMotionLiveViewStopped()));
   }
-
-  // hide locator
-  if (m_locator && m_locator->isVisible()) m_locator->hide();
 }
 
 int SceneViewer::getVGuideCount() {
@@ -2194,8 +2190,11 @@ void SceneViewer::drawScene() {
   // Guided Tweening Check
   int useGuidedDrawing  = Preferences::instance()->getGuidedDrawingType();
   TTool *tool           = app->getCurrentTool()->getTool();
-  int guidedFrontStroke = tool ? tool->getViewer()->getGuidedFrontStroke() : -1;
-  int guidedBackStroke  = tool ? tool->getViewer()->getGuidedBackStroke() : -1;
+  int guidedFrontStroke = tool && tool->getViewer()
+                              ? tool->getViewer()->getGuidedFrontStroke()
+                              : -1;
+  int guidedBackStroke =
+      tool && tool->getViewer() ? tool->getViewer()->getGuidedBackStroke() : -1;
 
   m_minZ = 0;
   if (is3DView()) {

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -196,7 +196,6 @@ class SceneViewer final : public GLWidgetForHighDpi,
     TOP_3D,
   } m_current3DDevice;
 
-  LocatorPopup *m_locator;
   bool m_isLocator;
   bool m_isStyleShortcutSwitchable;
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -216,12 +216,11 @@ void SceneViewer::onButtonPressed(FlipConsole::EGadget button) {
     break;
 
   // open locator. Create one for the first time
-  case FlipConsole::eLocator:
-    if (!m_locator) m_locator = new LocatorPopup(this);
-    m_locator->show();
-    m_locator->raise();
-    m_locator->activateWindow();
+  case FlipConsole::eLocator: {
+    QAction *action = CommandManager::instance()->getAction(MI_OpenLocator);
+    action->trigger();
     break;
+  }
 
   case FlipConsole::eZoomIn:
     zoomIn();
@@ -685,8 +684,9 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     TPointD worldPos = winToWorld(curPos);
     TPointD pos      = tool->getMatrix().inv() * worldPos;
 
-    if (m_locator) {
-      m_locator->onChangeViewAff(worldPos);
+    LocatorPopup *locator = TApp::instance()->getActiveLocator();
+    if (!m_isLocator && locator) {
+      locator->onChangeViewAff(worldPos);
     }
 
     TObjectHandle *objHandle = TApp::instance()->getCurrentObject();

--- a/toonz/sources/toonz/tapp.h
+++ b/toonz/sources/toonz/tapp.h
@@ -28,6 +28,7 @@ class TMainWindow;
 class ComboViewerPanel;
 class SceneViewer;
 class XsheetViewer;
+class LocatorPopup;
 
 //=============================================================================
 // TXsheeHandle
@@ -84,6 +85,7 @@ class TApp final : public QObject,
 
   SceneViewer *m_activeViewer;
   XsheetViewer *m_xsheetViewer;
+  LocatorPopup *m_activeLocator;
 
   int m_autosavePeriod;  // minutes
   bool m_autosaveSuspended;
@@ -222,6 +224,14 @@ public:
   bool isSaveInProgress() { return m_saveInProgress; }
   void setSaveInProgress(bool inProgress) { m_saveInProgress = inProgress; }
 
+  void setActiveLocator(LocatorPopup *locator) {
+    if (m_activeLocator == locator) return;
+    m_activeLocator = locator;
+    emit activeLocatorChanged();
+  }
+
+  LocatorPopup *getActiveLocator() const { return m_activeLocator; }
+
 protected:
   bool eventFilter(QObject *obj, QEvent *event) override;
   bool m_showTitleBars    = true;
@@ -269,6 +279,7 @@ signals:
 
   void
   activeViewerChanged();  // TODO: put widgets-related stuffs in some new handle
+  void activeLocatorChanged();
 };
 
 #endif  // TAPP_H

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -84,6 +84,8 @@
 
 #include "toonzqt/insertfxpopup.h"
 
+#include "../../toonz/locatorpopup.h"
+
 // TnzBase includes
 #include "trasterfx.h"
 #include "toutputproperties.h"
@@ -1785,3 +1787,43 @@ public:
 //=============================================================================
 OpenFloatingPanel openFxBrowserCommand(MI_InsertFx, "FxBrowser",
                                         QObject::tr("Fx Browser"));
+
+//-----------------------------------------------------------------------------
+
+//=============================================================================
+// LocatorPanel
+//-----------------------------------------------------------------------------
+
+LocatorPanel::LocatorPanel(QWidget *parent) : TPanel(parent) {
+  m_locator = new LocatorPopup(parent);
+
+  setWidget(m_locator);
+}
+
+//=============================================================================
+// LocatorFactory
+//-----------------------------------------------------------------------------
+
+class LocatorFactory final : public TPanelFactory {
+public:
+  LocatorFactory() : TPanelFactory("Locator") {}
+
+  TPanel *createPanel(QWidget *parent) override {
+    LocatorPanel *panel = new LocatorPanel(parent);
+    panel->move(qApp->desktop()->screenGeometry(panel).center());
+    panel->setObjectName(getPanelType());
+    panel->setWindowTitle(QObject::tr("Locator"));
+    panel->allowMultipleInstances(false);
+    panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
+    connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
+            SLOT(showTitleBar(bool)));
+    return panel;
+  }
+
+  void initialize(TPanel *panel) override { assert(0); }
+
+} LocatorFactory;
+
+//=============================================================================
+OpenFloatingPanel openLocatorCommand(MI_OpenLocator, "Locator",
+                                       QObject::tr("Locator"));

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -34,6 +34,7 @@ class FxSelection;
 class StageObjectSelection;
 class XsheetViewer;
 class InsertFxPopup;
+class LocatorPopup;
 
 //=========================================================
 // PaletteViewerPanel
@@ -392,6 +393,19 @@ class FxBrowserPanel final : public TPanel {
 
 public:
   FxBrowserPanel(QWidget *parent);
+};
+
+//=========================================================
+// LocatorPanel
+//---------------------------------------------------------
+
+class LocatorPanel final : public TPanel {
+  Q_OBJECT
+
+  LocatorPopup *m_locator;
+
+public:
+  LocatorPanel(QWidget *parent);
 };
 
 #endif


### PR DESCRIPTION
This change makes the Locator window dockable.

There can only be 1 Locator window (docked or floating) per room.  Floating Locator windows will be automatically closed when switching rooms.

`Locator` is now listed in the `Panels` menu and can be assigned a shortcut.

