### PR TITLE
Fix getPreviewFrameCount

### DIFF
--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1782,4 +1782,6 @@ int ToonzScene::getPreviewFrameCount() {
       frameCount = std::max(frameCount, (r1 + 1));
     }
   }
+
+  return frameCount;
 }


### PR DESCRIPTION
This fixes an issue caused by new logic implemented in #1417 to fix an issue with particle fx preview generation.

The new function `getPreviewFrameCount` was missing a final return.  This didn't seem to cause an issue in Windows or macOS builds, presumably returning 0. However, for Linux builds, I believe it might have been returning some insanely high number causing T2D to never get past the splash screen while consuming a lot of memory.  In my case it would eventually crash.



I will be merging this upon successful build and verification this corrects Linux builds so i can correct the Linux nightlies.
