### PR TITLE
Fix popups hiding behind main window

### DIFF
--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -79,7 +79,7 @@ public:
 std::map<TStageObjectId, CameraSettingsPopup *> CameraSettingsPopup::m_popups;
 
 CameraSettingsPopup::CameraSettingsPopup()
-    : QDialog(TApp::instance()->getMainWindow()) {
+    : Dialog(TApp::instance()->getMainWindow()) {
   m_nameFld              = new LineEdit();
   m_cameraSettingsWidget = new CameraSettingsWidget();
 
@@ -102,7 +102,8 @@ CameraSettingsPopup::CameraSettingsPopup()
 
     mainLay->addWidget(m_cameraSettingsWidget, 1);
   }
-  setLayout(mainLay);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLay);
 
   //---- signal-slot connections
   bool ret = true;

--- a/toonz/sources/toonz/camerasettingspopup.h
+++ b/toonz/sources/toonz/camerasettingspopup.h
@@ -30,7 +30,7 @@ class MeasuredDoubleLineEdit;
 // CameraSettingsPopup
 //-----------------------------------------------------------------------------
 
-class CameraSettingsPopup final : public QDialog {
+class CameraSettingsPopup final : public DVGui::Dialog {
   Q_OBJECT
   static std::map<TStageObjectId, CameraSettingsPopup *> m_popups;
 

--- a/toonz/sources/toonz/cleanuppopup.cpp
+++ b/toonz/sources/toonz/cleanuppopup.cpp
@@ -284,7 +284,7 @@ public:
 //*****************************************************************************
 
 CleanupPopup::CleanupPopup()
-    : QDialog(TApp::instance()->getMainWindow())
+    : Dialog(TApp::instance()->getMainWindow(), false, false)
     , m_params(new CleanupParameters)
     , m_updater(new LevelUpdater)
     , m_originalLevelPath()
@@ -343,7 +343,8 @@ CleanupPopup::CleanupPopup()
     mainLayout->addLayout(buttonLay);
     mainLayout->addStretch();
   }
-  setLayout(mainLayout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLayout);
 
   //--- signal-slot connections
 

--- a/toonz/sources/toonz/cleanuppopup.h
+++ b/toonz/sources/toonz/cleanuppopup.h
@@ -39,7 +39,7 @@ class QGroupBox;
 //    CleanupPopup declaration
 //*****************************************************************************
 
-class CleanupPopup final : public QDialog {
+class CleanupPopup final : public DVGui::Dialog {
   Q_OBJECT
 
 public:

--- a/toonz/sources/toonz/convertfolderpopup.cpp
+++ b/toonz/sources/toonz/convertfolderpopup.cpp
@@ -179,7 +179,9 @@ public:
 //=============================================================================
 
 ConvertResultPopup::ConvertResultPopup(QString log, TFilePath path)
-    : QDialog(), m_logTxt(log), m_targetPath(path) {
+    : Dialog(TApp::instance()->getMainWindow())
+    , m_logTxt(log)
+    , m_targetPath(path) {
   setModal(true);
 
   QTextEdit* edit            = new QTextEdit(this);
@@ -206,7 +208,8 @@ ConvertResultPopup::ConvertResultPopup(QString log, TFilePath path)
     }
     mainLay->addLayout(buttonsLay, 0);
   }
-  setLayout(mainLay);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLay);
 
   connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
   connect(saveLogButton, SIGNAL(clicked()), this, SLOT(onSaveLog()));

--- a/toonz/sources/toonz/convertfolderpopup.h
+++ b/toonz/sources/toonz/convertfolderpopup.h
@@ -92,7 +92,7 @@ private:
   bool m_isConverting;
 };
 
-class ConvertResultPopup : public QDialog {
+class ConvertResultPopup : public DVGui::Dialog {
   Q_OBJECT
 
   QString m_logTxt;

--- a/toonz/sources/toonz/duplicatepopup.cpp
+++ b/toonz/sources/toonz/duplicatepopup.cpp
@@ -96,7 +96,7 @@ void DuplicateUndo::repeat() const {}
 //-----------------------------------------------------------------------------
 /*--  "Repeat..." というコマンド  --*/
 DuplicatePopup::DuplicatePopup()
-    : QDialog(TApp::instance()->getMainWindow()), m_count(0), m_upTo(0) {
+    : Dialog(TApp::instance()->getMainWindow()), m_count(0), m_upTo(0) {
   setWindowTitle(tr("Repeat"));
 
   m_countFld = new DVGui::IntLineEdit(this);
@@ -133,7 +133,8 @@ DuplicatePopup::DuplicatePopup()
     }
     mainLayout->addLayout(bottomLay, 0);
   }
-  setLayout(mainLayout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLayout);
 
   //----signal-slot connections
   bool ret = true;

--- a/toonz/sources/toonz/duplicatepopup.h
+++ b/toonz/sources/toonz/duplicatepopup.h
@@ -15,7 +15,7 @@ class QPushButton;
 // DuplicatePopup
 //-----------------------------------------------------------------------------
 
-class DuplicatePopup final : public QDialog {
+class DuplicatePopup final : public DVGui::Dialog {
   Q_OBJECT
 
   QPushButton *m_okBtn;

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -78,7 +78,7 @@
 FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
                                    QString applyButtonTxt,
                                    QWidget *customWidget)
-    : QDialog(TApp::instance()->getMainWindow())
+    : Dialog(TApp::instance()->getMainWindow(), false, false)
     , m_isDirectoryOnly(false)
     , m_multiSelectionEnabled(options & MULTISELECTION)
     , m_forSaving(options & FOR_SAVING)
@@ -141,7 +141,8 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
       }
       mainLayout->addLayout(buttonsLay);
     }
-    setLayout(mainLayout);
+    m_topLayout->setMargin(0);
+    m_topLayout->addLayout(mainLayout);
   }
 
   // Establish connections

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -44,7 +44,7 @@ class ColorField;
 //    FileBrowserPopup  declaration
 //********************************************************************************
 
-class FileBrowserPopup : public QDialog {
+class FileBrowserPopup : public DVGui::Dialog {
   Q_OBJECT
 
 public:

--- a/toonz/sources/toonz/fxparameditorpopup.cpp
+++ b/toonz/sources/toonz/fxparameditorpopup.cpp
@@ -30,7 +30,7 @@ using namespace DVGui;
 //-----------------------------------------------------------------------------
 
 FxParamEditorPopup::FxParamEditorPopup()
-    : QDialog(TApp::instance()->getMainWindow()) {
+    : Dialog(TApp::instance()->getMainWindow()) {
   setWindowTitle(tr("Fx Settings"));
   setMinimumSize(20, 20);
 
@@ -53,7 +53,8 @@ FxParamEditorPopup::FxParamEditorPopup()
   mainLayout->setMargin(0);
   mainLayout->setSpacing(10);
   { mainLayout->addWidget(fxSettings); }
-  setLayout(mainLayout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLayout);
 
   move(parentWidget()->geometry().center() - rect().bottomRight() / 2.0);
 }

--- a/toonz/sources/toonz/fxparameditorpopup.h
+++ b/toonz/sources/toonz/fxparameditorpopup.h
@@ -9,7 +9,7 @@
 // FxParamEditorPopup
 //-----------------------------------------------------------------------------
 
-class FxParamEditorPopup final : public QDialog {
+class FxParamEditorPopup final : public DVGui::Dialog {
   Q_OBJECT
 
 public:

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -39,7 +39,7 @@ using namespace DVGui;
 //-----------------------------------------------------------------------------
 
 HistogramPopup::HistogramPopup(QString title)
-    : QDialog(TApp::instance()->getMainWindow()) {
+    : Dialog(TApp::instance()->getMainWindow()) {
   setTitle(title);
 
   m_histogram = new ComboHistogram(this);
@@ -48,7 +48,8 @@ HistogramPopup::HistogramPopup(QString title)
   mainLay->setMargin(0);
   mainLay->setSpacing(0);
   { mainLay->addWidget(m_histogram); }
-  setLayout(mainLay);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLay);
   mainLay->setSizeConstraint(QLayout::SetFixedSize);
   setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 }

--- a/toonz/sources/toonz/histogrampopup.h
+++ b/toonz/sources/toonz/histogrampopup.h
@@ -13,7 +13,7 @@ class ComboHistogram;
 // HistogramPopup
 //-----------------------------------------------------------------------------
 
-class HistogramPopup : public QDialog {
+class HistogramPopup : public DVGui::Dialog {
   Q_OBJECT
 
 protected:

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1276,7 +1276,7 @@ inline TPaletteP dirtyWhite(const TPaletteP &plt) {
 
 // Per ora e' usato solo per i formato "tzp" e "tzu".
 IoCmd::ConvertingPopup::ConvertingPopup(QWidget *parent, QString fileName)
-    : QDialog(parent) {
+    : Dialog(parent) {
   setModal(true);
   setWindowFlags(Qt::Dialog | Qt::WindowTitleHint);
   setMinimumSize(70, 50);
@@ -1288,7 +1288,8 @@ IoCmd::ConvertingPopup::ConvertingPopup(QWidget *parent, QString fileName)
       QObject::tr("Converting %1 images to tlv format...").arg(fileName)));
   mainLayout->addWidget(label);
 
-  setLayout(mainLayout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLayout);
 }
 
 IoCmd::ConvertingPopup::~ConvertingPopup() {}

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -8,12 +8,11 @@
 // TnzLib includes
 #include "toonz/preferences.h"
 
+#include "toonzqt/dvdialog.h"
+
 // TnzCore includes
 #include "tfilepath.h"
 #include "tundo.h"
-
-// Qt includes
-#include <QDialog>
 
 // boost includes
 #include <boost/optional.hpp>
@@ -166,7 +165,7 @@ public:
 
 //------------------------------------------------------------------------
 
-class ConvertingPopup final : public QDialog {
+class ConvertingPopup final : public DVGui::Dialog {
 public:
   ConvertingPopup(QWidget *parent, QString fileName);
   ~ConvertingPopup();

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -335,7 +335,7 @@ void PreferencesPopup::Display30bitChecker::GLView::paintGL() {
 
 PreferencesPopup::Display30bitChecker::Display30bitChecker(
     PreferencesPopup* parent)
-    : QDialog(parent) {
+    : Dialog(parent) {
   setModal(true);
   m_currentDefaultFormat = QSurfaceFormat::defaultFormat();
 
@@ -364,7 +364,8 @@ PreferencesPopup::Display30bitChecker::Display30bitChecker(
     lay->addWidget(new QLabel(infoLabel, this));
     lay->addWidget(closeBtn, 0, Qt::AlignCenter);
   }
-  setLayout(lay);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(lay);
   lay->setSizeConstraint(QLayout::SetFixedSize);
 
   connect(closeBtn, SIGNAL(clicked()), this, SLOT(accept()));
@@ -1612,7 +1613,7 @@ inline T PreferencesPopup::getUI(PreferencesItemId id) {
 //**********************************************************************************
 
 PreferencesPopup::PreferencesPopup()
-    : QDialog(TApp::instance()->getMainWindow())
+    : Dialog(TApp::instance()->getMainWindow())
     , m_formatProperties()
     , m_additionalStyleEdit(nullptr)
     , m_viewerEventLogPopup(0) {
@@ -1668,7 +1669,8 @@ PreferencesPopup::PreferencesPopup()
     mainLayout->addLayout(categoryLayout, 0);
     mainLayout->addWidget(m_stackedWidget, 1);
   }
-  setLayout(mainLayout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLayout);
 
   bool ret = connect(m_categoryList, SIGNAL(currentRowChanged(int)),
                      m_stackedWidget, SLOT(setCurrentIndex(int)));

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -59,7 +59,7 @@ class PreferencesPopup;
 
 typedef void (PreferencesPopup::*OnEditedPopupFunc)();
 
-class PreferencesPopup final : public QDialog {
+class PreferencesPopup final : public DVGui::Dialog {
   Q_OBJECT
 
   QMap<QWidget*, PreferencesItemId> m_controlIdMap;
@@ -245,7 +245,7 @@ private slots:
 //   PreferencesPopup::Display30bitCheckerView  definition
 //**********************************************************************************
 
-class PreferencesPopup::Display30bitChecker final : public QDialog {
+class PreferencesPopup::Display30bitChecker final : public DVGui::Dialog {
   Q_OBJECT
 
   QSurfaceFormat m_currentDefaultFormat;

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -167,7 +167,7 @@ QImage::Format_ARGB32);
 // CellMarksPopup
 //-----------------------------------------------------------------------------
 
-CellMarksPopup::CellMarksPopup(QWidget *parent) : QDialog(parent) {
+CellMarksPopup::CellMarksPopup(QWidget *parent) : Dialog(parent) {
   setWindowTitle(tr("Cell Marks Settings"));
 
   QList<TSceneProperties::CellMark> marks = TApp::instance()
@@ -203,7 +203,8 @@ CellMarksPopup::CellMarksPopup(QWidget *parent) : QDialog(parent) {
     }
   }
   layout->setColumnStretch(2, 1);
-  setLayout(layout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(layout);
 }
 
 void CellMarksPopup::update() {
@@ -284,7 +285,7 @@ void CellMarksPopup::onNameChanged() {
 // ColorFiltersPopup
 //-----------------------------------------------------------------------------
 
-ColorFiltersPopup::ColorFiltersPopup(QWidget *parent) : QDialog(parent) {
+ColorFiltersPopup::ColorFiltersPopup(QWidget *parent) : Dialog(parent) {
   setWindowTitle(tr("Color Filters Settings"));
 
   QList<TSceneProperties::ColorFilter> filters = TApp::instance()
@@ -331,7 +332,8 @@ ColorFiltersPopup::ColorFiltersPopup(QWidget *parent) : QDialog(parent) {
     }
   }
   layout->setColumnStretch(1, 1);
-  setLayout(layout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(layout);
 }
 
 void ColorFiltersPopup::updateContents() {
@@ -461,7 +463,7 @@ void ColorFiltersPopup::onClearButtonClicked() {
 //-----------------------------------------------------------------------------
 
 SceneSettingsPopup::SceneSettingsPopup()
-    : QDialog(TApp::instance()->getMainWindow())
+    : Dialog(TApp::instance()->getMainWindow())
     , m_cellMarksPopup(nullptr)
     , m_colorFiltersPopup(nullptr) {
   setWindowTitle(tr("Scene Settings"));
@@ -591,7 +593,8 @@ SceneSettingsPopup::SceneSettingsPopup()
   mainLayout->setColumnStretch(3, 0);
   mainLayout->setColumnStretch(4, 1);
   mainLayout->setRowStretch(9, 1);
-  setLayout(mainLayout);
+  m_topLayout->setMargin(0);
+  m_topLayout->addLayout(mainLayout);
 
   // signal-slot connections
   bool ret = true;

--- a/toonz/sources/toonz/scenesettingspopup.h
+++ b/toonz/sources/toonz/scenesettingspopup.h
@@ -16,7 +16,7 @@ class TSceneProperties;
 class QComboBox;
 class QLineEdit;
 
-class CellMarksPopup final : public QDialog {
+class CellMarksPopup final : public DVGui::Dialog {
   Q_OBJECT
   struct MarkerField {
     int id;
@@ -34,7 +34,7 @@ protected slots:
   void onNameChanged();
 };
 
-class ColorFiltersPopup final : public QDialog {
+class ColorFiltersPopup final : public DVGui::Dialog {
   Q_OBJECT
   struct FilterField {
     DVGui::ColorField *colorField;
@@ -56,7 +56,7 @@ protected slots:
 // SceneSettingsPopup
 //-----------------------------------------------------------------------------
 
-class SceneSettingsPopup final : public QDialog {
+class SceneSettingsPopup final : public DVGui::Dialog {
   Q_OBJECT
 
   DVGui::DoubleLineEdit *m_frameRateFld;


### PR DESCRIPTION
This change was primarily made to fix an issue on macOS builds where some popups may initially appear or move behind the main window when the main window has the focus.  This behavior appears to be macOS specific.

Some popups are defined using the `QDialog` base class but the window is not set as a `Qt::Tool` which would keep the popup in front of the main window.

T2D has a custom dialog class `DVGui::Dialog` used by most other windows.  This class sets the window as `Qt::Tool`, so I've opted to convert any popup defined with `QDialog` to use the custom class for consistency.

This change impacts the following popups:
- Camera Settings
- Cleanup
- Repeat (Cell menu)
- File Browser via Load Scene, Load Level, etc.
- Histogram
- Preferences
- Scene Settings
  - Edit Cell Marks
  - Edit Column Color Filters
