### PR TITLE
Fix brush and eraser resizing

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -753,7 +753,7 @@ void FullColorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   //} else
   if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed() &&
       Preferences::instance()->useCtrlAltToResizeBrushEnabled()) {
-    const TPointD &diff = pos - m_mousePos;
+    const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
@@ -763,6 +763,7 @@ void FullColorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   }
 
   m_mousePos = pos;
+  m_windowMousePos = -e.m_pos;
 
   invalidate();
 }

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -101,8 +101,9 @@ protected:
   bool m_enabledPressure;
   int m_minCursorThick, m_maxCursorThick;
 
-  TPointD m_mousePos,  //!< Current mouse position, in world coordinates.
-      m_brushPos;      //!< World position the brush will be painted at.
+  TPointD m_mousePos,    //!< Current mouse position, in world coordinates.
+      m_brushPos,        //!< World position the brush will be painted at.
+      m_windowMousePos;  //!< Current mouse position, in window coordinates.
 
   TRasterP m_backUpRas;
   TRaster32P m_workRaster;

--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -391,6 +391,7 @@ private:
   TRectD m_selectingRect, m_firstRect;
 
   TPointD m_mousePos, m_brushPos, m_firstPos;
+  TPointD m_windowMousePos;
   TMouseEvent m_mouseEvent;
   double m_thick;
 
@@ -1142,7 +1143,7 @@ void FullColorEraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   switch (e.getModifiersMask()) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
-    const TPointD &diff = pos - m_mousePos;
+    const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
@@ -1156,6 +1157,7 @@ void FullColorEraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   }
 
   m_mousePos = pos;
+  m_windowMousePos = -e.m_pos;
   invalidate();
 }
 

--- a/toonz/sources/tnztools/pumptool.cpp
+++ b/toonz/sources/tnztools/pumptool.cpp
@@ -299,8 +299,8 @@ void PumpTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
   QMutexLocker lock(vi->getMutex());
 
   // set current point and init parameters
-  m_oldPoint  = pos;
-  m_downPoint = pos;
+  m_oldPoint  = e.m_pos;
+  m_downPoint = e.m_pos;
 
   m_inStroke = m_outStroke = 0;
   m_stroke1Idx = m_stroke2Idx = -1;
@@ -373,7 +373,7 @@ void PumpTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
   delete m_outStroke;
 
   // Retrieve cursor's vertical displacement
-  TPointD delta = TPointD(0, (pos - m_downPoint).y);
+  TPointD delta = TPointD(0, (e.m_pos - m_downPoint).y * getPixelSize());
   int deltaSign = tsign(delta.y);
   if (deltaSign == 0) {
     // Use a copy of the original stroke
@@ -442,7 +442,7 @@ void PumpTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
     }
 
     if (m_outStroke &&
-        !areAlmostEqual(m_downPoint, pos, PickRadius * getPixelSize())) {
+        !areAlmostEqual(m_downPoint, e.m_pos, PickRadius * getPixelSize())) {
       // Accept action
 
       // Clone input stroke - it is someway needed by the stroke change
@@ -502,11 +502,11 @@ void PumpTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   m_isCtrlPressed = e.isCtrlPressed();
 
   // Cursor preview updates on 3-pixel steps
-  if (tdistance2(pos, m_oldPoint) < 9.0 * sq(getPixelSize())) return;
+  if (tdistance2(e.m_pos, m_oldPoint) < 9.0 * sq(getPixelSize())) return;
 
   if (!m_draw) m_draw = true;
 
-  m_oldPoint = pos;
+  m_oldPoint = e.m_pos;
 
   if (moveCursor(pos)) {
     m_cursorEnabled = true;

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -790,6 +790,7 @@ private:
   ColorType m_colorTypeEraser;
 
   TPointD m_mousePos, m_brushPos, m_firstPos;
+  TPointD m_windowMousePos;
 
   SymmetryStroke m_polyline;
 
@@ -2254,7 +2255,7 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   switch (e.getModifiersMask()) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
-    const TPointD &diff = pos - m_mousePos;
+    const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
@@ -2268,6 +2269,7 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   }
 
   m_mousePos = pos;
+  m_windowMousePos = -e.m_pos;
   invalidate();
 }
 

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2307,7 +2307,7 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed() &&
       Preferences::instance()->useCtrlAltToResizeBrushEnabled()) {
     // Resize the brush if CTRL+ALT is pressed and the preference is enabled.
-    const TPointD &diff = pos - m_mousePos;
+    const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
@@ -2320,6 +2320,7 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   } else {
     m_mousePos = pos;
     m_brushPos = getCenteredCursorPos(pos);
+    m_windowMousePos = -e.m_pos;
 
     invalidateRect += TRectD(pos - halfThick, pos + halfThick);
   }

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -196,8 +196,9 @@ protected:
 
   int m_targetType;
   TPointD m_dpiScale,
