### PR TITLE
Fix Release v1.4.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,8 +40,9 @@ body:
       label: Software Version
       description: What version of the software are you running?
       options:
-        - 1.4.1 
+        - 1.4.2
         - Nightly (Specify below)
+        - 1.4.1 
         - 1.4
         - 1.3.1
         - 1.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.4.1{build}
+version: 1.4.2{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export TAHOMA2DVERSION=1.4.1
+export TAHOMA2DVERSION=1.4.2
 
 if [ -d /usr/local/Cellar/qt@5 ]
 then

--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.4.1</string>
+	<string>1.4.2</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>

--- a/toonz/installer/windows/setup.iss
+++ b/toonz/installer/windows/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Tahoma2D"
-#define MyAppVersion "1.4.1"
+#define MyAppVersion "1.4.2"
 #define MyAppPublisher "Tahoma2D"
 #define MyAppURL "https://tahoma2d.org/"
 #define MyAppExeName "Tahoma2D.exe"

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -19,7 +19,7 @@ public:
 private:
   const char *applicationName     = "Tahoma2D";
   const float applicationVersion  = 1.4f;
-  const float applicationRevision = 1;
+  const float applicationRevision = 2;
   const char *applicationNote     = "";
 };
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(VERSION 1.4.1)
+set(VERSION 1.4.2)
 
 set(MOC_HEADERS
     aboutpopup.h

--- a/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
+++ b/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
@@ -26,6 +26,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.4.2" date="2024-04-02"/>
     <release version="1.4.1" date="2024-02-01"/>
     <release version="1.4.0" date="2023-12-01"/>
     <release version="1.3.0" date="2022-05-06"/>


### PR DESCRIPTION
This is to mark and update the nightly to the fix release version v1.4.2 in the master.

Version 1.4.2 is being build in a separate branch containing just fix PRs which I plan to release April 2nd.