### PR TITLE
Inbetween from Timeline/Xsheet and Hook movement tweening

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1522,7 +1522,7 @@ void inbetweenWithoutUndo(TXshSimpleLevel *sl, std::vector<TFrameId> fids,
     if (hooks) {
       for (int j = 0; j < hooks->getHookCount(); j++) {
         Hook *hook = hooks->getHook(j);
-        if (!hook) continue;
+        if (!hook || hook->isEmpty()) continue;
         TPointD firstPos = hook->getAPos(fid0);
         TPointD lastPos  = hook->getAPos(fid1);
         TPointD iPos     = firstPos * (1 - t) + lastPos * t;

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -5,6 +5,7 @@
 
 #include "toonzqt/selection.h"
 #include "tgeometry.h"
+#include "tinbetween.h"
 #include <set>
 
 class TimeStretchPopup;
@@ -133,6 +134,12 @@ public:
   void stopFrameHold(int row, int col, bool inRange);
   void stopFrameHold();
   void fillEmptyCell();
+
+  void inbetween(TInbetween::TweenAlgorithm algorithm);
+  void inbetweenLinear() { inbetween(TInbetween::LinearInterpolation); }
+  void inbetweenEaseIn() { inbetween(TInbetween::EaseInInterpolation); }
+  void inbetweenEaseOut() { inbetween(TInbetween::EaseOutInterpolation); }
+  void inbetweenEaseInOut() { inbetween(TInbetween::EaseInOutInterpolation); }
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1289,6 +1289,16 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   menu->addAction(cm->getAction(MI_ExposeResource));
   if (!isSubsequenceLevel && !isReadOnly) {
     menu->addAction(cm->getAction(MI_AddFrames));
+    if (sl && sl->getType() == PLI_XSHLEVEL) {
+      QMenu *inbetweenMenu = new QMenu(tr("Inbetween"), this);
+      {
+        inbetweenMenu->addAction(cm->getAction(MI_InbetweenLinear));
+        inbetweenMenu->addAction(cm->getAction(MI_InbetweenEaseIn));
+        inbetweenMenu->addAction(cm->getAction(MI_InbetweenEaseOut));
+        inbetweenMenu->addAction(cm->getAction(MI_InbetweenEaseInOut));
+      }
+      menu->addMenu(inbetweenMenu);
+    }
     menu->addAction(cm->getAction(MI_Renumber));
     if (sl && sl->getType() == TZP_XSHLEVEL)
       menu->addAction(cm->getAction(MI_RevertToCleanedUp));

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -2756,7 +2756,7 @@ void FilmstripCmd::inbetweenWithoutUndo(
     if (hooks) {
       for (int j = 0; j < hooks->getHookCount(); j++) {
         Hook *hook = hooks->getHook(j);
-        if (!hook) continue;
+        if (!hook || hook->isEmpty()) continue;
         TPointD firstPos = hook->getAPos(fid0);
         TPointD lastPos  = hook->getAPos(fid1);
         TPointD iPos     = firstPos * (1 - s) + lastPos * s;

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -2631,6 +2631,7 @@ namespace {
 
 class UndoInbetween final : public TUndo {
   TXshSimpleLevelP m_level;
+  HookSet m_oldHooks;
   std::vector<TFrameId> m_fids;
   std::vector<TVectorImageP> m_images;
   FilmstripCmd::InbetweenInterpolation m_interpolation;
@@ -2645,6 +2646,9 @@ public:
       m_images.push_back(m_level->getFrame(
           *it, false));  // non si fa clone perche' il livello subito dopo
                          // rilascia queste immagini a causa dell'inbetweener
+
+    HookSet *hookSet = m_level->getHookSet();
+    m_oldHooks       = *hookSet;
   }
 
   void undo() const override {
@@ -2655,6 +2659,9 @@ public:
       IconGenerator::instance()->invalidate(m_level.getPointer(),
                                             m_fids[count]);
     }
+
+    HookSet *hookSet      = m_level->getHookSet();
+    if (hookSet) *hookSet = m_oldHooks;
 
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
@@ -2734,6 +2741,8 @@ void FilmstripCmd::inbetweenWithoutUndo(
     break;
   }
 
+  HookSet *hooks = sl->getHookSet();
+
   TInbetween inbetween(img0, img1);
   int i;
   for (i = ia + 1; i < ib; i++) {
@@ -2743,6 +2752,22 @@ void FilmstripCmd::inbetweenWithoutUndo(
     TVectorImageP vi = inbetween.tween(s);
     sl->setFrame(fids[i], vi);
     IconGenerator::instance()->invalidate(sl, fids[i]);
+
+    if (hooks) {
+      for (int j = 0; j < hooks->getHookCount(); j++) {
+        Hook *hook = hooks->getHook(j);
+        if (!hook) continue;
+        TPointD firstPos = hook->getAPos(fid0);
+        TPointD lastPos  = hook->getAPos(fid1);
+        TPointD iPos     = firstPos * (1 - s) + lastPos * s;
+        hook->setAPos(fids[i], iPos);
+
+        firstPos = hook->getBPos(fid0);
+        lastPos  = hook->getBPos(fid1);
+        iPos     = firstPos * (1 - s) + lastPos * s;
+        hook->setBPos(fids[i], iPos);
+      }
+    }
   }
   sl->setDirtyFlag(true);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -97,6 +97,13 @@ void TFilmstripSelection::enableCommands() {
 
   if (doEnable && !isNotEditableFullColorLevel)
     enableCommand(this, MI_Renumber, &TFilmstripSelection::renumberFrames);
+
+  if (type == PLI_XSHLEVEL) {
+    enableCommand(this, MI_InbetweenLinear, &TFilmstripSelection::inbetweenLinear);
+    enableCommand(this, MI_InbetweenEaseIn, &TFilmstripSelection::inbetweenEaseIn);
+    enableCommand(this, MI_InbetweenEaseOut, &TFilmstripSelection::inbetweenEaseOut);
+    enableCommand(this, MI_InbetweenEaseInOut, &TFilmstripSelection::inbetweenEaseInOut);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -390,4 +397,48 @@ void TFilmstripSelection::renumberFrames() {
   }
   FilmstripCmd::renumber(sl, m_selectedFrames, startFrame, stepFrame);
   updateInbetweenRange();
+}
+
+//-----------------------------------------------------------------------------
+
+void TFilmstripSelection::inbetweenLinear() {
+  TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
+  if (!sl) return;
+  if (m_selectedFrames.size() < 3) return;
+  TFrameId fid1  = *m_selectedFrames.begin();
+  TFrameId fid2  = *m_selectedFrames.rbegin();
+  FilmstripCmd::inbetween(sl, fid1, fid2, FilmstripCmd::II_Linear);
+}
+
+//-----------------------------------------------------------------------------
+
+void TFilmstripSelection::inbetweenEaseIn() {
+  TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
+  if (!sl) return;
+  if (m_selectedFrames.size() < 3) return;
+  TFrameId fid1 = *m_selectedFrames.begin();
+  TFrameId fid2 = *m_selectedFrames.rbegin();
+  FilmstripCmd::inbetween(sl, fid1, fid2, FilmstripCmd::II_EaseIn);
+}
+
+//-----------------------------------------------------------------------------
+
+void TFilmstripSelection::inbetweenEaseOut() {
+  TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
+  if (!sl) return;
+  if (m_selectedFrames.size() < 3) return;
+  TFrameId fid1 = *m_selectedFrames.begin();
+  TFrameId fid2 = *m_selectedFrames.rbegin();
+  FilmstripCmd::inbetween(sl, fid1, fid2, FilmstripCmd::II_EaseOut);
+}
+
+//-----------------------------------------------------------------------------
+
+void TFilmstripSelection::inbetweenEaseInOut() {
+  TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
+  if (!sl) return;
+  if (m_selectedFrames.size() < 3) return;
+  TFrameId fid1 = *m_selectedFrames.begin();
+  TFrameId fid2 = *m_selectedFrames.rbegin();
+  FilmstripCmd::inbetween(sl, fid1, fid2, FilmstripCmd::II_EaseInOut);
 }

--- a/toonz/sources/toonz/filmstripselection.h
+++ b/toonz/sources/toonz/filmstripselection.h
@@ -60,6 +60,10 @@ public:
   void duplicateFrames();
   void exposeFrames();
   void renumberFrames();
+  void inbetweenLinear();
+  void inbetweenEaseIn();
+  void inbetweenEaseOut();
+  void inbetweenEaseInOut();
 };
 
 #endif  // TFILMSTRIPSELECTION_H

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2266,6 +2266,15 @@ void MainWindow::defineActions() {
   createMenuCellsAction(MI_FillEmptyCell, QT_TR_NOOP("&Fill In Empty Cells"),
                         "", "fill_empty_cells");
 
+  createMenuCellsAction(MI_InbetweenLinear, QT_TR_NOOP("&Linear"), "",
+                        "inbetween_linear");
+  createMenuCellsAction(MI_InbetweenEaseIn, QT_TR_NOOP("&Ease In"), "",
+                        "inbetween_easein");
+  createMenuCellsAction(MI_InbetweenEaseOut, QT_TR_NOOP("&Ease Out"), "",
+                        "inbetween_easeout");
+  createMenuCellsAction(MI_InbetweenEaseInOut, QT_TR_NOOP("&Ease In/Out"), "",
+                        "inbetween_easeinout");
+
   // Menu - Play
 
   createToggle(MI_Link, QT_TR_NOOP("Link Flipbooks"), "",

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -549,6 +549,13 @@ void TopBar::loadMenubar() {
     addMenuItem(drawingSubMenu, MI_DrawingSubGroupBackward);
   }
   cellsMenu->addSeparator();
+  QMenu *inbetweenMenu = cellsMenu->addMenu(tr("Inbetween"));
+  {
+    addMenuItem(inbetweenMenu, MI_InbetweenLinear);
+    addMenuItem(inbetweenMenu, MI_InbetweenEaseIn);
+    addMenuItem(inbetweenMenu, MI_InbetweenEaseOut);
+    addMenuItem(inbetweenMenu, MI_InbetweenEaseInOut);
+  }
   addMenuItem(cellsMenu, MI_Autorenumber);
   addMenuItem(cellsMenu, MI_CreateBlankDrawing);
   addMenuItem(cellsMenu, MI_Duplicate);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -530,4 +530,9 @@
 #define MI_ShowPerspectiveGrids "MI_ShowPerspectiveGrids"
 
 #define MI_OpenLocator "MI_OpenLocator"
+
+#define MI_InbetweenLinear "MI_InbetweenLinear"
+#define MI_InbetweenEaseIn "MI_InbetweenEaseIn"
+#define MI_InbetweenEaseOut "MI_InbetweenEaseOut"
+#define MI_InbetweenEaseInOut "MI_InbetweenEaseInOut"
 #endif

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -4444,6 +4444,19 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
 
       menu.addSeparator();
 
+      if (cell.m_level && cell.m_level->getSimpleLevel() &&
+          cell.m_level->getType() == PLI_XSHLEVEL) {
+        QMenu *inbetweenMenu = new QMenu(tr("Inbetween"), this);
+        {
+          inbetweenMenu->addAction(cmdManager->getAction(MI_InbetweenLinear));
+          inbetweenMenu->addAction(cmdManager->getAction(MI_InbetweenEaseIn));
+          inbetweenMenu->addAction(cmdManager->getAction(MI_InbetweenEaseOut));
+          inbetweenMenu->addAction(
+              cmdManager->getAction(MI_InbetweenEaseInOut));
+        }
+        menu.addMenu(inbetweenMenu);
+      }
+
       if (!soundTextCellsSelected && !isImplicitCell)
         menu.addAction(cmdManager->getAction(MI_Autorenumber));
     }


### PR DESCRIPTION
This allows inbetweening vector frames directly in the timeline/xsheet in the same way inbetweens are done in the `Level Strip`.

- Similiar to Inbetweening in the Level Strip, you must select a starting explicit frame and an ending explicit frame with 1 or more explicit frames between them. Held frames do not count.
- You can select multiple vector column levels to inbetween at the same time
- Within the area of selection of multiple columns
  - Non-vector and empty columns are ignored
  - The first and last exposed frames of each column are used for inbetweening. They do not all need to have the same number of frames

After selecting the frames, use the `Cells` menu or right-click a vector cell and select the desired interpolation:

![image](https://github.com/tahoma2d/tahoma2d/assets/19245851/a358649a-3809-4897-bb29-ce7a5f50d2d8)

Can also trigger the inbetween if you set shortcuts for the interpolation

Inbetween menu options and shortcuts also work in the Level Strip.

Additional change:
- Hook movements are now also tweened via Level Strip and Timeline/Xsheet Inbetween