### PR TITLE
Dockable Output/Preview settings panels

### DIFF
--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -2289,6 +2289,43 @@ void OutputSettingsPopup::onBoardSettingsBtnClicked() {
   popup.exec();
 }
 
+void OutputSettingsPopup::save(QSettings &settings, bool forPopupIni) const {
+  if (m_isPreviewSettings) return;
+
+  int visibleParts = 0;
+  if (m_showCameraSettingsButton->isChecked()) visibleParts |= 0x01;
+  if (m_showColorSettingsButton->isChecked()) visibleParts |= 0x02;
+  if (m_showAdvancedSettingsButton->isChecked()) visibleParts |= 0x04;
+  if (m_showMoreSettingsButton->isChecked()) visibleParts |= 0x08;
+  settings.setValue("visibleParts", visibleParts);
+}
+
+void OutputSettingsPopup::load(QSettings &settings) {
+  if (m_isPreviewSettings) return;
+
+  QVariant visibleParts = settings.value("visibleParts");
+  if (visibleParts.canConvert(QVariant::Int)) {
+    int visiblePartsInt = visibleParts.toInt();
+
+    if (visiblePartsInt & 0x01)
+      m_showCameraSettingsButton->setChecked(true);
+    else
+      m_showCameraSettingsButton->setChecked(false);
+    if (visiblePartsInt & 0x02)
+      m_showColorSettingsButton->setChecked(true);
+    else
+      m_showColorSettingsButton->setChecked(false);
+    if (visiblePartsInt & 0x04)
+      m_showAdvancedSettingsButton->setChecked(true);
+    else
+      m_showAdvancedSettingsButton->setChecked(false);
+    if (visiblePartsInt & 0x08)
+      m_showMoreSettingsButton->setChecked(true);
+    else
+      m_showMoreSettingsButton->setChecked(false);
+  }
+}
+
 //-----------------------------------------------------------------------------
 /*
 OpenPopupCommandHandler<OutputSettingsPopup> openOutputSettingsPopup(

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -174,9 +174,8 @@ bool checkForSeqNum(QString type) {
    number field
                 to set values for frame and time stretch.
 */
-OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
-    : Dialog(TApp::instance()->getMainWindow(), false, isPreview,
-             isPreview ? "PreviewSettings" : "OutputSettings")
+OutputSettingsPopup::OutputSettingsPopup(QWidget *parent, bool isPreview)
+    : QFrame(parent)
     , m_subcameraChk(nullptr)
     , m_applyShrinkChk(nullptr)
     , m_outputCameraOm(nullptr)
@@ -184,7 +183,6 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     , m_allowMT(Preferences::instance()->getFfmpegMultiThread())
     , m_presetCombo(nullptr)
     , m_syncColorSettingsButton(nullptr) {
-  setWindowTitle(isPreview ? tr("Preview Settings") : tr("Output Settings"));
   if (!isPreview) setObjectName("OutputSettingsPopup");
   // create panel
   QFrame *panel = createPanel(isPreview);
@@ -194,6 +192,8 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
   renderButton->setIconSize(QSize(20, 20));
   if (isPreview)
     renderButton->setText(tr("Preview"));
+
+  m_topLayout = new QVBoxLayout(this);
 
   // preview settings
   if (isPreview) {
@@ -1083,7 +1083,6 @@ void OutputSettingsPopup::hideEvent(QHideEvent *e) {
                             SLOT(updateField()));
     assert(ret);
   }
-  Dialog::hideEvent(e);
   m_hideAlreadyCalled = true;
 }
 
@@ -2291,8 +2290,9 @@ void OutputSettingsPopup::onBoardSettingsBtnClicked() {
 }
 
 //-----------------------------------------------------------------------------
-
+/*
 OpenPopupCommandHandler<OutputSettingsPopup> openOutputSettingsPopup(
     MI_OutputSettings);
 OpenPopupCommandHandler<PreviewSettingsPopup> openPreviewSettingsPopup(
     MI_PreviewSettings);
+*/

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -46,8 +46,10 @@ public:
   QColor color() { return Qt::black; }
 };
 
