### PR TITLE
Fix missing selection change notification

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3870,6 +3870,8 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
           m_viewer->dragToolClick(event);
           isInDragArea = false;
         }
+        // Before switching drag tool, trigger cell selection switch notification
+        if (m_viewer->getDragTool()) m_viewer->dragToolRelease(event);
       }
 
       if (isInDragArea) {

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3361,7 +3361,10 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
                 !(event->modifiers() & Qt::ShiftModifier)) {
               // Switch to column and allow immediate drag
               setDragTool(XsheetGUI::DragTool::makeSelectionTool(m_viewer));
+              // Before switching drag tool, trigger column selection switch notification
+              m_viewer->dragToolClick(event);
               isInDragArea = true;
+              m_viewer->dragToolRelease(event);
             }
           } else if (event->modifiers() & Qt::ControlModifier)
             isInDragArea = false;


### PR DESCRIPTION
This fixes a bug introduce by changes in #1330 that only occurs when dragbars are not in use. 

When clicking on a different cell or column, a selection change notification is not generated so other parts of T2D can change accordingly like the Level Settings popup window.