-      m_mousePos,  //!< Current mouse position, in world coordinates.
-      m_brushPos;  //!< World position the brush will be painted at.
+      m_mousePos,        //!< Current mouse position, in world coordinates.
+      m_brushPos,        //!< World position the brush will be painted at.
+      m_windowMousePos;  //!< Current mouse position, in window coordinates.
 
   RasterBlurredBrush *m_bluredBrush;
   QRadialGradient m_brushPad;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1790,7 +1790,7 @@ void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed() &&
       Preferences::instance()->useCtrlAltToResizeBrushEnabled()) {
     // Resize the brush if CTRL+ALT is pressed and the preference is enabled.
-    const TPointD &diff = pos - m_mousePos;
+    const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
@@ -1803,6 +1803,7 @@ void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   } else {
     m_mousePos = pos;
     m_brushPos = pos;
+    m_windowMousePos = -e.m_pos;
 
     TPointD snapThick(6.0 * m_pixelSize, 6.0 * m_pixelSize);
     // In order to clear the previous snap indicator

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -194,7 +194,9 @@ protected:
   TPointD m_dpiScale,
       m_mousePos,  //!< Current mouse position, in world coordinates.
       m_brushPos,  //!< World position the brush will be painted at.
-      m_firstSnapPoint, m_lastSnapPoint;
+      m_firstSnapPoint, m_lastSnapPoint,
+      m_windowMousePos; //!< Current mouse position, in window coordinates.
+
 
   QRadialGradient m_brushPad;
 

--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -329,6 +329,8 @@ private:
       m_firstPos;      //!< Either The first point inserted either in m_track or
                        //! m_polyline
   //!  (depending on selected erase mode).
+  TPointD m_windowMousePos;
+
   UndoEraser *m_undo;
   std::vector<int> m_indexes;
 
@@ -1387,7 +1389,7 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   switch (e.getModifiersMask()) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
-    const TPointD &diff = pos - m_mousePos;
+    const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
@@ -1401,6 +1403,7 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   }
 
   m_oldMousePos = m_mousePos = pos;
+  m_windowMousePos = -e.m_pos;
   invalidate();
 }
 

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -1104,20 +1104,19 @@ void DragSelectionTool::VectorChangeThicknessTool::addUndo() {
 void DragSelectionTool::VectorChangeThicknessTool::leftButtonDown(
     const TPointD &pos, const TMouseEvent &e) {
   m_curPos   = pos;
-  m_firstPos = pos;
+  m_firstPos = e.m_pos;
 }
 
 //-----------------------------------------------------------------------------
 
 void DragSelectionTool::VectorChangeThicknessTool::leftButtonDrag(
     const TPointD &pos, const TMouseEvent &e) {
-  TAffine aff;
-  TPointD delta    = pos - m_curPos;
+  TPointD delta = e.m_pos - m_firstPos;
   TVectorImageP vi = getTool()->getImage(true);
   if (!vi) return;
   VectorSelectionTool *tool = dynamic_cast<VectorSelectionTool *>(m_tool);
   tool->setResetCenter(false);
-  m_thicknessChange = (pos.y - m_firstPos.y) * 0.2;
+  m_thicknessChange = delta.y * m_tool->getViewer()->getPixelSize() * 0.2;
   changeImageThickness(*vi, m_thicknessChange);
   getTool()->m_deformValues.m_maxSelectionThickness = m_thicknessChange;
   getTool()->computeBBox();


### PR DESCRIPTION
This PR fixes #1449.
By using mouse position in window coordinates, we get the correct delta when the viewer is rotated or flipped.