-class OutputSettingsPopup : public DVGui::Dialog {
+class OutputSettingsPopup : public QFrame {
   Q_OBJECT
+
+  QVBoxLayout *m_topLayout;
 
   DVGui::FileField *m_saveInFileFld;
   DVGui::LineEdit *m_fileNameFld;
@@ -105,7 +107,8 @@ class OutputSettingsPopup : public DVGui::Dialog {
   QFrame *createMoreSettingsBox();
 
 public:
-  OutputSettingsPopup(bool isPreview = false);
+  OutputSettingsPopup(QWidget *parent = 0, bool isPreview = false);
+  ~OutputSettingsPopup() {}
 
 protected:
   ToonzScene *getCurrentScene() const;
@@ -160,7 +163,8 @@ protected slots:
 
 class PreviewSettingsPopup final : public OutputSettingsPopup {
 public:
-  PreviewSettingsPopup() : OutputSettingsPopup(true) {}
+  PreviewSettingsPopup(QWidget *parent = 0)
+      : OutputSettingsPopup(parent, true) {}
 };
 
 #endif  // OUTPUTSETTINGSPOPUP_H

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -3,6 +3,8 @@
 #ifndef OUTPUTSETTINGSPOPUP_H
 #define OUTPUTSETTINGSPOPUP_H
 
+#include "saveloadqsettings.h"
+
 #include "toonzqt/dvdialog.h"
 
 #include "toonz/sceneproperties.h"
@@ -46,7 +48,7 @@ public:
   QColor color() { return Qt::black; }
 };
 
-class OutputSettingsPopup : public QFrame {
+class OutputSettingsPopup : public QFrame, public SaveLoadQSettings {
   Q_OBJECT
 
   QVBoxLayout *m_topLayout;
@@ -109,6 +111,11 @@ class OutputSettingsPopup : public QFrame {
 public:
   OutputSettingsPopup(QWidget *parent = 0, bool isPreview = false);
   ~OutputSettingsPopup() {}
+
+  // SaveLoadQSettings
+  virtual void save(QSettings &settings,
+                    bool forPopupIni = false) const override;
+  virtual void load(QSettings &settings) override;
 
 protected:
   ToonzScene *getCurrentScene() const;

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -83,8 +83,8 @@
 #include "toonz/tstageobjectcmd.h"
 
 #include "toonzqt/insertfxpopup.h"
-
 #include "../../toonz/locatorpopup.h"
+#include "../toonz/outputsettingspopup.h"
 
 // TnzBase includes
 #include "trasterfx.h"
@@ -1827,3 +1827,74 @@ public:
 //=============================================================================
 OpenFloatingPanel openLocatorCommand(MI_OpenLocator, "Locator",
                                        QObject::tr("Locator"));
+
+//=========================================================
+// OutputSettingsPanel
+//---------------------------------------------------------
+
+OutputSettingsPanel::OutputSettingsPanel(QWidget *parent) : TPanel(parent) {
+  OutputSettingsPopup *pane = new OutputSettingsPopup(this);
+  setWidget(pane);
+  setIsMaximizable(false);
+}
+
+//=============================================================================
+// OutputSettingsFactory
+//-----------------------------------------------------------------------------
+
+class OutputSettingsFactory final : public TPanelFactory {
+public:
+  OutputSettingsFactory() : TPanelFactory("OutputSettingsPanel") {}
+  TPanel *createPanel(QWidget *parent) override {
+    TPanel *panel = new OutputSettingsPanel(parent);
+    panel->setObjectName(getPanelType());
+    panel->setWindowTitle(QObject::tr("Output Settings"));
+    panel->setMinimumWidth(378);
+    panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
+    connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
+            SLOT(showTitleBar(bool)));
+
+    return panel;
+  }
+  void initialize(TPanel *panel) override {}
+} OutputSettingsFactory;
+
+//=============================================================================
+OpenFloatingPanel openOutputSettingsPanelCommand(
+    MI_OutputSettings, "OutputSettingsPanel",
+    QObject::tr("Output Settings"));
+
+//=========================================================
+// PreviewSettingsPanel
+//---------------------------------------------------------
+
+PreviewSettingsPanel::PreviewSettingsPanel(QWidget *parent) : TPanel(parent) {
+  PreviewSettingsPopup *pane = new PreviewSettingsPopup(this);
+  setWidget(pane);
+  setIsMaximizable(false);
+}
+
+//=============================================================================
+// PreviewSettingsFactory
+//-----------------------------------------------------------------------------
+
+class PreviewSettingsFactory final : public TPanelFactory {
+public:
+  PreviewSettingsFactory() : TPanelFactory("PreviewSettingsPanel") {}
+  TPanel *createPanel(QWidget *parent) override {
+    TPanel *panel = new PreviewSettingsPanel(parent);
+    panel->setObjectName(getPanelType());
+    panel->setWindowTitle(QObject::tr("Preview Settings"));
+    panel->setMinimumWidth(321);
+    panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
+    connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
+            SLOT(showTitleBar(bool)));
+
+    return panel;
+  }
+  void initialize(TPanel *panel) override {}
+} PreviewSettingsFactory;
+
+//=============================================================================
+OpenFloatingPanel openPreviewSettingsPanelCommand(
+    MI_PreviewSettings, "PreviewSettingsPanel", QObject::tr("Preview Settings"));

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -408,4 +408,26 @@ public:
   LocatorPanel(QWidget *parent);
 };
 
+//=========================================================
+// OutputSettingsPanel
+//---------------------------------------------------------
+
+class OutputSettingsPanel final : public TPanel {
+  Q_OBJECT
+
+public:
+  OutputSettingsPanel(QWidget *parent);
+};
+
+//=========================================================
+// PreviewSettingsPanel
+//---------------------------------------------------------
+
+class PreviewSettingsPanel final : public TPanel {
+  Q_OBJECT
+
+public:
+  PreviewSettingsPanel(QWidget *parent);
+};
+
 #endif


### PR DESCRIPTION
This change makes the Output Settings and Preview Settings windows dockable.

Additionally, the open state of the Camera, Color, Advanced and More sections in the Output Settings dialog is saved between sessions.

