### PR TITLE
Frame Range tool option enhancements

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -530,9 +530,9 @@ class FillToolOptionsBox final : public ToolOptionsBox {
 
   int m_targetType;
   QLabel *m_fillDepthLabel;
-  ToolOptionCombo *m_colorMode, *m_toolType, *m_rasterGapSettings;
-  ToolOptionCheckbox *m_selectiveMode, *m_segmentMode, *m_onionMode,
-      *m_multiFrameMode, *m_autopaintMode;
+  ToolOptionCombo *m_colorMode, *m_toolType, *m_rasterGapSettings,
+      *m_multiFrameMode;
+  ToolOptionCheckbox *m_selectiveMode, *m_segmentMode, *m_onionMode, *m_autopaintMode;
   ToolOptionPairSlider *m_fillDepthField;
   ToolOptionSlider *m_rasterGapSlider;
   StyleIndexFieldAndChip *m_styleIndex;
@@ -550,7 +550,7 @@ protected slots:
   void onColorModeChanged(int);
   void onToolTypeChanged(int);
   void onOnionModeToggled(bool);
-  void onMultiFrameModeToggled(bool);
+  void onMultiFrameModeChanged(int);
   void onGapSettingChanged(int);
 };
 

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -604,9 +604,9 @@ protected slots:
 class EraserToolOptionsBox final : public ToolOptionsBox {
   Q_OBJECT
 
-  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode,
-      *m_eraseOnlySavebox, *m_pressure;
-  ToolOptionCombo *m_toolType, *m_colorMode;
+  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_eraseOnlySavebox,
+      *m_pressure;
+  ToolOptionCombo *m_toolType, *m_colorMode, *m_multiFrameMode;
   QLabel *m_hardnessLabel, *m_colorModeLabel;
   ToolOptionSlider *m_hardnessField;
 

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -665,7 +665,7 @@ class TapeToolOptionsBox final : public ToolOptionsBox {
   Q_OBJECT
 
   ToolOptionCheckbox *m_smoothMode, *m_joinStrokesMode;
-  ToolOptionCombo *m_toolMode, *m_typeMode;
+  ToolOptionCombo *m_toolMode, *m_typeMode, *m_multiFrameMode;
   QLabel *m_autocloseLabel;
   ToolOptionSlider *m_autocloseField;
 

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -33,7 +33,7 @@ public:
   enum Type { RECT, FREEHAND, POLYLINE, FREEPICK };
 
 private:
-  bool m_frameRange;
+  int m_frameRange;
   bool m_onlyUnfilled;
   Type m_type;
 
@@ -78,7 +78,7 @@ public:
   void leftButtonUp(const TPointD &pos, const TMouseEvent &e, bool fillGaps,
                     bool closeGaps, int closeStyleIndex);
   void onImageChanged();
-  bool onPropertyChanged(bool multi, bool onlyUnfilled, bool onion, Type type,
+  bool onPropertyChanged(int multi, bool onlyUnfilled, bool onion, Type type,
                          std::wstring colorType, bool autopaintLines,
                          bool fillOnlySavebox);
   void onActivate();
@@ -99,7 +99,7 @@ class FillTool final : public QObject, public TTool {
   TEnumProperty m_colorType;  // Line, Area
   TEnumProperty m_fillType;   // Rect, Polyline etc.
   TBoolProperty m_onion;
-  TBoolProperty m_frameRange;
+  TEnumProperty m_frameRange;
   TBoolProperty m_selective;
   TDoublePairProperty m_fillDepth;
   TBoolProperty m_segment;

--- a/toonz/sources/tnztools/fullcolorfilltool.cpp
+++ b/toonz/sources/tnztools/fullcolorfilltool.cpp
@@ -12,6 +12,7 @@
 #include "toonz/tframehandle.h"
 #include "toonz/tonionskinmaskhandle.h"
 #include "toonz/tpalettehandle.h"
+#include "toonz/tcolumnhandle.h"
 
 #include "tools/toolhandle.h"
 #include "tools/toolutils.h"
@@ -20,6 +21,7 @@
 #include "tpalette.h"
 #include "tsystem.h"
 #include "symmetrytool.h"
+#include "tinbetween.h"
 
 using namespace ToolUtils;
 
@@ -29,6 +31,8 @@ TEnv::IntVar FullColorFillReferenced("InknpaintFullColorFillReferenced", 0);
 
 TEnv::StringVar FullColorRasterGapSetting("InknpaintFullColorRasterGapSetting",
                                           "Ignore Gaps");
+TEnv::IntVar FullColorFillRange("InknpaintFullColorFillRange", 0);
+
 extern TEnv::DoubleVar AutocloseDistance;
 
 namespace {
@@ -160,21 +164,31 @@ FullColorFillTool::FullColorFillTool()
     , m_referenced("Refer Visible", false)
     , m_closeStyleIndex("Style Index:", L"current")  // W_ToolOptions_InkIndex
     , m_rasterGapDistance("Distance:", 1, 100, 10)
-    , m_closeRasterGaps("Gaps:") {
+    , m_closeRasterGaps("Gaps:")
+    , m_frameRange("Frame Range:") 
+    , m_currCell(-1, -1) {
   bind(TTool::RasterImage);
   m_prop.bind(m_fillDepth);
   m_prop.bind(m_closeRasterGaps);
   m_prop.bind(m_rasterGapDistance);
   m_prop.bind(m_closeStyleIndex);
   m_prop.bind(m_referenced);
+  m_prop.bind(m_frameRange);
 
   m_closeRasterGaps.setId("CloseGaps");
   m_rasterGapDistance.setId("RasterGapDistance");
   m_closeStyleIndex.setId("RasterGapInkIndex");
+  m_frameRange.setId("FrameRange");
 
   m_closeRasterGaps.addValue(IGNOREGAPS);
   m_closeRasterGaps.addValue(FILLGAPS);
   m_closeRasterGaps.addValue(CLOSEANDFILLGAPS);
+
+  m_frameRange.addValue(L"Off");
+  m_frameRange.addValue(LINEAR_INTERPOLATION);
+  m_frameRange.addValue(EASE_IN_INTERPOLATION);
+  m_frameRange.addValue(EASE_OUT_INTERPOLATION);
+  m_frameRange.addValue(EASE_IN_OUT_INTERPOLATION);
 }
 
 void FullColorFillTool::updateTranslation() {
@@ -186,6 +200,13 @@ void FullColorFillTool::updateTranslation() {
   m_closeRasterGaps.setItemUIName(IGNOREGAPS, tr("Ignore Gaps"));
   m_closeRasterGaps.setItemUIName(FILLGAPS, tr("Fill Gaps"));
   m_closeRasterGaps.setItemUIName(CLOSEANDFILLGAPS, tr("Close and Fill"));
+
+  m_frameRange.setQStringName(tr("Frame Range:"));
+  m_frameRange.setItemUIName(L"Off", tr("Off"));
+  m_frameRange.setItemUIName(LINEAR_INTERPOLATION, tr("Linear"));
+  m_frameRange.setItemUIName(EASE_IN_INTERPOLATION, tr("Ease In"));
+  m_frameRange.setItemUIName(EASE_OUT_INTERPOLATION, tr("Ease Out"));
+  m_frameRange.setItemUIName(EASE_IN_OUT_INTERPOLATION, tr("Ease In/Out"));
 }
 
 FillParameters FullColorFillTool::getFillParameters() const {
@@ -213,23 +234,77 @@ void FullColorFillTool::leftButtonDown(const TPointD &pos,
     closeStyleIndex = app->getCurrentPalette()->getStyleIndex();
   }
 
-  int frameIndex = app->getCurrentFrame()->getFrameIndex();
-
   TXsheetHandle *xsh = app->getCurrentXsheet();
   TXsheet *xsheet =
-    params.m_referenced && !app->getCurrentFrame()->isEditingLevel() && xsh
-    ? xsh->getXsheet()
-    : 0;
+      params.m_referenced && !app->getCurrentFrame()->isEditingLevel() && xsh
+          ? xsh->getXsheet()
+          : 0;
+
+  if (m_frameRange.getIndex()) {
+    bool isEditingLevel = app->getCurrentFrame()->isEditingLevel();
+
+    if (!m_firstClick) {
+      m_currCell = std::pair<int, int>(getColumnIndex(), getFrame());
+
+      m_firstClick   = true;
+      m_firstPoint   = pos;
+      m_firstFrameId = m_veryFirstFrameId = getCurrentFid();
+      m_firstFrameIdx = app->getCurrentFrame()->getFrameIndex();
+
+      invalidate();
+    } else {
+      qApp->processEvents();
+
+      TFrameId fid   = getCurrentFid();
+      m_lastFrameIdx = app->getCurrentFrame()->getFrameIndex();
+
+      TImageP image     = getImage(false);
+      TToonzImageP ti   = image;
+      TRasterCM32P ras  = ti ? ti->getRaster() : TRasterCM32P();
+      TPointD rasCenter = ti ? ras->getCenterD() : TPointD(0, 0);
+      TPointD dpiScale  = getViewer()->getDpiScale();
+      if (isEditingLevel)
+        processSequence(pos, params, closeStyleIndex, m_level.getPointer(),
+                        m_firstFrameId, fid, m_frameRange.getIndex());
+      else
+        processSequence(pos, params, closeStyleIndex, xsheet, m_firstFrameIdx,
+                        m_lastFrameIdx, m_frameRange.getIndex());
+      if (e.isShiftPressed()) {
+        m_firstPoint = pos;
+        if (isEditingLevel)
+          m_firstFrameId = getCurrentFid();
+        else {
+          m_firstFrameIdx = m_lastFrameIdx;
+          app->getCurrentFrame()->setFrame(m_firstFrameIdx);
+        }
+      } else {
+        m_firstClick = false;
+        if (app->getCurrentFrame()->isEditingScene()) {
+          app->getCurrentColumn()->setColumnIndex(m_currCell.first);
+          app->getCurrentFrame()->setFrame(m_currCell.second);
+        } else
+          app->getCurrentFrame()->setFid(m_veryFirstFrameId);
+      }
+      TTool *t = app->getCurrentTool()->getTool();
+      if (t) t->notifyImageChanged();
+    }
+
+    return;
+  }
+
+  int frameIndex = app->getCurrentFrame()->getFrameIndex();
 
   applyFill(getImage(true), pos, params, e.isShiftPressed(),
             m_level.getPointer(), getCurrentFid(), xsheet, frameIndex,
             m_closeRasterGaps.getIndex() > 0, m_closeRasterGaps.getIndex() > 1,
-            closeStyleIndex);
+            closeStyleIndex, false);
   invalidate();
 }
 
 void FullColorFillTool::leftButtonDrag(const TPointD &pos,
                                        const TMouseEvent &e) {
+  if (m_frameRange.getIndex()) return;
+
   FillParameters params = getFillParameters();
   if (m_clickPoint == pos) return;
   if (!m_level || !params.m_palette) return;
@@ -267,9 +342,17 @@ void FullColorFillTool::leftButtonDrag(const TPointD &pos,
   applyFill(img, pos, params, e.isShiftPressed(), m_level.getPointer(),
             getCurrentFid(), xsheet, frameIndex,
             m_closeRasterGaps.getIndex() > 0, m_closeRasterGaps.getIndex() > 1,
-            closeStyleIndex);
+            closeStyleIndex, false);
 
   invalidate();
+}
+
+void FullColorFillTool::resetMulti() {
+  m_firstClick   = false;
+  m_firstFrameId = -1;
+  m_firstPoint   = TPointD();
+  TXshLevel *xl  = TTool::getApplication()->getCurrentLevel()->getLevel();
+  m_level        = xl ? xl->getSimpleLevel() : 0;
 }
 
 bool FullColorFillTool::onPropertyChanged(std::string propertyName) {
@@ -291,6 +374,12 @@ bool FullColorFillTool::onPropertyChanged(std::string propertyName) {
     FullColorRasterGapSetting = ::to_string(m_closeRasterGaps.getValue());
   }
 
+  // Frame Range
+  else if (propertyName == m_frameRange.getName()) {
+    FullColorFillRange = m_frameRange.getIndex();
+    resetMulti();
+  }
+
   return true;
 }
 
@@ -305,6 +394,9 @@ void FullColorFillTool::onActivate() {
   m_closeRasterGaps.setValue(
       ::to_wstring(FullColorRasterGapSetting.getValue()));
   m_rasterGapDistance.setValue(AutocloseDistance);
+  m_frameRange.setIndex(FullColorFillRange);
+
+  resetMulti();
 }
 
 int FullColorFillTool::getCursorId() const {
@@ -314,17 +406,42 @@ int FullColorFillTool::getCursorId() const {
   return ret;
 }
 
+void FullColorFillTool::draw() {
+  if (m_frameRange.getIndex() && m_firstClick) {
+    tglColor(TPixel::Red);
+    drawCross(m_firstPoint, 6);
+
+    SymmetryTool *symmetryTool = dynamic_cast<SymmetryTool *>(
+        TTool::getTool("T_Symmetry", TTool::RasterImage));
+    if (symmetryTool && symmetryTool->isGuideEnabled()) {
+      TImageP image     = getImage(false);
+      TToonzImageP ti   = image;
+      TPointD dpiScale  = getViewer()->getDpiScale();
+      TRasterCM32P ras  = ti ? ti->getRaster() : TRasterCM32P();
+      TPointD rasCenter = ti ? ras->getCenterD() : TPointD(0, 0);
+      TPointD fillPt    = m_firstPoint + rasCenter;
+      std::vector<TPointD> symmPts =
+          symmetryTool->getSymmetryPoints(fillPt, rasCenter, dpiScale);
+
+      for (int i = 1; i < symmPts.size(); i++) {
+        drawCross(symmPts[i] - rasCenter, 6);
+      }
+    }
+  }
+}
+
 void FullColorFillTool::applyFill(const TImageP &img, const TPointD &pos,
                                   FillParameters &params, bool isShiftFill,
                                   TXshSimpleLevel *sl, const TFrameId &fid,
                                   TXsheet *xsheet, int frameIndex, bool fillGap,
-                                  bool closeGap, int closeStyleIndex) {
+                                  bool closeGap, int closeStyleIndex,
+                                  bool undoBlockStarted) {
   TRasterImageP ri = TRasterImageP(img);
 
   SymmetryTool *symmetryTool = dynamic_cast<SymmetryTool *>(
       TTool::getTool("T_Symmetry", TTool::RasterImage));
   if (ri && symmetryTool && symmetryTool->isGuideEnabled()) {
-    TUndoManager::manager()->beginBlock();
+    if (!undoBlockStarted) TUndoManager::manager()->beginBlock();
   }
 
   doFill(img, pos, params, isShiftFill, sl, fid, xsheet, frameIndex, fillGap,
@@ -344,8 +461,121 @@ void FullColorFillTool::applyFill(const TImageP &img, const TPointD &pos,
              frameIndex, fillGap, closeGap, closeStyleIndex);
     }
 
-    TUndoManager::manager()->endBlock();
+    if (!undoBlockStarted) TUndoManager::manager()->endBlock();
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void FullColorFillTool::processSequence(const TPointD &pos,
+                                        FillParameters &params,
+                                        int closeStyleIndex,
+                                        TXshSimpleLevel *sl, TFrameId firstFid,
+                                        TFrameId lastFid, int multi) {
+  TTool::Application *app = TTool::getApplication();
+
+  bool backward           = false;
+  if (firstFid > lastFid) {
+    std::swap(firstFid, lastFid);
+    backward = true;
+  }
+  assert(firstFid <= lastFid);
+  std::vector<TFrameId> allFids;
+  sl->getFids(allFids);
+
+  std::vector<TFrameId>::iterator i0 = allFids.begin();
+  while (i0 != allFids.end() && *i0 < firstFid) i0++;
+  if (i0 == allFids.end()) return;
+  std::vector<TFrameId>::iterator i1 = i0;
+  while (i1 != allFids.end() && *i1 <= lastFid) i1++;
+  assert(i0 < i1);
+  std::vector<TFrameId> fids(i0, i1);
+  int m = fids.size();
+  assert(m > 0);
+
+  enum TInbetween::TweenAlgorithm algorithm = TInbetween::LinearInterpolation;
+  if (multi == 2) {  // EASE_IN_INTERPOLATION)
+    algorithm = TInbetween::EaseInInterpolation;
+  } else if (multi == 3) {  // EASE_OUT_INTERPOLATION)
+    algorithm = TInbetween::EaseOutInterpolation;
+  } else if (multi == 4) {  // EASE_IN_OUT_INTERPOLATION)
+    algorithm = TInbetween::EaseInOutInterpolation;
+  }
+
+  TUndoManager::manager()->beginBlock();
+  for (int i = 0; i < m; ++i) {
+    TFrameId fid = fids[i];
+    assert(firstFid <= fid && fid <= lastFid);
+    TImageP img             = sl->getFrame(fid, true);
+    double t                = m > 1 ? (double)i / (double)(m - 1) : 0.5;
+    t                       = TInbetween::interpolation(t, algorithm);
+    if (backward) t         = 1 - t;
+    TPointD p               = m_firstPoint * (1 - t) + pos * t;
+    if (app) app->getCurrentFrame()->setFid(fid);
+    applyFill(img, p, params, false, sl, fid, 0, -1,
+              m_closeRasterGaps.getIndex() > 0,
+              m_closeRasterGaps.getIndex() > 1, closeStyleIndex, true);
+  }
+  TUndoManager::manager()->endBlock();
+}
+
+//-----------------------------------------------------------------------------
+
+void FullColorFillTool::processSequence(const TPointD &pos,
+                                        FillParameters &params,
+                                        int closeStyleIndex, TXsheet *xsheet,
+                                        int firstFidx, int lastFidx,
+                                        int multi) {
+  bool backwardidx = false;
+  if (firstFidx > lastFidx) {
+    std::swap(firstFidx, lastFidx);
+    backwardidx = true;
+  }
+
+  TTool::Application *app = TTool::getApplication();
+  TFrameId lastFrameId;
+  int col = app->getCurrentColumn()->getColumnIndex();
+  int row;
+
+  std::vector<std::pair<int, TXshCell>> cellList;
+
+  for (row = firstFidx; row <= lastFidx; row++) {
+    TXshCell cell = app->getCurrentXsheet()->getXsheet()->getCell(row, col);
+    if (cell.isEmpty()) continue;
+    TFrameId fid = cell.getFrameId();
+    if (lastFrameId == fid) continue;  // Skip held cells
+    cellList.push_back(std::pair<int, TXshCell>(row, cell));
+    lastFrameId = fid;
+  }
+
+  int m = cellList.size();
+
+  enum TInbetween::TweenAlgorithm algorithm = TInbetween::LinearInterpolation;
+  if (multi == 2) {  // EASE_IN_INTERPOLATION)
+    algorithm = TInbetween::EaseInInterpolation;
+  } else if (multi == 3) {  // EASE_OUT_INTERPOLATION)
+    algorithm = TInbetween::EaseOutInterpolation;
+  } else if (multi == 4) {  // EASE_IN_OUT_INTERPOLATION)
+    algorithm = TInbetween::EaseInOutInterpolation;
+  }
+
+  TUndoManager::manager()->beginBlock();
+  for (int i = 0; i < m; i++) {
+    row           = cellList[i].first;
+    TXshCell cell = cellList[i].second;
+    TFrameId fid  = cell.getFrameId();
+    TImageP img   = cell.getImage(true);
+    if (!img) continue;
+    double t           = m > 1 ? (double)i / (double)(m - 1) : 1.0;
+    t                  = TInbetween::interpolation(t, algorithm);
+    if (backwardidx) t = 1 - t;
+    TPointD p          = m_firstPoint * (1 - t) + pos * t;
+    if (app) app->getCurrentFrame()->setFrame(row);
+    applyFill(img, p, params, false, m_level.getPointer(), fid, xsheet, row,
+              m_closeRasterGaps.getIndex() > 0,
+              m_closeRasterGaps.getIndex() > 1, closeStyleIndex, true);
+  }
+  TUndoManager::manager()->endBlock();
 }
 
 FullColorFillTool FullColorRasterFillTool;

--- a/toonz/sources/tnztools/fullcolorfilltool.h
+++ b/toonz/sources/tnztools/fullcolorfilltool.h
@@ -18,6 +18,11 @@
 #define FILLGAPS L"Fill Gaps"
 #define CLOSEANDFILLGAPS L"Close and Fill"
 
+#define LINEAR_INTERPOLATION L"Linear"
+#define EASE_IN_INTERPOLATION L"Ease In"
+#define EASE_OUT_INTERPOLATION L"Ease Out"
+#define EASE_IN_OUT_INTERPOLATION L"Ease In/Out"
+
 class FullColorFillTool final : public QObject, public TTool {
   Q_DECLARE_TR_FUNCTIONS(FullColorFillTool)
 
@@ -29,6 +34,13 @@ class FullColorFillTool final : public QObject, public TTool {
   TDoubleProperty m_rasterGapDistance;
   TEnumProperty m_closeRasterGaps;
   TStyleIndexProperty m_closeStyleIndex;
+
+  TEnumProperty m_frameRange;
+  bool m_firstClick;
+  TPointD m_firstPoint;
+  std::pair<int, int> m_currCell;
+  TFrameId m_firstFrameId, m_veryFirstFrameId;
+  int m_firstFrameIdx, m_lastFrameIdx;
 
 public:
   FullColorFillTool();
@@ -44,16 +56,26 @@ public:
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
 
+  void resetMulti();
   bool onPropertyChanged(std::string propertyName) override;
 
   void onActivate() override;
   int getCursorId() const override;
 
+  void draw() override;
+
 private:
   void applyFill(const TImageP &img, const TPointD &pos, FillParameters &params,
                  bool isShiftFill, TXshSimpleLevel *sl, const TFrameId &fid,
                  TXsheet *xsheet, int frameIndex, bool fillGap, bool closeGap,
-                 int closeStyleIndex);
+                 int closeStyleIndex, bool undoBlockStarted);
+
+  void processSequence(const TPointD &pos, FillParameters &params,
+                       int closeStyleIndex, TXshSimpleLevel *sl,
+                       TFrameId firstFid, TFrameId lastFid, int multi);
+  void processSequence(const TPointD &pos, FillParameters &params,
+                       int closeStyleIndex, TXsheet *xsheet, int firstFidx,
+                       int lastFidx, int multi);
 };
 
 #endif  // FULLCOLORFILLTOOL_H

--- a/toonz/sources/tnztools/hookselection.cpp
+++ b/toonz/sources/tnztools/hookselection.cpp
@@ -218,6 +218,7 @@ void HookSelection::enableCommands() {
 //---------------------------------------------------------------------------
 
 void HookSelection::deleteSelectedHooks() {
+  if (isEmpty()) return;
   TTool::Application *app = TTool::getApplication();
   TTool *tool             = app->getCurrentTool()->getTool();
   if (!app) return;
@@ -265,6 +266,7 @@ void HookSelection::copySelectedHooks() {
 //---------------------------------------------------------------------------
 
 void HookSelection::cutSelectedHooks() {
+  if (isEmpty()) return;
   copySelectedHooks();
   TXshLevel *xl    = TTool::getApplication()->getCurrentLevel()->getLevel();
   TUndo *undo      = new HookUndo(xl);
@@ -285,6 +287,7 @@ void HookSelection::cutSelectedHooks() {
 //---------------------------------------------------------------------------
 
 void HookSelection::pasteSelectedHooks() {
+  if (isEmpty()) return;
   const QMimeData *data      = QApplication::clipboard()->mimeData();
   const HooksData *hooksData = dynamic_cast<const HooksData *>(data);
   if (!hooksData) return;

--- a/toonz/sources/tnztools/hookselection.h
+++ b/toonz/sources/tnztools/hookselection.h
@@ -30,6 +30,12 @@ public:
   void redo() const override;
 
   int getSize() const override;
+
+private:
+  QString getHistoryString() override {
+    return QObject::tr("Hook Tool   Level : %1")
+        .arg(QString::fromStdWString(m_level->getName()));
+  }
 };
 
 //=============================================================================

--- a/toonz/sources/tnztools/symmetrystroke.cpp
+++ b/toonz/sources/tnztools/symmetrystroke.cpp
@@ -10,6 +10,25 @@
 // SymmetryStroke
 //-----------------------------------------------------------------------------
 
+SymmetryStroke &SymmetryStroke::operator=(const SymmetryStroke &src) {
+  m_joinDistance    = src.m_joinDistance;
+  m_allowSpeed      = src.m_allowSpeed;
+  m_radius          = src.m_radius;
+  m_edgeCount       = src.m_edgeCount;
+  m_drawStartCircle = src.m_drawStartCircle;
+  m_drawToMousePos  = src.m_drawToMousePos;
+  m_brushCount      = src.m_brushCount;
+  m_rotation        = src.m_rotation;
+  m_centerPoint     = src.m_centerPoint;
+  m_useLineSymmetry = src.m_useLineSymmetry;
+  m_rasCenter       = src.m_rasCenter;
+  m_dpiScale        = src.m_dpiScale;
+
+  for (int i = 0; i < src.m_brushCount; i++) m_brush[i] = src.m_brush[i];
+
+  return *this;
+}
+
 void SymmetryStroke::addSymmetryBrushes(double lines, double rotation,
                                         TPointD centerPoint,
                                         bool useLineSymmetry,

--- a/toonz/sources/tnztools/symmetrystroke.h
+++ b/toonz/sources/tnztools/symmetrystroke.h
@@ -36,6 +36,8 @@ public:
       , m_drawToMousePos(true){};
   ~SymmetryStroke() {}
 
+  SymmetryStroke &operator=(const SymmetryStroke &src);
+
   void addSymmetryBrushes(double lines, double rotation, TPointD centerPoint,
                           bool useLineSymmetry, TPointD dpiScale);
   bool hasSymmetryBrushes() { return m_brushCount > 1; }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2588,11 +2588,13 @@ TapeToolOptionsBox::TapeToolOptionsBox(QWidget *parent, TTool *tool,
       dynamic_cast<ToolOptionSlider *>(m_controls.value("Distance"));
   if (m_autocloseField)
     m_autocloseLabel = m_labels.value(m_autocloseField->propertyName());
+  m_multiFrameMode   = dynamic_cast<ToolOptionCombo *>(m_controls.value("Frame Range:"));
 
   bool isNormalType = m_typeMode->getProperty()->getValue() == L"Normal";
   m_toolMode->setEnabled(isNormalType);
   m_autocloseField->setEnabled(!isNormalType);
   m_autocloseLabel->setEnabled(!isNormalType);
+  m_multiFrameMode->setEnabled(!isNormalType);
 
   bool isLineToLineMode =
       m_toolMode->getProperty()->getValue() == L"Line to Line";
@@ -2626,6 +2628,7 @@ void TapeToolOptionsBox::onToolTypeChanged(int index) {
   m_toolMode->setEnabled(isNormalType);
   m_autocloseField->setEnabled(!isNormalType);
   m_autocloseLabel->setEnabled(!isNormalType);
+  m_multiFrameMode->setEnabled(!isNormalType);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2300,7 +2300,7 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
   m_pressure = dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Pressure"));
   m_invertMode = dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Invert"));
   m_multiFrameMode =
-      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Frame Range"));
+      dynamic_cast<ToolOptionCombo *>(m_controls.value("Frame Range:"));
   m_pencilMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Pencil Mode"));
   m_eraseOnlySavebox =

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1561,7 +1561,7 @@ void GeometricToolOptionsBox::filterControls() {
                (it.key() == "Opacity:") || (it.key() == "Shape:") ||
                (it.key() == "Polygon Sides:") || (it.key() == "rotate") ||
                (it.key() == "Snap") || (it.key() == "Draw Under") ||
-               (it.key() == "Smooth"));
+               (it.key() == "Smooth" || (it.key() == "Range:")));
     it.value()->setVisible(visible);
   }
 
@@ -1574,7 +1574,7 @@ void GeometricToolOptionsBox::filterControls() {
                (it.key() == "Opacity:") || (it.key() == "Shape:") ||
                (it.key() == "Polygon Sides:") || (it.key() == "rotate") ||
                (it.key() == "Snap") || (it.key() == "Draw Under") ||
-               (it.key() == "Smooth"));
+               (it.key() == "Smooth" || (it.key() == "Range:")));
     if (QWidget *widget = dynamic_cast<QWidget *>(it.value()))
       widget->setVisible(visible);
   }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1849,7 +1849,7 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
   m_referenced =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Refer Visible"));
   m_multiFrameMode =
-      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Frame Range"));
+      dynamic_cast<ToolOptionCombo *>(m_controls.value("Frame Range:"));
   m_autopaintMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Autopaint Lines"));
   m_rasterGapSettings =
@@ -1871,8 +1871,8 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
                        SLOT(onToolTypeChanged(int)));
   ret = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
                        SLOT(onOnionModeToggled(bool)));
-  ret = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
-                       SLOT(onMultiFrameModeToggled(bool)));
+  ret = ret && connect(m_multiFrameMode, SIGNAL(currentIndexChanged(int)), this,
+                       SLOT(onMultiFrameModeChanged(int)));
   if (m_targetType == TTool::ToonzImage) {
     ret = ret && connect(m_rasterGapSettings, SIGNAL(currentIndexChanged(int)),
                          this, SLOT(onGapSettingChanged(int)));
@@ -1888,7 +1888,7 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
       m_fillDepthField->setEnabled(false);
     }
     if (m_toolType->getProperty()->getValue() == L"Normal" ||
-        m_multiFrameMode->isChecked())
+        m_multiFrameMode->getProperty()->getIndex())
       m_onionMode->setEnabled(false);
     if (m_autopaintMode) m_autopaintMode->setEnabled(false);
     if (m_referenced) m_referenced->setEnabled(false);
@@ -1896,7 +1896,7 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
   if (m_toolType->getProperty()->getValue() != L"Normal") {
     if (m_segmentMode) m_segmentMode->setEnabled(false);
     if (m_colorMode->getProperty()->getValue() == L"Lines" ||
-        m_multiFrameMode->isChecked())
+        m_multiFrameMode->getProperty()->getIndex())
       m_onionMode->setEnabled(false);
   }
   if (m_onionMode->isChecked()) m_multiFrameMode->setEnabled(false);
@@ -1926,7 +1926,8 @@ void FillToolOptionsBox::onColorModeChanged(int index) {
     m_segmentMode->setEnabled(
         enabled ? m_toolType->getProperty()->getValue() == L"Normal" : false);
   }
-  enabled = range[index] != L"Lines" && !m_multiFrameMode->isChecked();
+  enabled =
+      range[index] != L"Lines" && !m_multiFrameMode->getProperty()->getIndex();
   m_onionMode->setEnabled(enabled);
   if (m_referenced) m_referenced->setEnabled(enabled);
   checkGapSettingsVisibility();
@@ -1991,7 +1992,7 @@ void FillToolOptionsBox::onToolTypeChanged(int index) {
     m_segmentMode->setEnabled(
         enabled ? m_colorMode->getProperty()->getValue() != L"Areas" : false);
   enabled = enabled || (m_colorMode->getProperty()->getValue() != L"Lines" &&
-                        !m_multiFrameMode->isChecked());
+                        !m_multiFrameMode->getProperty()->getIndex());
   m_onionMode->setEnabled(enabled);
 }
 
@@ -2036,7 +2037,7 @@ void FillToolOptionsBox::onOnionModeToggled(bool value) {
 
 //-----------------------------------------------------------------------------
 
-void FillToolOptionsBox::onMultiFrameModeToggled(bool value) {
+void FillToolOptionsBox::onMultiFrameModeChanged(int value) {
   m_onionMode->setEnabled(!value);
 }
 

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -83,9 +83,9 @@ TEnv::IntVar V_VectorBrushSnapGrid("VectorBrushSnapGrid", 0);
 #define CUSTOM_WSTR L"<custom>"
 
 #define LINEAR_WSTR L"Linear"
-#define EASEIN_WSTR L"In"
-#define EASEOUT_WSTR L"Out"
-#define EASEINOUT_WSTR L"In&Out"
+#define EASEIN_WSTR L"Ease In"
+#define EASEOUT_WSTR L"Ease Out"
+#define EASEINOUT_WSTR L"Ease In/Out"
 
 #define LOW_WSTR L"Low"
 #define MEDIUM_WSTR L"Med"
@@ -628,9 +628,9 @@ void ToonzVectorBrushTool::updateTranslation() {
   m_snapSensitivity.setQStringName("");
   m_frameRange.setItemUIName(L"Off", tr("Off"));
   m_frameRange.setItemUIName(LINEAR_WSTR, tr("Linear"));
-  m_frameRange.setItemUIName(EASEIN_WSTR, tr("In"));
-  m_frameRange.setItemUIName(EASEOUT_WSTR, tr("Out"));
-  m_frameRange.setItemUIName(EASEINOUT_WSTR, tr("In&Out"));
+  m_frameRange.setItemUIName(EASEIN_WSTR, tr("Ease In"));
+  m_frameRange.setItemUIName(EASEOUT_WSTR, tr("Ease Out"));
+  m_frameRange.setItemUIName(EASEINOUT_WSTR, tr("Ease In/Out"));
   m_snapSensitivity.setItemUIName(LOW_WSTR, tr("Low"));
   m_snapSensitivity.setItemUIName(MEDIUM_WSTR, tr("Med"));
   m_snapSensitivity.setItemUIName(HIGH_WSTR, tr("High"));

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1165,6 +1165,7 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
       if (m_autoClose.getValue()) stroke->setSelfLoop(true);
       m_firstStroke                   = new TStroke(*stroke);
       m_firstFrameId                  = getFrameId();
+      m_firstFrameIdx                 = getFrame();
       TTool::Application *application = TTool::getApplication();
       if (application) {
         m_col        = application->getCurrentColumn()->getColumnIndex();
@@ -1220,12 +1221,23 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
             lastStrokes[i]->setSelfLoop(true);
         }
       }
-      bool success = doFrameRangeStrokes(
+      bool success;
+      
+      if (application->getCurrentFrame()->isEditingLevel())
+        success = doFrameRangeStrokes(
           m_firstFrameId, m_firstStroke, getFrameId(), stroke,
           m_frameRange.getIndex(), m_breakAngles.getValue(),
           m_autoGroup.getValue(), m_autoFill.getValue(), m_firstFrameRange,
           true, true, m_sendToBack.getValue() > 0, m_firstSymmetryStrokes,
           lastStrokes);
+      else
+        success = doFrameRangeStrokes(
+            m_firstFrameIdx, m_firstStroke, getFrame(), stroke,
+            m_frameRange.getIndex(), m_breakAngles.getValue(),
+            m_autoGroup.getValue(), m_autoFill.getValue(), m_firstFrameRange,
+            true, true, m_sendToBack.getValue() > 0, m_firstSymmetryStrokes,
+            lastStrokes);
+
       if (e.isCtrlPressed() && e.isAltPressed() && e.isShiftPressed()) {
         if (application) {
           if (m_firstFrameId > currentId) {
@@ -1240,6 +1252,7 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
         m_firstStroke     = new TStroke(*stroke);
         m_rangeTrack      = m_track;
         m_firstFrameId    = currentId;
+        m_firstFrameIdx   = getFrame();
         m_firstFrameRange = false;
       }
 
@@ -1411,26 +1424,23 @@ bool ToonzVectorBrushTool::doFrameRangeStrokes(
                       ? getApplication()->getCurrentFrame()->getFrameIndex()
                       : -1;
   TFrameId cFid = getApplication()->getCurrentFrame()->getFid();
+
+  enum TInbetween::TweenAlgorithm algorithm = TInbetween::LinearInterpolation;
+  if (interpolationType == 2) {  // EASE_IN_INTERPOLATION) {
+    algorithm = TInbetween::EaseInInterpolation;
+  } else if (interpolationType == 3) {  // EASE_OUT_INTERPOLATION) {
+    algorithm = TInbetween::EaseOutInterpolation;
+  } else if (interpolationType == 4) {  // EASE_IN_OUT_INTERPOLATION) {
+    algorithm = TInbetween::EaseInOutInterpolation;
+  }
+
   for (int i = 0; i < m; ++i) {
     TFrameId fid = fids[i];
     assert(firstFrameId <= fid && fid <= lastFrameId);
 
     // This is an attempt to divide the tween evenly
     double t = m > 1 ? (double)i / (double)(m - 1) : 0.5;
-    double s = t;
-    switch (interpolationType) {
-    case 1:  // LINEAR_WSTR
-      break;
-    case 2:  // EASEIN_WSTR
-      s = t * (2 - t);
-      break;  // s'(1) = 0
-    case 3:   // EASEOUT_WSTR
-      s = t * t;
-      break;  // s'(0) = 0
-    case 4:   // EASEINOUT_WSTR:
-      s = t * t * (3 - 2 * t);
-      break;  // s'(0) = s'(1) = 0
-    }
+    t        = TInbetween::interpolation(t, algorithm);
 
     TTool::Application *app = TTool::getApplication();
     if (app) app->getCurrentFrame()->setFid(fid);
@@ -1455,8 +1465,142 @@ bool ToonzVectorBrushTool::doFrameRangeStrokes(
     } else {
 //      assert(firstImage->getStrokeCount() == 1);
 //      assert(lastImage->getStrokeCount() == 1);
-      TVectorImageP vi = TInbetween(firstImage, lastImage).tween(s);
+      TVectorImageP vi = TInbetween(firstImage, lastImage).tween(t);
 //      assert(vi->getStrokeCount() == 1);
+      for (int i = 0; i < vi->getStrokeCount(); i++) {
+        if (m_autoClose.getValue()) vi->getStroke(i)->setSelfLoop(true);
+        addStrokeToImage(getApplication(), img, vi->getStroke(i), breakAngles,
+                         autoGroup, autoFill, m_isFrameCreated,
+                         m_isLevelCreated, sl, fid, sendToBack);
+      }
+    }
+  }
+  if (row != -1)
+    getApplication()->getCurrentFrame()->setFrame(row);
+  else
+    getApplication()->getCurrentFrame()->setFid(cFid);
+
+  if (withUndo) TUndoManager::manager()->endBlock();
+  notifyImageChanged();
+  return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+bool ToonzVectorBrushTool::doFrameRangeStrokes(
+    int firstFrameIdx, TStroke *firstStroke, int lastFrameIdx,
+    TStroke *lastStroke, int interpolationType, bool breakAngles,
+    bool autoGroup, bool autoFill, bool drawFirstStroke, bool drawLastStroke,
+    bool withUndo, bool sendToBack, std::vector<TStroke *> firstSymmetryStrokes,
+    std::vector<TStroke *> lastSymmetryStrokes) {
+  TXshSimpleLevel *sl =
+      TTool::getApplication()->getCurrentLevel()->getLevel()->getSimpleLevel();
+  TStroke *first           = new TStroke();
+  TStroke *last            = new TStroke();
+  TVectorImageP firstImage = new TVectorImage();
+  TVectorImageP lastImage  = new TVectorImage();
+
+  *first = *firstStroke;
+  *last  = *lastStroke;
+
+  bool swapped = false;
+  if (firstFrameIdx > lastFrameIdx) {
+    std::swap(firstFrameIdx, lastFrameIdx);
+    *first  = *lastStroke;
+    *last   = *firstStroke;
+    swapped = true;
+  }
+
+  if (m_autoClose.getValue()) {
+    first->setSelfLoop(true);
+    last->setSelfLoop(true);
+  }
+
+  firstImage->addStroke(first, false, sendToBack);
+  for (int i = 0; i < firstSymmetryStrokes.size(); i++) {
+    TStroke *stroke =
+        swapped ? lastSymmetryStrokes[i] : firstSymmetryStrokes[i];
+    if (m_autoClose.getValue()) stroke->setSelfLoop(true);
+    firstImage->addStroke(stroke, sendToBack);
+  }
+  lastImage->addStroke(last, false, sendToBack);
+  for (int i = 0; i < lastSymmetryStrokes.size(); i++) {
+    TStroke *stroke =
+        swapped ? firstSymmetryStrokes[i] : lastSymmetryStrokes[i];
+    if (m_autoClose.getValue()) stroke->setSelfLoop(true);
+    lastImage->addStroke(stroke, sendToBack);
+  }
+  assert(firstFrameId <= lastFrameId);
+
+  TTool::Application *app = TTool::getApplication();
+  TFrameId lastFrameId;
+  int col = app->getCurrentColumn()->getColumnIndex();
+  int row;
+
+  std::vector<std::pair<int, TXshCell>> cellList;
+
+  for (row = firstFrameIdx; row <= lastFrameIdx; row++) {
+    TXshCell cell = app->getCurrentXsheet()->getXsheet()->getCell(row, col);
+    if (cell.isEmpty()) continue;
+    TFrameId fid = cell.getFrameId();
+    if (lastFrameId == fid) continue;  // Skip held cells
+    cellList.push_back(std::pair<int, TXshCell>(row, cell));
+    lastFrameId = fid;
+  }
+
+  int m = cellList.size();
+
+  if (withUndo) TUndoManager::manager()->beginBlock();
+  row = getApplication()->getCurrentFrame()->isEditingScene()
+            ? getApplication()->getCurrentFrame()->getFrameIndex()
+            : -1;
+
+  TFrameId cFid = getApplication()->getCurrentFrame()->getFid();
+
+  enum TInbetween::TweenAlgorithm algorithm = TInbetween::LinearInterpolation;
+  if (interpolationType == 2) {  // EASE_IN_INTERPOLATION) {
+    algorithm = TInbetween::EaseInInterpolation;
+  } else if (interpolationType == 3) {  // EASE_OUT_INTERPOLATION) {
+    algorithm = TInbetween::EaseOutInterpolation;
+  } else if (interpolationType == 4) {  // EASE_IN_OUT_INTERPOLATION) {
+    algorithm = TInbetween::EaseInOutInterpolation;
+  }
+
+  for (int i = 0; i < m; ++i) {
+    int frame         = cellList[i].first;
+    TXshCell cell     = cellList[i].second;
+    TFrameId fid      = cell.getFrameId();
+    TVectorImageP img = (TVectorImageP)cell.getImage(true);
+    if (!img) continue;
+
+    // This is an attempt to divide the tween evenly
+    double t = m > 1 ? (double)i / (double)(m - 1) : 0.5;
+    t        = TInbetween::interpolation(t, algorithm);
+
+    TTool::Application *app = TTool::getApplication();
+    if (app) app->getCurrentFrame()->setFrame(frame);
+
+    if (t == 0) {
+      if (!swapped && !drawFirstStroke) {
+      } else {
+        for (int i = 0; i < firstImage->getStrokeCount(); i++)
+          addStrokeToImage(getApplication(), img, firstImage->getStroke(i),
+                           breakAngles, autoGroup, autoFill, m_isFrameCreated,
+                           m_isLevelCreated, sl, fid, sendToBack);
+      }
+    } else if (t == 1) {
+      if (swapped && !drawFirstStroke) {
+      } else if (drawLastStroke) {
+        for (int i = 0; i < lastImage->getStrokeCount(); i++)
+          addStrokeToImage(getApplication(), img, lastImage->getStroke(i),
+                           breakAngles, autoGroup, autoFill, m_isFrameCreated,
+                           m_isLevelCreated, sl, fid, sendToBack);
+      }
+    } else {
+      //      assert(firstImage->getStrokeCount() == 1);
+      //      assert(lastImage->getStrokeCount() == 1);
+      TVectorImageP vi = TInbetween(firstImage, lastImage).tween(t);
+      //      assert(vi->getStrokeCount() == 1);
       for (int i = 0; i < vi->getStrokeCount(); i++) {
         if (m_autoClose.getValue()) vi->getStroke(i)->setSelfLoop(true);
         addStrokeToImage(getApplication(), img, vi->getStroke(i), breakAngles,
@@ -1943,6 +2087,7 @@ TPropertyGroup *ToonzVectorBrushTool::getProperties(int idx) {
 void ToonzVectorBrushTool::resetFrameRange() {
   m_rangeTrack.clear();
   m_firstFrameId = -1;
+  m_firstFrameIdx = -1;
   if (m_firstStroke) {
     delete m_firstStroke;
     m_firstStroke = 0;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -136,6 +136,14 @@ public:
       bool withUndo = true, bool sendToBack = false,
       std::vector<TStroke *> firstSymmetryStrokes = std::vector<TStroke *>(),
       std::vector<TStroke *> lastSymmetryStrokes  = std::vector<TStroke *>());
+  bool doFrameRangeStrokes(
+      int firstFrameIdx, TStroke *firstStroke, int lastFrameIdx,
+      TStroke *lastStroke, int interpolationType, bool breakAngles,
+      bool autoGroup = false, bool autoFill = false,
+      bool drawFirstStroke = true, bool drawLastStroke = true,
+      bool withUndo = true, bool sendToBack = false,
+      std::vector<TStroke *> firstSymmetryStrokes = std::vector<TStroke *>(),
+      std::vector<TStroke *> lastSymmetryStrokes  = std::vector<TStroke *>());
   void checkGuideSnapping(bool beforeMousePress, bool invertCheck);
   void checkStrokeSnapping(bool beforeMousePress, bool invertCheck);
   bool doGuidedAutoInbetween(TFrameId cFid, const TVectorImageP &cvi,
@@ -171,6 +179,7 @@ protected:
   TTileSetCM32 *m_tileSet;
   TTileSaverCM32 *m_tileSaver;
   TFrameId m_firstFrameId, m_veryFirstFrameId;
+  int m_firstFrameIdx;
   TPixel32 m_currentColor;
   int m_styleId;
   double m_minThick, m_maxThick;

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3048,6 +3048,16 @@ void MainWindow::defineActions() {
                           QT_TR_NOOP("Break sharp angles"), "");
   createToolOptionsAction("A_ToolOption_FrameRange", QT_TR_NOOP("Frame range"),
                           "F6");
+  createToolOptionsAction("A_ToolOption_FrameRange:Off",
+                          QT_TR_NOOP("Frame range - Off"), "");
+  createToolOptionsAction("A_ToolOption_FrameRange:Linear",
+                          QT_TR_NOOP("Frame range - Linear"), "");
+  createToolOptionsAction("A_ToolOption_FrameRange:Ease In",
+                          QT_TR_NOOP("Frame range - Ease In"), "");
+  createToolOptionsAction("A_ToolOption_FrameRange:Ease Out",
+                          QT_TR_NOOP("Frame range - Ease Out"), "");
+  createToolOptionsAction("A_ToolOption_FrameRange:Ease In/Out",
+                          QT_TR_NOOP("Frame range - Ease In/Out"), "");
   createToolOptionsAction("A_ToolOption_IK", QT_TR_NOOP("Inverse Kinematics"),
                           "");
   createToolOptionsAction("A_ToolOption_Invert", QT_TR_NOOP("Invert"), "");


### PR DESCRIPTION
Following up on #1410, this enhances the `Frame Range` tool option as follows

- Combines separate `Frame Range`-checkbox and `Interpolation`-combobox into 1 `Frame Range`-combobox with the options: `Off`, `Linear`, `Ease In`, `Ease Out`, `Ease In/Out`
  - Eraser Tool (All level types)
  - Brush Tool (Vector) - Was already 1 combobox, but updated the text in the dropdown to match
- Converts `Frame Range`-checkbox to `Frame Range`-combobox in the following tools:
  - Fill Tool (Vector/Smart Raster)
  - Tape Tool (Smart Raster)
- Adds new `Frame Range` -combobox option to the following tools:
  - Fill Tool (Raster)
  - Tape Tool (Vector - Rectangular)
  - Geometry Tool (All level types)
  - Hook Tool 
- Fixes Vector Brush Tool's frame range logic to work using only exposed frames in the timeline/xsheet while in Scene edit mode
- Adds `Tool Modifiers` shortcuts for `Frame Range`-combobox items
