### PR TITLE
Qt 5.15

### DIFF
--- a/ci-scripts/windows/tahoma-build.bat
+++ b/ci-scripts/windows/tahoma-build.bat
@@ -13,13 +13,19 @@ REM Setup for local builds
 set MSVCVERSION="Visual Studio 16 2019"
 set BOOST_ROOT=C:\boost\boost_1_74_0
 set OPENCV_DIR=C:\opencv\451\build
-set QT_PATH=C:\Qt\5.9.7\msvc2019_64
+REM set QT_PATH=C:\Qt\5.9.7\msvc2019_64
+set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
 
 REM These are effective when running from Actions
 IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
 IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 (
-	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
+REM IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 (
+REM 	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
+REM )
+
+set WITH_WINTAB=Y
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64 (
+	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64
 )
 
 set WITH_CANON=N
@@ -28,7 +34,7 @@ IF EXIST ..\..\thirdparty\canon\Header set WITH_CANON=Y
 set WITH_GPHOTO2=N
 IF EXIST ..\..\thirdparty\libgphoto2\include set WITH_GPHOTO2=Y
 
-cmake ..\sources -G %MSVCVERSION%  -Ax64 -DQT_PATH=%QT_PATH% -DBOOST_ROOT=%BOOST_ROOT% -DOpenCV_DIR=%OPENCV_DIR% -DWITH_CANON=%WITH_CANON% -DWITH_GPHOTO2=%WITH_GPHOTO2%
+cmake ..\sources -G %MSVCVERSION%  -Ax64 -DQT_PATH=%QT_PATH% -DBOOST_ROOT=%BOOST_ROOT% -DOpenCV_DIR=%OPENCV_DIR% -DWITH_CANON=%WITH_CANON% -DWITH_GPHOTO2=%WITH_GPHOTO2% -DWITH_WINTAB=%WITH_WINTAB%
 
 
 IF EXIST C:\ProgramData\chocolatey\bin\cl.exe (

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -38,15 +38,17 @@ del Tahoma2D\*.ilk
 echo ">>> Configuring Tahoma2D.exe for deployment"
 
 REM Setup for local builds
-set QT_PATH=C:\Qt\5.9.7\msvc2019_64
+REM set QT_PATH=C:\Qt\5.9.7\msvc2019_64
+set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
 
 REM These are effective when running from Actions/Appveyor
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
+REM IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
+IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64
 
 set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
 IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC" set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"
 
-%QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe
+%QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe --opengl
 
 del /A- /S Tahoma2D\tahomastuff\*.gitkeep
 

--- a/ci-scripts/windows/tahoma-install.bat
+++ b/ci-scripts/windows/tahoma-install.bat
@@ -1,9 +1,15 @@
 choco install opencv --version=4.5.1
 choco install boost-msvc-14.2
 
-REM Install Qt 5.9
-curl -fsSL -o Qt5.9.7_msvc2019_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.9.7/Qt5.9.7_msvc2019_64.zip
-7z x Qt5.9.7_msvc2019_64.zip
-rename Qt5.9.7_msvc2019_64 5.9
 mkdir thirdparty\qt
-move 5.9 thirdparty\qt
+
+REM Install Qt 5.9
+REM curl -fsSL -o Qt5.9.7_msvc2019_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.9.7/Qt5.9.7_msvc2019_64.zip
+REM 7z x Qt5.9.7_msvc2019_64.zip
+REM rename Qt5.9.7_msvc2019_64 5.9
+REM move 5.9 thirdparty\qt
+
+REM Install Custom Qt 5.15.2 with WinTab support
+curl -fsSL -o Qt5.15.2_wintab.zip https://github.com/tahoma2d/qt5/releases/download/v5.15.2/Qt5.15.2_wintab.zip
+7z x Qt5.15.2_wintab.zip
+move Qt5.15.2_wintab\5.15.2_wintab thirdparty\qt

--- a/doc/how_to_build_win.md
+++ b/doc/how_to_build_win.md
@@ -1,6 +1,6 @@
 # Build Tahoma2D on Windows
 
-This software can be built using Visual Studio 2019 or above and Qt 5.9 (later Qt versions still not working correctly.)
+This software can be built using Visual Studio 2019 or above and Qt 5.15 (min 5.15.2)
 
 Throughout these instructions `$tahoma2d` represents the full path to your local Git repository for Tahoma2D.
 
@@ -14,31 +14,39 @@ Throughout these instructions `$tahoma2d` represents the full path to your local
 
 ### Qt - cross-platform GUI framework.
 - [ ] Install via **one** of the following methods.
-  - (option 1) Install Qt 5.9.9 from here: https://www.qt.io/download-open-source/. Click the `Download the Qt Online Installer` button at the bottom of the page. It should recommend the Windows installer, if not, select it. The installer is a small file and any additional needed files are downloaded during the install.
-    - [ ] Run the the downloaded file. 
-    - [ ] On the filter tick the Archive checkbox to see older versions in the list. In the list choose version `Qt 5.9.9`. 
+  - If you want WinTab support, install the customized Qt 5.15.2 w/ WinTab support created by Shun-iwasawa.
+	- [ ] Download `Qt5.15.2_wintab.zip` from https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab
+	- [ ] Extract the contents to `C:\Qt\5.15.2_wintab`
 
-  - (option 2) Install using the [Qt 5.9.9 Offline Installer](http://download.qt.io/official_releases/qt/5.9/5.9.9/qt-opensource-windows-x86-5.9.9.exe). It is a large installer file which can be run offline.
-
-From the site: *"We recommend you use the Qt Online Installer for first time installations and the Qt Maintenance Tool for changes to a current install."*
-The Maintenance Tool for Qt is in the Qt installation folder, `C:\Qt\MaintenanceTool.exe`,
+  - Install Qt 5.15.x (min 5.15.2) from https://www.qt.io/download-open-source/.
+    - [ ] Click the `Download the Qt Online Installer` button at the bottom of the page.
+    - [ ] Run the the installer and choose the Qt version to install.
+      - If you do not see 5.15.x you may need to tick the Archive checkbox to see older versions in the list.
+      - Include the following components
+        - `MSVC 2019 64-bit`
+        - `Qt Script (Deprecated)`
+        - `Qt Charts`
+        - `Qt Data Visualization`
+        - `Qt Network Authorization`
 
 ### CMake
 This will be used to create the `MSVC` project file.
 - [ ] If CMake was installed with Qt, no additional installation is required.
 
   The typical location of CMake installed with Qt is: `C:\Qt\Tools\CMake_64\bin\cmake-gui.exe`
-- [ ] If CMake was not installed then get it here and install it: https://cmake.org/download/
+- [ ] If CMake was not installed download and install https://cmake.org/download/
 
-### boost
+### Boost
 Boost 1.55.0 or later is required (tested up to 1.75.0).
-- [ ] Download boost_1_75_0.zip from http://www.boost.org/users/history/version_1_75_0.html
-- [ ] Extract all contents to the - '$tahoma2d\thirdparty\boost' directory. The result will be something like this: `$tahoma2d\thirdparty\boost\boost_1_75_0`
+- [ ] Download `boost_1_75_0.zip` from http://www.boost.org/users/history/version_1_75_0.html
+- [ ] Extract contents to a directory.
+  - For example: `C:\boost\boost_1_75_0`
 
 ### OpenCV
-- [ ] Install OpenCV. (https://opencv.org/) (v4.4.0 and later). 
+- [ ] Download OpenCV v4.5.1 or later from https://opencv.org/. 
+- [ ] Install to a directory such as `C:\opencv\451`
 
-  OpenCV version 4.4.0 is the version distributed with Tahoma2D 1.1.
+  Recommend using the version currently used by Tahoma2D.
 
 ## Acquire the Source Code
 You can use GitHub Desktop https://desktop.github.com/ or Git command line.
@@ -58,137 +66,120 @@ You can use GitHub Desktop https://desktop.github.com/ or Git command line.
   - [ ] `git lfs pull`
 
 ### Use CMake to Create a Visual Studio Project
-- [ ] Launch CMake GUI. You can find it in this Qt subfolder: `C:\Qt\Tools\CMake_64\bin\cmake-gui.exe`, or wherever you installed it.
-- [ ] In `Where is the source code`, navigate to `$tahoma2d/toonz/sources`
-- [ ] In `Where to build the binaries`, navigate to `$tahoma2d/toonz/build` or to wherever you usually build to.
-  - [ ] If the build directory is in the git repository, be sure to add the directory to .gitignore.
-  - If the build directory is different from the one above, be sure to change to the specified directory where appropriate below.
-- [ ] Click on Configure, a pop-up should appear the first time this is done.
-- If no pop-up appears then a cached version from a prior run of CMake was found at the locations you selected above. 
-  - [ ] Clear the cache using: File -> Delete Cache.
-  - [ ] Click on Configure, the pop-up should now appear.
-- In the pop-up that appears:
-  - [ ] Select the version of Visual Studio you are using. 
-  - [ ] Select the x64 Target Environment.
-- If Qt was installed to a directory other than the default, and the error `Specify QT_PATH properly` appears:
-  - Click on the value for `QT_PATH` in the top half of the CMake window.
-  - [ ] navigate to the `QT_DIR` install folder and down to the subfolder that most closely matches your version of Visual Studio, for example: `C:\Qt\5.9.9\msvc2017_64` for Visual Studio 2017. 
-  - [ ] Rerun Configure.
-- If OpenCV was installed to a directory other than the default and a message about `set "OpenCV_DIR"` appears:
-  - Click on the value for `OpenCV_DIR` in the top half of the CMake window.
-  - [ ] navigate to the OpenCV install folder and down to the level of the `build` folder. Example: `C:\opencv_4.4.0\build`.
-  - [ ] Rerun Configure.
-- If red warning lines appear in the bottom box, you can safely ignore them.
-- [ ] Click Generate.
-- Should the CMakeLists.txt file change, such as during automatic build cleanup in Visual Studio, there is no need to rerun CMake.
+- This is only done 1x unless changing Qt, OpenCV or Boost version.
+- [ ] Launch CMake GUI. You can find it in this Qt subfolder
+- [ ] In `Where is the source code`, navigate to `$tahoma2d\toonz\sources`
+- [ ] In `Where to build the binaries`, navigate to or enter `$tahoma2d\toonz\build`
+- [ ] Click on `Configure`
+- [ ] If this is the 1st time for this build directory, a pop-up will appear
+  - Select the version of Visual Studio you are using. 
+  - Select the `x64` Target Environment.
+- [ ] Click on the value for `QT_PATH` in the top half of the CMake window and update the path to match where your QT library was installed.
+    - For example: `C:\Qt\5.15.5_wintab\msvc2019_64` for Visual Studio 2019. 
+- [ ] Select the following as desired
+    - `WITH_CANON` - For Stop motion with Canon DSLR cameras.
+  	- `WITH_GPHOTO2` - For Stop Motion using non-Canon cameras.
+  	- `WITH_WINTAB` - Only use if you installed the customized Qt 5.15.2 w/ WinTab, mentioned above
+- [ ] For generating PDB files needed for detailed crash reporting, add `/Zi` to the following entries (example: `/MDd /Zi /Ob0 /Od /RTC1`)
+  - `CMAKE_CXX_FLAGS_DEBUG`
+  - `CMAKE_CXX_FLAGS_RELWITHDEBINFO`
+  - `CMAKE_C_FLAGS_DEBUG`
+  - `CMAKE_C_FLAGS_RELWITHDEBINFO`
+- [ ] Rerun `Configure`.
+above.
+- [ ] Click on `OpenCV_DIR` and update the path to match where your OpenCV library was installed.
+  - For example: `C:\opencv\451\build`.
+- [ ] Rerun `Configure`.
+- [ ] Click on `BOOST_ROOT` and `Boost_INCLUDE_DIR` and update the path to match where your Boost library was installed.
+  - For example: `C:\boost\boost_1_75_0`
+- [ ] Rerun `Configure`.
+- [ ] Review the log for any errors.  If any, resolve errors and reconfigure until no errors are reported.
+- [ ] Click `Generate`
 
 ## Set Up Libraries
 Rename the following files:
-- [ ] `$tahoma2d/thirdparty/LibJPEG/jpeg-9/jconfig.vc` to
-  - `$tahoma2d/thirdparty/LibJPEG/jpeg-9/jconfig.h`
-- [ ] `$tahoma2d/thirdparty/tiff-4.2.0/libtiff/tif_config.vc.h` to
-  - `$tahoma2d/thirdparty/tiff-4.2.0/libtiff/tif_config.h`
-- [ ] `$tahoma2d/thirdparty/tiff-4.2.0/libtiff/tiffconf.vc.h` to
-  - `$tahoma2d/thirdparty/tiff-4.2.0/libtiff/tiffconf.h`
-- [ ] `$tahoma2d/thirdparty/libpng-1.6.21/scripts/pnglibconf.h.prebuilt` to
-  - `$tahoma2d/thirdparty/libpng-1.6.21/pnglibconf.h` 
+- [ ] `$tahoma2d\thirdparty\tiff-4.2.0\libtiff\tif_config.vc.h` to
+  - `$tahoma2d\thirdparty\tiff-4.2.0\libtiff\tif_config.h`
+- [ ] `$tahoma2d\thirdparty\tiff-4.2.0\libtiff\tiffconf.vc.h` to
+  - `$tahoma2d\thirdparty\tiff-4.2.0\libtiff\tiffconf.h`
+- [ ] `$tahoma2d\thirdparty\libpng-1.6.21\scripts\pnglibconf.h.prebuilt` to
+  - `$tahoma2d\thirdparty\libpng-1.6.21\pnglibconf.h` 
   - Note that the destination folder is different for this file.
 
-## Build
-- [ ] Start Visual Studio and open the solution `$tahoma2d/toonz/build/Tahoma2D.sln`.
-- [ ] Change to `Debug`, `RelWithDebInfo`, or `Release` in the top bar.
-- [ ] Build the solution.
-- [ ] Find the output in the folder `$tahoma2d/toonz/build/`
+## Library setup for stop motion with Canon DSLR cameras.
+- You will need to get a copy of the Canon SDK.  This requires applying for the Canon developer program and downloading the SDK.
 
-## Build with extended stop motion support for webcams and Canon DSLR cameras.
-You will need two additional libraries.
- - [ ] Get [libjpeg-turbo](https://www.libjpeg-turbo.org/)
- - [ ] Get the Canon SDK.  This requires applying for the Canon developer program and downloading the SDK.
+- [ ] Copy the following folders into the `$tahoma2d\thirdparty\canon` folder.
+   - `Header`
+   - `library`
+     - Make sure that the library is the one from the `EDSDK_64` folder.
 
-Copy the following folders into the `$tahoma2d/thirdparty` folder.
- - [ ] Copy the Header and library folders from the Canon SDK to `$tahoma2d/thirdparty/canon`
- - Make sure that the library is the one from the EDSDK_64 folder.
- - [ ] Copy the lib and include folders from libjpeg-turbo64 into `$tahoma2d/thirdparty/libjpeg-turbo`.
- - [ ] Check the checkbox in CMake to build with stop motion support.
+## Quick setup to build and run in Debug/RelWithDebInfo Mode
+- `RelWithDebInfo` is recommended for developers because it allows you to debug with optimal performance.  Use `Debug` if you want `Asserts` to be triggered
+- [ ] Obtain the latest Tahoma2D portable release from https://tahoma2d.org/ if you don't have it already
+- [ ] Create the folder `$tahoma2d\toonz\build\Debug` or `RelWithDebInfo`
+- [ ] Copy all files and subfolders from the latest release into the `Debug`/`RelWithDebInfo` folder, except `tahomastuff`, `ffmpeg` and `rhubarb`
+- [ ] Copy the `$tahoma2d\stuff` folder to `$tahoma2d\toonz\build\toonz` and rename it `tahomastuff`
+- [ ] Copy the `ffmpeg` and `rhubarb` folders from the release to `$tahoma2d\toonz\build\toonz`
 
-To run the program with stop motion support, you will need to copy the .dll files from opencv2, libjpeg-turbo and the Canon SDK into the folder where your project is built.
+## Build/Debug
+- [ ] Start Visual Studio by double-clicking on`$tahoma2d\toonz\build\Tahoma2D.sln`.
+- [ ] Change the Solution Configuration to `Debug`, `RelWithDebInfo` or, `Release` in the top bar.
+- [ ] To build: `Build` -> `Build Solution`
+- [ ] To debug:
+  - [ ] In the Solution Explorer window, right click on `Tahoma2D` and choose `Set as StartUp Project`.
+  - [ ]  `Debug` -> `Start Debugging`
 
-## Quick Setup and Run in Debug Mode - suitable for most people
-- Use this method if you are interested in analyzing Tahoma2D rather than just creating a running copy.
-- [ ] Start with a local working Tahoma2D installation. The latest release version is available here: https://tahoma2d.org/
-  - [ ] Copy all files and subfolders from the working Tahoma2D folder, except `tahomastuff` and `ffmpeg`.
-  - Paste to the build folder where the compiler generates output. 
-    - `$tahoma2d/toonz/build/Debug` or `$tahoma2d/toonz/build/RelWithDebug` are typical build folders and the name is based on the `Solution Configuration` choice you make in Visual Studio during build.
-  - If the `Debug` or `RelWithDebug` subfolder does not already exist then create that folder manually or skip this step and come back to it after doing at least one build to create one of those folders. The Tahoma2d dlls and exe in the folder will be replaced when the next build is run.
-  - [ ] Copy the `tahomastuff` folder to `$tahoma2d/toonz/build/toonz` to get this result: `$tahoma2d/toonz/build/toonz/tahomastuff`.
-- [ ] Start Visual Studio and load the solution.
-- [ ] In Visual Studio set the `Solution Configuration` to `Debug` or `RelWithDebInfo` using the drop-down at the top of the screen.
-- [ ] In the Solution Explorer window, right click on the `Tahoma2D` project.
-  - [ ] In the pop-up context menu that appears, choose `Set as StartUp Project`.
-  - This is a one time step. The `Tahoma2D` project will now show in bold indicating it is the startup project for the solution.
-- [ ] Build the solution. 
-- [ ] Click the `Local Windows Debugger` to start Tahoma2D in debug mode.
-- Set breakpoints, checkpoints, view the output window, do step-through debugging.
-- To stop the debugging session exit Tahoma2D from its menu or stop the debugger in Visual Studio.
+## Build Release package
+- [ ] Create a `Tahoma2D` folder somewhere (i.e `C:\Tahoma2D`)
+- [ ] Copy the entire contents of `$tahoma2d\toonz\build\Release` or `RelWithDebInfo` to the `C:\Tahoma2D`
+- [ ] Do **one** of:
+    - (option 1) Open a Command Prompt and navigate to `QT_DIR\msvc2019_64\bin`. Run the Qt program `windeployqt.exe` `C:\Tahoma2D\Tahoma2D.exe` as an argument. 
 
-## Run the Program - More Steps, Individual File Copying - more awareness over which files are used
-1. - [ ] Copy the entire contents of $tahoma2d/toonz/build/Release to an appropriate folder.
-2. - [ ] Do **one** of:
-      - (option 1) Open a Command Prompt and navigate to `QT_DIR/msvc2019_64/bin`. Run the Qt program `windeployqt.exe` with the path for `Tahoma2D.exe` as an argument. 
+     - (option 2) Another way to do this is to open two windows in Windows Explorer. In the first window navigate to the folder containing `windeployqt.exe`. In a second window navigate to and drag and drop `C:\Tahoma2D\Tahoma2D.exe` onto `windeployqt.exe` in the other window.
 
-      - (option 2) Another way to do this is to open two windows in Windows Explorer. In the first window navigate to the folder containing `windeployqt.exe`. In a second window navigate to the Release folder contining the Tahoma2D.exe you built. Drag and drop Tahoma2D.exe onto `windeployqt.exe` in the other window.
-    - This will automatically generate the QT files and folders you will need.
-
-3. Confirm the result.
-- These necessary Qt library files should be in the same folder as `Tahoma2D.exe`
-    - [ ] `Qt5Core.dll`
-    - [ ] `Qt5Gui.dll`
-    - [ ] `Qt5Multimedia.dll`
-    - [ ] `Qt5Network.dll`
-    - [ ] `Qt5OpenGL.dll`
-    - [ ] `Qt5PrintSupport.dll`
-    - [ ] `Qt5Script.dll`
-    - [ ] `Qt5SerialPort.dll`
-    - [ ] `Qt5Svg.dll`
-    - [ ] `Qt5Widgets.dll`
-    - [ ] `Qt5Xml.dll`
-    - and these files should be in corresponding sub-folders
-    - [ ] `/bearer/qgenericbearer.dll`
-    - [ ] `/iconengines/qsvgicon.dll`
-    - [ ] `/imageformats/qgif.dll`
-    - [ ] `/imageformats/qicns.dll`
-    - [ ] `/imageformats/qico.dll`
-    - [ ] `/imageformats/qjpeg.dll`
-    - [ ] `/imageformats/qsvg.dll`
-    - [ ] `/imageformats/qtga.dll`
-    - [ ] `/imageformats/qtiff.dll`
-    - [ ] `/imageformats/qwbmp.dll`
-    - [ ] `/imageformats/qwebp.dll`
-    - [ ] `/platforms/qwindows.dll`
-
-4. Copy the following files to the same folder as `Tahoma2D.exe`
-  - [ ] `$tahoma2d/thirdparty/freeglut/bin/x64/freeglut.dll`
-  - [ ] `$tahoma2d/thirdparty/glew/glew-1.9.0/bin/64bit/glew32.dll`
-  - [ ] `$tahoma2d/thirdparty/libjpeg-turbo64/dist/turbojpeg.dll`
-  - [ ] `$tahoma2d/thirdparty/libmypaint/dist/64/libjson-c-2.dll`
-  - [ ] `$tahoma2d/thirdparty/libmypaint/dist/64/libmypaint-1-4-0.dll`
-  - [ ] `$OpenCV_DIR/build/x64/vc15/bin/opencv_world440.dll` Use the same OpenCV that was used to build the solution.
+- [ ] Confirm the following files and folders have been added to `C:\Tahoma2D`
+  - `Qt5Core.dll`
+  - `Qt5Gui.dll`
+  - `Qt5Multimedia.dll`
+  - `Qt5Network.dll`
+  - `Qt5OpenGL.dll`
+  - `Qt5PrintSupport.dll`
+  - `Qt5Script.dll`
+  - `Qt5SerialPort.dll`
+  - `Qt5Svg.dll`
+  - `Qt5Widgets.dll`
+  - `Qt5Xml.dll`
+  - `audio\`
+  - `bearer\`
+  - `iconengines\`
+  - `imageformats\`
+  - `mediaservice\`
+  - `platforms\`
+  - `playlistformats\`
+  - `printsupport\`
+  - `translations\`
+  - `concrt140.dll`
+  - `msvcp140.dll`
   
-5. Copy the following files from a downloaded release copy of Tahoma2D to the same folder as `Tahoma2D.exe`. The latest release version is available here: https://tahoma2d.org/.
-  - [ ] `concrt140.dll`
-  - [ ] `EDSDK.dll`
-  - [ ] `EdsImage.dll`
-  - [ ] `ffmpeg.exe`
-  - [ ] `ffprobe.exe`
-  - [ ] `libiconv-2.dll`
-  - [ ] `libintl-8.dll`
-  - [ ] `msvcp140.dll`
-  - [ ] `vcruntime140.dll`
-  - [ ] `vcruntime140_1.dll`
+- [ ] Copy the following files and folders to `C:\Tahoma2D`
+  - `$tahoma2d\thirdparty\freeglut\bin\x64\freeglut.dll`
+  - `$tahoma2d\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll`
+  - `$tahoma2d\thirdparty\libmypaint\dist\64\libiconv-2.dll`
+  - `$tahoma2d\thirdparty\libmypaint\dist\64\libintl-8.dll`
+  - `$tahoma2d\thirdparty\libmypaint\dist\64\libjson-c-2.dll`
+  - `$tahoma2d\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll`
+  - `$tahoma2d\thirdparty\libgphoto2\bin\*`
+  - `$OpenCV_DIR\build\x64\vc15\bin\opencv_world451.dll`
+  
+- [ ] Copy the following files and folders from a recent Tahoma2D release to `C:\Tahoma2D`
+  - `EDSDK.dll`
+  - `EdsImage.dll`
+  - `ffmpeg\`
+  - `rhubarb\`
 
-### Create the stuff Folder
-- [ ] Create an empty `tahomastuff` folder inside the folder where `Tahoma2D.exe` is located.
-- [ ] Copy the files from `$tahoma2d/stuff` to the new folder.
+- [ ] Create the stuff Folder
+  - Copy the files from `$tahoma2d\stuff` to `C:\Tahoma2D` and rename it `tahomastuff`
 
 ### Run
 `Tahoma2D.exe` can now be run.  Congratulations!

--- a/doc/how_to_build_win.md
+++ b/doc/how_to_build_win.md
@@ -1,6 +1,6 @@
 # Build Tahoma2D on Windows
 
-This software can be built using Visual Studio 2019 or above and Qt 5.15 (min 5.15.2)
+This software can be built using Visual Studio 2019 or above and Qt 5 (min 5.15.2)
 
 Throughout these instructions `$tahoma2d` represents the full path to your local Git repository for Tahoma2D.
 
@@ -9,12 +9,12 @@ Throughout these instructions `$tahoma2d` represents the full path to your local
 ### Microsoft Visual Studio 2019 or higher for Windows Desktop
 - [ ] Install Microsoft Visual Studio 2019 or higher for Windows Desktop, https://www.visualstudio.com/vs/older-downloads/
   - Community and Professional versions of Visual Studio for Windows Desktop also work.
-  - [ ] Make sure the target platform is "for Windows Desktop", not "for Windows".
+  - [ ] Make sure the architecture is "x64".
   - [ ] During the installation, make sure to select all the Visual C++ packages.
 
 ### Qt - cross-platform GUI framework.
 - [ ] Install via **one** of the following methods.
-  - If you want WinTab support, install the customized Qt 5.15.2 w/ WinTab support created by Shun-iwasawa.
+  - If you want WinTab support, install the customized Qt 5.15.2 w/ WinTab support created by Shun-iwasawa. **(This is required if you plan on running on a Wacom tablet!)**
 	- [ ] Download `Qt5.15.2_wintab.zip` from https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab
 	- [ ] Extract the contents to `C:\Qt\5.15.2_wintab`
 
@@ -77,7 +77,7 @@ You can use GitHub Desktop https://desktop.github.com/ or Git command line.
 - [ ] Click on the value for `QT_PATH` in the top half of the CMake window and update the path to match where your QT library was installed.
     - For example: `C:\Qt\5.15.5_wintab\msvc2019_64` for Visual Studio 2019. 
 - [ ] Select the following as desired
-    - `WITH_CANON` - For Stop motion with Canon DSLR cameras.
+    - `WITH_CANON` - For Stop motion with Canon DSLR cameras. (Only use if you have the Canon SDK)
   	- `WITH_GPHOTO2` - For Stop Motion using non-Canon cameras.
   	- `WITH_WINTAB` - Only use if you installed the customized Qt 5.15.2 w/ WinTab, mentioned above
 - [ ] For generating PDB files needed for detailed crash reporting, add `/Zi` to the following entries (example: `/MDd /Zi /Ob0 /Od /RTC1`)
@@ -86,7 +86,6 @@ You can use GitHub Desktop https://desktop.github.com/ or Git command line.
   - `CMAKE_C_FLAGS_DEBUG`
   - `CMAKE_C_FLAGS_RELWITHDEBINFO`
 - [ ] Rerun `Configure`.
-above.
 - [ ] Click on `OpenCV_DIR` and update the path to match where your OpenCV library was installed.
   - For example: `C:\opencv\451\build`.
 - [ ] Rerun `Configure`.
@@ -94,7 +93,7 @@ above.
   - For example: `C:\boost\boost_1_75_0`
 - [ ] Rerun `Configure`.
 - [ ] Review the log for any errors.  If any, resolve errors and reconfigure until no errors are reported.
-- [ ] Click `Generate`
+- [ ] Click `Generate`.
 
 ## Set Up Libraries
 Rename the following files:
@@ -173,8 +172,8 @@ Rename the following files:
   - `$OpenCV_DIR\build\x64\vc15\bin\opencv_world451.dll`
   
 - [ ] Copy the following files and folders from a recent Tahoma2D release to `C:\Tahoma2D`
-  - `EDSDK.dll`
-  - `EdsImage.dll`
+  - `EDSDK.dll` (if you compiled with Canon support)
+  - `EdsImage.dll` (if you compiled with Canon support)
   - `ffmpeg\`
   - `rhubarb\`
 

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -139,8 +139,8 @@ if(BUILD_ENV_MSVC)
     endif()
     set(QT_LIB_PATH ${QT_PATH})
     set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT_PATH}/lib/cmake/")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4251")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /std:c++17 /wd4251")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /wd4251")
     add_definitions(
         -DVC_EXTRALEAN
         -DNOMINMAX
@@ -164,8 +164,8 @@ elseif(BUILD_ENV_APPLE)
             -Di386
             -D__MACOS__
         )
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -std=c++11 -stdlib=libc++ -fno-implicit-templates")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m64 -std=c++11 -stdlib=libc++ -fno-implicit-templates")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -std=c++17 -stdlib=libc++ -fno-implicit-templates")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m64 -std=c++17 -stdlib=libc++ -fno-implicit-templates")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
     elseif(PLATFORM EQUAL 32)
         set(QT_PATH "~/Qt5.9.2/5.9.2/clang_32/lib" CACHE PATH "Qt installation directory")
@@ -178,7 +178,7 @@ elseif(BUILD_ENV_APPLE)
             -Di386
             -D__MACOS__
         )
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=c++11 -stdlib=libc++ -fno-implicit-templates -D HAS_QUICKDRAW")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=c++17 -stdlib=libc++ -fno-implicit-templates -D HAS_QUICKDRAW")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
         set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -m32")
     else()
@@ -207,11 +207,11 @@ elseif(BUILD_ENV_UNIXLIKE)
         message(WARNING "Support for generic Unix (Not Apple or Linux) isn't yet working!")
     endif()
 
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 17)
 
     find_package(Qt5Widgets)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
     if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++")
     endif()

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -222,6 +222,7 @@ add_definitions(
     -DQT_NETWORK_LIB
     -DQT_CORE_LIB
     -DQT_SHARED
+    -DQT_DISABLE_DEPRECATED_BEFORE=0x050F02
 )
 
 # Find includes in corresponding build directories

--- a/toonz/sources/common/tgl/tgl.cpp
+++ b/toonz/sources/common/tgl/tgl.cpp
@@ -20,7 +20,8 @@
 #endif
 
 #if defined(MACOSX) || defined(LINUX) || defined(FREEBSD) || defined(HAIKU)
-#include <QGLContext>
+#include <QOpenGLContext>
+#include <QOffscreenSurface>
 #endif
 
 //#include "tthread.h"
@@ -621,21 +622,22 @@ void tglDoneCurrent(TGlContext) { wglMakeCurrent(NULL, NULL); }
 
 TGlContext tglGetCurrentContext() {
   return reinterpret_cast<TGlContext>(
-      const_cast<QGLContext *>(QGLContext::currentContext()));
+      const_cast<QOpenGLContext *>(QOpenGLContext::currentContext()));
 
-  // (Daniele) I'm not sure why QGLContext::currentContext() returns
+  // (Daniele) I'm not sure why QOpenGLContext::currentContext() returns
   // const. I think it shouldn't, and guess (hope) this is safe...
 }
 
 void tglMakeCurrent(TGlContext context) {
   if (context)
-    reinterpret_cast<QGLContext *>(context)->makeCurrent();
+    reinterpret_cast<QOpenGLContext *>(context)->makeCurrent(
+        new QOffscreenSurface());
   else
     tglDoneCurrent(tglGetCurrentContext());
 }
 
 void tglDoneCurrent(TGlContext context) {
-  if (context) reinterpret_cast<QGLContext *>(context)->doneCurrent();
+  if (context) reinterpret_cast<QOpenGLContext *>(context)->doneCurrent();
 }
 
 #else

--- a/toonz/sources/common/tipc/tipc.cpp
+++ b/toonz/sources/common/tipc/tipc.cpp
@@ -633,7 +633,7 @@ retry:
 */
 bool tipc::writeShMemBuffer(Stream &stream, Message &msg, int bufSize,
                             ShMemWriter *dataWriter) {
-  tipc_debug(QTime time; time.start());
+  tipc_debug(QElapsedTimer time; time.start());
   tipc_debug(qDebug("tipc::writeShMemBuffer entry"));
 
   static QSemaphore sem(tipc::shm_maxSegmentCount());
@@ -652,7 +652,7 @@ bool tipc::writeShMemBuffer(Stream &stream, Message &msg, int bufSize,
     int chunkData, remainingData = bufSize;
     while (remainingData > 0) {
       // Write to the shared memory segment
-      tipc_debug(QTime xchTime; xchTime.start());
+      tipc_debug(QElapsedTimer xchTime; xchTime.start());
       shmem.lock();
       remainingData -= chunkData = dataWriter->write(
           (char *)shmem.data(), std::min(shmem.size(), remainingData));
@@ -688,7 +688,7 @@ err:
 */
 bool tipc::readShMemBuffer(Stream &stream, Message &msg,
                            ShMemReader *dataReader) {
-  tipc_debug(QTime time; time.start(););
+  tipc_debug(QElapsedTimer time; time.start(););
   tipc_debug(qDebug("tipc::readShMemBuffer entry"));
 
   // Read the id from stream
@@ -716,7 +716,7 @@ bool tipc::readShMemBuffer(Stream &stream, Message &msg,
   while (true) {
     msg >> chunkData;
 
-    tipc_debug(QTime xchTime; xchTime.start());
+    tipc_debug(QElapsedTimer xchTime; xchTime.start());
     shmem.lock();
     remainingData -= dataReader->read((const char *)shmem.data(), chunkData);
     shmem.unlock();

--- a/toonz/sources/common/tmsgcore.cpp
+++ b/toonz/sources/common/tmsgcore.cpp
@@ -133,11 +133,7 @@ void TMsgCore::readFromSocket(QTcpSocket *socket)  // server side
     message.chop(lastbegin);
   }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList messages = message.split("#TMSG", Qt::SkipEmptyParts);
-#else
-  QStringList messages = message.split("#TMSG", QString::SkipEmptyParts);
-#endif
 
   for (int i = 0; i < messages.size(); i++) {
     QString str = messages.at(i).simplified();

--- a/toonz/sources/common/trop/tresample.cpp
+++ b/toonz/sources/common/trop/tresample.cpp
@@ -4858,7 +4858,7 @@ void rop_resample_rgbm_2(TRasterPT<T> rout, const TRasterCM32P &rin,
   }
 
 #if defined(USE_SSE2)
-  TRaster32P rout32 = rout;
+  TRaster32P rout32 = (TRaster32P)rout;
   if ((TSystem::getCPUExtensions() & TSystem::CpuSupportsSse2) && rout32)
     resample_main_cm32_rgbm_SSE2<TPixel32>(
         rout32, rin, aff_xy2uv, aff0_uv2fg, min_pix_ref_u, min_pix_ref_v,

--- a/toonz/sources/common/tsystem/tfilepath_io.cpp
+++ b/toonz/sources/common/tsystem/tfilepath_io.cpp
@@ -10,7 +10,6 @@
 #include <fstream>
 #include <iostream>
 
-using namespace std;
 #ifdef _MSC_VER
 
 #include <io.h>
@@ -23,7 +22,7 @@ using namespace std;
    ... , to
          know mode view _wfopen_s documentation.
 */
-FILE *fopen(const TFilePath &fp, string mode) {
+FILE *fopen(const TFilePath &fp, std::string mode) {
   FILE *pFile;
   errno_t err =
       _wfopen_s(&pFile, fp.getWideString().c_str(), ::to_wstring(mode).c_str());
@@ -31,7 +30,7 @@ FILE *fopen(const TFilePath &fp, string mode) {
   return pFile;
 }
 
-Tifstream::Tifstream(const TFilePath &fp) : ifstream(m_file = fopen(fp, "rb")) {
+Tifstream::Tifstream(const TFilePath &fp) : std::ifstream(m_file = fopen(fp, "rb")) {
   // manually set the fail bit here, since constructor ifstream::ifstream(FILE*)
   // does not so even if the argument is null pointer.
   // the state will be referred in "TIStream::operator bool()" ( in tstream.cpp )
@@ -51,7 +50,7 @@ void Tifstream::close() {
 }
 
 Tofstream::Tofstream(const TFilePath &fp, bool append_existing)
-    : ofstream(m_file = fopen(fp, append_existing ? "ab" : "wb")) {
+    : std::ofstream(m_file = fopen(fp, append_existing ? "ab" : "wb")) {
   // manually set the fail bit here, since constructor ofstream::ofstream(FILE*)
   // does not so even if the argument is null pointer.
   // the state will be referred in "TOStream::operator bool()" ( in tstream.cpp )
@@ -83,14 +82,14 @@ bool Tofstream::isOpen() const { return m_file != 0; }
 //
 //======================
 
-FILE *fopen(const TFilePath &fp, string mode) {
+FILE *fopen(const TFilePath &fp, std::string mode) {
   return fopen(QString::fromStdWString(fp.getWideString()).toUtf8().data(),
                mode.c_str());
 }
 
 Tifstream::Tifstream(const TFilePath &fp)
-    : ifstream(QString::fromStdWString(fp.getWideString()).toUtf8().data(),
-               ios::binary)
+    : std::ifstream(QString::fromStdWString(fp.getWideString()).toUtf8().data(),
+               std::ios::binary)
 /*: ifstream(openFileForReading(fp), ios::binary)
 NO! Questo costruttore non e' standard, anche se e' presente
 in molte versioni. Nel MAC non c'e e fa un cast a char*
@@ -101,9 +100,9 @@ sperando che sia il nome del file => compila ma non funziona
 Tifstream::~Tifstream() {}
 
 Tofstream::Tofstream(const TFilePath &fp, bool append_existing)
-    : ofstream(
+    : std::ofstream(
           QString::fromStdWString(fp.getWideString()).toUtf8().data(),
-          ios::binary | (append_existing ? ios_base::app : ios_base::trunc)) {}
+          std::ios::binary | (append_existing ? std::ios_base::app : std::ios_base::trunc)) {}
 
 Tofstream::~Tofstream() {}
 

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -2,8 +2,6 @@
 
 #include "tsystem.h"
 
-using namespace std;
-
 #include <set>
 #include "tfilepath_io.h"
 #include "tconvert.h"
@@ -157,7 +155,7 @@ TFilePath TSystem::getTempDir() {
 
 //------------------------------------------------------------
 
-TFilePath TSystem::getTestDir(string name) {
+TFilePath TSystem::getTestDir(std::string name) {
   return TFilePath("C:") + TFilePath(name);
 }
 
@@ -423,13 +421,12 @@ void TSystem::hideFile(const TFilePath &fp) {
 
 //------------------------------------------------------------
 
-class CaselessFilepathLess final
-    : public std::binary_function<TFilePath, TFilePath, bool> {
+class CaselessFilepathLess final {
 public:
   bool operator()(const TFilePath &a, const TFilePath &b) const {
     // Perform case sensitive compare, fallback to case insensitive.
-    const wstring a_str = a.getWideString();
-    const wstring b_str = b.getWideString();
+    const std::wstring a_str = a.getWideString();
+    const std::wstring b_str = b.getWideString();
 
     unsigned int i   = 0;
     int case_compare = -1;
@@ -1046,8 +1043,8 @@ bool TSystem::showDocument(const TFilePath &path) {
   }
   return true;
 #else
-  string cmd = "open ";
-  string thePath(::to_string(path));
+  std::string cmd = "open ";
+  std::string thePath(::to_string(path));
   UINT pos = 0, count = 0;
   // string newPath;
   char newPath[2048];
@@ -1061,7 +1058,7 @@ bool TSystem::showDocument(const TFilePath &path) {
   }
   newPath[count] = 0;
 
-  cmd = cmd + string(newPath);
+  cmd = cmd + std::string(newPath);
   system(cmd.c_str());
   return true;
 #endif
@@ -1114,7 +1111,7 @@ TSystemException::TSystemException(const TFilePath &fname,
     : m_fname(fname), m_err(-1), m_msg(::to_wstring(msg)) {}
 //--------------------------------------------------------------
 
-TSystemException::TSystemException(const TFilePath &fname, const wstring &msg)
+TSystemException::TSystemException(const TFilePath &fname, const std::wstring &msg)
     : m_fname(fname), m_err(-1), m_msg(msg) {}
 
 //--------------------------------------------------------------
@@ -1123,5 +1120,5 @@ TSystemException::TSystemException(const std::string &msg)
     : m_fname(""), m_err(-1), m_msg(::to_wstring(msg)) {}
 //--------------------------------------------------------------
 
-TSystemException::TSystemException(const wstring &msg)
+TSystemException::TSystemException(const std::wstring &msg)
     : m_fname(""), m_err(-1), m_msg(msg) {}

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -85,11 +85,7 @@ QDateTime TFileStatus::getLastModificationTime() const {
 
 QDateTime TFileStatus::getCreationTime() const {
   if (!m_exist) return QDateTime();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
   return m_fileInfo.birthTime();
-#else
-  return m_fileInfo.created();
-#endif
 }
 
 //-----------------------------------------------------------------------------------
@@ -162,11 +158,7 @@ TFilePath TSystem::getTestDir(std::string name) {
 //------------------------------------------------------------
 
 QString TSystem::getSystemValue(const TFilePath &name) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList strlist = toQString(name).split("\\", Qt::SkipEmptyParts);
-#else
-  QStringList strlist = toQString(name).split("\\", QString::SkipEmptyParts);
-#endif
 
   assert(strlist.size() > 3);
   assert(strlist.at(0) == "SOFTWARE");

--- a/toonz/sources/common/tsystem/tsystempd.cpp
+++ b/toonz/sources/common/tsystem/tsystempd.cpp
@@ -611,9 +611,13 @@ void TSystem::moveFileToRecycleBin(const TFilePath &fp) {
 
   QTextStream stream(&infoFile);
 
-  stream << "[Trash Info]" << endl;
-  stream << "Path=" + QString(QUrl::toPercentEncoding(FileName.absoluteFilePath(), "~_-./")) << endl;     // convert path to percentage encoded string
-  stream << "DeletionDate=" + currentTime.toString("yyyy-MM-dd") + "T" + currentTime.toString("hh:mm:ss") << endl;      // get date and time in format YYYY-MM-DDThh:mm:ss
+  stream << "[Trash Info]" << Qt::endl;
+  stream << "Path=" + QString(QUrl::toPercentEncoding(
+                          FileName.absoluteFilePath(), "~_-./"))
+         << Qt::endl;  // convert path to percentage encoded string
+  stream << "DeletionDate=" + currentTime.toString("yyyy-MM-dd") + "T" +
+                currentTime.toString("hh:mm:ss")
+         << Qt::endl;  // get date and time in format YYYY-MM-DDThh:mm:ss
 
   infoFile.close();
 

--- a/toonz/sources/common/tvrender/qtofflinegl.cpp
+++ b/toonz/sources/common/tvrender/qtofflinegl.cpp
@@ -125,39 +125,8 @@ void QtOfflineGL::createContext(TDimension rasterSize,
 
 */
 
-  QGLFormat fmt;
-
-#if defined(_WIN32)
-  fmt.setAlphaBufferSize(8);
-  fmt.setAlpha(true);
-  fmt.setRgba(true);
-  fmt.setDepthBufferSize(32);
-  fmt.setDepth(true);
-  fmt.setStencilBufferSize(32);
-  fmt.setStencil(true);
-  fmt.setAccum(false);
-  fmt.setPlane(0);
-#elif defined(MACOSX)
-  fmt = QGLFormat::defaultFormat();
-  // printf("GL Version: %s\n",glGetString(GL_VERSION));
-  fmt.setVersion(2, 1); /* 3.2 might not work on OSX10.8 */
-#if 0
-  fmt.setAlphaBufferSize(8);
-  fmt.setAlpha(true);
-  fmt.setRgba(true);
-  fmt.setDepthBufferSize(32);
-  fmt.setDepth(true);
-  fmt.setStencilBufferSize(8);
-  fmt.setStencil(true);
-  fmt.setAccum(false);
-  fmt.setPlane(0);
-  fmt.setDirectRendering(false);
-#endif
-#elif defined(LINUX) || defined(FREEBSD)
-  fmt = QGLFormat::defaultFormat();
-  // printf("GL Version: %s\n",glGetString(GL_VERSION));
-  fmt.setVersion(2, 1); /* XXX? */
-#endif
+  QOpenGLFramebufferObjectFormat fmt;
+  fmt.setAttachment(QOpenGLFramebufferObject::Attachment::CombinedDepthStencil);
 
   QSurfaceFormat format;
   format.setProfile(QSurfaceFormat::CompatibilityProfile);
@@ -205,7 +174,7 @@ void QtOfflineGL::doneCurrent() {
 //-----------------------------------------------------------------------------
 
 void QtOfflineGL::saveCurrentContext() {
-  //  m_oldContext = const_cast<QGLContext*>(QGLContext::currentContext());
+  //  m_oldContext = const_cast<QOpenGLContext*>(QOpenGLContext::currentContext());
 }
 
 //-----------------------------------------------------------------------------
@@ -230,7 +199,7 @@ void QtOfflineGL::getRaster(TRaster32P raster) {
   raster->unlock();
 }
 
-// QGLPixelBuffer::hasOpenGLPbuffers() (statica) -> true se la scheda supporta i
+// QOpenGLFramebufferObject::hasOpenGLPbuffers() (statica) -> true se la scheda supporta i
 // PBuffer
 
 //=============================================================================
@@ -277,39 +246,8 @@ SPECIFICHE  MAC = depth_size 24, stencil_size 8, alpha_size 1
 
 */
 
-  QGLFormat fmt;
-
-#if defined(_WIN32)
-  fmt.setAlphaBufferSize(8);
-  fmt.setAlpha(false);
-  fmt.setRgba(true);
-  fmt.setDepthBufferSize(32);
-  fmt.setDepth(true);
-  fmt.setStencilBufferSize(32);
-  fmt.setStencil(true);
-  fmt.setAccum(false);
-  fmt.setPlane(0);
-#elif defined(MACOSX)
-  fmt.setAlphaBufferSize(1);
-  fmt.setAlpha(false);
-  fmt.setRgba(true);
-  fmt.setDepthBufferSize(24);
-  fmt.setDepth(true);
-  fmt.setStencilBufferSize(8);
-  fmt.setStencil(true);
-  fmt.setAccum(false);
-  fmt.setPlane(0);
-#elif defined(LINUX) || defined(FREEBSD)
-  fmt.setAlphaBufferSize(1);
-  fmt.setAlpha(false);
-  fmt.setRgba(true);
-  fmt.setDepthBufferSize(24);
-  fmt.setDepth(true);
-  fmt.setStencilBufferSize(8);
-  fmt.setStencil(true);
-  fmt.setAccum(false);
-  fmt.setPlane(0);
-#endif
+  QOpenGLFramebufferObjectFormat fmt;
+  fmt.setAttachment(QOpenGLFramebufferObject::Attachment::CombinedDepthStencil);
 
   // Il PixelBuffer deve essere con width ed height potenze di 2
 
@@ -320,21 +258,21 @@ SPECIFICHE  MAC = depth_size 24, stencil_size 8, alpha_size 1
   while (pBufferSize < sizeMax) pBufferSize *= 2;
 
   m_context =
-      std::make_shared<QGLPixelBuffer>(QSize(pBufferSize, pBufferSize), fmt);
+      std::make_shared<QOpenGLFramebufferObject>(QSize(pBufferSize, pBufferSize), fmt);
 }
 
 //-----------------------------------------------------------------------------
 
 void QtOfflineGLPBuffer::makeCurrent() {
   if (m_context) {
-    m_context->makeCurrent();
+    m_context->bind();
   }
 }
 
 //-----------------------------------------------------------------------------
 
 void QtOfflineGLPBuffer::doneCurrent() {
-  if (m_context) m_context->doneCurrent();
+  if (m_context) m_context->release();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/common/tvrender/tfont_qt.cpp
+++ b/toonz/sources/common/tvrender/tfont_qt.cpp
@@ -179,11 +179,7 @@ TPoint TFont::drawChar(QImage &outImage, TPoint &unused, wchar_t charcode,
   // (21/1/2022) Use this workaround for all platforms as the crash also
   // occurred in windows when the display is scaled up.
   if (chars[0].isSpace()) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     int w = QFontMetrics(m_pimpl->m_font).horizontalAdvance(chars[0]);
-#else
-    int w = raw.averageCharWidth();
-#endif
 
     outImage =
         QImage(w, raw.ascent() + raw.descent(), QImage::Format_Grayscale8);
@@ -285,11 +281,7 @@ TPoint TFont::drawChar(TRaster32P &outImage, TPoint &unused, TPixel32 color,
 
 TPoint TFont::getDistance(wchar_t firstChar, wchar_t secondChar) const {
   QFontMetrics metrics(m_pimpl->m_font);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   return TPoint(metrics.horizontalAdvance(QChar(firstChar)), 0);
-#else
-  return TPoint(metrics.width(QChar(firstChar)), 0);
-#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/common/tvrender/tofflinegl.cpp
+++ b/toonz/sources/common/tvrender/tofflinegl.cpp
@@ -879,8 +879,7 @@ int TOfflineGL::getLy() const { return m_imp->getLy(); }
 
 namespace {
 
-struct DimensionLess final
-    : public std::binary_function<TDimension, TDimension, bool> {
+struct DimensionLess final {
   bool operator()(const TDimension &d1, const TDimension &d2) const {
     return d1.lx < d2.lx || (d1.lx == d2.lx && d1.ly < d2.ly);
   }

--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -93,17 +93,9 @@ std::string fidsToString(const std::vector<TFrameId> &fids) {
 std::vector<TFrameId> strToFids(std::string fidsStr) {
   std::vector<TFrameId> ret;
   QString str = QString::fromStdString(fidsStr);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList chunks = str.split(',', Qt::SkipEmptyParts);
-#else
-  QStringList chunks = str.split(',', QString::SkipEmptyParts);
-#endif
   for (const auto &chunk : chunks) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QStringList nums = chunk.split('-', Qt::SkipEmptyParts);
-#else
-    QStringList nums = chunk.split('-', QString::SkipEmptyParts);
-#endif
     assert(nums.count() > 0 && nums.count() <= 2);
     if (nums.count() == 1)
       ret.push_back(TFrameId(nums[0].toInt()));

--- a/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
+++ b/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
@@ -385,7 +385,7 @@ public:
   };
   //----------------------------------------------
 
-  struct KeyLess final : public std::binary_function<Key, Key, bool> {
+  struct KeyLess final {
     bool operator()(const Key &d1, const Key &d2) const {
       return d1.m_glContext < d2.m_glContext ||
              (d1.m_glContext == d2.m_glContext &&

--- a/toonz/sources/image/sgi/filesgi.cpp
+++ b/toonz/sources/image/sgi/filesgi.cpp
@@ -200,7 +200,7 @@ static IMAGERGB *iopen(int fd, OpenMode openMode, unsigned int type,
                        unsigned int dim, unsigned int xsize, unsigned int ysize,
                        unsigned int zsize, short dorev) {
   IMAGERGB *image;
-  extern int errno;
+//  extern int errno;
   int tablesize, f = fd;
 
   image = (IMAGERGB *)malloc((int)sizeof(IMAGERGB));

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -5,7 +5,7 @@
 #include <math.h>
 
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QTextStream>
 #include <QFile>
 
@@ -2194,7 +2194,7 @@ TStroke *buildStroke(NSVGpath *path, float width, float scale) {
 //-----------------------------------------------------------------------------
 
 TImageP TImageReaderSvg::load() {
-  static int devPixRatio = QApplication::desktop()->devicePixelRatio();
+  static int devPixRatio = QApplication::primaryScreen()->devicePixelRatio();
 
   NSVGimage *svgImg =
       nsvgParseFromFile(m_path.getQString().toStdString().c_str());

--- a/toonz/sources/include/qtofflinegl.h
+++ b/toonz/sources/include/qtofflinegl.h
@@ -6,9 +6,8 @@
 #include <memory>
 
 #include <QtOpenGL>
-#include <QGLFormat>
-#include <QGLContext>
-#include <QGLPixelBuffer>
+#include <QOpenGLFramebufferObjectFormat>
+#include <QOpenGLContext>
 #include <QOpenGLFramebufferObject>
 
 #include "tofflinegl.h"
@@ -38,7 +37,7 @@ public:
 
 class QtOfflineGLPBuffer final : public TOfflineGL::Imp {
 public:
-  std::shared_ptr<QGLPixelBuffer> m_context;
+  std::shared_ptr<QOpenGLFramebufferObject> m_context;
 
   QtOfflineGLPBuffer(TDimension rasterSize);
   ~QtOfflineGLPBuffer();

--- a/toonz/sources/include/tools/screenpicker.h
+++ b/toonz/sources/include/tools/screenpicker.h
@@ -17,6 +17,8 @@ class ScreenPicker final : public QObject, public DVGui::ScreenBoard::Drawing {
 
   bool m_mousePressed, m_mouseGrabbed;
 
+  QWidget *m_pickWidget;
+
 public:
   ScreenPicker(QWidget *parent = 0);
 

--- a/toonz/sources/include/toonz/stage.h
+++ b/toonz/sources/include/toonz/stage.h
@@ -32,7 +32,7 @@ class TRasterImage;
 class TToonzImage;
 class QPainter;
 class QPolygon;
-class QMatrix;
+class QTransform;
 //=============================================================================
 
 //=============================================================================

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -44,7 +44,7 @@ class TToonzImage;
 class TMeshImage;
 class QPainter;
 class QPolygon;
-class QMatrix;
+class QTransform;
 
 namespace Stage {
 class Player;
@@ -287,7 +287,7 @@ public:
   int getNodesCount();
   void clearNodes();
 
-  TRasterP getRaster(int index, QMatrix &matrix);
+  TRasterP getRaster(int index, QTransform &matrix);
 
   void flushRasterImages();
   void drawRasterImages(QPainter &p, QPolygon cameraRect);

--- a/toonz/sources/include/toonz/tframehandle.h
+++ b/toonz/sources/include/toonz/tframehandle.h
@@ -4,7 +4,7 @@
 #define TFRAMEHANDLE_H
 
 #include <QObject>
-#include <QTime>
+#include <QElapsedTimer>
 #include "tfilepath.h"
 #include "toonz/txshsoundcolumn.h"
 
@@ -51,7 +51,7 @@ private:
   TXsheet *m_xsheet;
   std::pair<int, int> m_scrubRange;
   double m_fps;
-  QTime m_clock;
+  QElapsedTimer m_clock;
 
   // void startPlaying(bool looping);
   // void stopPlaying();

--- a/toonz/sources/include/toonzqt/dvdialog.h
+++ b/toonz/sources/include/toonzqt/dvdialog.h
@@ -169,7 +169,7 @@ class DVAPI Dialog : public QDialog {
   // If the dialog has button then is modal too.
   bool m_hasButton;
   QString m_name;
-  int m_currentScreen = -1;
+  QScreen *m_currentScreen;
   // gmt. rendo m_buttonLayout protected per ovviare ad un problema
   // sull'addButtonBarWidget(). cfr filebrowserpopup.cpp.
   // Dobbiamo discutere di Dialog.

--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -9,7 +9,7 @@
 #include <QList>
 #include <QTime>
 #include <QStyleOption>
-#include <QStyleOptionFrameV3>
+#include <QStyleOptionFrame>
 #include <QColor>
 #include <QImage>
 

--- a/toonz/sources/include/toonzqt/glwidget_for_highdpi.h
+++ b/toonz/sources/include/toonzqt/glwidget_for_highdpi.h
@@ -5,7 +5,7 @@
 
 #include <QOpenGLWidget>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QOpenGLFunctions>
 #include "toonzqt/gutil.h"
 

--- a/toonz/sources/include/toonzqt/pickrgbutils.h
+++ b/toonz/sources/include/toonzqt/pickrgbutils.h
@@ -63,9 +63,9 @@ inline QRgb pickRGB(QOpenGLWidget *widget, const QPoint &pos) {
 \warning In general, grabbing an area outside the screen is not safe.
          This depends on the underlying window system.
 */
-QRgb DVAPI pickScreenRGB(const QRect &rect);
-inline QRgb pickScreenRGB(const QPoint &pos) {
-  return pickScreenRGB(QRect(pos.x(), pos.y(), 1, 1));
+QRgb DVAPI pickScreenRGB(const QRect &rect, QWidget *widget);
+inline QRgb pickScreenRGB(const QPoint &pos, QWidget *widget) {
+  return pickScreenRGB(QRect(pos.x(), pos.y(), 1, 1), widget);
 }
 
 #endif  // PICK_RGB_UTILS_H

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -43,23 +43,19 @@ protected:
   void focusOutEvent(QFocusEvent *fe) override;
 
   void keyPressEvent(QKeyEvent *ke) override;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
-#endif
 
 signals:
   void focusOut();
 
 protected slots:
   void onContentsChanged();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   void onPopupHide();
   void onCut();
   void onCopy();
   void onPaste();
   void onDelete();
   void onSelectAll();
-#endif
 };
 
 //========================================================

--- a/toonz/sources/stdfx/iwa_floorbumpfx.cpp
+++ b/toonz/sources/stdfx/iwa_floorbumpfx.cpp
@@ -3,7 +3,7 @@
 #include "tparamuiconcept.h"
 #include "iwa_fresnel.h"
 
-#include <QMatrix>
+#include <QTransform>
 
 namespace {
 
@@ -508,7 +508,7 @@ inline void Iwa_FloorBumpFx::initVars(FloorBumpVars &vars, TTile &tile,
   // distance from the Eye (P) to the center of the projection plane (T)
   vars.d_PT = vars.H / (2.0 * tan(angle_halfFov));
 
-  QMatrix cam_tilt;
+  QTransform cam_tilt;
   cam_tilt.rotate(-vars.angle_el / M_PI_180);
   // Z-Y position of the center of top edge of the projection plane (A)
   vars.A =

--- a/toonz/sources/stdfx/iwa_timecodefx.cpp
+++ b/toonz/sources/stdfx/iwa_timecodefx.cpp
@@ -60,11 +60,7 @@ void Iwa_TimeCodeFx::doCompute(TTile &tile, double frame,
   font.setWeight(QFont::Normal);
   QFontMetrics fm(font);
   QString timeCodeStr = getTimeCodeStr(frame, ri);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int width = fm.horizontalAdvance(timeCodeStr);
-#else
-  int width           = fm.width(timeCodeStr);
-#endif
   int height          = fm.height();
 
   QImage img(width, height, QImage::Format_ARGB32);

--- a/toonz/sources/stdfx/shaderfx.cpp
+++ b/toonz/sources/stdfx/shaderfx.cpp
@@ -883,9 +883,9 @@ void ShaderFx::getInputData(const TRectD &rect, double frame,
 #else
     std::vector<const GLchar *> varyingNames(
         boost::make_transform_iterator(varyingStrings.begin(),
-                                       std::mem_fun_ref(&std::string::c_str)),
+                                       std::mem_fn(&std::string::c_str)),
         boost::make_transform_iterator(varyingStrings.end(),
-                                       std::mem_fun_ref(&std::string::c_str)));
+                                       std::mem_fn(&std::string::c_str)));
 #endif
     prog = touchShaderProgram(sd, context, int(varyingNames.size()),
                               &varyingNames[0]);

--- a/toonz/sources/stdfx/shaderfx.cpp
+++ b/toonz/sources/stdfx/shaderfx.cpp
@@ -236,7 +236,7 @@ class ShadingContextManager final : public QObject {
 public:
   ShadingContextManager() {
     /*
-The ShadingContext's QGLPixelBuffer must be destroyed *before* the global
+The ShadingContext's QOpenGLFramebufferObject must be destroyed *before* the global
 QApplication
 is. So, we will attach to a suitable parent object whose lifespan is shorter.
 

--- a/toonz/sources/stdfx/shadingcontext.cpp
+++ b/toonz/sources/stdfx/shadingcontext.cpp
@@ -131,9 +131,9 @@ ShadingContext::ShadingContext(QOffscreenSurface *surface) : m_imp(new Imp) {
 //--------------------------------------------------------
 
 ShadingContext::~ShadingContext() {
-  // Destructor of QGLPixelBuffer calls QOpenGLContext::makeCurrent()
+  // Destructor of QOpenGLFramebufferObject calls QOpenGLContext::makeCurrent()
   // internally,
-  // so the current thread must be the owner of QGLPixelBuffer context,
+  // so the current thread must be the owner of QOpenGLFramebufferObject context,
   // when the destructor of m_imp->m_context is called.
   m_imp->m_context->moveToThread(QThread::currentThread());
 }
@@ -141,7 +141,7 @@ ShadingContext::~ShadingContext() {
 //--------------------------------------------------------
 
 ShadingContext::Support ShadingContext::support() {
-  // return !QGLPixelBuffer::hasOpenGLPbuffers()
+  // return !QOpenGLFramebufferObject::hasOpenGLPbuffers()
   //           ? NO_PIXEL_BUFFER
   //           : !QOpenGLShaderProgram::hasOpenGLShaderPrograms() ? NO_SHADERS :
   //           OK;

--- a/toonz/sources/stopmotion/gphotocam.cpp
+++ b/toonz/sources/stopmotion/gphotocam.cpp
@@ -303,7 +303,10 @@ void GPhotoCam::onTimeout() {
         m_cameraName.contains("1000D") || m_cameraName.contains("40D")) {
       // Nikon: Turn off autofocus from a libgphoto2 point of view.
       // Does not work for Canon but may work for others.
-      retVal = gp_setting_set("ptp2", "autofocus", "off");
+      char id[5] = "ptp2";
+      char key[10] = "autofocus";
+      char value[4] = "off";
+      retVal = gp_setting_set(id, key, value);
       retVal = gp_camera_trigger_capture(m_camera, m_gpContext);
     } else {
       retVal = setCameraConfigValue("eosremoterelease", "Immediate");

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -33,7 +33,7 @@
 #include <QCamera>
 #include <QCameraInfo>
 #include <QCoreApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QDialog>
 #include <QFile>
 #include <QString>

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -1779,7 +1779,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
                        SLOT(refreshCameraListCalled()));
   ret = ret && connect(m_cameraListCombo, SIGNAL(activated(int)), this,
                        SLOT(onCameraListComboActivated(int)));
-  ret = ret && connect(m_resolutionCombo, SIGNAL(activated(const QString &)),
+  ret = ret && connect(m_resolutionCombo, SIGNAL(textActivated(const QString &)),
                        this, SLOT(onResolutionComboActivated(const QString &)));
   if (m_captureFilterSettingsBtn)
     ret = ret && connect(m_captureFilterSettingsBtn, SIGNAL(clicked()), this,

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -47,7 +47,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QCommonStyle>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -347,11 +347,11 @@ StopMotionSaveInFolderPopup::StopMotionSaveInFolderPopup(QWidget *parent)
   addButtonBarWidget(okBtn, cancelBtn);
 
   //---- layout
-  m_topLayout->setMargin(10);
+  m_topLayout->setContentsMargins(10, 10, 10, 10);
   m_topLayout->setSpacing(10);
   {
     QGridLayout *saveInLay = new QGridLayout();
-    saveInLay->setMargin(0);
+    saveInLay->setContentsMargins(0, 0, 0, 0);
     saveInLay->setHorizontalSpacing(3);
     saveInLay->setVerticalSpacing(0);
     {
@@ -367,11 +367,11 @@ StopMotionSaveInFolderPopup::StopMotionSaveInFolderPopup(QWidget *parent)
     m_topLayout->addWidget(m_subFolderCB, 0, Qt::AlignLeft);
 
     QVBoxLayout *subFolderLay = new QVBoxLayout();
-    subFolderLay->setMargin(0);
+    subFolderLay->setContentsMargins(0, 0, 0, 0);
     subFolderLay->setSpacing(10);
     {
       QGridLayout *infoLay = new QGridLayout();
-      infoLay->setMargin(10);
+      infoLay->setContentsMargins(10, 10, 10, 10);
       infoLay->setHorizontalSpacing(3);
       infoLay->setVerticalSpacing(10);
       {
@@ -393,7 +393,7 @@ StopMotionSaveInFolderPopup::StopMotionSaveInFolderPopup(QWidget *parent)
       subFolderLay->addWidget(infoGroupBox, 0);
 
       QGridLayout *subNameLay = new QGridLayout();
-      subNameLay->setMargin(10);
+      subNameLay->setContentsMargins(10, 10, 10, 10);
       subNameLay->setHorizontalSpacing(3);
       subNameLay->setVerticalSpacing(10);
       {
@@ -841,7 +841,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
   m_saveInFolderPopup = new StopMotionSaveInFolderPopup(this);
   m_cameraListCombo   = new QComboBox(this);
   m_resolutionCombo   = new QComboBox(this);
-  m_resolutionCombo->setFixedWidth(fontMetrics().width("0000 x 0000") + 40);
+  m_resolutionCombo->setFixedWidth(fontMetrics().horizontalAdvance("0000 x 0000") + 40);
   m_resolutionLabel                 = new QLabel(tr("Resolution: "), this);
   m_cameraStatusLabel               = new QLabel(tr("Camera Status"), this);
   QPushButton *refreshCamListButton = new QPushButton(tr("Refresh"), this);
@@ -988,12 +988,12 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
 
   QVBoxLayout *controlLayout = new QVBoxLayout();
   controlLayout->setSpacing(0);
-  controlLayout->setMargin(5);
+  controlLayout->setContentsMargins(5, 5, 5, 5);
 
   {
     {
       QGridLayout *camLay = new QGridLayout();
-      camLay->setMargin(0);
+      camLay->setContentsMargins(0, 0, 0, 0);
       camLay->setSpacing(3);
       {
         camLay->addWidget(new QLabel(tr("Camera:"), this), 0, 0,
@@ -1015,18 +1015,18 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
       controlLayout->addLayout(camLay, 0);
 
       QVBoxLayout *fileLay = new QVBoxLayout();
-      fileLay->setMargin(8);
+      fileLay->setContentsMargins(8, 8, 8, 8);
       fileLay->setSpacing(5);
       {
         QGridLayout *levelLay = new QGridLayout();
-        levelLay->setMargin(0);
+        levelLay->setContentsMargins(0, 0, 0, 0);
         levelLay->setHorizontalSpacing(3);
         levelLay->setVerticalSpacing(5);
         {
           levelLay->addWidget(new QLabel(tr("Name:"), this), 0, 0,
                               Qt::AlignRight);
           QHBoxLayout *nameLay = new QHBoxLayout();
-          nameLay->setMargin(0);
+          nameLay->setContentsMargins(0, 0, 0, 0);
           nameLay->setSpacing(2);
           {
             nameLay->addWidget(m_previousLevelButton, 0);
@@ -1040,7 +1040,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
                               Qt::AlignRight);
 
           QHBoxLayout *frameLay = new QHBoxLayout();
-          frameLay->setMargin(0);
+          frameLay->setContentsMargins(0, 0, 0, 0);
           frameLay->setSpacing(2);
           {
             frameLay->addWidget(m_previousFrameButton, 0);
@@ -1056,7 +1056,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
         fileLay->addLayout(levelLay, 0);
 
         QHBoxLayout *fileTypeLay = new QHBoxLayout();
-        fileTypeLay->setMargin(0);
+        fileTypeLay->setContentsMargins(0, 0, 0, 0);
         fileTypeLay->setSpacing(3);
         {
           // fileTypeLay->addWidget(new QLabel(tr("File Type:"), this), 0);
@@ -1069,7 +1069,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
         fileLay->addLayout(fileTypeLay, 0);
 
         QHBoxLayout *saveInLay = new QHBoxLayout();
-        saveInLay->setMargin(0);
+        saveInLay->setContentsMargins(0, 0, 0, 0);
         saveInLay->setSpacing(3);
         {
           // saveInLay->addWidget(new QLabel(tr("Save In:"), this), 0);
@@ -1083,7 +1083,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
       controlLayout->addWidget(fileFrame, 0);
 
       QGridLayout *displayLay = new QGridLayout();
-      displayLay->setMargin(8);
+      displayLay->setContentsMargins(8, 8, 8, 8);
       displayLay->setHorizontalSpacing(3);
       displayLay->setVerticalSpacing(5);
       {
@@ -1093,7 +1093,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
         displayLay->addWidget(new QLabel(tr("Scene Frame:"), this), 1, 0,
                               Qt::AlignRight);
         QHBoxLayout *xsheetLay = new QHBoxLayout();
-        xsheetLay->setMargin(0);
+        xsheetLay->setContentsMargins(0, 0, 0, 0);
         xsheetLay->setSpacing(2);
         {
           xsheetLay->addWidget(m_previousXSheetFrameButton, Qt::AlignLeft);
@@ -1153,7 +1153,8 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     m_pictureStyleCombo   = new QComboBox(this);
     m_cameraSettingsLabel = new QLabel(tr("Camera Model"), this);
     m_cameraModeLabel     = new QLabel(tr("Camera Mode"), this);
-    m_exposureCombo->setFixedWidth(fontMetrics().width("000000") + 25);
+    m_exposureCombo->setFixedWidth(fontMetrics().horizontalAdvance("000000") +
+                                   25);
     m_liveViewCompensationLabel  = new QLabel(tr("Live View Offset: 0"), this);
     m_liveViewCompensationSlider = new QSlider(Qt::Horizontal, this);
     m_liveViewCompensationSlider->setRange(-15, 12);
@@ -1161,11 +1162,11 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     m_liveViewCompensationSlider->setFixedWidth(260);
     QVBoxLayout *settingsLayout = new QVBoxLayout;
     settingsLayout->setSpacing(0);
-    settingsLayout->setMargin(5);
+    settingsLayout->setContentsMargins(5, 5, 5, 5);
 
     QGridLayout *settingsGridLayout = new QGridLayout;
     {
-      settingsGridLayout->setMargin(0);
+      settingsGridLayout->setContentsMargins(0, 0, 0, 0);
       settingsGridLayout->setSpacing(3);
       settingsGridLayout->addWidget(m_cameraSettingsLabel, 0, 0, 1, 2,
                                     Qt::AlignCenter);
@@ -1224,12 +1225,12 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     settingsLayout->addLayout(settingsGridLayout, 0);
 
     QVBoxLayout *focusTestLayout = new QVBoxLayout;
-    focusTestLayout->setMargin(3);
+    focusTestLayout->setContentsMargins(3, 3, 3, 3);
     focusTestLayout->setSpacing(0);
     {
       focusTestLayout->addSpacing(2);
       m_focusAndZoomLayout = new QHBoxLayout;
-      m_focusAndZoomLayout->setMargin(0);
+      m_focusAndZoomLayout->setContentsMargins(0, 0, 0, 0);
       m_focusAndZoomLayout->setSpacing(0);
       {
         m_focusAndZoomLayout->addWidget(m_manualFocusSlider, Qt::AlignCenter);
@@ -1261,7 +1262,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
 
     QVBoxLayout *webcamSettingsLayout = new QVBoxLayout;
     webcamSettingsLayout->setSpacing(0);
-    webcamSettingsLayout->setMargin(5);
+    webcamSettingsLayout->setContentsMargins(5, 5, 5, 5);
     QHBoxLayout *webcamLabelLayout = new QHBoxLayout();
     QGroupBox *imageFrame          = new QGroupBox(tr("Image adjust"), this);
     m_webcamLabel        = new QLabel("insert webcam name here", this);
@@ -1296,7 +1297,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     webcamSettingsLayout->addSpacing(5);
 
     QGridLayout *webcamGridLay = new QGridLayout();
-    webcamGridLay->setMargin(0);
+    webcamGridLay->setContentsMargins(0, 0, 0, 0);
     webcamGridLay->setSpacing(3);
     webcamGridLay->setColumnStretch(0, 0);
     webcamGridLay->setColumnStretch(1, 1);
@@ -1368,7 +1369,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     }
 
     QGridLayout *imageLay = new QGridLayout();
-    imageLay->setMargin(8);
+    imageLay->setContentsMargins(8, 8, 8, 8);;
     imageLay->setHorizontalSpacing(3);
     imageLay->setVerticalSpacing(5);
     {
@@ -1420,7 +1421,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
 
     // Calibration
     QGridLayout *calibLay = new QGridLayout();
-    calibLay->setMargin(8);
+    calibLay->setContentsMargins(8, 8, 8, 8);;
     calibLay->setHorizontalSpacing(3);
     calibLay->setVerticalSpacing(5);
     {
@@ -1428,7 +1429,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
       calibLay->addWidget(m_calibrationUI.loadBtn, 0, 1);
       calibLay->addWidget(m_calibrationUI.exportBtn, 0, 2);
       QHBoxLayout *lay = new QHBoxLayout();
-      lay->setMargin(0);
+      lay->setContentsMargins(0, 0, 0, 0);
       lay->setSpacing(5);
       lay->addWidget(m_calibrationUI.capBtn, 1);
       lay->addWidget(m_calibrationUI.label, 0);
@@ -1440,7 +1441,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
 
     QVBoxLayout *commonSettingsLayout = new QVBoxLayout;
     commonSettingsLayout->setSpacing(0);
-    commonSettingsLayout->setMargin(5);
+    commonSettingsLayout->setContentsMargins(5, 5, 5, 5);
     commonSettingsLayout->addWidget(m_calibrationUI.groupBox);
     commonSettingsLayout->addStretch();
     m_commonFrame = new QFrame();
@@ -1502,7 +1503,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     QVBoxLayout *optionsOutsideLayout = new QVBoxLayout;
     QGridLayout *optionsLayout        = new QGridLayout;
     optionsLayout->setSpacing(3);
-    optionsLayout->setMargin(5);
+    optionsLayout->setContentsMargins(5, 5, 5, 5);
     QGridLayout *webcamLayout   = new QGridLayout;
     QGridLayout *dslrLayout     = new QGridLayout;
     QGridLayout *checkboxLayout = new QGridLayout;
@@ -1522,7 +1523,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     webcamBox->hide();
 
     QGridLayout *timerLay = new QGridLayout();
-    timerLay->setMargin(8);
+    timerLay->setContentsMargins(8, 8, 8, 8);;
     timerLay->setHorizontalSpacing(3);
     timerLay->setVerticalSpacing(5);
     {
@@ -1655,10 +1656,10 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     m_motionPage->setLayout(motionOutsideLayout);
 
     m_testsOutsideLayout = new QVBoxLayout;
-    m_testsOutsideLayout->setMargin(0);
+    m_testsOutsideLayout->setContentsMargins(0, 0, 0, 0);
     m_testsOutsideLayout->setSpacing(0);
     m_testsInsideLayout = new QVBoxLayout;
-    m_testsInsideLayout->setMargin(0);
+    m_testsInsideLayout->setContentsMargins(0, 0, 0, 0);
     m_testsInsideLayout->setSpacing(5);
     QVBoxLayout *testsButtonLayout = new QVBoxLayout;
     testsButtonLayout->setContentsMargins(0, 5, 0, 5);
@@ -1688,7 +1689,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     m_testsPage->setStyleSheet("padding:0; margin:0;");
 
     QVBoxLayout *pathsLayout = new QVBoxLayout(this);
-    pathsLayout->setMargin(0);
+    pathsLayout->setContentsMargins(0, 0, 0, 0);
     pathsLayout->setSpacing(0);
     pathsLayout->addWidget(new MotionPathPanel(this));
     m_pathsPage->setLayout(pathsLayout);
@@ -1737,11 +1738,11 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     controlButtonFrame->setLayout(controlButtonLay);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
-    mainLayout->setMargin(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(0);
     {
       QHBoxLayout *hLayout = new QHBoxLayout;
-      hLayout->setMargin(0);
+      hLayout->setContentsMargins(0, 0, 0, 0);
       {
         hLayout->addSpacing(4);
         hLayout->addWidget(m_tabBar);
@@ -2628,7 +2629,8 @@ void StopMotionController::refreshCameraList(QString activeCamera) {
       std::string name = webcams.at(c).deviceName().toStdString();
       QString camDesc  = webcams.at(c).description();
       m_cameraListCombo->addItem(camDesc, QVariant::fromValue(c));
-      maxTextLength = std::max(maxTextLength, fontMetrics().width(camDesc));
+      maxTextLength =
+          std::max(maxTextLength, fontMetrics().horizontalAdvance(camDesc));
     }
 #ifdef WITH_CANON
     for (int c = 0; c < m_stopMotion->m_canon->getCameraCount(); c++) {
@@ -2639,14 +2641,16 @@ void StopMotionController::refreshCameraList(QString activeCamera) {
       name = QString::fromStdString(m_stopMotion->m_canon->getCameraName());
       if (!open) m_stopMotion->m_canon->closeCameraSession();
       m_cameraListCombo->addItem(name, QVariant::fromValue(c));
-      maxTextLength = std::max(maxTextLength, fontMetrics().width(name));
+      maxTextLength =
+          std::max(maxTextLength, fontMetrics().horizontalAdvance(name));
     }
 #endif
 #ifdef WITH_GPHOTO2
     for (int c = 0; c < m_stopMotion->m_gphotocam->getCameraCount(); c++) {
       QString name = m_stopMotion->m_gphotocam->getCameraName(c);
       m_cameraListCombo->addItem(name, QVariant::fromValue(c));
-      maxTextLength = std::max(maxTextLength, fontMetrics().width(name));
+      maxTextLength =
+          std::max(maxTextLength, fontMetrics().horizontalAdvance(name));
     }
 #endif
 
@@ -2914,14 +2918,15 @@ void StopMotionController::refreshExposureList() {
 
   int maxTextLength = 0;
   for (int i = 0; i < exposureOptions.size(); i++) {
-    maxTextLength =
-        std::max(maxTextLength, fontMetrics().width(exposureOptions.at(i)));
+    maxTextLength = std::max(
+        maxTextLength, fontMetrics().horizontalAdvance(exposureOptions.at(i)));
   }
 
   if (m_exposureCombo->count() == 0) {
     m_exposureCombo->addItem(tr("Disabled"));
     m_exposureCombo->setDisabled(true);
-    m_exposureCombo->setMaximumWidth(fontMetrics().width("Disabled") + 25);
+    m_exposureCombo->setMaximumWidth(
+        fontMetrics().horizontalAdvance("Disabled") + 25);
   } else {
     m_exposureCombo->setEnabled(true);
     m_exposureCombo->setCurrentText(currentExposure);
@@ -2962,13 +2967,15 @@ void StopMotionController::refreshWhiteBalanceList() {
   int maxTextLength = 0;
   for (int i = 0; i < whiteBalanceOptions.size(); i++) {
     maxTextLength =
-        std::max(maxTextLength, fontMetrics().width(whiteBalanceOptions.at(i)));
+        std::max(maxTextLength,
+                 fontMetrics().horizontalAdvance(whiteBalanceOptions.at(i)));
   }
 
   if (m_whiteBalanceCombo->count() == 0) {
     m_whiteBalanceCombo->addItem(tr("Disabled"));
     m_whiteBalanceCombo->setDisabled(true);
-    m_whiteBalanceCombo->setMaximumWidth(fontMetrics().width("Disabled") + 25);
+    m_whiteBalanceCombo->setMaximumWidth(
+        fontMetrics().horizontalAdvance("Disabled") + 25);
   } else {
     m_whiteBalanceCombo->setEnabled(true);
     m_whiteBalanceCombo->setCurrentText(currentWhiteBalance);
@@ -3103,13 +3110,15 @@ void StopMotionController::refreshImageQualityList() {
   int maxTextLength = 0;
   for (int i = 0; i < imageQualityOptions.size(); i++) {
     maxTextLength =
-        std::max(maxTextLength, fontMetrics().width(imageQualityOptions.at(i)));
+        std::max(maxTextLength,
+                 fontMetrics().horizontalAdvance(imageQualityOptions.at(i)));
   }
 
   if (m_imageQualityCombo->count() == 0) {
     m_imageQualityCombo->addItem(tr("Disabled"));
     m_imageQualityCombo->setDisabled(true);
-    m_imageQualityCombo->setMaximumWidth(fontMetrics().width("Disabled") + 25);
+    m_imageQualityCombo->setMaximumWidth(
+        fontMetrics().horizontalAdvance("Disabled") + 25);
   } else {
     m_imageQualityCombo->setEnabled(true);
     m_imageQualityCombo->setCurrentText(currentImageQuality);
@@ -3149,14 +3158,15 @@ void StopMotionController::refreshImageSizeList() {
   m_imageSizeCombo->addItems(imageSizeOptions);
   int maxTextLength = 0;
   for (int i = 0; i < imageSizeOptions.size(); i++) {
-    maxTextLength =
-        std::max(maxTextLength, fontMetrics().width(imageSizeOptions.at(i)));
+    maxTextLength = std::max(
+        maxTextLength, fontMetrics().horizontalAdvance(imageSizeOptions.at(i)));
   }
 
   if (m_imageSizeCombo->count() == 0) {
     m_imageSizeCombo->addItem(tr("Disabled"));
     m_imageSizeCombo->setDisabled(true);
-    m_imageSizeCombo->setMaximumWidth(fontMetrics().width("Disabled") + 25);
+    m_imageSizeCombo->setMaximumWidth(
+        fontMetrics().horizontalAdvance("Disabled") + 25);
   } else {
     m_imageSizeCombo->setEnabled(true);
     m_imageSizeCombo->setCurrentText(currentImageSize);
@@ -3197,13 +3207,15 @@ void StopMotionController::refreshPictureStyleList() {
   int maxTextLength = 0;
   for (int i = 0; i < pictureStyleOptions.size(); i++) {
     maxTextLength =
-        std::max(maxTextLength, fontMetrics().width(pictureStyleOptions.at(i)));
+        std::max(maxTextLength,
+                 fontMetrics().horizontalAdvance(pictureStyleOptions.at(i)));
   }
 
   if (m_pictureStyleCombo->count() == 0) {
     m_pictureStyleCombo->addItem(tr("Disabled"));
     m_pictureStyleCombo->setDisabled(true);
-    m_pictureStyleCombo->setMaximumWidth(fontMetrics().width("Disabled") + 25);
+    m_pictureStyleCombo->setMaximumWidth(
+        fontMetrics().horizontalAdvance("Disabled") + 25);
   } else {
     m_pictureStyleCombo->setEnabled(true);
     m_pictureStyleCombo->setCurrentText(currentPictureStyle);

--- a/toonz/sources/stopmotion/stopmotionlight.cpp
+++ b/toonz/sources/stopmotion/stopmotionlight.cpp
@@ -5,7 +5,7 @@
 
 #include <QDialog>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QWindow>
 #include <QPainter>
 #include <QLabel>
@@ -24,7 +24,7 @@ TEnv::IntVar StopMotionBlackCapture("StopMotionBlackCapture", 0);
 
 StopMotionLight::StopMotionLight() {
   m_blackCapture = StopMotionBlackCapture;
-  m_screenCount  = QApplication::desktop()->screenCount();
+  m_screenCount  = QApplication::screens().size();
 
   for (int i = 0; i < m_screenCount; i++) {
     QScreen* screen      = QGuiApplication::screens().at(i);
@@ -45,7 +45,7 @@ StopMotionLight::StopMotionLight() {
   m_label1  = new QLabel();
   m_layout1 = new QHBoxLayout();
   m_layout1->addWidget(m_label1);
-  m_layout1->setMargin(0);
+  m_layout1->setContentsMargins(0, 0, 0, 0);
   m_layout1->setSpacing(0);
   m_fullScreen1->setLayout(m_layout1);
 
@@ -56,7 +56,7 @@ StopMotionLight::StopMotionLight() {
     m_label2  = new QLabel();
     m_layout2 = new QHBoxLayout();
     m_layout2->addWidget(m_label2);
-    m_layout2->setMargin(0);
+    m_layout2->setContentsMargins(0, 0, 0, 0);
     m_layout2->setSpacing(0);
     m_fullScreen2->setLayout(m_layout2);
 
@@ -67,7 +67,7 @@ StopMotionLight::StopMotionLight() {
       m_label3  = new QLabel();
       m_layout3 = new QHBoxLayout();
       m_layout3->addWidget(m_label3);
-      m_layout3->setMargin(0);
+      m_layout3->setContentsMargins(0, 0, 0, 0);
       m_layout3->setSpacing(0);
       m_fullScreen3->setLayout(m_layout3);
     }
@@ -188,7 +188,7 @@ void StopMotionLight::showOverlays() {
       m_label1->clear();
     }
     m_fullScreen1->showFullScreen();
-    m_fullScreen1->setGeometry(QApplication::desktop()->screenGeometry(0));
+    m_fullScreen1->setGeometry(QApplication::screens()[0]->geometry());
     m_shown = true;
   }
   if (m_screenCount > 1 && (getBlackCapture() || m_useScreen2Overlay) &&
@@ -199,7 +199,7 @@ void StopMotionLight::showOverlays() {
       m_label2->clear();
     }
     m_fullScreen2->showFullScreen();
-    m_fullScreen2->setGeometry(QApplication::desktop()->screenGeometry(1));
+    m_fullScreen2->setGeometry(QApplication::screens()[1]->geometry());
     m_shown = true;
   }
   if (m_screenCount > 2 && (getBlackCapture() || m_useScreen3Overlay) &&
@@ -210,7 +210,7 @@ void StopMotionLight::showOverlays() {
       m_label3->clear();
     }
     m_fullScreen3->showFullScreen();
-    m_fullScreen3->setGeometry(QApplication::desktop()->screenGeometry(2));
+    m_fullScreen3->setGeometry(QApplication::screens()[2]->geometry());
     m_shown = true;
   }
 

--- a/toonz/sources/tnzext/NotSymmetricBezierPotential.cpp
+++ b/toonz/sources/tnzext/NotSymmetricBezierPotential.cpp
@@ -13,11 +13,10 @@ using namespace ToonzExt;
 //-----------------------------------------------------------------------------
 
 namespace {
-typedef unary_function<double, double> unary_functionDD;
 
 //---------------------------------------------------------------------------
 
-class myBlendFunc : unary_functionDD {
+struct myBlendFunc final {
   // TCubic  c;
   TQuadratic curve;
 
@@ -28,9 +27,9 @@ public:
     curve.setP2(TPointD(1.0, 0.0));
   }
 
-  result_type operator()(argument_type x) {
-    result_type out = 0.0;
-    x               = fabs(x);
+  double operator()(double x) {
+    double out = 0.0;
+    x          = fabs(x);
     if (x >= 1.0) return 0.0;
     out = curve.getPoint(x).y;
     return out;

--- a/toonz/sources/tnzext/NotSymmetricExpPotential.cpp
+++ b/toonz/sources/tnzext/NotSymmetricExpPotential.cpp
@@ -10,20 +10,18 @@ using namespace std;
 //-----------------------------------------------------------------------------
 
 namespace {
-typedef unary_function<double, double> unary_functionDD;
-
 //---------------------------------------------------------------------------
 
-class mySqr : unary_functionDD {
+struct mySqr final {
 public:
-  result_type operator()(argument_type x) { return 1.0 - sq(x); }
+  double operator()(double x) { return 1.0 - sq(x); }
 };
 
 //---------------------------------------------------------------------------
 
-class myExp : unary_functionDD {
+struct myExp final {
 public:
-  result_type operator()(argument_type x) { return exp(-sq(x)); }
+  double operator()(double x) { return exp(-sq(x)); }
 };
 
 //---------------------------------------------------------------------------

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -481,7 +481,7 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
       }
     }
 
-    TVectorImageP vi = getImage(false);
+    TVectorImageP vi = TImageP(getImage(false));
     if (!vi) return;
     double dist2, t = 0;
     UINT index = -1;
@@ -512,7 +512,7 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
       m_selection.selectNone();
     return;
   }
-  TVectorImageP vi = getImage(true);
+  TVectorImageP vi = TImageP(getImage(true));
   if (!vi) return;
 
   if (pointType == ControlPointEditorStroke::SPEED_IN ||
@@ -613,7 +613,7 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
 
 void ControlPointEditorTool::rightButtonDown(const TPointD &pos,
                                              const TMouseEvent &) {
-  TVectorImageP vi = getImage(true);
+  TVectorImageP vi = TImageP(getImage(true));
   if (!vi) return;
   double maxDist  = 5 * getPixelSize();
   double maxDist2 = maxDist * maxDist;
@@ -641,7 +641,7 @@ void ControlPointEditorTool::leftButtonDoubleClick(const TPointD &pos,
   ControlPointEditorStroke::PointType pointType =
       m_controlPointEditorStroke.getPointTypeAt(pos, maxDist2, pointIndex);
 
-  TVectorImageP vi = getImage(true);
+  TVectorImageP vi = TImageP(getImage(true));
   if (!vi) return;
 
   if (pointType != ControlPointEditorStroke::SEGMENT) return;

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -32,7 +32,7 @@
 
 #include <QDebug>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 
 //=============================================================================
 // Scale Constraints

--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -24,7 +24,7 @@
 #include "toonz/tcamera.h"
 
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QVector2D>
 
 using namespace EditToolGadgets;

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2823,7 +2823,7 @@ bool FillTool::onPropertyChanged(std::string propertyName) {
             propertyName == m_maxGapDistance.getName() + "withUndo")) {
     TXshLevel *xl = TTool::getApplication()->getCurrentLevel()->getLevel();
     m_level       = xl ? xl->getSimpleLevel() : 0;
-    if (TVectorImageP vi = getImage(true)) {
+    if (TVectorImageP vi = TImageP(getImage(true))) {
       if (m_changedGapOriginalValue == -1.0) {
         ImageUtils::getFillingInformationInArea(vi, m_oldFillInformation,
                                                 vi->getBBox());
@@ -2896,7 +2896,7 @@ void FillTool::onImageChanged() {
     m_rectFill->onImageChanged();
     return;
   }
-  if (TVectorImageP vi = getImage(true)) {
+  if (TVectorImageP vi = TImageP(getImage(true))) {
     m_frameSwitched = true;
     if (m_maxGapDistance.getValue() != vi->getAutocloseTolerance()) {
       m_maxGapDistance.setValue(vi->getAutocloseTolerance());
@@ -2911,7 +2911,7 @@ void FillTool::onImageChanged() {
 
 void FillTool::onFrameSwitched() {
   m_frameSwitched = true;
-  if (TVectorImageP vi = getImage(true)) {
+  if (TVectorImageP vi = TImageP(getImage(true))) {
     if (m_maxGapDistance.getValue() != vi->getAutocloseTolerance()) {
       m_maxGapDistance.setValue(vi->getAutocloseTolerance());
       getApplication()->getCurrentTool()->notifyToolChanged();

--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -417,7 +417,7 @@ PlasticToolOptionsBox::PlasticToolOptionsBox(QWidget *parent, TTool *tool,
         new GenericToolOptionsBox(0, tool, pltHandle, m, 0, false);
 
   meshifyButton->setFixedHeight(20);
-  int buttonWidth = fontMetrics().width(meshifyButton->text()) + 20;
+  int buttonWidth = fontMetrics().horizontalAdvance(meshifyButton->text()) + 20;
   meshifyButton->setFixedWidth(buttonWidth);
   QAction *meshifyAction =
       CommandManager::instance()->getAction("A_ToolOption_Meshify");

--- a/toonz/sources/tnztools/plastictool_meshedit.cpp
+++ b/toonz/sources/tnztools/plastictool_meshedit.cpp
@@ -870,7 +870,7 @@ public:
   int getSize() const override { return 1 << 20; }
 
   bool do_() const {
-    TMeshImageP mi = TTool::getImage(true);
+    TMeshImageP mi = TImageP(TTool::getImage(true));
 
     if (::cutMesh(*mi, m_edgesSelection)) {
       PlasticDeformerStorage::instance()->releaseMeshData(mi.getPointer());
@@ -897,7 +897,7 @@ public:
   void undo() const override {
     PlasticTool::TemporaryActivation tempActivate(m_row, m_col);
 
-    TMeshImageP mi = TTool::getImage(true);
+    TMeshImageP mi = TImageP(TTool::getImage(true));
 
     // Restore the original image
     *mi = *m_origImage;
@@ -919,7 +919,7 @@ public:
 //****************************************************************************************
 
 void PlasticTool::storeMeshImage() {
-  TMeshImageP mi = getImage(false);
+  TMeshImageP mi = TImageP(getImage(false));
 
   if (mi != m_mi) {
     m_mi = mi;
@@ -1152,7 +1152,7 @@ void PlasticTool::moveVertex_mesh(const std::vector<TPointD> &origVxsPos,
   assert(origVxsPos.size() == m_mvSel.objects().size());
 
   // Move selected vertices
-  TMeshImageP mi = getImage(true);
+  TMeshImageP mi = TImageP(getImage(true));
   assert(m_mi == mi);
 
   int v, vCount = int(m_mvSel.objects().size());

--- a/toonz/sources/tnztools/plastictool_rigidity.cpp
+++ b/toonz/sources/tnztools/plastictool_rigidity.cpp
@@ -140,7 +140,7 @@ void RigidityPainter::paint(const TPointD &pos) {
       dynamic_cast<TXshSimpleLevel *>(cell.m_level.getPointer());
   if (!sl) return;
 
-  TMeshImageP meshImg = TTool::getImage(true);
+  TMeshImageP meshImg = TImageP(TTool::getImage(true));
   if (!meshImg) return;
 
   // Soil the level - schedules it for save

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -2210,7 +2210,7 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
 //----------------------------------------------------------------------
 
 void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
-#if (!defined(LINUX) && !defined(FREEBSD)) || QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+#if (!defined(LINUX) && !defined(FREEBSD))
   qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 #endif
 

--- a/toonz/sources/tnztools/screenpicker.cpp
+++ b/toonz/sources/tnztools/screenpicker.cpp
@@ -94,6 +94,8 @@ void ScreenPicker::mouseReleaseEvent(QWidget *widget, QMouseEvent *me) {
   QPoint pos(widget->mapToGlobal(me->pos()));
   m_geometry = QRect(QRect(m_start, QSize(1, 1)) | QRect(pos, QSize(1, 1)));
 
+  m_pickWidget = widget;
+
   // TimerEvents execution is delayed until all other events have been
   // processed.
   // In particular, we want to pick after the screen refreshes
@@ -108,7 +110,7 @@ void ScreenPicker::pick() {
   // Process them before picking.
   QCoreApplication::processEvents();
 
-  QColor color(pickScreenRGB(m_geometry));
+  QColor color(pickScreenRGB(m_geometry, m_pickWidget));
   RGBPicker::setCurrentColorWithUndo(
       TPixel32(color.red(), color.green(), color.blue()));
 

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -40,7 +40,6 @@
 // Qt includes
 #include <QCoreApplication>  // Qt translation support
 #include <QPainter>
-#include <QGLWidget>  // for QGLWidget::convertToGLFormat
 #include <QPainterPath>
 #include <QString>
 #include <QImage>
@@ -1355,7 +1354,7 @@ void SkeletonTool::drawDrawingBrowser(const TXshCell &cell,
       imgPainter.drawPath(dnArrow);
     }
 
-    QImage texture = QGLWidget::convertToGLFormat(img);
+    QImage texture = img.mirrored().convertToFormat(QImage::Format_RGBA8888);
 
     glRasterPos2f(p.x, p.y);
     // glBitmap(0,0,0,0,  0,-size.height()+(y+delta.y),  NULL); //
@@ -1415,7 +1414,7 @@ void SkeletonTool::drawMainGadget(const TPointD &center) {
 
   p.setBrush(QColor(54, 213, 54));
   p.drawRect(6, 6, 6, 6);
-  QImage texture = QGLWidget::convertToGLFormat(img);
+  QImage texture = img.mirrored().convertToFormat(QImage::Format_RGBA8888);
   // texture.save("c:\\urka.png");
 
   glRasterPos2f(center.x + r * 1.1, center.y - r * 1.1);

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -1015,7 +1015,7 @@ void SkeletonTool::drawHooks() {
   // glColor3d(0,1,1);
   // tglDrawRect(0,100,Stage::inch,110);
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
 
   m_magicLinks.clear();

--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -725,7 +725,7 @@ void StrokeSelection::paste() {
     const StrokesData *stData = dynamic_cast<const StrokesData *>(
         QApplication::clipboard()->mimeData());
     if (!stData) return;
-    TVectorImageP splineImg = tool->getImage(true);
+    TVectorImageP splineImg = TImageP(tool->getImage(true));
     TVectorImageP img       = stData->m_image;
     if (!splineImg || !img) return;
 
@@ -742,7 +742,7 @@ void StrokeSelection::paste() {
     return;
   }
 
-  TVectorImageP tarImg = tool->touchImage();
+  TVectorImageP tarImg = TImageP(tool->touchImage());
   if (!tarImg) return;
   TPaletteP palette       = tarImg->getPalette();
   TPaletteP oldPalette    = new TPalette();

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -93,13 +93,13 @@ ToolOptionsBox::ToolOptionsBox(QWidget *parent, bool isScrollable)
   setFixedHeight(26);
 
   m_layout = new QHBoxLayout;
-  m_layout->setMargin(0);
+  m_layout->setContentsMargins(0, 0, 0, 0);
   m_layout->setSpacing(5);
   m_layout->addSpacing(5);
 
   if (isScrollable) {
     QHBoxLayout *hLayout = new QHBoxLayout;
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(0);
     setLayout(hLayout);
 
@@ -606,7 +606,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
 
     // Pick combobox only available on "All" axis mode
     QHBoxLayout *pickLay = new QHBoxLayout();
-    pickLay->setMargin(0);
+    pickLay->setContentsMargins(0, 0, 0, 0);
     pickLay->setSpacing(0);
     {
       pickLay->addSpacing(5);
@@ -622,7 +622,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Position
       QFrame *posFrame    = new QFrame(this);
       QHBoxLayout *posLay = new QHBoxLayout();
-      posLay->setMargin(0);
+      posLay->setContentsMargins(0, 0, 0, 0);
       posLay->setSpacing(0);
       posFrame->setLayout(posLay);
       {
@@ -670,7 +670,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Rotation
       QFrame *rotFrame    = new QFrame(this);
       QHBoxLayout *rotLay = new QHBoxLayout();
-      rotLay->setMargin(0);
+      rotLay->setContentsMargins(0, 0, 0, 0);
       rotLay->setSpacing(0);
       rotFrame->setLayout(rotLay);
       {
@@ -694,7 +694,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Scale
       QFrame *scaleFrame    = new QFrame(this);
       QHBoxLayout *scaleLay = new QHBoxLayout();
-      scaleLay->setMargin(0);
+      scaleLay->setContentsMargins(0, 0, 0, 0);
       scaleLay->setSpacing(0);
       scaleFrame->setLayout(scaleLay);
       {
@@ -739,7 +739,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Shear
       QFrame *shearFrame    = new QFrame(this);
       QHBoxLayout *shearLay = new QHBoxLayout();
-      shearLay->setMargin(0);
+      shearLay->setContentsMargins(0, 0, 0, 0);
       shearLay->setSpacing(0);
       shearFrame->setLayout(shearLay);
       {
@@ -771,7 +771,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Center Position
       QFrame *centerPosFrame    = new QFrame(this);
       QHBoxLayout *centerPosLay = new QHBoxLayout();
-      centerPosLay->setMargin(0);
+      centerPosLay->setContentsMargins(0, 0, 0, 0);
       centerPosLay->setSpacing(0);
       centerPosFrame->setLayout(centerPosLay);
       {
@@ -2473,7 +2473,7 @@ RulerToolOptionsBox::RulerToolOptionsBox(QWidget *parent, TTool *tool)
 
   // layout
   QHBoxLayout *lay = new QHBoxLayout();
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
   lay->setSpacing(3);
   {
     lay->addWidget(new QLabel(tr("X:", "ruler tool option"), this), 0);
@@ -2719,7 +2719,7 @@ RGBPickerToolOptionsBox::RGBPickerToolOptionsBox(
       CommandManager::instance()->getAction("A_ToolOption_PickScreen");
 
   QPushButton *button = new QPushButton(tr("Pick Screen"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 10;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(pickScreenAction);
@@ -2857,9 +2857,9 @@ ShiftTraceToolOptionBox::ShiftTraceToolOptionBox(QWidget *parent, TTool *tool)
 
   m_resetPrevGhostBtn  = new QPushButton(tr("Reset Previous"), this);
   m_resetAfterGhostBtn = new QPushButton(tr("Reset Following"), this);
-  int buttonWidth      = fontMetrics().width(m_resetPrevGhostBtn->text()) + 10;
+  int buttonWidth      = fontMetrics().horizontalAdvance(m_resetPrevGhostBtn->text()) + 10;
   m_resetPrevGhostBtn->setFixedWidth(buttonWidth);
-  buttonWidth = fontMetrics().width(m_resetAfterGhostBtn->text()) + 10;
+  buttonWidth = fontMetrics().horizontalAdvance(m_resetAfterGhostBtn->text()) + 10;
   m_resetAfterGhostBtn->setFixedWidth(buttonWidth);
 
   m_prevRadioBtn  = new QRadioButton(tr("Previous Drawing"), this);
@@ -3391,7 +3391,7 @@ SymmetryToolOptionBox::SymmetryToolOptionBox(QWidget *parent, TTool *tool,
   m_useLineSymmetry = new ToolOptionCheckbox(tool, lineSymmetry, toolHandle);
 
   QPushButton *resetButton = new QPushButton(tr("Reset Position"));
-  int buttonWidth          = fontMetrics().width(resetButton->text()) + 10;
+  int buttonWidth          = fontMetrics().horizontalAdvance(resetButton->text()) + 10;
   resetButton->setFixedWidth(buttonWidth);
   resetButton->setFixedHeight(20);
 
@@ -3570,7 +3570,7 @@ ZoomToolOptionsBox::ZoomToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_ZoomReset);
 
   QPushButton *button = new QPushButton(tr("Reset Zoom"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 10;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetZoomAction);
@@ -3597,7 +3597,7 @@ RotateToolOptionsBox::RotateToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_RotateReset);
 
   QPushButton *button = new QPushButton(tr("Reset Rotation"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 10;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetRotationAction);
@@ -3624,7 +3624,7 @@ HandToolOptionsBox::HandToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_PositionReset);
 
   QPushButton *button = new QPushButton(tr("Reset Position"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 20;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 20;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetPositionAction);
@@ -3642,7 +3642,7 @@ HandToolOptionsBox::HandToolOptionsBox(QWidget *parent, TTool *tool,
 
 ToolOptions::ToolOptions() : m_panel(0) {
   QHBoxLayout *mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   setLayout(mainLayout);
 }

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -45,7 +45,7 @@ using namespace DVGui;
 using namespace ToolOptionsControls;
 
 int ToolOptionsControls::getMaximumWidthForMeasuredValueField(QWidget *widget) {
-  static int fieldMaxWidth = widget->fontMetrics().width("-0000.00 field") + 10;
+  static int fieldMaxWidth = widget->fontMetrics().horizontalAdvance("-0000.00 field") + 10;
   return fieldMaxWidth;
 }
 
@@ -147,7 +147,7 @@ ToolOptionSlider::ToolOptionSlider(TTool *tool, TDoubleProperty *property,
   // set the maximum width of the widget according to the text length (with 5
   // pixels margin)
   txt.fill('0', textMaxLength);
-  int widgetWidth = fontMetrics().width(txt) + 5;
+  int widgetWidth = fontMetrics().horizontalAdvance(txt) + 5;
   m_lineEdit->parentWidget()->setMaximumWidth(widgetWidth);
   // set the maximum width of the slider to 250 pixels
   setMaximumWidth(250 + widgetWidth);
@@ -201,7 +201,7 @@ ToolOptionPairSlider::ToolOptionPairSlider(TTool *tool,
   // set the maximum width of the widget according to the text length (with 5
   // pixels margin)
   txt.fill('0', textMaxLength);
-  int widgetWidth = fontMetrics().width(txt) + 5;
+  int widgetWidth = fontMetrics().horizontalAdvance(txt) + 5;
   m_leftLineEdit->setFixedWidth(widgetWidth);
   m_rightLineEdit->setFixedWidth(widgetWidth);
   m_leftMargin  = widgetWidth + 12;
@@ -363,7 +363,7 @@ void ToolOptionCombo::loadEntries() {
                       }");
       }
     }
-    int tmpWidth = fontMetrics().width(items[i].UIName);
+    int tmpWidth = fontMetrics().horizontalAdvance(items[i].UIName);
     if (tmpWidth > maxWidth) maxWidth = tmpWidth;
   }
 

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -1708,7 +1708,7 @@ void ToolUtils::drawHook(const TPointD &pos, ToolUtils::HookType type,
 //---------------------------------------------------------------------------------------------
 
 bool ToolUtils::isJustCreatedSpline(TImage *image) {
-  TVectorImageP vi = image;
+  TVectorImageP vi = TImageP(image);
   if (!vi) return false;
   if (vi->getStrokeCount() != 1) return false;
   TStroke *stroke = vi->getStroke(0);

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -43,7 +43,6 @@
 
 #include <QPainter>
 #include <QPainterPath>
-#include <QGLWidget>  // for QGLWidget::convertToGLFormat
 #include <QFont>
 #include <QFontMetrics>
 
@@ -1641,7 +1640,7 @@ void ToolUtils::drawBalloon(const TPointD &pos, std::string text,
   p.setFont(font);
   p.drawText(textRect, Qt::AlignCenter | Qt::TextDontClip, qText);
 
-  QImage texture = QGLWidget::convertToGLFormat(label);
+  QImage texture = label.mirrored().convertToFormat(QImage::Format_RGBA8888);
 
   glRasterPos2f(pos.x, pos.y);
   glBitmap(0, 0, 0, 0, 0, -size.height() + (y + delta.y), NULL);  //
@@ -1695,7 +1694,7 @@ void ToolUtils::drawHook(const TPointD &pos, ToolUtils::HookType type,
     painter.drawLine(r, 0, r, d);
   }
 
-  QImage texture = QGLWidget::convertToGLFormat(image);
+  QImage texture = image.mirrored().convertToFormat(QImage::Format_RGBA8888);
   glRasterPos2f(pos.x, pos.y);
   glBitmap(0, 0, 0, 0, -r * devPixRatio, -r * devPixRatio, NULL);
   glEnable(GL_BLEND);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2289,7 +2289,7 @@ void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
 //---------------------------------------------------------------------------------------------------------------
 // 明日はここをMyPaintのときにカーソルを消せるように修正する！！！！！！
 void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
-#if (!defined(LINUX) && !defined(FREEBSD)) || QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+#if (!defined(LINUX) && !defined(FREEBSD))
   qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 #endif
 

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1742,7 +1742,7 @@ void ToonzVectorBrushTool::flushTrackPoint() {
 //---------------------------------------------------------------------------------------------------------------
 
 void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
-#if (!defined(LINUX) && !defined(FREEBSD)) || QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+#if (!defined(LINUX) && !defined(FREEBSD))
   qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 #endif
 

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1072,7 +1072,7 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
     }
     int points = stroke->getControlPointCount();
 
-    TVectorImageP vi = getImage(true);
+    TVectorImageP vi = TImageP(getImage(true));
     struct Cleanup {
       ToonzVectorBrushTool *m_this;
       ~Cleanup() { m_this->m_track.clear(), m_this->invalidate(); }
@@ -1105,7 +1105,7 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
     return;
   }
 
-  TVectorImageP vi = getImage(true);
+  TVectorImageP vi = TImageP(getImage(true));
   if (m_track.isEmpty()) {
     m_styleId = 0;
     m_track.clear();

--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -1310,7 +1310,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
   viene richiamato il metodo \b eraseRegion*/
 void EraserTool::leftButtonDoubleClick(const TPointD &pos,
                                        const TMouseEvent &e) {
-  TVectorImageP vi = getImage(true);
+  TVectorImageP vi = TImageP(getImage(true));
   if (m_eraseType.getValue() == POLYLINE_ERASE) {
     closePolyline(pos);
 

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -914,7 +914,7 @@ void DragSelectionTool::VectorScaleTool::leftButtonDrag(const TPointD &pos,
 DragSelectionTool::VectorChangeThicknessTool::VectorChangeThicknessTool(
     VectorSelectionTool *tool)
     : DragTool(tool), m_curPos(), m_firstPos(), m_thicknessChange(0) {
-  TVectorImageP vi = tool->getImage(false);
+  TVectorImageP vi = TImageP(tool->getImage(false));
   assert(vi);
 
   setStrokesThickness(*vi);
@@ -1039,7 +1039,7 @@ void DragSelectionTool::VectorChangeThicknessTool::changeImageThickness(
 //-----------------------------------------------------------------------------
 
 void DragSelectionTool::VectorChangeThicknessTool::addUndo() {
-  TVectorImageP curVi = getTool()->getImage(true);
+  TVectorImageP curVi = TImageP(getTool()->getImage(true));
   if (!curVi) return;
 
   m_undo->registerStrokes();
@@ -1112,7 +1112,7 @@ void DragSelectionTool::VectorChangeThicknessTool::leftButtonDown(
 void DragSelectionTool::VectorChangeThicknessTool::leftButtonDrag(
     const TPointD &pos, const TMouseEvent &e) {
   TPointD delta = e.m_pos - m_firstPos;
-  TVectorImageP vi = getTool()->getImage(true);
+  TVectorImageP vi = TImageP(getTool()->getImage(true));
   if (!vi) return;
   VectorSelectionTool *tool = dynamic_cast<VectorSelectionTool *>(m_tool);
   tool->setResetCenter(false);
@@ -1130,7 +1130,7 @@ void DragSelectionTool::VectorChangeThicknessTool::leftButtonDrag(
 
 void DragSelectionTool::VectorChangeThicknessTool::leftButtonUp(
     const TPointD &pos, const TMouseEvent &e) {
-  TVectorImageP curVi = getTool()->getImage(true);
+  TVectorImageP curVi = TImageP(getTool()->getImage(true));
   if (!curVi) return;
   addUndo();
   m_strokesThickness.clear();
@@ -1263,8 +1263,8 @@ VectorSelectionTool::VectorSelectionTool(int targetType)
 void VectorSelectionTool::setNewFreeDeformer() {
   clearDeformers();
 
-  TVectorImageP vi =
-      getImage(true);  // BAD: Should not be done at tool creation...
+  TVectorImageP vi = TImageP(getImage(
+      true));  // BAD: Should not be done at tool creation...
   if (!vi) return;
 
   // Current freeDeformer always at index 0
@@ -1435,7 +1435,7 @@ void VectorSelectionTool::updateSelectionTarget() {
 //-----------------------------------------------------------------------------
 
 void VectorSelectionTool::finalizeSelection() {
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
   if (vi && !m_levelSelection.isEmpty()) {
     std::vector<int> &selection = m_strokeSelection.getSelection();
     selection.clear();
@@ -1531,7 +1531,7 @@ void VectorSelectionTool::modifySelectionOnClick(TImageP image,
 
 void VectorSelectionTool::leftButtonDoubleClick(const TPointD &pos,
                                                 const TMouseEvent &e) {
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
   if (!vi) return;
 
   if (m_strokeSelectionType.getIndex() == POLYLINE_SELECTION_IDX &&
@@ -1573,7 +1573,7 @@ void VectorSelectionTool::leftButtonDrag(const TPointD &pos,
     return;
   }
 
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
   if (!vi) return;
 
   double pixelSize        = getPixelSize();
@@ -1682,7 +1682,7 @@ void VectorSelectionTool::leftButtonUp(const TPointD &pos,
   if (!m_selecting) return;
 
   // Complete selection
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
 
   if (vi) {
     if (m_strokeSelectionType.getIndex() == RECT_SELECTION_IDX) {
@@ -1785,7 +1785,7 @@ void VectorSelectionTool::drawGroup(const TVectorImage &vi) {
 //-----------------------------------------------------------------------------
 
 void VectorSelectionTool::draw() {
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
   if (!vi) return;
 
   if (isLevelType() || isSelectedFramesType()) {
@@ -1825,7 +1825,7 @@ void VectorSelectionTool::draw() {
 
 TSelection *VectorSelectionTool::getSelection() {
   TImage *image    = getImage(false);
-  TVectorImageP vi = image;
+  TVectorImageP vi = TImageP(image);
   if (!vi) return 0;
 
   return &m_strokeSelection;
@@ -1834,8 +1834,8 @@ TSelection *VectorSelectionTool::getSelection() {
 //-----------------------------------------------------------------------------
 
 bool VectorSelectionTool::isSelectionEmpty() {
-  TVectorImageP vi =
-      getImage(false);  // We want at least current image to be visible.
+  TVectorImageP vi = TImageP(getImage(
+      false));           // We want at least current image to be visible.
   if (!vi)              // This is somewhat in line to preventing tool actions
     return true;        // on non-visible levels.
 
@@ -1849,7 +1849,7 @@ void VectorSelectionTool::computeBBox() {
   m_bboxs.clear();
   if (canResetCenter()) m_centers.clear();
 
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
   if (!vi) return;
 
   if (isLevelType() || isSelectedFramesType()) {
@@ -1917,7 +1917,7 @@ void VectorSelectionTool::computeBBox() {
 //-----------------------------------------------------------------------------
 
 bool VectorSelectionTool::selectStroke(int index, bool toggle) {
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
   assert(vi);
   assert(m_strokeSelection.getImage() == vi);
 
@@ -1986,7 +1986,7 @@ void VectorSelectionTool::onDeactivate() {
 //-----------------------------------------------------------------------------
 
 void VectorSelectionTool::doOnActivate() {
-  TVectorImageP vi = getImage(false);
+  TVectorImageP vi = TImageP(getImage(false));
   m_strokeSelection.setImage(vi);
 
   updateSelectionTarget();
@@ -1998,7 +1998,7 @@ void VectorSelectionTool::doOnActivate() {
 //-----------------------------------------------------------------------------
 
 void VectorSelectionTool::onImageChanged() {
-  TVectorImageP vi          = getImage(false);
+  TVectorImageP vi          = TImageP(getImage(false));
   TVectorImageP selectedImg = m_strokeSelection.getImage();
 
   if (vi != selectedImg) {

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -41,7 +41,6 @@ set(MOC_HEADERS
     filebrowser.h
     filebrowsermodel.h
     filebrowserpopup.h
-    fileinfopopup.h
     filmstrip.h
     flipbook.h
     formatsettingspopups.h

--- a/toonz/sources/toonz/aboutpopup.cpp
+++ b/toonz/sources/toonz/aboutpopup.cpp
@@ -5,7 +5,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QTextEdit>
 #include <QDesktopServices>
 

--- a/toonz/sources/toonz/addfilmstripframespopup.cpp
+++ b/toonz/sources/toonz/addfilmstripframespopup.cpp
@@ -31,7 +31,7 @@ AddFilmstripFramesPopup::AddFilmstripFramesPopup()
   m_cancelBtn = new QPushButton(tr("Cancel"), this);
 
   QGridLayout *upperLay = new QGridLayout();
-  upperLay->setMargin(0);
+  upperLay->setContentsMargins(0, 0, 0, 0);
   upperLay->setSpacing(5);
   {
     upperLay->addWidget(new QLabel(tr("From Frame:"), this), 0, 0,
@@ -50,7 +50,7 @@ AddFilmstripFramesPopup::AddFilmstripFramesPopup()
   upperLay->setColumnStretch(1, 1);
   m_topLayout->addLayout(upperLay, 1);
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(m_okBtn);

--- a/toonz/sources/toonz/adjustlevelspopup.cpp
+++ b/toonz/sources/toonz/adjustlevelspopup.cpp
@@ -130,7 +130,7 @@ public:
 
 EditableMarksBar::EditableMarksBar(QWidget *parent) : QFrame(parent) {
   QVBoxLayout *layout = new QVBoxLayout;
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(2);
   setLayout(layout);
 
@@ -157,7 +157,7 @@ EditableMarksBar::EditableMarksBar(QWidget *parent) : QFrame(parent) {
 
   // Add fields layout
   QHBoxLayout *hLayout = new QHBoxLayout;
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   hLayout->setContentsMargins(4, 0, 5, 0);
   layout->addLayout(hLayout);
 

--- a/toonz/sources/toonz/alignmentpane.cpp
+++ b/toonz/sources/toonz/alignmentpane.cpp
@@ -91,7 +91,7 @@ AlignmentPane::AlignmentPane(QWidget* parent, Qt::WindowFlags flags)
   connect(m_distributeVBtn, SIGNAL(clicked()), action, SLOT(trigger()));
 
   QGridLayout* mainlayout = new QGridLayout();
-  mainlayout->setMargin(5);
+  mainlayout->setContentsMargins(5, 5, 5, 5);
   mainlayout->setSpacing(2);
   {
     mainlayout->addWidget(new QLabel(tr("Relative to: ")), 0, 0,
@@ -100,7 +100,7 @@ AlignmentPane::AlignmentPane(QWidget* parent, Qt::WindowFlags flags)
 
     QGroupBox* alignBox      = new QGroupBox(tr("Align"), this);
     QGridLayout* alignLayout = new QGridLayout();
-    alignLayout->setMargin(1);
+    alignLayout->setContentsMargins(1, 1, 1, 1);
     alignLayout->setSpacing(1);
     {
       alignLayout->addWidget(m_alignLeftBtn, 0, 0, Qt::AlignCenter);
@@ -116,7 +116,7 @@ AlignmentPane::AlignmentPane(QWidget* parent, Qt::WindowFlags flags)
 
     QGroupBox* distributeBox      = new QGroupBox(tr("Distribute"), this);
     QGridLayout* distributeLayout = new QGridLayout();
-    distributeLayout->setMargin(1);
+    distributeLayout->setContentsMargins(1, 1, 1, 1);
     distributeLayout->setSpacing(1);
     {
       distributeLayout->addWidget(m_distributeHBtn, 0, 0, Qt::AlignCenter);

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -170,12 +170,12 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_refreshDevicesButton->setToolTip(
       tr("Refresh list of connected audio input devices"));
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(8);
 
   QVBoxLayout *mainLay = new QVBoxLayout();
   mainLay->setSpacing(3);
-  mainLay->setMargin(3);
+  mainLay->setContentsMargins(3, 3, 3, 3);
   {
     QGridLayout *recordGridLay = new QGridLayout();
     recordGridLay->setHorizontalSpacing(2);

--- a/toonz/sources/toonz/autoinputcellnumberpopup.cpp
+++ b/toonz/sources/toonz/autoinputcellnumberpopup.cpp
@@ -275,7 +275,7 @@ AutoInputCellNumberPopup::AutoInputCellNumberPopup()
   m_buttonFrame->setFixedHeight(45);
 
   m_buttonLayout = new QHBoxLayout;
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   m_buttonLayout->setAlignment(Qt::AlignHCenter);
   {

--- a/toonz/sources/toonz/batchserversviewer.cpp
+++ b/toonz/sources/toonz/batchserversviewer.cpp
@@ -277,7 +277,7 @@ BatchServersViewer::BatchServersViewer(QWidget *parent, Qt::WindowFlags flags)
   setObjectName("OnePixelMarginFrame");
 
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(15);
+  layout->setContentsMargins(15, 15, 15, 15);
   layout->setSpacing(8);
 
   layout->addWidget(new QLabel(tr("Process with:")), row, 0, Qt::AlignRight);

--- a/toonz/sources/toonz/boardsettingspopup.cpp
+++ b/toonz/sources/toonz/boardsettingspopup.cpp
@@ -361,7 +361,7 @@ ItemInfoView::ItemInfoView(QWidget* parent) : QStackedWidget(parent) {
   //----- layout
 
   QGridLayout* mainLay = new QGridLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setHorizontalSpacing(3);
   mainLay->setVerticalSpacing(10);
   {
@@ -374,13 +374,13 @@ ItemInfoView::ItemInfoView(QWidget* parent) : QStackedWidget(parent) {
     mainLay->addWidget(m_typeCombo, 1, 1);
 
     QVBoxLayout* extraInfoLay = new QVBoxLayout();
-    extraInfoLay->setMargin(0);
+    extraInfoLay->setContentsMargins(0, 0, 0, 0);
     extraInfoLay->setSpacing(0);
     {
       extraInfoLay->addWidget(m_textEdit, 1);
 
       QGridLayout* imgPropLay = new QGridLayout();
-      imgPropLay->setMargin(0);
+      imgPropLay->setContentsMargins(0, 0, 0, 0);
       imgPropLay->setHorizontalSpacing(3);
       imgPropLay->setVerticalSpacing(10);
       {
@@ -401,7 +401,7 @@ ItemInfoView::ItemInfoView(QWidget* parent) : QStackedWidget(parent) {
       extraInfoLay->addSpacing(5);
 
       QGridLayout* fontPropLay = new QGridLayout();
-      fontPropLay->setMargin(0);
+      fontPropLay->setContentsMargins(0, 0, 0, 0);
       fontPropLay->setHorizontalSpacing(3);
       fontPropLay->setVerticalSpacing(10);
       {
@@ -677,11 +677,11 @@ ItemListView::ItemListView(QWidget* parent) : QWidget(parent) {
   m_list->setMaximumWidth(225);
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(5);
   {
     QVBoxLayout* buttonsLay = new QVBoxLayout();
-    buttonsLay->setMargin(0);
+    buttonsLay->setContentsMargins(0, 0, 0, 0);
     buttonsLay->setSpacing(3);
     {
       buttonsLay->addWidget(newItemBtn, 0);
@@ -863,15 +863,15 @@ BoardSettingsPopup::BoardSettingsPopup(QWidget* parent)
   //--- layout
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(10);
   {
     QVBoxLayout* leftLay = new QVBoxLayout();
-    leftLay->setMargin(0);
+    leftLay->setContentsMargins(0, 0, 0, 0);
     leftLay->setSpacing(0);
     {
       QHBoxLayout* leftTopLay = new QHBoxLayout();
-      leftTopLay->setMargin(5);
+      leftTopLay->setContentsMargins(5, 5, 5, 5);
       leftTopLay->setSpacing(3);
       {
         leftTopLay->addWidget(new QLabel(tr("Duration (frames):"), this), 0);
@@ -891,7 +891,7 @@ BoardSettingsPopup::BoardSettingsPopup(QWidget* parent)
     mainLay->addLayout(leftLay, 1);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(0);
+    rightLay->setContentsMargins(0, 0, 0, 0);
     rightLay->setSpacing(15);
     {
       rightLay->addWidget(m_itemInfoView, 0);

--- a/toonz/sources/toonz/cameracapturelevelcontrol.cpp
+++ b/toonz/sources/toonz/cameracapturelevelcontrol.cpp
@@ -288,12 +288,12 @@ CameraCaptureLevelControl::CameraCaptureLevelControl(QWidget* parent)
   m_gammaFld->setToolTip(tr("Gamma Value"));
 
   QVBoxLayout* mainLay = new QVBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(4);
   {
     mainLay->addWidget(m_histogram, 0, Qt::AlignHCenter);
     QHBoxLayout* fieldsLay = new QHBoxLayout();
-    fieldsLay->setMargin(1);
+    fieldsLay->setContentsMargins(1, 1, 1, 1);
     fieldsLay->setSpacing(0);
     {
       fieldsLay->addWidget(m_blackFld, 0);

--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -88,11 +88,11 @@ CameraSettingsPopup::CameraSettingsPopup()
 
   //---- layout
   QVBoxLayout *mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(8);
   {
     QHBoxLayout *nameLay = new QHBoxLayout();
-    nameLay->setMargin(0);
+    nameLay->setContentsMargins(0, 0, 0, 0);
     nameLay->setSpacing(3);
     {
       nameLay->addWidget(new QLabel(tr("Name:")), 0);
@@ -102,7 +102,7 @@ CameraSettingsPopup::CameraSettingsPopup()
 
     mainLay->addWidget(m_cameraSettingsWidget, 1);
   }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLay);
 
   //---- signal-slot connections

--- a/toonz/sources/toonz/canvassizepopup.cpp
+++ b/toonz/sources/toonz/canvassizepopup.cpp
@@ -153,7 +153,7 @@ PeggingWidget::PeggingWidget(QWidget *parent)
 
   QGridLayout *gridLayout = new QGridLayout(this);
   gridLayout->setSpacing(1);
-  gridLayout->setMargin(1);
+  gridLayout->setContentsMargins(1, 1, 1, 1);
 
   m_buttonGroup = new QButtonGroup();
   m_buttonGroup->setExclusive(true);
@@ -225,7 +225,7 @@ void PeggingWidget::createButton(QPushButton **button,
   QPixmap pix(1, 1);
   switch (position) {
   case e00:
-    pix = m_topRightPix.transformed(QMatrix().rotate(-90),
+    pix = m_topRightPix.transformed(QTransform().rotate(-90),
                                     Qt::SmoothTransformation);
     break;
   case e01:
@@ -235,20 +235,23 @@ void PeggingWidget::createButton(QPushButton **button,
     pix = m_topRightPix;
     break;
   case e10:
-    pix = m_topPix.transformed(QMatrix().rotate(-90), Qt::SmoothTransformation);
+    pix = m_topPix.transformed(QTransform().rotate(-90),
+                               Qt::SmoothTransformation);
     break;
   case e12:
-    pix = m_topPix.transformed(QMatrix().rotate(90), Qt::SmoothTransformation);
+    pix =
+        m_topPix.transformed(QTransform().rotate(90), Qt::SmoothTransformation);
     break;
   case e20:
-    pix = m_topRightPix.transformed(QMatrix().rotate(180),
+    pix = m_topRightPix.transformed(QTransform().rotate(180),
                                     Qt::SmoothTransformation);
     break;
   case e21:
-    pix = m_topPix.transformed(QMatrix().rotate(180), Qt::SmoothTransformation);
+    pix = m_topPix.transformed(QTransform().rotate(180),
+                               Qt::SmoothTransformation);
     break;
   case e22:
-    pix = m_topRightPix.transformed(QMatrix().rotate(90),
+    pix = m_topRightPix.transformed(QTransform().rotate(90),
                                     Qt::SmoothTransformation);
     break;
   default:
@@ -264,12 +267,12 @@ void PeggingWidget::on00() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_00->setIcon(pix);
-  m_01->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_01->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
-  m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+  m_11->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
-  m_10->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_10->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_02->setIcon(pix);
@@ -286,17 +289,17 @@ void PeggingWidget::on01() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_01->setIcon(pix);
-  m_00->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_00->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
-  m_10->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+  m_10->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
-  m_12->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+  m_12->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
-  m_02->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_02->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
 
   m_20->setIcon(pix);
@@ -311,12 +314,12 @@ void PeggingWidget::on02() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_02->setIcon(pix);
-  m_01->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_01->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
-  m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+  m_11->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_12->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_12->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -333,17 +336,17 @@ void PeggingWidget::on10() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_10->setIcon(pix);
-  m_00->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_00->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
-  m_01->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+  m_01->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
-  m_21->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+  m_21->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
-  m_20->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_20->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_02->setIcon(pix);
@@ -358,25 +361,25 @@ void PeggingWidget::on11() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_11->setIcon(pix);
-  m_00->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+  m_00->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_01->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_01->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
-  m_02->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+  m_02->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_10->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_10->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
-  m_12->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_12->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
-  m_20->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+  m_20->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_21->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_21->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
-  m_22->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+  m_22->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
 }
 
@@ -387,17 +390,17 @@ void PeggingWidget::on12() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_12->setIcon(pix);
-  m_02->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_02->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
-  m_01->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+  m_01->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
-  m_21->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+  m_21->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_22->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_22->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -412,12 +415,12 @@ void PeggingWidget::on20() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_20->setIcon(pix);
-  m_10->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_10->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
-  m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+  m_11->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_21->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_21->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -434,17 +437,17 @@ void PeggingWidget::on21() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_21->setIcon(pix);
-  m_20->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_20->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
-  m_10->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+  m_10->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
-  m_12->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+  m_12->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_22->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_22->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -459,12 +462,12 @@ void PeggingWidget::on22() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_22->setIcon(pix);
-  m_12->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_12->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
-  m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+  m_11->setIcon(m_topRightPix.transformed(
+      QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_21->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_21->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);

--- a/toonz/sources/toonz/canvassizepopup.cpp
+++ b/toonz/sources/toonz/canvassizepopup.cpp
@@ -204,7 +204,7 @@ void PeggingWidget::resetWidget() {
 
 void PeggingWidget::paintEvent(QPaintEvent *) {
   QStyleOption opt;
-  opt.init(this);
+  opt.initFrom(this);
   QPainter p(this);
   style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 }

--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -470,7 +470,7 @@ CastBrowser::CastBrowser(QWidget *parent, Qt::WindowFlags flags)
   QFrame *box = new QFrame(this);
   box->setFrameStyle(QFrame::StyledPanel);
   QVBoxLayout *boxLayout = new QVBoxLayout(box);
-  boxLayout->setMargin(0);
+  boxLayout->setContentsMargins(0, 0, 0, 0);
   boxLayout->setSpacing(0);
 
   m_folderName = new QLabel("", box);

--- a/toonz/sources/toonz/cleanuppaletteviewer.cpp
+++ b/toonz/sources/toonz/cleanuppaletteviewer.cpp
@@ -67,13 +67,13 @@ CleanupPaletteViewer::CleanupPaletteViewer(QWidget *parent)
   //----- layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   {
     mainLayout->addWidget(m_scrollArea, 1);
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;
     buttonLayout->setSpacing(7);
-    buttonLayout->setMargin(0);
+    buttonLayout->setContentsMargins(0, 0, 0, 0);
     {
       buttonLayout->addWidget(m_add);
       buttonLayout->addWidget(m_remove);
@@ -109,7 +109,7 @@ void CleanupPaletteViewer::buildGUI() {
   m_scrollWidget->setLayout(scrollLayout);
 
   scrollLayout->setSpacing(10);
-  scrollLayout->setMargin(0);
+  scrollLayout->setContentsMargins(0, 0, 0, 0);
 
   TPalette *palette = TApp::instance()
                           ->getPaletteController()

--- a/toonz/sources/toonz/cleanuppopup.cpp
+++ b/toonz/sources/toonz/cleanuppopup.cpp
@@ -1436,7 +1436,7 @@ CleanupPopup::OverwriteDialog::OverwriteDialog()
     : DVGui::ValidatedChoiceDialog(TApp::instance()->getMainWindow()) {
   setWindowTitle(tr("Warning!"));
 
-  bool ret = connect(m_buttonGroup, SIGNAL(buttonClicked(int)),
+  bool ret = connect(m_buttonGroup, SIGNAL(idClicked(int)),
                      SLOT(onButtonClicked(int)));
   assert(ret);
 

--- a/toonz/sources/toonz/cleanuppopup.cpp
+++ b/toonz/sources/toonz/cleanuppopup.cpp
@@ -316,7 +316,7 @@ CleanupPopup::CleanupPopup()
 
   //---layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   mainLayout->setSpacing(5);
   {
     mainLayout->addWidget(m_progressLabel, 0);
@@ -325,13 +325,13 @@ CleanupPopup::CleanupPopup()
     mainLayout->addWidget(m_cleanupQuestionLabel);
 
     QVBoxLayout *imgBoxLay = new QVBoxLayout();
-    imgBoxLay->setMargin(5);
+    imgBoxLay->setContentsMargins(5, 5, 5, 5);
     { imgBoxLay->addWidget(m_imageViewer); }
     m_imgViewBox->setLayout(imgBoxLay);
     mainLayout->addWidget(m_imgViewBox, 1);
 
     QHBoxLayout *buttonLay = new QHBoxLayout();
-    buttonLay->setMargin(0);
+    buttonLay->setContentsMargins(0, 0, 0, 0);
     buttonLay->setSpacing(5);
     {
       buttonLay->addWidget(m_cleanupButton);
@@ -343,7 +343,7 @@ CleanupPopup::CleanupPopup()
     mainLayout->addLayout(buttonLay);
     mainLayout->addStretch();
   }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLayout);
 
   //--- signal-slot connections

--- a/toonz/sources/toonz/cleanupsettingspane.cpp
+++ b/toonz/sources/toonz/cleanupsettingspane.cpp
@@ -167,11 +167,11 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
   //----layout
   QVBoxLayout *mainLay = new QVBoxLayout();
   mainLay->setSpacing(2);
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   {
     // Autocenter
     QGridLayout *autocenterLay = new QGridLayout();
-    autocenterLay->setMargin(5);
+    autocenterLay->setContentsMargins(5, 5, 5, 5);
     autocenterLay->setSpacing(3);
     {
       autocenterLay->addWidget(new QLabel(tr("Pegbar Holes")), 0, 0,
@@ -188,7 +188,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Rotate&Flip
     QGridLayout *rotFlipLay = new QGridLayout();
-    rotFlipLay->setMargin(5);
+    rotFlipLay->setContentsMargins(5, 5, 5, 5);
     rotFlipLay->setSpacing(3);
     {
       rotFlipLay->addWidget(new QLabel(tr("Rotate")), 0, 0,
@@ -207,7 +207,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Camera
     QVBoxLayout *cleanupCameraFrameLay = new QVBoxLayout();
-    cleanupCameraFrameLay->setMargin(0);
+    cleanupCameraFrameLay->setContentsMargins(0, 0, 0, 0);
     cleanupCameraFrameLay->setSpacing(0);
     { cleanupCameraFrameLay->addWidget(m_cameraWidget); }
     cameraFrame->setLayout(cleanupCameraFrameLay);
@@ -215,7 +215,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Cleanup Palette
     QGridLayout *lineProcLay = new QGridLayout();
-    lineProcLay->setMargin(5);
+    lineProcLay->setContentsMargins(5, 5, 5, 5);
     lineProcLay->setSpacing(3);
     {
       lineProcLay->addWidget(new QLabel(tr("Line Processing:")), 0, 0,
@@ -251,7 +251,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Bottom Parts
     QHBoxLayout *pathLay = new QHBoxLayout();
-    pathLay->setMargin(0);
+    pathLay->setContentsMargins(0, 0, 0, 0);
     pathLay->setSpacing(3);
     {
       pathLay->addWidget(new QLabel(tr("Save In")), 0);
@@ -262,7 +262,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
     mainLay->addSpacing(5);
 
     QHBoxLayout *saveLoadLay = new QHBoxLayout();
-    saveLoadLay->setMargin(0);
+    saveLoadLay->setContentsMargins(0, 0, 0, 0);
     saveLoadLay->setSpacing(1);
     {
       saveLoadLay->addWidget(saveBtn);

--- a/toonz/sources/toonz/cleanupsettingspopup.cpp
+++ b/toonz/sources/toonz/cleanupsettingspopup.cpp
@@ -51,7 +51,7 @@ CleanupTab::CleanupTab() {
 
   mainLayout->setSizeConstraint(QLayout::SetMinimumSize);
   mainLayout->setSpacing(0);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QWidget *settingsBox = new QWidget(this);
   mainLayout->addWidget(settingsBox);
@@ -62,7 +62,7 @@ CleanupTab::CleanupTab() {
 
   settingsLayout->setSizeConstraint(QLayout::SetMaximumSize);
   settingsLayout->setSpacing(9);
-  settingsLayout->setMargin(12);
+  settingsLayout->setContentsMargins(12, 12, 12, 12);
 
   int row = 0;
 
@@ -133,7 +133,7 @@ CleanupTab::CleanupTab() {
   flipWidget->setLayout(flipLayout);
 
   flipLayout->setSizeConstraint(QLayout::SetFixedSize);
-  flipLayout->setMargin(0);
+  flipLayout->setContentsMargins(0, 0, 0, 0);
 
   m_flipX = new DVGui::CheckBox(tr("Horizontal"), flipWidget);
   flipLayout->addWidget(m_flipX, 0, Qt::AlignLeft);
@@ -254,7 +254,7 @@ ProcessingTab::ProcessingTab() {
   m_settingsFrame->setLayout(settingsLayout);
 
   settingsLayout->setSpacing(9);
-  settingsLayout->setMargin(6);
+  settingsLayout->setContentsMargins(6, 6, 6, 6);
   settingsLayout->setSizeConstraint(QLayout::SetMinimumSize);
   settingsLayout->setColumnStretch(1, 1);  // needed when lpNone
 
@@ -510,7 +510,7 @@ void CameraTab::onGenericSettingsChange() {
 CleanupSettings::CleanupSettings(QWidget *parent)
     : QWidget(parent), m_attached(false) {
   QVBoxLayout *vLayout = new QVBoxLayout(this);
-  vLayout->setMargin(1);  // NOTE: This works to show the 1-pix black border,
+  vLayout->setContentsMargins(1, 1, 1, 1);  // NOTE: This works to show the 1-pix black border,
                           // because this is a QWidget (not QFrame) heir...
   setLayout(vLayout);
 
@@ -520,7 +520,7 @@ CleanupSettings::CleanupSettings(QWidget *parent)
   TabBarContainter *tabBarContainer = new TabBarContainter(this);
   QHBoxLayout *hLayout              = new QHBoxLayout(tabBarContainer);
 
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   hLayout->setAlignment(Qt::AlignLeft);
   hLayout->addSpacing(6);
 
@@ -602,7 +602,7 @@ CleanupSettings::CleanupSettings(QWidget *parent)
   QHBoxLayout *toolBarLayout = new QHBoxLayout(toolBarWidget);
   toolBarWidget->setLayout(toolBarLayout);
 
-  toolBarLayout->setMargin(0);
+  toolBarLayout->setContentsMargins(0, 0, 0, 0);
   toolBarLayout->setSpacing(0);
 
   QToolBar *leftToolBar = new QToolBar(toolBarWidget);

--- a/toonz/sources/toonz/cleanupswatch.cpp
+++ b/toonz/sources/toonz/cleanupswatch.cpp
@@ -23,7 +23,7 @@ CleanupSwatch::CleanupSwatch(QWidget *parent, int lx, int ly)
 {
   setStyleSheet("background: transparent");
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
 
   m_leftSwatch = new CleanupSwatchArea(this, true);

--- a/toonz/sources/toonz/cleanupswatch.cpp
+++ b/toonz/sources/toonz/cleanupswatch.cpp
@@ -199,11 +199,7 @@ void CleanupSwatch::CleanupSwatchArea::wheelEvent(QWheelEvent *event) {
   if ((factor < 1 && sqrt(scale) < minZoom) || (factor > 1 && scale > 1200.0))
     return;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   TPointD delta(event->position().x(), height() - event->position().y());
-#else
-  TPointD delta(event->pos().x(), height() - event->pos().y());
-#endif
   m_sw->m_viewAff =
       (TTranslation(delta) * TScale(factor) * TTranslation(-delta)) *
       m_sw->m_viewAff;

--- a/toonz/sources/toonz/colormodelbehaviorpopup.cpp
+++ b/toonz/sources/toonz/colormodelbehaviorpopup.cpp
@@ -62,7 +62,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
 
   QGroupBox* paletteBox   = new QGroupBox(this);
   QVBoxLayout* paletteLay = new QVBoxLayout();
-  paletteLay->setMargin(15);
+  paletteLay->setContentsMargins(15, 15, 15, 15);;
   paletteLay->setSpacing(15);
 
   paletteLay->addWidget(keepColorModelPltButton);
@@ -132,7 +132,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
     m_colorChipOrder->setExclusive(true);
 
     QGridLayout* pickColorLay = new QGridLayout();
-    pickColorLay->setMargin(10);
+    pickColorLay->setContentsMargins(10, 10, 10, 10);;
     pickColorLay->setHorizontalSpacing(5);
     pickColorLay->setVerticalSpacing(10);
     {
@@ -141,7 +141,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
       pickColorLay->addWidget(m_pickColorCombo, 0, 1, Qt::AlignLeft);
 
       QGridLayout* colorChipGridLay = new QGridLayout();
-      colorChipGridLay->setMargin(0);
+      colorChipGridLay->setContentsMargins(0, 0, 0, 0);
       colorChipGridLay->setHorizontalSpacing(5);
       colorChipGridLay->setVerticalSpacing(10);
       {
@@ -157,7 +157,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
         colorChipGridLay->addWidget(new QLabel(tr("Chip Order:"), this), 2, 0,
                                     Qt::AlignRight | Qt::AlignVCenter);
         QHBoxLayout* orderLay = new QHBoxLayout();
-        orderLay->setMargin(0);
+        orderLay->setContentsMargins(0, 0, 0, 0);
         orderLay->setSpacing(0);
         {
           orderLay->addWidget(upperLeftOrderBtn, 0);

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -55,7 +55,7 @@ ComboViewerPanel::ComboViewerPanel(QWidget *parent, Qt::WindowFlags flags)
     m_mainLayout->insertWidget(1, m_toolOptions, 0);
 
     QGridLayout *viewerL = new QGridLayout();
-    viewerL->setMargin(0);
+    viewerL->setContentsMargins(0, 0, 0, 0);
     viewerL->setSpacing(0);
     {
       viewerL->addWidget(m_vRuler, 1, 0);

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -533,11 +533,11 @@ CommandBarPopup::CommandBarPopup(QString barId, bool isQuickToolbar)
   QLineEdit* searchEdit = new QLineEdit(this);
 
   //--- layout
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
   {
     QGridLayout* mainUILay = new QGridLayout();
-    mainUILay->setMargin(5);
+    mainUILay->setContentsMargins(5, 5, 5, 5);
     mainUILay->setHorizontalSpacing(8);
     mainUILay->setVerticalSpacing(5);
     {
@@ -547,7 +547,7 @@ CommandBarPopup::CommandBarPopup(QString barId, bool isQuickToolbar)
       mainUILay->addWidget(m_menuBarTree, 1, 1, 2, 1);
 
       QHBoxLayout* searchLay = new QHBoxLayout();
-      searchLay->setMargin(0);
+      searchLay->setContentsMargins(0, 0, 0, 0);
       searchLay->setSpacing(5);
       {
         searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
@@ -567,18 +567,18 @@ CommandBarPopup::CommandBarPopup(QString barId, bool isQuickToolbar)
     m_topLayout->addLayout(mainUILay, 1);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(0);
   {
     QGridLayout* buttonGridLay = new QGridLayout();
-    buttonGridLay->setMargin(0);
+    buttonGridLay->setContentsMargins(0, 0, 0, 0);
     buttonGridLay->setHorizontalSpacing(8);
     buttonGridLay->setVerticalSpacing(0);
     {
       if (!isQuickToolbar) buttonGridLay->addWidget(m_saveAsDefaultCB, 0, 0);
 
       QHBoxLayout* buttonsLay = new QHBoxLayout();
-      buttonsLay->setMargin(0);
+      buttonsLay->setContentsMargins(0, 0, 0, 0);
       buttonsLay->setSpacing(30);
       {
         buttonsLay->addWidget(okBtn, 0);

--- a/toonz/sources/toonz/convertfolderpopup.cpp
+++ b/toonz/sources/toonz/convertfolderpopup.cpp
@@ -192,14 +192,14 @@ ConvertResultPopup::ConvertResultPopup(QString log, TFilePath path)
   edit->setReadOnly(true);
 
   QVBoxLayout* mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(10);
   {
     mainLay->addWidget(edit, 1);
     mainLay->addWidget(new QLabel(tr("Do you want to save the log?")), 0);
 
     QHBoxLayout* buttonsLay = new QHBoxLayout();
-    buttonsLay->setMargin(0);
+    buttonsLay->setContentsMargins(0, 0, 0, 0);
     buttonsLay->setSpacing(10);
     buttonsLay->setAlignment(Qt::AlignCenter);
     {
@@ -208,7 +208,7 @@ ConvertResultPopup::ConvertResultPopup(QString log, TFilePath path)
     }
     mainLay->addLayout(buttonsLay, 0);
   }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLay);
 
   connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
@@ -256,11 +256,11 @@ ConvertFolderPopup::ConvertFolderPopup()
   m_progressDialog->setWindowModality(Qt::WindowModal);
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     QHBoxLayout* folderLay = new QHBoxLayout();
-    folderLay->setMargin(0);
+    folderLay->setContentsMargins(0, 0, 0, 0);
     folderLay->setSpacing(5);
     {
       folderLay->addWidget(new QLabel(tr("Folder to convert:"), this), 0);
@@ -269,11 +269,11 @@ ConvertFolderPopup::ConvertFolderPopup()
     m_topLayout->addLayout(folderLay, 0);
 
     QHBoxLayout* mainLay = new QHBoxLayout();
-    mainLay->setMargin(0);
+    mainLay->setContentsMargins(0, 0, 0, 0);
     mainLay->setSpacing(5);
     {
       QVBoxLayout* leftLay = new QVBoxLayout();
-      leftLay->setMargin(0);
+      leftLay->setContentsMargins(0, 0, 0, 0);
       leftLay->setSpacing(5);
       {
         leftLay->addWidget(m_skip, 0);
@@ -286,7 +286,7 @@ ConvertFolderPopup::ConvertFolderPopup()
     }
     m_topLayout->addLayout(mainLay, 1);
   }
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   {
     m_buttonLayout->addWidget(m_okBtn);

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -405,11 +405,11 @@ ConvertPopup::ConvertPopup(bool specifyInput)
   m_progressDialog->setWindowModality(Qt::WindowModal);
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     QGridLayout *upperLay = new QGridLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(5);
     {
       int row = 0;
@@ -461,7 +461,7 @@ ConvertPopup::ConvertPopup(bool specifyInput)
     m_topLayout->addWidget(m_tlvFrame);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   {
     m_buttonLayout->addWidget(m_okBtn);

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -487,14 +487,14 @@ ConvertPopup::ConvertPopup(bool specifyInput)
   qRegisterMetaType<TFilePath>("TFilePath");
 
   bool ret = true;
-  ret = ret && connect(m_tlvMode, SIGNAL(currentIndexChanged(const QString &)),
+  ret = ret && connect(m_tlvMode, SIGNAL(currentTextChanged(const QString &)),
                        this, SLOT(onTlvModeSelected(const QString &)));
   ret = ret && connect(m_fromFld, SIGNAL(editingFinished()), this,
                        SLOT(onRangeChanged()));
   ret = ret && connect(m_toFld, SIGNAL(editingFinished()), this,
                        SLOT(onRangeChanged()));
   ret =
-      ret && connect(m_fileFormat, SIGNAL(currentIndexChanged(const QString &)),
+      ret && connect(m_fileFormat, SIGNAL(currentTextChanged(const QString &)),
                      this, SLOT(onFormatSelected(const QString &)));
   ret = ret && connect(m_formatOptions, SIGNAL(clicked()), this,
                        SLOT(onOptionsClicked()));

--- a/toonz/sources/toonz/custompaneleditorpopup.cpp
+++ b/toonz/sources/toonz/custompaneleditorpopup.cpp
@@ -325,7 +325,7 @@ void CustomPanelEditorPopup::createFields() {
     gridLay = dynamic_cast<QGridLayout*>(m_UiFieldsContainer->layout());
   else {
     gridLay = new QGridLayout();
-    gridLay->setMargin(15);
+    gridLay->setContentsMargins(15, 15, 15, 15);;
     gridLay->setHorizontalSpacing(10);
     gridLay->setVerticalSpacing(15);
     gridLay->setColumnStretch(0, 0);
@@ -698,11 +698,11 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
   beginHLayout();
 
   QVBoxLayout* leftLay = new QVBoxLayout();
-  leftLay->setMargin(0);
+  leftLay->setContentsMargins(0, 0, 0, 0);
   leftLay->setSpacing(10);
   {
     QHBoxLayout* templateLay = new QHBoxLayout();
-    templateLay->setMargin(0);
+    templateLay->setContentsMargins(0, 0, 0, 0);
     templateLay->setSpacing(5);
     {
       templateLay->addWidget(new QLabel(tr("Template:"), this), 0);
@@ -715,12 +715,12 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
   addLayout(leftLay);
 
   QVBoxLayout* rightLay = new QVBoxLayout();
-  rightLay->setMargin(0);
+  rightLay->setContentsMargins(0, 0, 0, 0);
   rightLay->setSpacing(10);
   {
     rightLay->addWidget(commandItemListLabel, 0);
     QHBoxLayout* searchLay = new QHBoxLayout();
-    searchLay->setMargin(0);
+    searchLay->setContentsMargins(0, 0, 0, 0);
     searchLay->setSpacing(5);
     {
       searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
@@ -735,7 +735,7 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
 
   m_buttonLayout->addStretch(1);
   QHBoxLayout* nameLay = new QHBoxLayout();
-  nameLay->setMargin(0);
+  nameLay->setContentsMargins(0, 0, 0, 0);
   nameLay->setSpacing(3);
   {
     nameLay->addWidget(new QLabel(tr("Panel name:"), this), 0);

--- a/toonz/sources/toonz/custompaneleditorpopup.cpp
+++ b/toonz/sources/toonz/custompaneleditorpopup.cpp
@@ -485,13 +485,8 @@ void CustomPanelEditorPopup::onTemplateSwitched() {
 
   delete customWidget;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (customPaneFolderPath().isAncestorOf(TFilePath(fp)))
     m_panelNameEdit->setText(m_templateCombo->currentText().chopped(7));
-#else
-  if (customPaneFolderPath().isAncestorOf(TFilePath(fp)))
-    m_panelNameEdit->setText(m_templateCombo->currentText().left(7));
-#endif
 
   updateGeometry();
 }

--- a/toonz/sources/toonz/custompanelmanager.cpp
+++ b/toonz/sources/toonz/custompanelmanager.cpp
@@ -210,7 +210,7 @@ void CustomPanelManager::initializeControl(QWidget* customWidget) {
 
     if (customControl) {
       QHBoxLayout* lay = new QHBoxLayout();
-      lay->setMargin(0);
+      lay->setContentsMargins(0, 0, 0, 0);
       lay->setSpacing(0);
       lay->addWidget(customControl);
       widget->setLayout(lay);

--- a/toonz/sources/toonz/duplicatepopup.cpp
+++ b/toonz/sources/toonz/duplicatepopup.cpp
@@ -108,11 +108,11 @@ DuplicatePopup::DuplicatePopup()
 
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(10);
+  mainLayout->setContentsMargins(10, 10, 10, 10);
   mainLayout->setSpacing(10);
   {
     QHBoxLayout *upperLay = new QHBoxLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(5);
     {
       upperLay->addWidget(new QLabel(tr("Times:"), this), 0);
@@ -124,7 +124,7 @@ DuplicatePopup::DuplicatePopup()
     mainLayout->addLayout(upperLay, 0);
 
     QHBoxLayout *bottomLay = new QHBoxLayout();
-    bottomLay->setMargin(0);
+    bottomLay->setContentsMargins(0, 0, 0, 0);
     bottomLay->setSpacing(10);
     {
       bottomLay->addWidget(m_okBtn);
@@ -133,7 +133,7 @@ DuplicatePopup::DuplicatePopup()
     }
     mainLayout->addLayout(bottomLay, 0);
   }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLayout);
 
   //----signal-slot connections

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -275,7 +275,7 @@ void DvDirTreeViewDelegate::setModelData(QWidget *editor,
                                          const QModelIndex &index) const {
   if (index.data().canConvert(QMetaType::QString)) {
     NodeEditor *nodeEditor = qobject_cast<NodeEditor *>(editor);
-    model->setData(index, qVariantFromValue(
+    model->setData(index, QVariant::fromValue(
                               nodeEditor->getText()));  // starEditor->text()));
   } else
     QAbstractItemDelegate::setModelData(editor, model, index);
@@ -1702,7 +1702,7 @@ NodeEditor::NodeEditor(QWidget *parent, QRect rect, int leftMargin)
   setGeometry(rect);
   m_lineEdit          = new LineEdit();
   QHBoxLayout *layout = new QHBoxLayout();
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->addSpacing(leftMargin);
   layout->addWidget(m_lineEdit);
   setLayout(layout);

--- a/toonz/sources/toonz/dvitemview.cpp
+++ b/toonz/sources/toonz/dvitemview.cpp
@@ -98,11 +98,7 @@ void getFileFids(TFilePath path, std::vector<TFrameId> &fids) {
 
 QString hyphenText(const QString &srcText, const QFont &font, int width) {
   QFontMetrics metrics(font);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int srcWidth = metrics.horizontalAdvance(srcText);
-#else
-  int srcWidth = metrics.width(srcText);
-#endif
   if (srcWidth < width) return srcText;
 
   int count = double(srcWidth) / double(width);
@@ -114,13 +110,8 @@ QString hyphenText(const QString &srcText, const QFont &font, int width) {
   int hyphenCount = 1;
   for (i = 0; i < srcText.size(); i++) {
     QChar c       = srcText.at(i);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     int cWidth    = metrics.horizontalAdvance(c);
     int textWidth = metrics.horizontalAdvance(text) + cWidth;
-#else
-    int cWidth    = metrics.width(c);
-    int textWidth = metrics.width(text) + cWidth;
-#endif
     if ((c.isSpace() && textWidth > (hyphenCount - 1) * width + diff) ||
         (textWidth > hyphenCount * width)) {
       ++hyphenCount;

--- a/toonz/sources/toonz/dvwidgets.cpp
+++ b/toonz/sources/toonz/dvwidgets.cpp
@@ -15,7 +15,7 @@ using namespace DVGui;
 
 PropertyComboBox::PropertyComboBox(QWidget *parent, TEnumProperty *prop)
     : QComboBox(parent), PropertyWidget(prop) {
-  connect(this, SIGNAL(currentIndexChanged(const QString &)), this,
+  connect(this, SIGNAL(currentTextChanged(const QString &)), this,
           SLOT(onCurrentIndexChanged(const QString &)));
   setMaximumHeight(WidgetHeight);
 }

--- a/toonz/sources/toonz/exportcameratrackpopup.cpp
+++ b/toonz/sources/toonz/exportcameratrackpopup.cpp
@@ -795,15 +795,7 @@ QImage ExportCameraTrackPopup::generateCameraTrackImg(
     QPointF textPos = data.textPos + QPointF(5, 0);
     textRect.translate(textPos);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     while (data.polygon.intersects(textRect)) {
-#else
-    while (
-        data.polygon.containsPoint(textRect.topLeft(), Qt::OddEvenFill) ||
-        data.polygon.containsPoint(textRect.topRight(), Qt::OddEvenFill) ||
-        data.polygon.containsPoint(textRect.bottomLeft(), Qt::OddEvenFill) ||
-        data.polygon.containsPoint(textRect.bottomRight(), Qt::OddEvenFill)) {
-#endif
       textRect.translate(data.offsetVec.toPointF());
       textPos += QPointF(data.offsetVec.toPointF());
     }
@@ -901,13 +893,8 @@ void ExportCameraTrackPopup::getInfoFromUI(ExportCameraTrackInfo& info) {
   // camera rect settings
   info.cameraRectOnKeys = m_cameraRectOnKeysCB->isChecked();
   info.cameraRectOnTags = m_cameraRectOnTagsCB->isChecked();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
   QStringList framesStrList =
       m_cameraRectFramesEdit->text().split(",", Qt::SkipEmptyParts);
-#else
-  QStringList framesStrList =
-      m_cameraRectFramesEdit->text().split(",", QString::SkipEmptyParts);
-#endif
   for (auto fStr : framesStrList) {
     bool ok;
     int f = fStr.toInt(&ok);

--- a/toonz/sources/toonz/exportcameratrackpopup.cpp
+++ b/toonz/sources/toonz/exportcameratrackpopup.cpp
@@ -335,17 +335,17 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
   cancelButton->setFocusPolicy(Qt::NoFocus);
   //----------
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(m_previewArea, 1);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(10);
+    rightLay->setContentsMargins(10, 10, 10, 10);;
     rightLay->setSpacing(10);
 
     QGridLayout* appearanceLay = new QGridLayout();
-    appearanceLay->setMargin(0);
+    appearanceLay->setContentsMargins(0, 0, 0, 0);
     appearanceLay->setHorizontalSpacing(5);
     appearanceLay->setVerticalSpacing(10);
     {
@@ -366,7 +366,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
 
     QGroupBox* cameraRectGB    = new QGroupBox(tr("Camera Rectangles"), this);
     QGridLayout* cameraRectLay = new QGridLayout();
-    cameraRectLay->setMargin(10);
+    cameraRectLay->setContentsMargins(10, 10, 10, 10);;
     cameraRectLay->setHorizontalSpacing(5);
     cameraRectLay->setVerticalSpacing(10);
     {
@@ -383,7 +383,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
 
     QGroupBox* trackLineGB    = new QGroupBox(tr("Track Lines"), this);
     QGridLayout* trackLineLay = new QGridLayout();
-    trackLineLay->setMargin(10);
+    trackLineLay->setContentsMargins(10, 10, 10, 10);;
     trackLineLay->setHorizontalSpacing(10);
     trackLineLay->setVerticalSpacing(10);
     {
@@ -403,7 +403,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
 
     QGroupBox* frameNumberGB    = new QGroupBox(tr("Frame Numbers"), this);
     QGridLayout* frameNumberLay = new QGridLayout();
-    frameNumberLay->setMargin(10);
+    frameNumberLay->setContentsMargins(10, 10, 10, 10);;
     frameNumberLay->setHorizontalSpacing(5);
     frameNumberLay->setVerticalSpacing(10);
     {
@@ -428,7 +428,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
     rightLay->addStretch(1);
 
     QHBoxLayout* buttonsLay = new QHBoxLayout();
-    buttonsLay->setMargin(5);
+    buttonsLay->setContentsMargins(5, 5, 5, 5);
     buttonsLay->setSpacing(20);
     {
       buttonsLay->addWidget(exportButton, 0);

--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -355,7 +355,7 @@ ExportLevelPopup::ExportLevelPopup()
     }
     mainLayout->addLayout(bottomLay, 0);
   }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLayout);
 
   // Establish connections

--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -277,13 +277,13 @@ ExportLevelPopup::ExportLevelPopup()
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(3);
   {
     mainLayout->addWidget(tabBarContainer, 0);
 
     QHBoxLayout *tabBarLayout = new QHBoxLayout;
-    tabBarLayout->setMargin(0);
+    tabBarLayout->setContentsMargins(0, 0, 0, 0);
     {
       tabBarLayout->addSpacing(6);
       tabBarLayout->addWidget(tabBar);
@@ -294,7 +294,7 @@ ExportLevelPopup::ExportLevelPopup()
     stackedWidget->addWidget(m_browser);
     // Export Options Page
     QVBoxLayout *eoPageLayout = new QVBoxLayout;
-    eoPageLayout->setMargin(0);
+    eoPageLayout->setContentsMargins(0, 0, 0, 0);
     eoPageLayout->setSpacing(0);
     {
       // top area - options
@@ -331,14 +331,14 @@ ExportLevelPopup::ExportLevelPopup()
 
     //-------------- Buttons Toolbar ---------------------
     QHBoxLayout *bottomLay = new QHBoxLayout();
-    bottomLay->setMargin(5);
+    bottomLay->setContentsMargins(5, 5, 5, 5);
     bottomLay->setSpacing(3);
     {
       bottomLay->addWidget(m_nameFieldLabel);
       bottomLay->addWidget(m_nameField, 1);
 
       QHBoxLayout *fileFormatLayout = new QHBoxLayout;
-      fileFormatLayout->setMargin(0);
+      fileFormatLayout->setContentsMargins(0, 0, 0, 0);
       fileFormatLayout->setSpacing(8);
       fileFormatLayout->setAlignment(Qt::AlignHCenter);
       {
@@ -742,7 +742,7 @@ ExportLevelPopup::ExportOptions::ExportOptions(QWidget *parent)
       QGridLayout *layout = locals::newGridLayout();
       m_pliOptions->setLayout(layout);
 
-      layout->setMargin(0);
+      layout->setContentsMargins(0, 0, 0, 0);
 
       int row = 0;
 

--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -362,7 +362,7 @@ ExportLevelPopup::ExportLevelPopup()
   bool ret = true;
   ret      = connect(tabBar, SIGNAL(currentChanged(int)), stackedWidget,
                 SLOT(setCurrentIndex(int)));
-  ret      = connect(m_format, SIGNAL(currentIndexChanged(const QString &)),
+  ret      = connect(m_format, SIGNAL(currentTextChanged(const QString &)),
                 SLOT(onformatChanged(const QString &))) &&
         ret;
   ret = connect(m_retas, SIGNAL(stateChanged(int)), SLOT(onRetas(int))) && ret;

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -855,7 +855,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
 
   m_fileFormat->addItems(formats);
   m_fileFormat->setFixedHeight(DVGui::WidgetHeight + 2);
-  connect(m_fileFormat, SIGNAL(currentIndexChanged(const QString &)),
+  connect(m_fileFormat, SIGNAL(currentTextChanged(const QString &)),
           SLOT(onFormatChanged(const QString &)));
 
   QPushButton *fileFormatButton = new QPushButton(QString(tr("Options")));

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -795,7 +795,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
   box->setStyleSheet("#exportPanel { margin: 1px; border: 0px; }");
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   mainLayout->setAlignment(Qt::AlignTop);
   // ClipList
@@ -811,7 +811,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
   settingsBox->setObjectName("settingsBox");
   settingsBox->setFrameStyle(QFrame::StyledPanel);
   QVBoxLayout *settingsLayout = new QVBoxLayout();
-  settingsLayout->setMargin(15);
+  settingsLayout->setContentsMargins(15, 15, 15, 15);;
   settingsLayout->setSpacing(5);
   settingsLayout->setAlignment(Qt::AlignTop);
 
@@ -822,7 +822,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
 
   // Label + saveInFileFld
   QHBoxLayout *saveIn = new QHBoxLayout;
-  saveIn->setMargin(0);
+  saveIn->setContentsMargins(0, 0, 0, 0);
   saveIn->setSpacing(5);
   m_saveInFileFld = new DVGui::FileField(settingsBox);
   m_saveInFileFld->setPath(QString::fromStdWString(scenePath.getWideString()));
@@ -834,7 +834,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
 
   // Label + m_fileNameFld
   QHBoxLayout *fileNname = new QHBoxLayout;
-  fileNname->setMargin(0);
+  fileNname->setContentsMargins(0, 0, 0, 0);
   fileNname->setSpacing(5);
   m_fileNameFld =
       new DVGui::LineEdit(QString::fromStdWString(sceneName), settingsBox);

--- a/toonz/sources/toonz/exportscenepopup.cpp
+++ b/toonz/sources/toonz/exportscenepopup.cpp
@@ -570,7 +570,7 @@ ExportScenePopup::ExportScenePopup(std::vector<TFilePath> scenes)
   layout->addWidget(newProjectWidget);
 
   ret = ret &&
-        connect(group, SIGNAL(buttonClicked(int)), this, SLOT(switchMode(int)));
+        connect(group, SIGNAL(idClicked(int)), this, SLOT(switchMode(int)));
 
   addLayout(layout, false);
 

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -1959,16 +1959,16 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
   exportBtn->setObjectName("LargeSizedText");
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(5);
   {
     QVBoxLayout* previewLay = new QVBoxLayout();
-    previewLay->setMargin(0);
+    previewLay->setContentsMargins(0, 0, 0, 0);
     previewLay->setSpacing(0);
     {
       previewLay->addWidget(m_previewArea, 1);
       QHBoxLayout* prevBtnLay = new QHBoxLayout();
-      prevBtnLay->setMargin(15);
+      prevBtnLay->setContentsMargins(15, 15, 15, 15);;
       prevBtnLay->setSpacing(10);
       {
         prevBtnLay->addStretch(1);
@@ -1982,20 +1982,20 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
     mainLay->addLayout(previewLay, 1);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(0);
+    rightLay->setContentsMargins(0, 0, 0, 0);
     rightLay->setSpacing(10);
     {
       QScrollArea* scrollArea = new QScrollArea(this);
       scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
       QWidget* scrollPanel    = new QWidget(this);
       QVBoxLayout* controlLay = new QVBoxLayout();
-      controlLay->setMargin(20);
+      controlLay->setContentsMargins(20, 20, 20, 20);
       controlLay->setSpacing(10);
       {
         QGroupBox* tmplGBox = new QGroupBox(tr("Template Settings"), this);
 
         QGridLayout* tmplLay = new QGridLayout();
-        tmplLay->setMargin(10);
+        tmplLay->setContentsMargins(10, 10, 10, 10);;
         tmplLay->setHorizontalSpacing(5);
         tmplLay->setVerticalSpacing(10);
         {
@@ -2029,7 +2029,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
         QGroupBox* exportGBox = new QGroupBox(tr("Export Settings"), this);
 
         QGridLayout* exportLay = new QGridLayout();
-        exportLay->setMargin(10);
+        exportLay->setContentsMargins(10, 10, 10, 10);;
         exportLay->setHorizontalSpacing(5);
         exportLay->setVerticalSpacing(10);
         {
@@ -2053,7 +2053,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
                                Qt::AlignLeft | Qt::AlignVCenter);
 
           QGridLayout* checksLay = new QGridLayout();
-          checksLay->setMargin(0);
+          checksLay->setContentsMargins(0, 0, 0, 0);
           checksLay->setHorizontalSpacing(10);
           checksLay->setVerticalSpacing(10);
           {
@@ -2102,7 +2102,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
       rightLay->addWidget(scrollArea, 1);
 
       QGridLayout* saveLay = new QGridLayout();
-      saveLay->setMargin(15);
+      saveLay->setContentsMargins(15, 15, 15, 15);;
       saveLay->setHorizontalSpacing(5);
       saveLay->setVerticalSpacing(10);
       {
@@ -2118,7 +2118,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
       rightLay->addLayout(saveLay, 0);
 
       QHBoxLayout* btnLay = new QHBoxLayout();
-      btnLay->setMargin(10);
+      btnLay->setContentsMargins(10, 10, 10, 10);;
       btnLay->setSpacing(10);
       {
         btnLay->addStretch(1);

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -997,13 +997,8 @@ void XSheetPDFTemplate::drawCellNumber(QPainter& painter, QRect rect,
       circlePen.setWidth(mm2px(0.3));
       painter.setPen(circlePen);
       QFontMetrics fm(font);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
       int keyR_width =
         std::max(param(RowHeight), fm.horizontalAdvance(str) + mm2px(1));
-#else
-      int keyR_width =
-        std::max(param(RowHeight), fm.boundingRect(str).width() + mm2px(1));
-#endif
       QRect keyR(0, 0, keyR_width, param(RowHeight));
       keyR.moveCenter(rect.center());
       painter.drawEllipse(keyR);
@@ -1693,11 +1688,7 @@ XSheetPDFTemplate_Custom::XSheetPDFTemplate_Custom(
     m_p.documentPageSize = str2PageSizeId(pageStr);
 
     QString marginStr = s.value("Margin").toString();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QStringList m = marginStr.split(QLatin1Char(','), Qt::SkipEmptyParts);
-#else
-    QStringList m = marginStr.split(QLatin1Char(','), QString::SkipEmptyParts);
-#endif
     assert(m.size() == 4);
     if (m.size() == 4)
       m_p.documentMargin = QMarginsF(m[0].toDouble(), m[1].toDouble(),
@@ -1739,12 +1730,7 @@ XSheetPDFTemplate_Custom::XSheetPDFTemplate_Custom(
     {
       for (auto key : s.childKeys()) {
         QString rectStr = s.value(key).toString();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
         QStringList r = rectStr.split(QLatin1Char(','), Qt::SkipEmptyParts);
-#else
-        QStringList r =
-            rectStr.split(QLatin1Char(','), QString::SkipEmptyParts);
-#endif
         assert(r.size() == 4);
         if (r.size() == 4)
           m_dataRects[dataStr2Type(key)] =

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -54,7 +54,7 @@
 #include <QDateTime>
 #include <QInputDialog>
 #include <QDesktopServices>
-#include <QDirModel>
+#include <QFileSystemModel>
 #include <QDir>
 #include <QPixmap>
 #include <QUrl>

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -188,13 +188,13 @@ FileBrowser::FileBrowser(QWidget *parent, Qt::WindowFlags flags,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setSpacing(2);
   {
     mainLayout->addWidget(buttonBar);
 
     QHBoxLayout *folderLay = new QHBoxLayout();
-    folderLay->setMargin(0);
+    folderLay->setContentsMargins(0, 0, 0, 0);
     folderLay->setSpacing(0);
     {
       folderLay->addWidget(folderLabel, 0);
@@ -204,7 +204,7 @@ FileBrowser::FileBrowser(QWidget *parent, Qt::WindowFlags flags,
 
     m_mainSplitter->addWidget(m_folderTreeView);
     QVBoxLayout *boxLayout = new QVBoxLayout(box);
-    boxLayout->setMargin(0);
+    boxLayout->setContentsMargins(0, 0, 0, 0);
     boxLayout->setSpacing(0);
     {
       boxLayout->addWidget(titleBar, 0);
@@ -626,8 +626,8 @@ void FileBrowser::refreshCurrentFolderItems() {
         QFileInfo fileInfo(QString::fromStdWString(it->getWideString()));
         // Update level infos
         if (levelItem.m_creationDate.isNull() ||
-            (fileInfo.created() < levelItem.m_creationDate))
-          levelItem.m_creationDate = fileInfo.created();
+            (fileInfo.birthTime() < levelItem.m_creationDate))
+          levelItem.m_creationDate = fileInfo.birthTime();
         if (levelItem.m_modifiedDate.isNull() ||
             (fileInfo.lastModified() > levelItem.m_modifiedDate))
           levelItem.m_modifiedDate = fileInfo.lastModified();
@@ -831,7 +831,7 @@ void FileBrowser::readInfo(Item &item) {
   TFilePath fp = item.m_path;
   QFileInfo info(toQString(fp));
   if (info.exists()) {
-    item.m_creationDate = info.created();
+    item.m_creationDate = info.birthTime();
     item.m_modifiedDate = info.lastModified();
     item.m_fileType     = info.suffix();
     item.m_fileSize     = info.size();

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -1138,7 +1138,7 @@ void DvDirModelRootNode::refreshDefaultProjectPath() {
       Preferences::instance()->getDefaultProjectPath();
   if (!defaultProjectPaths.isEmpty()) {
     QStringList projectRoots =
-        defaultProjectPaths.split(";", QString::SkipEmptyParts);
+        defaultProjectPaths.split(";", Qt::SkipEmptyParts);
     int folderCount = 0;
     for (int i = 0; i < projectRoots.size(); i++) {
       TFilePath projectRootDir(projectRoots.at(i));
@@ -1207,7 +1207,7 @@ void DvDirModelRootNode::refreshChildren() {
         Preferences::instance()->getDefaultProjectPath();
     if (!defaultProjectPaths.isEmpty()) {
       QStringList projectRoots =
-          defaultProjectPaths.split(";", QString::SkipEmptyParts);
+          defaultProjectPaths.split(";", Qt::SkipEmptyParts);
       for (int i = 0; i < projectRoots.size(); i++) {
         TFilePath projectRootDir(projectRoots.at(i));
         if (!TFileStatus(projectRootDir).isDirectory()) continue;

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -114,13 +114,13 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
   // layout
   if (!(options & CUSTOM_LAYOUT)) {
     QVBoxLayout *mainLayout = new QVBoxLayout();
-    mainLayout->setMargin(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(3);
     {
       mainLayout->addWidget(m_browser, 1);
 
       QHBoxLayout *bottomLay = new QHBoxLayout();
-      bottomLay->setMargin(5);
+      bottomLay->setContentsMargins(5, 5, 5, 5);
       bottomLay->setSpacing(3);
       {
         bottomLay->addWidget(m_nameFieldLabel, 0);
@@ -131,7 +131,7 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
       if (m_customWidget) mainLayout->addWidget(m_customWidget);
 
       QHBoxLayout *buttonsLay = new QHBoxLayout();
-      buttonsLay->setMargin(5);
+      buttonsLay->setContentsMargins(5, 5, 5, 5);
       buttonsLay->setSpacing(15);
       {
         buttonsLay->addStretch();
@@ -141,7 +141,7 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
       }
       mainLayout->addLayout(buttonsLay);
     }
-    m_topLayout->setMargin(0);
+    m_topLayout->setContentsMargins(0, 0, 0, 0);
     m_topLayout->addLayout(mainLayout);
   }
 
@@ -796,13 +796,13 @@ LoadLevelPopup::LoadLevelPopup()
   //----layout
   auto createVBoxLayout = [](int margin, int spacing) {
     QVBoxLayout *layout = new QVBoxLayout();
-    layout->setMargin(margin);
+    layout->setContentsMargins(margin, margin, margin, margin);
     layout->setSpacing(spacing);
     return layout;
   };
   auto createHBoxLayout = [](int margin, int spacing) {
     QHBoxLayout *layout = new QHBoxLayout();
-    layout->setMargin(margin);
+    layout->setContentsMargins(margin, margin, margin, margin);
     layout->setSpacing(spacing);
     return layout;
   };
@@ -822,7 +822,7 @@ LoadLevelPopup::LoadLevelPopup()
     QHBoxLayout *subsequenceHeadLay = createHBoxLayout(0, 5);
     {
       QFontMetrics metrics(font());
-      subsequenceHeadLay->addSpacing(metrics.width("File name:") + 3);
+      subsequenceHeadLay->addSpacing(metrics.horizontalAdvance("File name:") + 3);
       subsequenceHeadLay->addWidget(m_notExistLabel, 0);
       subsequenceHeadLay->addStretch(1);
 
@@ -855,7 +855,7 @@ LoadLevelPopup::LoadLevelPopup()
     QHBoxLayout *bottomLay = createHBoxLayout(0, 10);
     {
       QGridLayout *levelLay = new QGridLayout();
-      levelLay->setMargin(5);
+      levelLay->setContentsMargins(5, 5, 5, 5);
       levelLay->setSpacing(5);
       {
         levelLay->addWidget(new QLabel(tr("Level Name:"), this), 0, 0,
@@ -889,7 +889,7 @@ LoadLevelPopup::LoadLevelPopup()
       bottomLay->addWidget(m_levelPropertiesFrame, 0);
 
       QGridLayout *arrLay = new QGridLayout();
-      arrLay->setMargin(5);
+      arrLay->setContentsMargins(5, 5, 5, 5);
       arrLay->setSpacing(5);
       {
         arrLay->addWidget(new QLabel(tr("From:"), this), 0, 0,
@@ -1954,7 +1954,7 @@ LoadColorModelPopup::LoadColorModelPopup()
 
   // layout
   QHBoxLayout *mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   mainLayout->setSpacing(5);
   {
     mainLayout->addStretch(1);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1115,7 +1115,7 @@ void FilmstripFrames::mouseMoveEvent(QMouseEvent *e) {
     } else
       stopAutoPanning();
     update();
-  } else if (e->buttons() & Qt::MidButton) {
+  } else if (e->buttons() & Qt::MiddleButton) {
     // scroll con il tasto centrale
     pos = e->globalPos();
     if (m_isVertical) {
@@ -1178,12 +1178,12 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
   else if (event->key() == Qt::Key_PageDown) {
     if (m_isVertical) {
       int frameHeight   = m_iconSize.height();
-      int visibleHeight = visibleRegion().rects()[0].height();
+      int visibleHeight = visibleRegion().begin()[0].height();
       int visibleFrames = double(visibleHeight) / double(frameHeight);
       scroll(visibleFrames * frameHeight);
     } else {
       int frameWidth    = m_iconSize.width();
-      int visibleWidth  = visibleRegion().rects()[0].width();
+      int visibleWidth  = visibleRegion().begin()[0].width();
       int visibleFrames = double(visibleWidth) / double(frameWidth);
       scroll(visibleFrames * frameWidth);
     }
@@ -1191,12 +1191,12 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_PageUp) {
     if (m_isVertical) {
       int frameHeight   = m_iconSize.height();
-      int visibleHeight = visibleRegion().rects()[0].height();
+      int visibleHeight = visibleRegion().begin()[0].height();
       int visibleFrames = double(visibleHeight) / double(frameHeight);
       scroll(-visibleFrames * frameHeight);
     } else {
       int frameWidth    = m_iconSize.width();
-      int visibleWidth  = visibleRegion().rects()[0].width();
+      int visibleWidth  = visibleRegion().begin()[0].width();
       int visibleFrames = double(visibleWidth) / double(frameWidth);
       scroll(-visibleFrames * frameWidth);
     }
@@ -1213,7 +1213,7 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
 //-----------------------------------------------------------------------------
 
 void FilmstripFrames::wheelEvent(QWheelEvent *event) {
-  scroll(-event->delta());
+  scroll(-event->angleDelta().y());
 }
 
 //-----------------------------------------------------------------------------
@@ -1553,7 +1553,7 @@ Filmstrip::Filmstrip(QWidget *parent, Qt::WindowFlags flags) : QWidget(parent) {
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_chooseLevelCombo, 0);

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -70,7 +70,7 @@
 
 // Qt includes
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QSettings>
 #include <QPainter>
 #include <QDialogButtonBox>
@@ -210,7 +210,7 @@ FlipBook::FlipBook(QWidget *parent, QString viewerTitle,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(fsWidget, 1);
@@ -391,7 +391,7 @@ LoadImagesPopup::LoadImagesPopup(FlipBook *flip)
 
   // layout
   QHBoxLayout *frameRangeLayout = new QHBoxLayout();
-  frameRangeLayout->setMargin(5);
+  frameRangeLayout->setContentsMargins(5, 5, 5, 5);
   frameRangeLayout->setSpacing(5);
   {
     frameRangeLayout->addStretch(1);
@@ -898,8 +898,7 @@ FlipBook *FlipBookPool::pop() {
       flipbook->setPoolIndex(m_geometryPool.begin()->first);
       QRect geometry(m_geometryPool.begin()->second);
       panel->setGeometry(geometry);
-      if ((geometry & QApplication::desktop()->availableGeometry(panel))
-              .isEmpty())
+      if ((geometry & panel->screen()->availableGeometry()).isEmpty())
         panel->move(x += 50, y += 50);
       m_geometryPool.erase(m_geometryPool.begin());
     }
@@ -2017,9 +2016,7 @@ void FlipBook::adaptGeometryForFullPreview(const TRect &imgRect) {
   // Get screen geometry
   TPanel *panel = static_cast<TPanel *>(parentWidget());
   if (!panel->isFloating()) return;
-  QDesktopWidget *desk =
-      static_cast<QApplication *>(QApplication::instance())->desktop();
-  QRect screenGeom = desk->availableGeometry(panel);
+  QRect screenGeom = panel->screen()->availableGeometry();
 
   while (1) {
     TAffine toWidgetRef(m_imageViewer->getImgToWidgetAffine(imgRectD));
@@ -2061,9 +2058,7 @@ void FlipBook::adaptWidGeometry(const TRect &interestWidGeom,
   //  imageGeom.top(), imageGeom.bottom());
 
   // Get screen geometry
-  QDesktopWidget *desk =
-      static_cast<QApplication *>(QApplication::instance())->desktop();
-  QRect screenGeom = desk->availableGeometry(panel);
+  QRect screenGeom = panel->screen()->availableGeometry();
 
   // Get panel margin measures
   QRect margins;

--- a/toonz/sources/toonz/floatingpanelcommand.cpp
+++ b/toonz/sources/toonz/floatingpanelcommand.cpp
@@ -10,7 +10,7 @@
 #include "toonzqt/styleeditor.h"
 
 #include <QMainWindow>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QApplication>
 #include <../toonzqt/tdockwindows.h>
 
@@ -19,8 +19,7 @@
 // mette il widget al centro dello schermo e lo fa diventare la finestra
 // corrente
 static void activateWidget(QWidget *w) {
-  QDesktopWidget *desktop = qApp->desktop();
-  QRect screenRect        = desktop->screenGeometry(w);
+  QRect screenRect = w->screen()->geometry();
 
   QPoint p((screenRect.width() - w->width()) / 2,
            (screenRect.height() - w->height()) / 2);

--- a/toonz/sources/toonz/formatsettingspopups.cpp
+++ b/toonz/sources/toonz/formatsettingspopups.cpp
@@ -190,7 +190,7 @@ void FormatSettingsPopup::buildPropertyComboBox(int index,
   m_widgets[prop->getName()]        = comboBox;
 
 #ifdef _WIN32
-  connect(comboBox, SIGNAL(currentIndexChanged(const QString &)), this,
+  connect(comboBox, SIGNAL(currentTextChanged(const QString &)), this,
           SLOT(onComboBoxIndexChanged(const QString &)));
 #endif
   TEnumProperty::Range range = prop->getRange();

--- a/toonz/sources/toonz/formatsettingspopups.cpp
+++ b/toonz/sources/toonz/formatsettingspopups.cpp
@@ -66,7 +66,7 @@ FormatSettingsPopup::FormatSettingsPopup(QWidget *parent,
   setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint);
 
   m_mainLayout = new QGridLayout();
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setVerticalSpacing(5);
   m_mainLayout->setHorizontalSpacing(5);
   m_mainLayout->setColumnStretch(0, 0);

--- a/toonz/sources/toonz/frameheadgadget.cpp
+++ b/toonz/sources/toonz/frameheadgadget.cpp
@@ -255,7 +255,7 @@ bool FrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
         return false;
       }
       viewer->update();
-    } else if (mouseEvent->buttons() & Qt::MidButton)
+    } else if (mouseEvent->buttons() & Qt::MiddleButton)
       return false;
   } else
     return false;
@@ -831,7 +831,7 @@ bool FilmstripFrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
         return false;
       }
       viewer->update();
-    } else if (mouseEvent->buttons() & Qt::MidButton)
+    } else if (mouseEvent->buttons() & Qt::MiddleButton)
       return false;
   } else
     return false;

--- a/toonz/sources/toonz/fxparameditorpopup.cpp
+++ b/toonz/sources/toonz/fxparameditorpopup.cpp
@@ -50,10 +50,10 @@ FxParamEditorPopup::FxParamEditorPopup()
   fxSettings->setCurrentFx();
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(10);
   { mainLayout->addWidget(fxSettings); }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLayout);
 
   move(parentWidget()->geometry().center() - rect().bottomRight() / 2.0);

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -127,12 +127,7 @@ void HistogramPopup::moveNextToWidget(QWidget *widget) {
   if (minimumSize().isEmpty()) grab();
   QSize popupSize = frameSize();
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QRect screenRect = widget->screen()->availableGeometry();
-#else
-  int currentScreen = QApplication::desktop()->screenNumber(widget);
-  QRect screenRect  = QApplication::desktop()->availableGeometry(currentScreen);
-#endif
   QRect viewerRect = widget->rect();
   viewerRect.moveTo(widget->mapToGlobal(QPoint(0, 0)));
   // decide which side to open the popup

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -23,7 +23,7 @@
 // Qt includes
 #include <QTimer>
 #include <QMainWindow>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QFocusEvent>
 #include <QScreen>
 
@@ -45,10 +45,10 @@ HistogramPopup::HistogramPopup(QString title)
   m_histogram = new ComboHistogram(this);
 
   QVBoxLayout *mainLay = new QVBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(0);
   { mainLay->addWidget(m_histogram); }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLay);
   mainLay->setSizeConstraint(QLayout::SetFixedSize);
   setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);

--- a/toonz/sources/toonz/historypane.cpp
+++ b/toonz/sources/toonz/historypane.cpp
@@ -201,7 +201,7 @@ HistoryPane::HistoryPane(QWidget *parent, Qt::WindowFlags flags)
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   { mainLayout->addWidget(m_frameArea, 1); }
   setLayout(mainLayout);
 

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -247,10 +247,8 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
   if (Preferences::instance()->isColorCalibrationEnabled())
     m_lutCalibrator = new LutCalibrator();
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (Preferences::instance()->is30bitDisplayEnabled())
     setTextureFormat(TGL_TexFmt10);
-#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -1311,13 +1309,8 @@ void ImageViewer::wheelEvent(QWheelEvent *event) {
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
       int d = delta > 0 ? 120 : -120;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       QPoint center(event->position().x() * getDevPixRatio() - width() / 2,
                     -event->position().y() * getDevPixRatio() + height() / 2);
-#else
-      QPoint center(event->pos().x() * getDevPixRatio() - width() / 2,
-                    -event->pos().y() * getDevPixRatio() + height() / 2);
-#endif
       zoomQt(center, exp(0.001 * d));
     }
   }

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1281,14 +1281,14 @@ IoCmd::ConvertingPopup::ConvertingPopup(QWidget *parent, QString fileName)
   setWindowFlags(Qt::Dialog | Qt::WindowTitleHint);
   setMinimumSize(70, 50);
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   mainLayout->setSpacing(0);
 
   QLabel *label = new QLabel(QString(
       QObject::tr("Converting %1 images to tlv format...").arg(fileName)));
   mainLayout->addWidget(label);
 
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLayout);
 }
 

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -225,11 +225,11 @@ LevelCreatePopup::LevelCreatePopup()
   okBtn->setDefault(true);
 
   //--- layout
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
   {
     QGridLayout *guiLay = new QGridLayout();
-    guiLay->setMargin(10);
+    guiLay->setContentsMargins(10, 10, 10, 10);;
     guiLay->setVerticalSpacing(10);
     guiLay->setHorizontalSpacing(5);
     {
@@ -289,7 +289,7 @@ LevelCreatePopup::LevelCreatePopup()
     m_topLayout->addLayout(guiLay, 1);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(30);
   {
     m_buttonLayout->addStretch(1);

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -457,13 +457,13 @@ LevelSettingsPopup::LevelSettingsPopup()
   m_activateFlags[m_colorSpaceGammaFld]   = linearFlag;
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     //--Name&Path
     QGroupBox *nameBox      = new QGroupBox(tr("Name && Path"), this);
     QGridLayout *nameLayout = new QGridLayout();
-    nameLayout->setMargin(5);
+    nameLayout->setContentsMargins(5, 5, 5, 5);
     nameLayout->setSpacing(5);
     {
       nameLayout->addWidget(new QLabel(tr("Name:"), this), 0, 0,
@@ -492,7 +492,7 @@ LevelSettingsPopup::LevelSettingsPopup()
     else
       dpiBox               = new QGroupBox(tr("DPI && Resolution"), this);
     QGridLayout *dpiLayout = new QGridLayout();
-    dpiLayout->setMargin(5);
+    dpiLayout->setContentsMargins(5, 5, 5, 5);
     dpiLayout->setSpacing(5);
     {
       dpiLayout->addWidget(m_dpiTypeOm, 0, 1, 1, 3);
@@ -541,7 +541,7 @@ LevelSettingsPopup::LevelSettingsPopup()
 
     //---subsampling
     QGridLayout *bottomLay = new QGridLayout();
-    bottomLay->setMargin(3);
+    bottomLay->setContentsMargins(3, 3, 3, 3);
     bottomLay->setSpacing(3);
     {
       bottomLay->addWidget(m_softnessLabel, 0, 0);

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -215,7 +215,7 @@ LipSyncPopup::LipSyncPopup()
   m_dataFrame->setContentsMargins(0,0,0,0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   {
     hLayout->addSpacing(4);
     hLayout->addWidget(m_tabBar);
@@ -286,7 +286,7 @@ LipSyncPopup::LipSyncPopup()
   rhubarbLayout->addWidget(m_scriptLabel, 2, 0, 1, 3);
   rhubarbLayout->addWidget(m_scriptEdit, 3, 0, 1, 5);
   rhubarbLayout->setSpacing(4);
-  rhubarbLayout->setMargin(10);
+  rhubarbLayout->setContentsMargins(10, 10, 10, 10);;
   m_audioFrame->setLayout(rhubarbLayout);
 
   m_file = new DVGui::FileField(this, QString(""));
@@ -300,7 +300,7 @@ LipSyncPopup::LipSyncPopup()
 
   QGridLayout *fileLay = new QGridLayout();
   fileLay->setSpacing(4);
-  fileLay->setMargin(10);
+  fileLay->setContentsMargins(10, 10, 10, 10);;
   fileLay->addWidget(pathLabel, 0, 0, Qt::AlignLeft);
   fileLay->addWidget(m_file, 1, 0, Qt::AlignLeft);
   fileLay->addWidget(new QLabel(""), 2, 0, Qt::AlignLeft);
@@ -327,7 +327,7 @@ LipSyncPopup::LipSyncPopup()
   }
 
   //--- layout
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
 
   m_topLayout->addWidget(m_tabBarContainer);
@@ -335,7 +335,7 @@ LipSyncPopup::LipSyncPopup()
 
   {
     QGridLayout *phonemeLay = new QGridLayout();
-    phonemeLay->setMargin(10);
+    phonemeLay->setContentsMargins(10, 10, 10, 10);;
     phonemeLay->setVerticalSpacing(10);
     phonemeLay->setHorizontalSpacing(10);
     int i = 0;  // navButtons
@@ -444,10 +444,10 @@ LipSyncPopup::LipSyncPopup()
   }
 
   QHBoxLayout *optionsLay = new QHBoxLayout();
-  optionsLay->setMargin(10);
+  optionsLay->setContentsMargins(10, 10, 10, 10);;
   optionsLay->setSpacing(15);
   QHBoxLayout *insertAtLay = new QHBoxLayout();
-  insertAtLay->setMargin(0);
+  insertAtLay->setContentsMargins(0, 0, 0, 0);
   insertAtLay->setSpacing(4);
   m_insertAtLabel = new QLabel(tr("Insert at Frame: "));
   insertAtLay->addWidget(m_insertAtLabel);
@@ -458,7 +458,7 @@ LipSyncPopup::LipSyncPopup()
   m_topLayout->addLayout(optionsLay);
 
   m_topLayout->setAlignment(Qt::AlignHCenter);
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(0);
   {
     m_buttonLayout->addStretch();
@@ -760,7 +760,7 @@ void LipSyncPopup::onOutputReady() {
                .replace("\\\"", "")
                .replace("\"", "");
   QStringList outputList =
-      output.mid(2, (output.size() - 4)).split(", ", QString::SkipEmptyParts);
+      output.mid(2, (output.size() - 4)).split(", ", Qt::SkipEmptyParts);
   if (outputList.size()) {
     QStringList outputType = outputList.at(0).split(": ");
     if (outputType.at(1) == "progress") {

--- a/toonz/sources/toonz/locatorpopup.cpp
+++ b/toonz/sources/toonz/locatorpopup.cpp
@@ -20,7 +20,7 @@ LocatorPopup::LocatorPopup(QWidget *parent, Qt::WindowFlags flags)
 
   //---- layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->addWidget(m_viewer, 1);
   setLayout(mainLayout);
 

--- a/toonz/sources/toonz/magpiefileimportpopup.cpp
+++ b/toonz/sources/toonz/magpiefileimportpopup.cpp
@@ -65,7 +65,7 @@ MagpieFileImportPopup::MagpieFileImportPopup()
   fromToWidget->setFixedHeight(DVGui::WidgetHeight);
   fromToWidget->setFixedSize(210, DVGui::WidgetHeight);
   QHBoxLayout *fromToLayout = new QHBoxLayout(fromToWidget);
-  fromToLayout->setMargin(0);
+  fromToLayout->setContentsMargins(0, 0, 0, 0);
   fromToLayout->setSpacing(0);
   m_fromField = new DVGui::IntLineEdit(fromToWidget, 1, 1, 1);
   fromToLayout->addWidget(m_fromField, 0, Qt::AlignLeft);
@@ -111,7 +111,7 @@ MagpieFileImportPopup::MagpieFileImportPopup()
   frame->setStyleSheet(
       "#LipSynkViewer { border: 1px solid rgb(150,150,150); }");
   QVBoxLayout *frameLayout = new QVBoxLayout(frame);
-  frameLayout->setMargin(0);
+  frameLayout->setContentsMargins(0, 0, 0, 0);
   frameLayout->setSpacing(0);
   std::vector<int> buttonMask = {FlipConsole::eRate,
                                  FlipConsole::eSound,

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -77,7 +77,7 @@
 #include <QAbstractEventDispatcher>
 #include <QAbstractNativeEventFilter>
 #include <QSplashScreen>
-#include <QGLPixelBuffer>
+#include <QOpenGLFramebufferObject>
 #include <QTranslator>
 #include <QFileInfo>
 #include <QSettings>
@@ -558,10 +558,8 @@ int main(int argc, char *argv[]) {
   a.processEvents();
 
   // OpenGL
-  QGLFormat fmt;
-  fmt.setAlpha(true);
-  fmt.setStencil(true);
-  QGLFormat::setDefaultFormat(fmt);
+  QOpenGLFramebufferObjectFormat fmt;
+  fmt.setAttachment(QOpenGLFramebufferObject::Attachment::CombinedDepthStencil);
 
 #ifndef __HAIKU__
   glutInit(&argc, argv);

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -412,7 +412,7 @@ int main(int argc, char *argv[]) {
 
   // Enable to render smooth icons on high dpi monitors
   a.setAttribute(Qt::AA_UseHighDpiPixmaps);
-#if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+#if defined(_WIN32)
   // Compress tablet events with application attributes instead of implementing
   // the delay-timer by ourselves
   a.setAttribute(Qt::AA_CompressHighFrequencyEvents);
@@ -883,7 +883,7 @@ int main(int argc, char *argv[]) {
 
 // Windows Ink Support was introduce into Qt 5.12 so disable
 // our version when compiling with it
-#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
+#if defined(_WIN32)
   if (Preferences::instance()->isWinInkEnabled()) {
     KisTabletSupportWin8 *penFilter = new KisTabletSupportWin8();
     if (penFilter->init()) {

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -49,7 +49,7 @@
 #include <QStackedWidget>
 #include <QSettings>
 #include <QApplication>
-#include <QGLPixelBuffer>
+#include <QOpenGLFramebufferObject>
 #include <QDebug>
 #include <QDesktopServices>
 #include <QButtonGroup>
@@ -1309,7 +1309,7 @@ void MainWindow::onMenuCheckboxChanged() {
   else if (cm->getAction(MI_FieldGuide) == action)
     FieldGuideToggleAction = isChecked;
   else if (cm->getAction(MI_RasterizePli) == action) {
-    if (!QGLPixelBuffer::hasOpenGLPbuffers()) isChecked = 0;
+//    if (!QOpenGLFramebufferObject::hasOpenGLPbuffers()) isChecked = 0;
     RasterizePliToggleAction = isChecked;
   } else if (cm->getAction(MI_SafeArea) == action)
     SafeAreaToggleAction = isChecked;
@@ -2411,12 +2411,12 @@ void MainWindow::defineActions() {
   createToggle(MI_VectorGuidedDrawing, QT_TR_NOOP("Vector Guided Tweening"), "",
                Preferences::instance()->isGuidedDrawingEnabled(),
                MenuViewCommandType, "view_guided_drawing");
-  if (QGLPixelBuffer::hasOpenGLPbuffers())
+//  if (QOpenGLFramebufferObject::hasOpenGLPbuffers())
     createToggle(MI_RasterizePli, QT_TR_NOOP("&Visualize Vector As Raster"), "",
                  RasterizePliToggleAction ? 1 : 0, MenuViewCommandType,
                  "view_vector_as_raster");
-  else
-    RasterizePliToggleAction = 0;
+//  else
+//    RasterizePliToggleAction = 0;
   createToggle(MI_ToggleLightTable, QT_TR_NOOP("Light Table"), "", false,
                MenuViewCommandType, "light_table");
   createToggle(MI_CurrentDrawingOnTop, QT_TR_NOOP("Current Drawing On Top"), "", false,

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -440,7 +440,7 @@ MainWindow::MainWindow(const QString &argumentLayoutFileName, QWidget *parent,
 centralWidget->setFrameStyle(QFrame::StyledPanel);
 centralWidget->setObjectName("centralWidget");
 QHBoxLayout *centralWidgetLayout = new QHBoxLayout;
-centralWidgetLayout->setMargin(3);
+centralWidgetLayout->setContentsMargins(3, 3, 3, 3);
 centralWidgetLayout->addWidget(m_stackedWidget);
 centralWidget->setLayout(centralWidgetLayout);*/
 

--- a/toonz/sources/toonz/matchline.cpp
+++ b/toonz/sources/toonz/matchline.cpp
@@ -396,11 +396,11 @@ MatchlinesDialog::MatchlinesDialog()
 
   //----layout
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     QGridLayout *inkUsageLay = new QGridLayout();
-    inkUsageLay->setMargin(5);
+    inkUsageLay->setContentsMargins(5, 5, 5, 5);
     inkUsageLay->setSpacing(5);
     {
       inkUsageLay->addWidget(m_button1, 0, 0, 1, 2);
@@ -414,11 +414,11 @@ MatchlinesDialog::MatchlinesDialog()
     m_topLayout->addWidget(inkUsageGroupBox);
 
     QVBoxLayout *lineOrderLay = new QVBoxLayout();
-    lineOrderLay->setMargin(5);
+    lineOrderLay->setContentsMargins(5, 5, 5, 5);
     lineOrderLay->setSpacing(5);
     {
       QGridLayout *buttonsLay = new QGridLayout();
-      buttonsLay->setMargin(0);
+      buttonsLay->setContentsMargins(0, 0, 0, 0);
       buttonsLay->setSpacing(5);
       {
         buttonsLay->addWidget(new QLabel(tr("L-Up R-Down"), this), 0, 1);
@@ -441,7 +441,7 @@ MatchlinesDialog::MatchlinesDialog()
       lineOrderLay->addLayout(buttonsLay, 1);
 
       QHBoxLayout *inkPrevalenceLay = new QHBoxLayout();
-      inkPrevalenceLay->setMargin(0);
+      inkPrevalenceLay->setContentsMargins(0, 0, 0, 0);
       inkPrevalenceLay->setSpacing(5);
       {
         inkPrevalenceLay->addWidget(new QLabel(tr("Line Prevalence"), this), 0);
@@ -455,7 +455,7 @@ MatchlinesDialog::MatchlinesDialog()
     m_topLayout->addStretch();
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(okBtn);
@@ -942,10 +942,10 @@ std::vector<int> string2Indexes(const QString &values) {
   std::vector<int> ret;
   int i, j;
   bool ok;
-  QStringList vals = values.split(',', QString::SkipEmptyParts);
+  QStringList vals = values.split(',', Qt::SkipEmptyParts);
   for (i = 0; i < vals.size(); i++) {
     if (vals.at(i).contains('-')) {
-      QStringList vals1 = vals.at(i).split('-', QString::SkipEmptyParts);
+      QStringList vals1 = vals.at(i).split('-', Qt::SkipEmptyParts);
       if (vals1.size() != 2) return std::vector<int>();
       int from = vals1.at(0).toInt(&ok);
       if (!ok) return std::vector<int>();
@@ -992,11 +992,11 @@ DeleteInkDialog::DeleteInkDialog(const QString &str, int inkIndex)
   okBtn->setDefault(true);
 
   //--- layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(10);
   {
     QGridLayout *upperLay = new QGridLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(5);
     {
       upperLay->addWidget(new QLabel(tr("Style Index:"), this), 0, 0,
@@ -1010,7 +1010,7 @@ DeleteInkDialog::DeleteInkDialog(const QString &str, int inkIndex)
     m_topLayout->addLayout(upperLay);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(okBtn);

--- a/toonz/sources/toonz/matchline.cpp
+++ b/toonz/sources/toonz/matchline.cpp
@@ -468,7 +468,7 @@ MatchlinesDialog::MatchlinesDialog()
           SLOT(onChooseInkClicked(bool)));
   connect(okBtn, SIGNAL(clicked()), this, SLOT(accept()));
   connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
-  connect(lineStackButtonGroup, SIGNAL(buttonPressed(int)),
+  connect(lineStackButtonGroup, SIGNAL(idPressed(int)),
           SLOT(onLineStackButtonPressed(int)));
   connect(m_inkPrevalence, SIGNAL(valueChanged(bool)),
           SLOT(onInkPrevalenceChanged(bool)));

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -767,11 +767,11 @@ TopBar::TopBar(QWidget *parent) : QToolBar(parent) {
 
   QHBoxLayout *mainLayout = new QHBoxLayout();
   mainLayout->setSpacing(0);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   {
     QVBoxLayout *menuLayout = new QVBoxLayout();
     menuLayout->setSpacing(0);
-    menuLayout->setMargin(0);
+    menuLayout->setContentsMargins(0, 0, 0, 0);
     {
       menuLayout->addStretch(1);
       menuLayout->addWidget(m_menuBar, 0);

--- a/toonz/sources/toonz/mergecmapped.cpp
+++ b/toonz/sources/toonz/mergecmapped.cpp
@@ -698,10 +698,10 @@ std::vector<int> string2Indexes(const QString &values) {
   std::vector<int> ret;
   int i, j;
   bool ok;
-  QStringList vals = values.split(',', QString::SkipEmptyParts);
+  QStringList vals = values.split(',', Qt::SkipEmptyParts);
   for (i = 0; i < vals.size(); i++) {
     if (vals.at(i).contains('-')) {
-      QStringList vals1 = vals.at(i).split('-', QString::SkipEmptyParts);
+      QStringList vals1 = vals.at(i).split('-', Qt::SkipEmptyParts);
       if (vals1.size() != 2) return std::vector<int>();
       int from = vals1.at(0).toInt(&ok);
       if (!ok) return std::vector<int>();

--- a/toonz/sources/toonz/messagepanel.cpp
+++ b/toonz/sources/toonz/messagepanel.cpp
@@ -30,11 +30,7 @@ protected:
 
     QFontMetrics fm    = p.fontMetrics();
     QString elidedText = fm.elidedText(m_text, Qt::ElideRight, width());
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     qreal textWidth = fm.horizontalAdvance(elidedText);
-#else
-    qreal textWidth    = fm.width(elidedText);
-#endif
     p.drawText((width() - textWidth) * 0.5, (height() - fm.height()) * 0.5,
                elidedText);
   }

--- a/toonz/sources/toonz/motionpathpanel.cpp
+++ b/toonz/sources/toonz/motionpathpanel.cpp
@@ -53,11 +53,11 @@ double distanceSquared(QPoint p1, QPoint p2) {
 MotionPathPanel::MotionPathPanel(QWidget* parent)
     : QWidget(parent), m_currentSpline(0), m_playbackExecutor() {
   m_outsideLayout = new QVBoxLayout();
-  m_outsideLayout->setMargin(0);
+  m_outsideLayout->setContentsMargins(0, 0, 0, 0);
   m_outsideLayout->setSpacing(0);
 
   m_insideLayout = new QVBoxLayout();
-  m_insideLayout->setMargin(0);
+  m_insideLayout->setContentsMargins(0, 0, 0, 0);
   m_insideLayout->setSpacing(0);
 
   m_pathsLayout = new QGridLayout();
@@ -103,7 +103,7 @@ MotionPathPanel::MotionPathPanel(QWidget* parent)
   m_toolbar->setIconSize(QSize(16, 16));
   m_toolLayout = new QHBoxLayout();
   m_toolLayout->setSpacing(2);
-  m_toolLayout->setMargin(2);
+  m_toolLayout->setContentsMargins(2, 2, 2, 2);
   m_toolLayout->addWidget(m_toolbar);
 
   QStringList geomOptions;
@@ -136,11 +136,11 @@ MotionPathPanel::MotionPathPanel(QWidget* parent)
   container->setLayout(m_toolLayout);
 
   m_controlsLayout = new QVBoxLayout();
-  m_controlsLayout->setMargin(10);
+  m_controlsLayout->setContentsMargins(10, 10, 10, 10);;
   m_controlsLayout->setSpacing(3);
 
   QHBoxLayout* graphLayout = new QHBoxLayout();
-  graphLayout->setMargin(0);
+  graphLayout->setContentsMargins(0, 0, 0, 0);
   graphLayout->setSpacing(0);
   graphLayout->addWidget(m_graphArea);
 

--- a/toonz/sources/toonz/ocaio.cpp
+++ b/toonz/sources/toonz/ocaio.cpp
@@ -536,7 +536,7 @@ void ExportOCACommand::execute() {
     rasVectors->setChecked(true);
 
     QGridLayout *customLay = new QGridLayout();
-    customLay->setMargin(5);
+    customLay->setContentsMargins(5, 5, 5, 5);
     customLay->setSpacing(5);
     customLay->addWidget(exrImageFormat, 0, 0);
     customLay->addWidget(rasVectors, 1, 0);

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -198,7 +198,7 @@ OutputSettingsPopup::OutputSettingsPopup(QWidget *parent, bool isPreview)
   // preview settings
   if (isPreview) {
 
-    m_topLayout->setMargin(5);
+    m_topLayout->setContentsMargins(5, 5, 5, 5);
     m_topLayout->addWidget(panel, 0);
     m_topLayout->addWidget(renderButton, 0);
 
@@ -240,10 +240,10 @@ OutputSettingsPopup::OutputSettingsPopup(QWidget *parent, bool isPreview)
   saveAndRenderButton->setIcon(createQIcon("render"));
   saveAndRenderButton->setIconSize(QSize(20, 20));
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   {
     QHBoxLayout *presetLay = new QHBoxLayout();
-    presetLay->setMargin(0);
+    presetLay->setContentsMargins(0, 0, 0, 0);
     presetLay->setSpacing(5);
     {
       presetLay->addStretch(1);
@@ -256,7 +256,7 @@ OutputSettingsPopup::OutputSettingsPopup(QWidget *parent, bool isPreview)
     m_topLayout->addLayout(presetLay, 0);
 
     QHBoxLayout *middleLay = new QHBoxLayout();
-    middleLay->setMargin(0);
+    middleLay->setContentsMargins(0, 0, 0, 0);
     middleLay->setSpacing(5);
     {
 //      middleLay->addWidget(categoryList, 0);
@@ -386,7 +386,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
   }
 
   QVBoxLayout *lay = new QVBoxLayout();
-  lay->setMargin(5);
+  lay->setContentsMargins(5, 5, 5, 5);
   lay->setSpacing(3);
   {
     if (!isPreview) {
@@ -396,7 +396,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
     }
 
     QHBoxLayout *cameraSettingsLabelLay = new QHBoxLayout();
-    cameraSettingsLabelLay->setMargin(0);
+    cameraSettingsLabelLay->setContentsMargins(0, 0, 0, 0);
     cameraSettingsLabelLay->setSpacing(3);
     {
       if (!isPreview)
@@ -409,7 +409,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
     lay->addSpacing(10);
 
     QHBoxLayout *colorLabelLay = new QHBoxLayout();
-    colorLabelLay->setMargin(0);
+    colorLabelLay->setContentsMargins(0, 0, 0, 0);
     colorLabelLay->setSpacing(3);
     {
       if (!isPreview) colorLabelLay->addWidget(m_showColorSettingsButton, 0);
@@ -424,7 +424,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
 
 
     QHBoxLayout *advancedSettingsLabelLay = new QHBoxLayout();
-    advancedSettingsLabelLay->setMargin(0);
+    advancedSettingsLabelLay->setContentsMargins(0, 0, 0, 0);
     advancedSettingsLabelLay->setSpacing(3);
     {
       if (!isPreview)
@@ -439,7 +439,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
       lay->addSpacing(10);
 
       QHBoxLayout *moreSettingsLabelLay = new QHBoxLayout();
-      moreSettingsLabelLay->setMargin(0);
+      moreSettingsLabelLay->setContentsMargins(0, 0, 0, 0);
       moreSettingsLabelLay->setSpacing(3);
       {
         moreSettingsLabelLay->addWidget(m_showMoreSettingsButton, 0);
@@ -517,12 +517,12 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
   //-----
 
   QVBoxLayout *lay = new QVBoxLayout();
-  lay->setMargin(10);
+  lay->setContentsMargins(10, 10, 10, 10);;
   lay->setSpacing(10);
   {
     // Frame start/end
     QGridLayout *frameStepLay = new QGridLayout();
-    frameStepLay->setMargin(0);
+    frameStepLay->setContentsMargins(0, 0, 0, 0);
     frameStepLay->setHorizontalSpacing(5);
     frameStepLay->setVerticalSpacing(10);
     {
@@ -546,7 +546,7 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
     lay->addLayout(frameStepLay);
 
     QGridLayout *fileGridLay = new QGridLayout();
-    fileGridLay->setMargin(0);
+    fileGridLay->setContentsMargins(0, 0, 0, 0);
     fileGridLay->setHorizontalSpacing(5);
     fileGridLay->setVerticalSpacing(10);
     {
@@ -630,12 +630,12 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   //-----
 
   QVBoxLayout *lay = new QVBoxLayout();
-  lay->setMargin(10);
+  lay->setContentsMargins(10, 10, 10, 10);;
   lay->setSpacing(10);
   {
     // Output Camera
     QHBoxLayout *outCamLay = new QHBoxLayout();
-    outCamLay->setMargin(0);
+    outCamLay->setContentsMargins(0, 0, 0, 0);
     outCamLay->setSpacing(5);
     {
       outCamLay->addWidget(new QLabel(tr("Output Camera:"), this), 0);
@@ -646,7 +646,7 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
 
     if (!isPreview) {
       QVBoxLayout *camParamLay = new QVBoxLayout();
-      camParamLay->setMargin(5);
+      camParamLay->setContentsMargins(5, 5, 5, 5);
       camParamLay->setSpacing(0);
       { camParamLay->addWidget(m_cameraSettings); }
       cameraParametersBox->setLayout(camParamLay);
@@ -657,7 +657,7 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
     if (isPreview) {
       // Frame start/end
       QGridLayout *frameStepLay = new QGridLayout();
-      frameStepLay->setMargin(0);
+      frameStepLay->setContentsMargins(0, 0, 0, 0);
       frameStepLay->setHorizontalSpacing(5);
       frameStepLay->setVerticalSpacing(10);
       {
@@ -683,7 +683,7 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
 
     // Frame start/end
     QGridLayout *frameShrinkLay = new QGridLayout();
-    frameShrinkLay->setMargin(0);
+    frameShrinkLay->setContentsMargins(0, 0, 0, 0);
     frameShrinkLay->setHorizontalSpacing(5);
     frameShrinkLay->setVerticalSpacing(10);
     {
@@ -770,7 +770,7 @@ QFrame *OutputSettingsPopup::createColorSettingsBox(bool isPreview) {
   }
 
   QGridLayout *gridLay = new QGridLayout();
-  gridLay->setMargin(5);
+  gridLay->setContentsMargins(5, 5, 5, 5);
   gridLay->setHorizontalSpacing(5);
   gridLay->setVerticalSpacing(10);
   {
@@ -843,11 +843,11 @@ QFrame *OutputSettingsPopup::createAdvancedSettingsBox(bool isPreview) {
   //-----
 
   QVBoxLayout *lay = new QVBoxLayout();
-  lay->setMargin(10);
+  lay->setContentsMargins(10, 10, 10, 10);;
   lay->setSpacing(10);
   {
     QGridLayout *bottomGridLay = new QGridLayout();
-    bottomGridLay->setMargin(0);
+    bottomGridLay->setContentsMargins(0, 0, 0, 0);
     bottomGridLay->setHorizontalSpacing(5);
     bottomGridLay->setVerticalSpacing(10);
     {
@@ -947,7 +947,7 @@ QFrame *OutputSettingsPopup::createMoreSettingsBox() {
   //-----
 
   QGridLayout *lay = new QGridLayout();
-  lay->setMargin(5);
+  lay->setContentsMargins(5, 5, 5, 5);
   lay->setHorizontalSpacing(5);
   lay->setVerticalSpacing(10);
   {

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -284,7 +284,7 @@ OutputSettingsPopup::OutputSettingsPopup(QWidget *parent, bool isPreview)
                        SLOT(onAddPresetButtonPressed()));
   ret = ret && connect(removePresetButton, SIGNAL(pressed()), this,
                        SLOT(onRemovePresetButtonPressed()));
-  ret = ret && connect(m_presetCombo, SIGNAL(activated(const QString &)), this,
+  ret = ret && connect(m_presetCombo, SIGNAL(textActivated(const QString &)), this,
                        SLOT(onPresetSelected(const QString &)));
 //  ret = ret && connect(categoryList, SIGNAL(itemClicked(QListWidgetItem *)),
 //                       this, SLOT(onCategoryActivated(QListWidgetItem *)));
@@ -584,7 +584,7 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
   ret = ret && connect(m_fileNameFld, SIGNAL(editingFinished()),
     SLOT(onNameChanged()));
   ret = ret &&
-    connect(m_fileFormat, SIGNAL(currentIndexChanged(const QString &)),
+    connect(m_fileFormat, SIGNAL(currentTextChanged(const QString &)),
       SLOT(onFormatChanged(const QString &)));
   ret = ret && connect(m_fileFormatButton, SIGNAL(pressed()), this,
     SLOT(openSettingsPopup()));
@@ -714,7 +714,7 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   }
 
   ret      = ret &&
-        connect(m_outputCameraOm, SIGNAL(currentIndexChanged(const QString &)),
+        connect(m_outputCameraOm, SIGNAL(currentTextChanged(const QString &)),
                 SLOT(onCameraChanged(const QString &)));
   ret = ret && connect(m_shrinkFld, SIGNAL(editingFinished()),
                        SLOT(onFrameFldEditFinished()));

--- a/toonz/sources/toonz/overwritepopup.cpp
+++ b/toonz/sources/toonz/overwritepopup.cpp
@@ -81,7 +81,7 @@ OverwriteDialog::OverwriteDialog()
   m_suffix->setEnabled(false);
 
   QHBoxLayout *boxLayout = new QHBoxLayout();
-  boxLayout->setMargin(0);
+  boxLayout->setContentsMargins(0, 0, 0, 0);
   boxLayout->setSpacing(0);
   boxLayout->addWidget(m_rename);
   boxLayout->addWidget(m_suffix);

--- a/toonz/sources/toonz/overwritepopup.cpp
+++ b/toonz/sources/toonz/overwritepopup.cpp
@@ -55,7 +55,7 @@ OverwriteDialog::OverwriteDialog()
 
   QButtonGroup *buttonGroup = new QButtonGroup(this);
   buttonGroup->setExclusive(true);
-  bool ret = connect(buttonGroup, SIGNAL(buttonClicked(int)), this,
+  bool ret = connect(buttonGroup, SIGNAL(idClicked(int)), this,
                      SLOT(onButtonClicked(int)));
 
   beginVLayout();

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -34,7 +34,7 @@
 #include <QFile>
 #include <qdrawutil.h>
 #include <assert.h>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QDialog>
 #include <QLineEdit>
 #include <QTextEdit>
@@ -192,7 +192,7 @@ void TPanel::restoreFloatingPanelState() {
 
   QRect geom = settings.value("geometry", saveGeometry()).toRect();
   // check if it can be visible in the current screen
-  if (!(geom & QApplication::desktop()->availableGeometry(this)).isEmpty())
+  if (!(geom & this->screen()->availableGeometry()).isEmpty())
     setGeometry(geom);
   // load optional settings
   if (SaveLoadQSettings *persistent =

--- a/toonz/sources/toonz/pltgizmopopup.cpp
+++ b/toonz/sources/toonz/pltgizmopopup.cpp
@@ -462,7 +462,7 @@ ValueAdjuster::ValueAdjuster(QWidget *parent, Qt::WindowFlags flags)
   m_valueLineEdit->setRange(0, 1000);
   //----layout
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(1);
   {
     layout->addWidget(plusBut, 0);
@@ -511,7 +511,7 @@ ValueShifter::ValueShifter(bool isHue, QWidget *parent, Qt::WindowFlags flags)
 
   //----layout
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(1);
   {
     layout->addWidget(plusBut, 0);
@@ -548,7 +548,7 @@ void ValueShifter::onClickedMinus() {
 ColorFader::ColorFader(QString name, QWidget *parent, Qt::WindowFlags flags)
     : QWidget(parent) {
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(6);
   layout->setSizeConstraint(QLayout::SetFixedSize);
 
@@ -606,11 +606,11 @@ PltGizmoPopup::PltGizmoPopup()
   QPushButton *zeroMatteButton = new QPushButton(tr("Zero Alpha"), this);
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(3);
   {
     QGridLayout *upperLay = new QGridLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(3);
     {
       upperLay->addWidget(new QLabel(tr("Scale (%)"), this), 0, 1);
@@ -644,11 +644,11 @@ PltGizmoPopup::PltGizmoPopup()
 
     QGroupBox *fadeBox   = new QGroupBox(tr("Fade to Color"), this);
     QVBoxLayout *fadeLay = new QVBoxLayout();
-    fadeLay->setMargin(3);
+    fadeLay->setContentsMargins(3, 3, 3, 3);
     fadeLay->setSpacing(3);
     {
       QHBoxLayout *colorLay = new QHBoxLayout();
-      colorLay->setMargin(0);
+      colorLay->setContentsMargins(0, 0, 0, 0);
       colorLay->setSpacing(4);
       {
         colorLay->addWidget(new QLabel(tr("Color"), this), 0);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -69,7 +69,7 @@ namespace {
 enum DpiPolicy { DP_ImageDpi, DP_CustomDpi };
 
 inline void setupLayout(QGridLayout* lay, int margin = 15) {
-  lay->setMargin(margin);
+  lay->setContentsMargins(margin, margin, margin, margin);
   lay->setHorizontalSpacing(5);
   lay->setVerticalSpacing(10);
   lay->setColumnStretch(2, 1);
@@ -99,7 +99,7 @@ SizeField::SizeField(QSize min, QSize max, QSize value, QWidget* parent)
       new DVGui::IntLineEdit(this, value.height(), min.height(), max.height());
   QHBoxLayout* lay = new QHBoxLayout();
   lay->setSpacing(5);
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
   lay->addWidget(m_fieldX, 1);
   lay->addWidget(new QLabel("x", this), 0);
   lay->addWidget(m_fieldY, 1);
@@ -354,7 +354,7 @@ PreferencesPopup::Display30bitChecker::Display30bitChecker(
 30bit display is available in the current configuration.");
 
   QVBoxLayout* lay = new QVBoxLayout();
-  lay->setMargin(10);
+  lay->setContentsMargins(10, 10, 10, 10);;
   lay->setSpacing(10);
   {
     lay->addWidget(view8bit);
@@ -362,7 +362,7 @@ PreferencesPopup::Display30bitChecker::Display30bitChecker(
     lay->addWidget(new QLabel(infoLabel, this));
     lay->addWidget(closeBtn, 0, Qt::AlignCenter);
   }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(lay);
   lay->setSizeConstraint(QLayout::SetFixedSize);
 
@@ -1198,7 +1198,7 @@ void PreferencesPopup::insertUI(PreferencesItemId id, QGridLayout* layout,
     else {
       bool isWideComboBox = false;
       for (auto cbItem : comboItems) {
-        if (widget->fontMetrics().width(cbItem.first) > 100) {
+        if (widget->fontMetrics().horizontalAdvance(cbItem.first) > 100) {
           isWideComboBox = true;
           break;
         }
@@ -1228,7 +1228,7 @@ void PreferencesPopup::insertDualUIs(PreferencesItemId leftId,
                       Qt::AlignRight | Qt::AlignVCenter);
   }
   QHBoxLayout* innerLay = new QHBoxLayout();
-  innerLay->setMargin(0);
+  innerLay->setContentsMargins(0, 0, 0, 0);
   innerLay->setSpacing(5);
   {
     innerLay->addWidget(
@@ -1656,19 +1656,19 @@ PreferencesPopup::PreferencesPopup()
   QPushButton* importPrefButton = new QPushButton("Import Preferences");
 
   QHBoxLayout* mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     // Category
     QVBoxLayout* categoryLayout = new QVBoxLayout();
-    categoryLayout->setMargin(5);
+    categoryLayout->setContentsMargins(5, 5, 5, 5);
     categoryLayout->setSpacing(10);
     categoryLayout->addWidget(m_categoryList, 1);
     categoryLayout->addWidget(importPrefButton, 0);
     mainLayout->addLayout(categoryLayout, 0);
     mainLayout->addWidget(m_stackedWidget, 1);
   }
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLayout);
 
   bool ret = connect(m_categoryList, SIGNAL(currentRowChanged(int)),
@@ -1940,7 +1940,7 @@ QWidget* PreferencesPopup::createLoadingPage() {
   lay->addWidget(new QLabel(tr("Level Settings by File Format:")), row, 0,
                  Qt::AlignRight | Qt::AlignVCenter);
   QHBoxLayout* levelFormatLay = new QHBoxLayout();
-  levelFormatLay->setMargin(0);
+  levelFormatLay->setContentsMargins(0, 0, 0, 0);
   levelFormatLay->setSpacing(5);
   {
     levelFormatLay->addWidget(m_levelFormatNames);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -299,9 +299,7 @@ PreferencesPopup::Display30bitChecker::GLView::GLView(QWidget* parent,
                                                       bool is30bit)
     : QOpenGLWidget(parent), m_is30bit(is30bit) {
   setFixedSize(500, 100);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (m_is30bit) setTextureFormat(TGL_TexFmt10);
-#endif
 }
 
 void PreferencesPopup::Display30bitChecker::GLView::initializeGL() {
@@ -1851,11 +1849,9 @@ QWidget* PreferencesPopup::createInterfacePage() {
 
   QGridLayout* colorCalibLay = insertGroupBoxUI(colorCalibrationEnabled, lay);
   { insertUI(colorCalibrationLutPaths, colorCalibLay); }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   insertUI(displayIn30bit, lay);
   row = lay->rowCount();
   lay->addWidget(check30bitBtn, row - 1, 2, Qt::AlignRight);
-#endif
   if (Preferences::instance()->isShowAdvancedOptionsEnabled())
     insertUI(showIconsInMenu, lay);
 
@@ -2383,7 +2379,7 @@ QWidget* PreferencesPopup::createVersionControlPage() {
 
 QWidget* PreferencesPopup::createTouchTabletPage() {
   bool winInkAvailable = false;
-#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
+#if defined(_WIN32)
   winInkAvailable = KisTabletSupportWin8::isAvailable();
 #endif
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1080,7 +1080,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
     if (id == interfaceFont) {  // create QFontComboBox
       QFontComboBox* combo = new QFontComboBox(this);
       combo->setCurrentText(item.value.toString());
-      ret    = connect(combo, SIGNAL(currentIndexChanged(const QString&)), this,
+      ret    = connect(combo, SIGNAL(currentTextChanged(const QString&)), this,
                        SLOT(onInterfaceFontChanged(const QString&)));
       widget = combo;
     } else if (!comboItems.isEmpty()) {  // create QComboBox

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -171,7 +171,7 @@ Note that this mode uses regular expression for file name validation and may slo
   pm->addListener(this);
 
   //---------
-  connect(m_rulePreferenceBG, SIGNAL(buttonClicked(int)), this,
+  connect(m_rulePreferenceBG, SIGNAL(idClicked(int)), this,
           SLOT(onRulePreferenceToggled(int)));
 }
 
@@ -385,7 +385,7 @@ ProjectSettingsPopup::ProjectSettingsPopup() : ProjectPopup(false) {
   connect(m_useSubSceneCbs, SIGNAL(stateChanged(int)), this, SLOT(onSomethingChanged()));
 
   // file path settings
-  connect(m_rulePreferenceBG, SIGNAL(buttonClicked(int)), this,
+  connect(m_rulePreferenceBG, SIGNAL(idClicked(int)), this,
           SLOT(onSomethingChanged()));
   connect(m_acceptNonAlphabetSuffixCB, SIGNAL(clicked(bool)), this,
           SLOT(onSomethingChanged()));

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -131,11 +131,11 @@ Note that this mode uses regular expression for file name validation and may slo
   m_settingsBox   = createSettingsBox();
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(10);
   {
     QGridLayout *upperLayout = new QGridLayout();
-    upperLayout->setMargin(5);
+    upperLayout->setContentsMargins(5, 5, 5, 5);
     upperLayout->setHorizontalSpacing(5);
     upperLayout->setVerticalSpacing(10);
     {
@@ -154,7 +154,7 @@ Note that this mode uses regular expression for file name validation and may slo
     m_topLayout->addLayout(upperLayout);
 
     QHBoxLayout *settingsLabelLay = new QHBoxLayout();
-    settingsLabelLay->setMargin(0);
+    settingsLabelLay->setContentsMargins(0, 0, 0, 0);
     settingsLabelLay->setSpacing(3);
     {
       settingsLabelLay->addWidget(m_showSettingsButton, 0);
@@ -186,7 +186,7 @@ QFrame *ProjectPopup::createSettingsBox() {
   QTabWidget *tabWidget = new QTabWidget(this);
 
   QVBoxLayout *settingsLayout       = new QVBoxLayout();
-  settingsLayout->setMargin(5);
+  settingsLayout->setContentsMargins(5, 5, 5, 5);
   settingsLayout->setSpacing(10);
   {
     settingsLayout->addWidget(tabWidget, 1);
@@ -194,7 +194,7 @@ QFrame *ProjectPopup::createSettingsBox() {
     // project folder settings
     QWidget *projectFolderPanel = new QWidget(this);
     QGridLayout *folderLayout = new QGridLayout();
-    folderLayout->setMargin(5);
+    folderLayout->setContentsMargins(5, 5, 5, 5);
     folderLayout->setHorizontalSpacing(5);
     folderLayout->setVerticalSpacing(10);
     {
@@ -223,7 +223,7 @@ QFrame *ProjectPopup::createSettingsBox() {
     // file path settings
     QWidget *filePathPanel = new QWidget(this);
     QVBoxLayout *fpLayout  = new QVBoxLayout();
-    fpLayout->setMargin(5);
+    fpLayout->setContentsMargins(5, 5, 5, 5);
     fpLayout->setSpacing(10);
     {
       fpLayout->addWidget(m_rulePreferenceBG->buttons()[0], 0); // standardRB
@@ -231,7 +231,7 @@ QFrame *ProjectPopup::createSettingsBox() {
 
       // add some indent
       QGridLayout *customLay = new QGridLayout();
-      customLay->setMargin(10);
+      customLay->setContentsMargins(10, 10, 10, 10);;
       customLay->setHorizontalSpacing(10);
       customLay->setVerticalSpacing(10);
       {
@@ -539,7 +539,7 @@ ProjectCreatePopup::ProjectCreatePopup() : ProjectPopup(true) {
   connect(okBtn, SIGNAL(clicked()), this, SLOT(createProject()));
   connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   {
     m_buttonLayout->addStretch();

--- a/toonz/sources/toonz/psdsettingspopup.cpp
+++ b/toonz/sources/toonz/psdsettingspopup.cpp
@@ -227,10 +227,10 @@ PsdSettingsPopup::PsdSettingsPopup()
   folderOptLayout->addStretch();
   addLayout(folderOptLayout, false);
 
-  ret = ret && connect(m_loadMode, SIGNAL(currentIndexChanged(const QString &)),
+  ret = ret && connect(m_loadMode, SIGNAL(currentTextChanged(const QString &)),
                        SLOT(onModeChanged()));
   assert(ret);
-  ret = ret && connect(m_psdFolderOptions, SIGNAL(buttonClicked(int)), this,
+  ret = ret && connect(m_psdFolderOptions, SIGNAL(idClicked(int)), this,
                        SLOT(onFolderOptionChange(int)));
   assert(ret);
   m_okBtn     = new QPushButton(tr("OK"), this);

--- a/toonz/sources/toonz/psdsettingspopup.cpp
+++ b/toonz/sources/toonz/psdsettingspopup.cpp
@@ -188,7 +188,7 @@ PsdSettingsPopup::PsdSettingsPopup()
 
   QGridLayout *gridMode = new QGridLayout();
   gridMode->setColumnMinimumWidth(0, 65);
-  gridMode->setMargin(0);
+  gridMode->setContentsMargins(0, 0, 0, 0);
   gridMode->addWidget(modeLbl, 0, 0, Qt::AlignRight);
   gridMode->addWidget(m_loadMode, 0, 1, Qt::AlignLeft);
   gridMode->addWidget(m_modeDescription, 1, 1, Qt::AlignLeft);

--- a/toonz/sources/toonz/reframepopup.cpp
+++ b/toonz/sources/toonz/reframepopup.cpp
@@ -33,7 +33,7 @@ ReframePopup::ReframePopup()
   m_blank->setObjectName("LargeSizedText");
   // layout
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(new QLabel(tr("Number of steps:"), this));
@@ -41,7 +41,7 @@ ReframePopup::ReframePopup()
     mainLay->addWidget(new QLabel(tr("s"), this));
 
     QHBoxLayout* blankLay = new QHBoxLayout();
-    blankLay->setMargin(0);
+    blankLay->setContentsMargins(0, 0, 0, 0);
     blankLay->setSpacing(5);
     {
       blankLay->addSpacing(10);
@@ -55,7 +55,7 @@ ReframePopup::ReframePopup()
   m_topLayout->addLayout(mainLay);
 
   QHBoxLayout* textLay = new QHBoxLayout();
-  textLay->setMargin(0);
+  textLay->setContentsMargins(0, 0, 0, 0);
   {
     textLay->addStretch(1);
     textLay->addWidget(m_blankCellCountLbl);

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -171,13 +171,13 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WindowFlags flags,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setSpacing(2);
   {
     mainLayout->addWidget(buttonBar);
 
     QHBoxLayout *folderLay = new QHBoxLayout();
-    folderLay->setMargin(0);
+    folderLay->setContentsMargins(0, 0, 0, 0);
     folderLay->setSpacing(0);
     {
       folderLay->addWidget(folderLabel, 0);
@@ -187,7 +187,7 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WindowFlags flags,
 
     // m_mainSplitter->addWidget(m_folderTreeView);
     QVBoxLayout *boxLayout = new QVBoxLayout(box);
-    boxLayout->setMargin(0);
+    boxLayout->setContentsMargins(0, 0, 0, 0);
     boxLayout->setSpacing(0);
     {
       boxLayout->addWidget(titleBar, 0);
@@ -562,8 +562,8 @@ void SceneBrowser::refreshCurrentFolderItems() {
         QFileInfo fileInfo(QString::fromStdWString(it->getWideString()));
         // Update level infos
         if (levelItem.m_creationDate.isNull() ||
-            (fileInfo.created() < levelItem.m_creationDate))
-          levelItem.m_creationDate = fileInfo.created();
+            (fileInfo.birthTime() < levelItem.m_creationDate))
+          levelItem.m_creationDate = fileInfo.birthTime();
         if (levelItem.m_modifiedDate.isNull() ||
             (fileInfo.lastModified() > levelItem.m_modifiedDate))
           levelItem.m_modifiedDate = fileInfo.lastModified();
@@ -756,7 +756,7 @@ void SceneBrowser::readInfo(Item &item) {
   TFilePath fp = item.m_path;
   QFileInfo info(toQString(fp));
   if (info.exists()) {
-    item.m_creationDate = info.created();
+    item.m_creationDate = info.birthTime();
     item.m_modifiedDate = info.lastModified();
     item.m_fileType     = info.suffix();
     item.m_fileSize     = info.size();

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -55,7 +55,7 @@
 #include <QDateTime>
 #include <QInputDialog>
 #include <QDesktopServices>
-#include <QDirModel>
+#include <QFileSystemModel>
 #include <QDir>
 #include <QPixmap>
 #include <QUrl>

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -177,7 +177,7 @@ CellMarksPopup::CellMarksPopup(QWidget *parent) : Dialog(parent) {
                                                 ->getCellMarks();
 
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(10);
+  layout->setContentsMargins(10, 10, 10, 10);;
   layout->setHorizontalSpacing(5);
   layout->setVerticalSpacing(10);
   {
@@ -203,7 +203,7 @@ CellMarksPopup::CellMarksPopup(QWidget *parent) : Dialog(parent) {
     }
   }
   layout->setColumnStretch(2, 1);
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(layout);
 }
 
@@ -295,7 +295,7 @@ ColorFiltersPopup::ColorFiltersPopup(QWidget *parent) : Dialog(parent) {
                                                      ->getColorFilters();
 
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(10);
+  layout->setContentsMargins(10, 10, 10, 10);;
   layout->setHorizontalSpacing(5);
   layout->setVerticalSpacing(10);
   {
@@ -332,7 +332,7 @@ ColorFiltersPopup::ColorFiltersPopup(QWidget *parent) : Dialog(parent) {
     }
   }
   layout->setColumnStretch(1, 1);
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(layout);
 }
 
@@ -528,7 +528,7 @@ SceneSettingsPopup::SceneSettingsPopup()
 
   // layout
   QGridLayout *mainLayout = new QGridLayout();
-  mainLayout->setMargin(10);
+  mainLayout->setContentsMargins(10, 10, 10, 10);;
   mainLayout->setHorizontalSpacing(5);
   mainLayout->setVerticalSpacing(15);
   {
@@ -593,7 +593,7 @@ SceneSettingsPopup::SceneSettingsPopup()
   mainLayout->setColumnStretch(3, 0);
   mainLayout->setColumnStretch(4, 1);
   mainLayout->setRowStretch(9, 1);
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->addLayout(mainLayout);
 
   // signal-slot connections

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -82,7 +82,7 @@
 // Qt includes
 #include <QMenu>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QInputMethod>
 #include <QGLContext>
 #include <QOpenGLFramebufferObject>
@@ -2842,7 +2842,7 @@ double SceneViewer::getZoomScaleFittingWithScreen() {
   // add small margin on the edge of the image
   int margin = 20;
   // get the desktop resolution
-  QRect rec = QApplication::desktop()->screenGeometry();
+  QRect rec = QApplication::primaryScreen()->geometry();
 
   // fit to either direction
   int moni_x = rec.width() - (margin * 2);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -893,10 +893,8 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
 
   if (Preferences::instance()->isColorCalibrationEnabled())
     m_lutCalibrator = new LutCalibrator();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (Preferences::instance()->is30bitDisplayEnabled())
     setTextureFormat(TGL_TexFmt10);
-#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -84,7 +84,7 @@
 #include <QApplication>
 #include <QScreen>
 #include <QInputMethod>
-#include <QGLContext>
+#include <QOpenGLContext>
 #include <QOpenGLFramebufferObject>
 #include <QMainWindow>
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -658,7 +658,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     }
 
     // if the middle mouse button is pressed while dragging, then do panning
-    if (event.buttons() & Qt::MidButton) {
+    if (event.buttons() & Qt::MiddleButton) {
       // panning
       QPointF p = curPos - m_pos;
       if (m_pos == QPointF() && p.manhattanLength() > 300) return;
@@ -727,8 +727,8 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     m_pos          = curPos;
     m_tabletMove   = false;
     m_toolSwitched = false;
-  } else if (m_mouseButton == Qt::MidButton) {
-    if ((event.buttons() & Qt::MidButton) == 0) m_mouseButton = Qt::NoButton;
+  } else if (m_mouseButton == Qt::MiddleButton) {
+    if ((event.buttons() & Qt::MiddleButton) == 0) m_mouseButton = Qt::NoButton;
     // scrub with shift and middle click
     else if (event.isShiftPressed() && event.isCtrlPressed()) {
       if (curPos.x() > m_pos.x()) {
@@ -815,7 +815,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
 
   // when using tablet, avoid unexpected drawing behavior occurs when
   // middle-click
-  if (m_tabletEvent && m_mouseButton == Qt::MidButton &&
+  if (m_tabletEvent && m_mouseButton == Qt::MiddleButton &&
       event.isLeftButtonPressed()) {
     return;
   }
@@ -1149,7 +1149,7 @@ void SceneViewer::wheelEvent(QWheelEvent *event) {
     else if ((m_gestureActive == true &&
               m_touchDevice == QTouchDevice::TouchScreen) ||
              m_gestureActive == false) {
-      zoomQt(event->pos() * getDevPixRatio(), exp(0.001 * delta));
+      zoomQt(event->position().toPoint() * getDevPixRatio(), exp(0.001 * delta));
       m_panning = false;
     }
   }
@@ -1486,7 +1486,7 @@ bool SceneViewer::event(QEvent *e) {
   }
 
   // discard too frequent move events
-  static QTime clock;
+  static QElapsedTimer clock;
   if (e->type() == QEvent::MouseButtonPress)
     clock.start();
   else if (e->type() == QEvent::MouseMove) {

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -363,7 +363,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     }
 #endif
     QPointF curPos = e->posF() * getDevPixRatio();
-#if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+#if defined(_WIN32)
     // Use the application attribute Qt::AA_CompressTabletEvents instead of the
     // delay timer
     // 21/4/2021 High frequent tablet event caused slowness when deforming with

--- a/toonz/sources/toonz/separatecolorspopup.cpp
+++ b/toonz/sources/toonz/separatecolorspopup.cpp
@@ -660,11 +660,11 @@ SeparateColorsPopup::SeparateColorsPopup()
   //----
   {
     QVBoxLayout* leftLay = new QVBoxLayout();
-    leftLay->setMargin(5);
+    leftLay->setContentsMargins(5, 5, 5, 5);
     leftLay->setSpacing(5);
     {
       QHBoxLayout* previewLay = new QHBoxLayout();
-      previewLay->setMargin(0);
+      previewLay->setContentsMargins(0, 0, 0, 0);
       previewLay->setSpacing(5);
       {
         previewLay->addWidget(new QLabel(tr("Preview Frame:"), this), 0,
@@ -690,11 +690,11 @@ SeparateColorsPopup::SeparateColorsPopup()
     mainSplitter->addWidget(leftWidget);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(10);
+    rightLay->setContentsMargins(10, 10, 10, 10);;
     rightLay->setSpacing(10);
     {
       QGridLayout* upperLay = new QGridLayout();
-      upperLay->setMargin(0);
+      upperLay->setContentsMargins(0, 0, 0, 0);
       upperLay->setHorizontalSpacing(5);
       upperLay->setVerticalSpacing(10);
       {
@@ -722,7 +722,7 @@ SeparateColorsPopup::SeparateColorsPopup()
         upperLay->addWidget(m_borderSmoothnessFld, 6, 1);
 
         QGridLayout* maskLay = new QGridLayout();
-        maskLay->setMargin(10);
+        maskLay->setContentsMargins(10, 10, 10, 10);;
         maskLay->setHorizontalSpacing(5);
         maskLay->setVerticalSpacing(10);
         {
@@ -744,14 +744,14 @@ SeparateColorsPopup::SeparateColorsPopup()
       rightLay->addLayout(upperLay, 0);
 
       QGridLayout* middleLay = new QGridLayout();
-      middleLay->setMargin(0);
+      middleLay->setContentsMargins(0, 0, 0, 0);
       middleLay->setHorizontalSpacing(5);
       middleLay->setVerticalSpacing(10);
       {
         middleLay->addWidget(new QLabel(tr("Start:"), this), 0, 0,
                              Qt::AlignRight);
         QHBoxLayout* rangeLay = new QHBoxLayout();
-        rangeLay->setMargin(0);
+        rangeLay->setContentsMargins(0, 0, 0, 0);
         rangeLay->setSpacing(5);
         {
           rangeLay->addWidget(m_fromFld, 0);
@@ -796,7 +796,7 @@ SeparateColorsPopup::SeparateColorsPopup()
       rightLay->addSpacing(10);
 
       QHBoxLayout* saveLoadLay = new QHBoxLayout();
-      saveLoadLay->setMargin(0);
+      saveLoadLay->setContentsMargins(0, 0, 0, 0);
       saveLoadLay->setSpacing(0);
       {
         saveLoadLay->addWidget(saveSettingsBtn, 1);
@@ -807,7 +807,7 @@ SeparateColorsPopup::SeparateColorsPopup()
       rightLay->addSpacing(10);
 
       QHBoxLayout* buttonLay = new QHBoxLayout();
-      buttonLay->setMargin(0);
+      buttonLay->setContentsMargins(0, 0, 0, 0);
       buttonLay->setSpacing(0);
       {
         buttonLay->addWidget(m_autoBtn, 0);

--- a/toonz/sources/toonz/separatecolorsswatch.cpp
+++ b/toonz/sources/toonz/separatecolorsswatch.cpp
@@ -249,11 +249,7 @@ void SeparateSwatchArea::wheelEvent(QWheelEvent *event) {
   if ((factor < 1 && sqrt(scale) < minZoom) || (factor > 1 && scale > 1200.0))
     return;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   TPointD delta(event->position().x(), height() - event->position().y());
-#else
-  TPointD delta(event->pos().x(), height() - event->pos().y());
-#endif
   m_sw->m_viewAff =
       (TTranslation(delta) * TScale(factor) * TTranslation(-delta)) *
       m_sw->m_viewAff;

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -433,11 +433,11 @@ ShortcutPopup::ShortcutPopup()
 
   QLineEdit *searchEdit = new QLineEdit(this);
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(8);
   {
     QHBoxLayout *searchLay = new QHBoxLayout();
-    searchLay->setMargin(0);
+    searchLay->setContentsMargins(0, 0, 0, 0);
     searchLay->setSpacing(5);
     {
       searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
@@ -446,7 +446,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addLayout(searchLay, 0);
 
     QVBoxLayout *listLay = new QVBoxLayout();
-    listLay->setMargin(0);
+    listLay->setContentsMargins(0, 0, 0, 0);
     listLay->setSpacing(0);
     {
       listLay->addWidget(noSearchResultLabel, 0,
@@ -456,7 +456,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addLayout(listLay, 1);
 
     QHBoxLayout *bottomLayout = new QHBoxLayout();
-    bottomLayout->setMargin(0);
+    bottomLayout->setContentsMargins(0, 0, 0, 0);
     bottomLayout->setSpacing(1);
     {
       bottomLayout->addWidget(m_sViewer, 1);
@@ -465,7 +465,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addLayout(bottomLayout, 0);
     m_topLayout->addSpacing(10);
     QHBoxLayout *presetLay = new QHBoxLayout();
-    presetLay->setMargin(5);
+    presetLay->setContentsMargins(5, 5, 5, 5);
     presetLay->setSpacing(5);
     {
       presetLay->addWidget(new QLabel(tr("Preset:"), this), 0);
@@ -478,7 +478,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addWidget(presetBox, 0, Qt::AlignCenter);
     m_topLayout->addSpacing(10);
     QHBoxLayout *exportLay = new QHBoxLayout();
-    exportLay->setMargin(0);
+    exportLay->setContentsMargins(0, 0, 0, 0);
     exportLay->setSpacing(5);
     {
       exportLay->addWidget(m_exportButton, 0);

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -40,7 +40,7 @@
 #include <QPushButton>
 #include <QMainWindow>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QMessageBox>
 #include <QTextStream>
 #include <QFrame>
@@ -188,21 +188,21 @@ StartupPopup::StartupPopup()
   m_buttonFrame->setFixedHeight(34);
 
   //--- layout
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
   {
     QGridLayout *guiLay      = new QGridLayout();
     QHBoxLayout *projectLay  = new QHBoxLayout();
     QGridLayout *newSceneLay = new QGridLayout();
     m_recentSceneLay         = new QVBoxLayout();
-    guiLay->setMargin(10);
+    guiLay->setContentsMargins(10, 10, 10, 10);;
     guiLay->setVerticalSpacing(10);
     guiLay->setHorizontalSpacing(10);
 
     guiLay->addWidget(label, 0, 0, 1, 2, Qt::AlignLeft);
 
     projectLay->setSpacing(8);
-    projectLay->setMargin(8);
+    projectLay->setContentsMargins(8, 8, 8, 8);;
     {
       projectLay->addWidget(m_projectLocationFld, 1);
       projectLay->addWidget(m_projectsCB, 1);
@@ -212,7 +212,7 @@ StartupPopup::StartupPopup()
     m_projectBox->setLayout(projectLay);
     guiLay->addWidget(m_projectBox, 1, 0, 1, 1, Qt::AlignCenter);
 
-    newSceneLay->setMargin(8);
+    newSceneLay->setContentsMargins(8, 8, 8, 8);;
     newSceneLay->setVerticalSpacing(8);
     newSceneLay->setHorizontalSpacing(8);
     {
@@ -227,7 +227,7 @@ StartupPopup::StartupPopup()
                              Qt::AlignRight | Qt::AlignVCenter);
       QHBoxLayout *resListLay = new QHBoxLayout();
       resListLay->setSpacing(3);
-      resListLay->setMargin(1);
+      resListLay->setContentsMargins(1, 1, 1, 1);
       {
         resListLay->addWidget(m_presetCombo, 1);
         resListLay->addWidget(m_addPresetBtn, 0);
@@ -267,7 +267,7 @@ StartupPopup::StartupPopup()
     m_sceneBox->setLayout(newSceneLay);
     guiLay->addWidget(m_sceneBox, 2, 0, 4, 1, Qt::AlignTop);
 
-    m_recentSceneLay->setMargin(5);
+    m_recentSceneLay->setContentsMargins(5, 5, 5, 5);
     m_recentSceneLay->setSpacing(2);
     {
       // Recent Scene List
@@ -279,7 +279,7 @@ StartupPopup::StartupPopup()
     m_topLayout->addLayout(guiLay, 0);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(m_showAtStartCB, Qt::AlignLeft);
@@ -418,10 +418,8 @@ void StartupPopup::showEvent(QShowEvent *) {
   // clear items if they exist first
   refreshRecentScenes();
   // center window
-  int currentScreen =
-      QApplication::desktop()->screenNumber(TApp::instance()->getMainWindow());
-  QPoint activeMonitorCenter =
-      QApplication::desktop()->availableGeometry(currentScreen).center();
+  QScreen *currentScreen = QApplication::primaryScreen();
+  QPoint activeMonitorCenter = currentScreen->availableGeometry().center();
   QPoint thisPopupCenter         = this->rect().center();
   QPoint centeredOnActiveMonitor = activeMonitorCenter - thisPopupCenter;
   this->move(centeredOnActiveMonitor);
@@ -955,7 +953,7 @@ bool StartupPopup::parsePresetString(const QString &str, QString &name,
   in order to keep compatibility with default (Harlequin's) reslist.txt
   */
 
-  QStringList tokens = str.split(",", QString::SkipEmptyParts);
+  QStringList tokens = str.split(",", Qt::SkipEmptyParts);
 
   if (!(tokens.count() == 3 ||
         (!forCleanup && tokens.count() == 4) || /*- with "fx x fy" token -*/

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -318,7 +318,7 @@ StartupPopup::StartupPopup()
         connect(m_resXFld, SIGNAL(valueChanged()), this, SLOT(updateSize()));
   ret = ret &&
         connect(m_resYFld, SIGNAL(valueChanged()), this, SLOT(updateSize()));
-  ret = ret && connect(m_presetCombo, SIGNAL(activated(const QString &)),
+  ret = ret && connect(m_presetCombo, SIGNAL(textActivated(const QString &)),
                        SLOT(onPresetSelected(const QString &)));
   ret = ret && connect(m_addPresetBtn, SIGNAL(clicked()), SLOT(addPreset()));
   ret = ret && connect(m_unitsCB, SIGNAL(currentIndexChanged(int)),

--- a/toonz/sources/toonz/svncommitdialog.cpp
+++ b/toonz/sources/toonz/svncommitdialog.cpp
@@ -63,7 +63,7 @@ SVNCommitDialog::SVNCommitDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   m_treeWidget = new QTreeWidget;
   m_treeWidget->header()->hide();
@@ -79,7 +79,7 @@ SVNCommitDialog::SVNCommitDialog(QWidget *parent, const QString &workingDir,
     mainLayout->addWidget(m_treeWidget);
 
     QHBoxLayout *belowTreeLayout = new QHBoxLayout;
-    belowTreeLayout->setMargin(0);
+    belowTreeLayout->setContentsMargins(0, 0, 0, 0);
 
     m_selectionCheckBox = new QCheckBox(tr("Select / Deselect All"), 0);
     connect(m_selectionCheckBox, SIGNAL(clicked(bool)), this,
@@ -127,7 +127,7 @@ SVNCommitDialog::SVNCommitDialog(QWidget *parent, const QString &workingDir,
   formLayout->setLabelAlignment(Qt::AlignRight);
   formLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
   formLayout->setSpacing(10);
-  formLayout->setMargin(0);
+  formLayout->setContentsMargins(0, 0, 0, 0);
 
   m_commentTextEdit = new QPlainTextEdit;
   m_commentTextEdit->setMaximumHeight(50);
@@ -930,7 +930,7 @@ SVNCommitFrameRangeDialog::SVNCommitFrameRangeDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 

--- a/toonz/sources/toonz/svndeletedialog.cpp
+++ b/toonz/sources/toonz/svndeletedialog.cpp
@@ -56,7 +56,7 @@ SVNDeleteDialog::SVNDeleteDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -100,7 +100,7 @@ SVNDeleteDialog::SVNDeleteDialog(QWidget *parent, const QString &workingDir,
   formLayout->setLabelAlignment(Qt::AlignRight);
   formLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
   formLayout->setSpacing(10);
-  formLayout->setMargin(0);
+  formLayout->setContentsMargins(0, 0, 0, 0);
 
   m_commentTextEdit = new QPlainTextEdit;
   m_commentTextEdit->setMaximumHeight(50);

--- a/toonz/sources/toonz/svnlockdialog.cpp
+++ b/toonz/sources/toonz/svnlockdialog.cpp
@@ -58,7 +58,7 @@ SVNLockDialog::SVNLockDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -93,7 +93,7 @@ SVNLockDialog::SVNLockDialog(QWidget *parent, const QString &workingDir,
   formLayout->setLabelAlignment(Qt::AlignRight);
   formLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
   formLayout->setSpacing(10);
-  formLayout->setMargin(0);
+  formLayout->setContentsMargins(0, 0, 0, 0);
 
   m_commentTextEdit = new QPlainTextEdit;
   m_commentTextEdit->setMaximumHeight(50);
@@ -454,7 +454,7 @@ SVNLockInfoDialog::SVNLockInfoDialog(QWidget *parent, const SVNStatus &status)
   setMinimumSize(300, 150);
 
   QFormLayout *mainLayout = new QFormLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setLabelAlignment(Qt::AlignLeft);
 
   mainLayout->addRow(tr("<b>Edited By:</b>"), new QLabel(m_status.m_lockOwner));

--- a/toonz/sources/toonz/svnlockframerangedialog.cpp
+++ b/toonz/sources/toonz/svnlockframerangedialog.cpp
@@ -38,7 +38,7 @@ SVNLockFrameRangeDialog::SVNLockFrameRangeDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -368,7 +368,7 @@ SVNLockMultiFrameRangeDialog::SVNLockMultiFrameRangeDialog(
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -666,7 +666,7 @@ SVNUnlockFrameRangeDialog::SVNUnlockFrameRangeDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -901,7 +901,7 @@ SVNUnlockMultiFrameRangeDialog::SVNUnlockMultiFrameRangeDialog(
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 

--- a/toonz/sources/toonz/svnrevertdialog.cpp
+++ b/toonz/sources/toonz/svnrevertdialog.cpp
@@ -48,7 +48,7 @@ SVNRevertDialog::SVNRevertDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -78,7 +78,7 @@ SVNRevertDialog::SVNRevertDialog(QWidget *parent, const QString &workingDir,
   if (!m_folderOnly) {
     mainLayout->addSpacing(10);
     QHBoxLayout *checkBoxLayout = new QHBoxLayout;
-    checkBoxLayout->setMargin(0);
+    checkBoxLayout->setContentsMargins(0, 0, 0, 0);
     m_revertSceneContentsCheckBox = new QCheckBox(this);
     connect(m_revertSceneContentsCheckBox, SIGNAL(toggled(bool)), this,
             SLOT(onRevertSceneContentsToggled(bool)));

--- a/toonz/sources/toonz/svnupdateandlockdialog.cpp
+++ b/toonz/sources/toonz/svnupdateandlockdialog.cpp
@@ -46,7 +46,7 @@ SVNUpdateAndLockDialog::SVNUpdateAndLockDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 

--- a/toonz/sources/toonz/svnupdatedialog.cpp
+++ b/toonz/sources/toonz/svnupdatedialog.cpp
@@ -51,7 +51,7 @@ SVNUpdateDialog::SVNUpdateDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -91,7 +91,7 @@ SVNUpdateDialog::SVNUpdateDialog(QWidget *parent, const QString &workingDir,
 
   if (!isFolderOnly) {
     QHBoxLayout *checkBoxLayout = new QHBoxLayout;
-    checkBoxLayout->setMargin(0);
+    checkBoxLayout->setContentsMargins(0, 0, 0, 0);
     m_updateSceneContentsCheckBox = new QCheckBox(this);
     m_updateSceneContentsCheckBox->setChecked(false);
     m_updateSceneContentsCheckBox->setText(tr("Get Scene Contents"));

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -67,7 +67,7 @@
 #include <QEvent>
 #include <QCoreApplication>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QKeyEvent>
 
 //===================================================================

--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -90,7 +90,7 @@ QWidget *TasksViewer::createToolBar() {
   add("delete", tr("&Remove"), saveToolbar, SLOT(remove(bool)), tr("Remove"));
 
   QVBoxLayout *toolbarLayout = new QVBoxLayout(toolBarWidget);
-  toolbarLayout->setMargin(0);
+  toolbarLayout->setContentsMargins(0, 0, 0, 0);
   toolbarLayout->setSpacing(0);
   {
     toolbarLayout->addWidget(cmdToolbar);
@@ -128,7 +128,7 @@ TasksViewer::TasksViewer(QWidget *parent, Qt::WindowFlags flags)
   box                  = new QFrame(this);
   QVBoxLayout *vLayout = new QVBoxLayout(box);
   box->setLayout(vLayout);
-  vLayout->setMargin(0);
+  vLayout->setContentsMargins(0, 0, 0, 0);
   vLayout->setSpacing(0);
 
   vLayout->addWidget(createToolBar());
@@ -846,7 +846,7 @@ TaskSheet::TaskSheet(TasksViewer *owner) : QScrollArea(owner) {
   m_viewer = owner;
 
   QGridLayout *layout = new QGridLayout(contentWidget);
-  layout->setMargin(15);
+  layout->setContentsMargins(15, 15, 15, 15);;
   layout->setSpacing(8);
   layout->setColumnStretch(3, 1);
   layout->setColumnStretch(5, 1);
@@ -888,7 +888,7 @@ TaskSheet::TaskSheet(TasksViewer *owner) : QScrollArea(owner) {
   m_boxComposer = new QFrame(contentWidget);
   m_boxComposer->setMinimumHeight(150);
   QGridLayout *layout1 = new QGridLayout(m_boxComposer);
-  layout1->setMargin(0);
+  layout1->setContentsMargins(0, 0, 0, 0);
   layout1->setSpacing(8);
   m_boxComposer->setLayout(layout1);
   ::create(m_outputPath, layout1, tr("Output:"), row1++, 4);
@@ -941,7 +941,7 @@ TaskSheet::TaskSheet(TasksViewer *owner) : QScrollArea(owner) {
   // tcleanupper Box
   m_boxCleanup         = new QFrame(contentWidget);
   QGridLayout *layout2 = new QGridLayout(m_boxCleanup);
-  layout2->setMargin(0);
+  layout2->setContentsMargins(0, 0, 0, 0);
   layout2->setSpacing(8);
   m_boxCleanup->setLayout(layout2);
   ::create(m_visible, layout2, tr("Visible Only"), 0);

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -284,9 +284,12 @@ void SchematicScenePanel::onDeleteFxs(const FxSelection *selection) {
   if (!ColumnCmd::checkExpressionReferences(colIndices, fxs)) return;
 
   TApp *app = TApp::instance();
-  TFxCommand::deleteSelection(selection->getFxs().toStdList(),
-                              selection->getLinks().toStdList(),
-                              selection->getColumnIndexes().toStdList(),
+  TFxCommand::deleteSelection(
+      std::list<TFxP>(selection->getFxs().begin(), selection->getFxs().end()),
+      std::list<Link>(selection->getLinks().begin(),
+                      selection->getLinks().end()),
+      std::list<int>(selection->getColumnIndexes().begin(),
+                selection->getColumnIndexes().end()),
                               app->getCurrentXsheet(), app->getCurrentFx());
 }
 
@@ -300,8 +303,12 @@ void SchematicScenePanel::onDeleteStageObjects(
 
   TApp *app = TApp::instance();
   TStageObjectCmd::deleteSelection(
-      selection->getObjects().toVector().toStdVector(),
-      selection->getLinks().toStdList(), selection->getSplines().toStdList(),
+      std::vector<TStageObjectId>(selection->getObjects().toVector().begin(),
+                  selection->getObjects().toVector().end()),
+      std::list<QPair<TStageObjectId, TStageObjectId>>(
+          selection->getLinks().begin(), selection->getLinks().end()),
+      std::list<int>(selection->getSplines().begin(),
+                     selection->getSplines().end()),
       app->getCurrentXsheet(), app->getCurrentObject(), app->getCurrentFx());
 }
 
@@ -1636,7 +1643,7 @@ void FxSettingsPanel::restoreFloatingPanelState() {
 
   QRect geom = settings.value("geometry", saveGeometry()).toRect();
   // check if it can be visible in the current screen
-  if (!(geom & QApplication::desktop()->availableGeometry(this)).isEmpty())
+  if (!(geom & this->screen()->availableGeometry()).isEmpty())
     move(geom.topLeft());
 
   // FxSettings has no optional settings (SaveLoadQSettings) to load
@@ -1652,7 +1659,7 @@ public:
 
   TPanel *createPanel(QWidget *parent) override {
     FxSettingsPanel *panel = new FxSettingsPanel(parent);
-    panel->move(qApp->desktop()->screenGeometry(panel).center());
+    panel->move(panel->screen()->geometry().center());
     panel->setObjectName(getPanelType());
     panel->setWindowTitle(QObject::tr("Fx Settings"));
     panel->setMinimumSize(390, 85);
@@ -1769,7 +1776,7 @@ public:
 
   TPanel *createPanel(QWidget *parent) override {
     FxBrowserPanel *panel = new FxBrowserPanel(parent);
-    panel->move(qApp->desktop()->screenGeometry(panel).center());
+    panel->move(panel->screen()->geometry().center());
     panel->setObjectName(getPanelType());
     panel->setWindowTitle(QObject::tr("Fx Browser"));
     panel->setMinimumWidth(233);
@@ -1810,7 +1817,7 @@ public:
 
   TPanel *createPanel(QWidget *parent) override {
     LocatorPanel *panel = new LocatorPanel(parent);
-    panel->move(qApp->desktop()->screenGeometry(panel).center());
+    panel->move(panel->screen()->geometry().center());
     panel->setObjectName(getPanelType());
     panel->setWindowTitle(QObject::tr("Locator"));
     panel->allowMultipleInstances(false);

--- a/toonz/sources/toonz/vectorguideddrawingpane.cpp
+++ b/toonz/sources/toonz/vectorguideddrawingpane.cpp
@@ -102,7 +102,7 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
   connect(m_FlipPrevDirectionBtn, SIGNAL(clicked()), action, SLOT(trigger()));
 
   QGridLayout *mainlayout = new QGridLayout();
-  mainlayout->setMargin(5);
+  mainlayout->setContentsMargins(5, 5, 5, 5);
   mainlayout->setSpacing(2);
   {
     QLabel *guideFrameLabel = new QLabel(this);
@@ -114,7 +114,7 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
     selectGuideStrokeLabel->setText(tr("Select Stroke:"));
     mainlayout->addWidget(selectGuideStrokeLabel, 1, 0, Qt::AlignRight);
     QHBoxLayout *selectBtnLayout = new QHBoxLayout();
-    selectBtnLayout->setMargin(0);
+    selectBtnLayout->setContentsMargins(0, 0, 0, 0);
     selectBtnLayout->setSpacing(2);
     {
       selectBtnLayout->addWidget(m_selectPrevGuideBtn, 0);
@@ -128,7 +128,7 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
     flipGuideStrokeLabel->setText(tr("Flip Stroke Direction:"));
     mainlayout->addWidget(flipGuideStrokeLabel, 2, 0, Qt::AlignRight);
     QHBoxLayout *flipBtnLayout = new QHBoxLayout();
-    flipBtnLayout->setMargin(0);
+    flipBtnLayout->setContentsMargins(0, 0, 0, 0);
     flipBtnLayout->setSpacing(2);
     {
       flipBtnLayout->addWidget(m_FlipPrevDirectionBtn, 0);

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -832,7 +832,7 @@ paramsLayout->addWidget(m_cThicknessRatio, row++, 1);*/
 
   // Connect value changes to update the global
   // VectorizerPopUpSettingsContainer.
-  // connect(m_typeMenu,SIGNAL(currentIndexChanged(const QString
+  // connect(m_typeMenu,SIGNAL(currentTextChanged(const QString
   // &)),this,SLOT(updateSceneSettings()));
   connect(m_cThreshold, SIGNAL(valueChanged(bool)), this,
           SLOT(onValueEdited(bool)));

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -478,7 +478,7 @@ VectorizerPopup::VectorizerPopup(QWidget *parent, Qt::WindowFlags flags)
     QHBoxLayout *toolbarsLayout = new QHBoxLayout(toolbarsContainer);
     toolbarsContainer->setLayout(toolbarsLayout);
 
-    toolbarsLayout->setMargin(0);
+    toolbarsLayout->setContentsMargins(0, 0, 0, 0);
     toolbarsLayout->setSpacing(0);
 
     QToolBar *spacingToolBar = new QToolBar(

--- a/toonz/sources/toonz/vectorizerswatch.cpp
+++ b/toonz/sources/toonz/vectorizerswatch.cpp
@@ -414,7 +414,7 @@ VectorizerSwatchArea::VectorizerSwatchArea(QWidget *parent) {
   setLayout(lay);
   lay->addWidget(m_leftSwatch);
   lay->addWidget(m_rightSwatch);
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
 
   setMinimumHeight(150);
 

--- a/toonz/sources/toonz/versioncontroltimeline.cpp
+++ b/toonz/sources/toonz/versioncontroltimeline.cpp
@@ -44,7 +44,7 @@ using namespace DVGui;
 
 TimelineWidget::TimelineWidget(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
 
   QLabel *label = new QLabel(tr("Recent Version"));
@@ -123,7 +123,7 @@ SVNTimeline::SVNTimeline(QWidget *parent, const QString &workingDir,
           this, SLOT(onSelectionChanged()));
 
   QHBoxLayout *checkBoxLayout = new QHBoxLayout;
-  checkBoxLayout->setMargin(0);
+  checkBoxLayout->setContentsMargins(0, 0, 0, 0);
   m_sceneContentsCheckBox = new QCheckBox(this);
   m_sceneContentsCheckBox->setVisible(m_fileName.endsWith(".tnz"));
   connect(m_sceneContentsCheckBox, SIGNAL(toggled(bool)), this,
@@ -135,7 +135,7 @@ SVNTimeline::SVNTimeline(QWidget *parent, const QString &workingDir,
   checkBoxLayout->addStretch();
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->addLayout(hLayout);
   mainLayout->addWidget(m_timelineWidget);
   mainLayout->addSpacing(5);

--- a/toonz/sources/toonz/versioncontrolwidget.cpp
+++ b/toonz/sources/toonz/versioncontrolwidget.cpp
@@ -17,7 +17,7 @@
 DateChooserWidget::DateChooserWidget(QWidget *parent)
     : QWidget(parent), m_selectedRadioIndex(0) {
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setAlignment(Qt::AlignTop);
 
   // Time
@@ -178,7 +178,7 @@ QString DateChooserWidget::getRevisionString() const {
 ConflictWidget::ConflictWidget(QWidget *parent)
     : QWidget(parent), m_button1Text(tr("Mine")), m_button2Text(tr("Theirs")) {
   m_mainLayout = new QVBoxLayout;
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setAlignment(Qt::AlignTop);
   setLayout(m_mainLayout);
 }
@@ -228,7 +228,7 @@ DoubleRadioWidget::DoubleRadioWidget(const QString &button1Text,
 
 {
   QHBoxLayout *mainLayout = new QHBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   m_firstButton = new QRadioButton(button1Text);
   connect(m_firstButton, SIGNAL(clicked()), this, SIGNAL(valueChanged()));

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -58,7 +58,7 @@ ViewerEventLogPopup::ViewerEventLogPopup(QWidget *parent)
 
   QFrame *filterBox          = new QFrame(this);
   QVBoxLayout *vFilterLayout = new QVBoxLayout(filterBox);
-  vFilterLayout->setMargin(10);
+  vFilterLayout->setContentsMargins(10, 10, 10, 10);
   vFilterLayout->setSpacing(5);
 
   vFilterLayout->addWidget(new QLabel(tr("Capture events:"), this));
@@ -156,7 +156,7 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QTabletEvent *te = dynamic_cast<QTabletEvent *>(e);
     QString operation =
         ((te->buttons() & Qt::LeftButton) ||
-         (te->buttons() & Qt::RightButton) || (te->buttons() & Qt::MidButton))
+         (te->buttons() & Qt::RightButton) || (te->buttons() & Qt::MiddleButton))
             ? tr("dragged")
             : tr("moved");
     float pressure = (int)(te->pressure() * 1000 + 0.5);
@@ -206,7 +206,7 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
             ? tr("LEFT")
             : (me->buttons() & Qt::RightButton)
                   ? tr("RIGHT")
-                  : (me->buttons() & Qt::MidButton) ? tr("MIDDLE") : tr("NO");
+                  : (me->buttons() & Qt::MiddleButton) ? tr("MIDDLE") : tr("NO");
 
     eventMsg = tr("Mouse %1 button pressed at X=%2 Y=%3")
                    .arg(usedButton)
@@ -220,7 +220,7 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
     QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
     QString operation =
         ((me->buttons() & Qt::LeftButton) ||
-         (me->buttons() & Qt::RightButton) || (me->buttons() & Qt::MidButton))
+         (me->buttons() & Qt::RightButton) || (me->buttons() & Qt::MiddleButton))
             ? tr("dragged")
             : tr("moved");
     eventMsg = tr("Mouse %1 to X=%2 Y=%3")
@@ -244,7 +244,7 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
             ? tr("LEFT")
             : (me->buttons() & Qt::RightButton)
                   ? tr("RIGHT")
-                  : (me->buttons() & Qt::MidButton) ? tr("MIDDLE") : tr("NO");
+                  : (me->buttons() & Qt::MiddleButton) ? tr("MIDDLE") : tr("NO");
 
     eventMsg = tr("Mouse %1 button double-clicked at X=%2 Y=%3")
                    .arg(usedButton)

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -99,7 +99,7 @@ BaseViewerPanel::BaseViewerPanel(QWidget *parent, Qt::WindowFlags flags)
   setFrameStyle(QFrame::StyledPanel);
 
   m_mainLayout = new QVBoxLayout();
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setSpacing(0);
 
   // Viewer
@@ -1117,7 +1117,7 @@ SceneViewerPanel::SceneViewerPanel(QWidget *parent, Qt::WindowFlags flags)
 
   {
     QGridLayout *viewerL = new QGridLayout();
-    viewerL->setMargin(0);
+    viewerL->setContentsMargins(0, 0, 0, 0);
     viewerL->setSpacing(0);
     {
       viewerL->addWidget(vRuler, 1, 0);

--- a/toonz/sources/toonz/xdtsimportpopup.cpp
+++ b/toonz/sources/toonz/xdtsimportpopup.cpp
@@ -70,7 +70,7 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
   QWidget* fieldsWidget = new QWidget(this);
 
   QGridLayout* fieldsLay = new QGridLayout();
-  fieldsLay->setMargin(0);
+  fieldsLay->setContentsMargins(0, 0, 0, 0);
   fieldsLay->setHorizontalSpacing(10);
   fieldsLay->setVerticalSpacing(10);
   fieldsLay->addWidget(new QLabel(tr("Level Name"), this), 0, 0,
@@ -97,7 +97,7 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
 
   // cell mark area
   QGridLayout* markLay = new QGridLayout();
-  markLay->setMargin(0);
+  markLay->setContentsMargins(0, 0, 0, 0);
   markLay->setHorizontalSpacing(10);
   markLay->setVerticalSpacing(10);
   {

--- a/toonz/sources/toonz/xdtsio.cpp
+++ b/toonz/sources/toonz/xdtsio.cpp
@@ -693,7 +693,7 @@ void ExportXDTSCommand::execute() {
     targetColumnCombo->setCurrentIndex(targetColumnCombo->findData(true));
 
     QGridLayout *customLay = new QGridLayout();
-    customLay->setMargin(0);
+    customLay->setContentsMargins(0, 0, 0, 0);
     customLay->setSpacing(10);
     {
       customLay->addWidget(

--- a/toonz/sources/toonz/xshbreadcrumbs.cpp
+++ b/toonz/sources/toonz/xshbreadcrumbs.cpp
@@ -300,7 +300,7 @@ void BreadcrumbArea::updateBreadcrumbs() {
 
   // Now let's put everything in a layout
   m_breadcrumbLayout = new QHBoxLayout();
-  m_breadcrumbLayout->setMargin(0);
+  m_breadcrumbLayout->setContentsMargins(0, 0, 0, 0);
   m_breadcrumbLayout->setSpacing(0);
   {
     if (!m_viewer->orientation()->isVerticalTimeline())
@@ -319,7 +319,7 @@ void BreadcrumbArea::updateBreadcrumbs() {
   m_breadcrumbLayout->addStretch(1);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   hLayout->setSpacing(0);
   setLayout(hLayout);
 

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1558,7 +1558,7 @@ void CellArea::drawExtenderHandles(QPainter &p) {
           .translated(selected.bottomRight() + smartTabPosOffset);
   p.setPen(Qt::black);
   p.setBrush(SmartTabColor);
-  p.drawRoundRect(m_levelExtenderRect, xyRadius.x(), xyRadius.y());
+  p.drawRoundedRect(m_levelExtenderRect, xyRadius.x(), xyRadius.y());
   QColor color = (distance > 0 && ((selRow1 + 1 - offset) % distance) != 0)
                      ? m_viewer->getLightLineColor()
                      : m_viewer->getMarkerLineColor();
@@ -1574,7 +1574,7 @@ void CellArea::drawExtenderHandles(QPainter &p) {
                                    .translated(properPoint + smartTabPosOffset);
     p.setPen(Qt::black);
     p.setBrush(SmartTabColor);
-    p.drawRoundRect(m_upperLevelExtenderRect, xyRadius.x(), xyRadius.y());
+    p.drawRoundedRect(m_upperLevelExtenderRect, xyRadius.x(), xyRadius.y());
     QColor color = (distance > 0 && ((selRow0 - offset) % distance) != 0)
                        ? m_viewer->getLightLineColor()
                        : m_viewer->getMarkerLineColor();
@@ -2376,7 +2376,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     QString text           = QString::fromStdWString(levelName);
     QFontMetrics fm(font);
     QString elidaName =
-        elideText(text, fm, nameRect.width() - fm.width(fnum), QString("~"));
+        elideText(text, fm, nameRect.width() - fm.horizontalAdvance(fnum), QString("~"));
     p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
   }
 }
@@ -2538,7 +2538,7 @@ xy,
 
   QFontMetrics metric(font);
 
-  int charWidth = metric.width(text, 1);
+  int charWidth = metric.horizontalAdvance(text, 1);
   if ((charWidth * 2) > nameRect.width()) nameRect.adjust(-2, 0, 4, 0);
 
   QString elidaName = elideText(text, metric, nameRect.width(), "~");
@@ -2822,7 +2822,7 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
         QString elided = elideText(text, fm, unitedRect.width(), "~");
         QFontMetrics metric(font);
         // If text wider than box, shift box left to display 1st character
-        int charWidth = metric.width(elided, 1);
+        int charWidth = metric.horizontalAdvance(elided, 1);
         if ((charWidth * 2) > unitedRect.width())
           unitedRect.adjust(-2, 0, 4, 0);
         p.drawText(unitedRect, Qt::AlignLeft | Qt::AlignBottom, elided);
@@ -3102,7 +3102,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
 
     QString text      = QString::fromStdWString(levelName);
     QString elidaName = elideText(
-        text, fm, nameRect.width() - fm.width(numberStr) - 2, QString("~"));
+        text, fm, nameRect.width() - fm.horizontalAdvance(numberStr) - 2, QString("~"));
 
     if (!sameLevel || isAfterMarkers || prevCell.getFrameId().isStopFrame())
       p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
@@ -3676,7 +3676,7 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
   m_isMousePressed = true;
   QPoint frameAdj  = m_viewer->getFrameZoomAdjustment();
 
-  if (event->button() == Qt::MidButton || m_viewer->m_panningArmed) {
+  if (event->button() == Qt::MiddleButton || m_viewer->m_panningArmed) {
     m_pos       = event->pos();
     m_isPanning = true;
   }

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -66,7 +66,7 @@
 #include <QComboBox>
 #include <QCheckBox>
 #include <QPushButton>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QGroupBox>
 
 #include <QBitmap>
@@ -612,7 +612,7 @@ void ChangeObjectParent::refresh() {
   for (i = 0; i < pegbarListID.size(); i++)
     addText(pegbarListID.at(i), pegbarListTr.at(i), pegbarListColor.at(i));
 
-  m_width = fontMetrics().width(theLongestTxt) + 32;
+  m_width = fontMetrics().horizontalAdvance(theLongestTxt) + 32;
   selectCurrent(currentId);
 }
 
@@ -1568,11 +1568,11 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   std::string handle = xsh->getStageObject(columnId)->getParentHandle();
   if (handle == "B") handleWidth = 0;  // Default handle
 
-  int width = QFontMetrics(font).width(name);
+  int width = QFontMetrics(font).horizontalAdvance(name);
 
   while (width > o->rect(PredefinedRect::PEGBAR_NAME).width() - handleWidth) {
     name.remove(-1, 1000);
-    width = QFontMetrics(font).width(name);
+    width = QFontMetrics(font).horizontalAdvance(name);
   }
 
   // pegbar name
@@ -2565,7 +2565,7 @@ m_value->setFont(font);*/
   m_maskGroupBox = new QGroupBox("Clipping Mask", this);
   m_maskGroupBox->setCheckable(true);
   QGridLayout *maskLay = new QGridLayout();
-  maskLay->setMargin(5);
+  maskLay->setContentsMargins(5, 5, 5, 5);
   maskLay->setHorizontalSpacing(6);
   maskLay->setVerticalSpacing(6);
   maskLay->setColumnStretch(2, 1);
@@ -2596,14 +2596,14 @@ m_value->setFont(font);*/
   }
 
   QGridLayout *mainLayout = new QGridLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setHorizontalSpacing(6);
   mainLayout->setVerticalSpacing(6);
   {
     mainLayout->addWidget(new QLabel(tr("Opacity:"), this), 0, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
     QHBoxLayout *hlayout = new QHBoxLayout;
-    hlayout->setMargin(0);
+    hlayout->setContentsMargins(0, 0, 0, 0);
     hlayout->setSpacing(3);
     {
       hlayout->addWidget(m_slider);
@@ -2621,7 +2621,7 @@ m_value->setFont(font);*/
 
     if (m_lockBtn) {
       QHBoxLayout *lockLay = new QHBoxLayout();
-      lockLay->setMargin(0);
+      lockLay->setContentsMargins(0, 0, 0, 0);
       lockLay->setSpacing(3);
       {
         lockLay->addWidget(m_lockBtn, 0);
@@ -2862,12 +2862,12 @@ SoundColumnPopup::SoundColumnPopup(QWidget *parent)
   QLabel *sliderLabel = new QLabel(tr("Volume:"), this);
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setSpacing(3);
   {
     QHBoxLayout *hlayout = new QHBoxLayout;
     // hlayout->setContentsMargins(0, 3, 0, 3);
-    hlayout->setMargin(0);
+    hlayout->setContentsMargins(0, 0, 0, 0);
     hlayout->setSpacing(3);
     hlayout->addWidget(sliderLabel, 0);
     hlayout->addWidget(m_slider);
@@ -3434,7 +3434,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     m_viewer->dragToolClick(event);
     update();
 
-  } else if (event->button() == Qt::MidButton) {
+  } else if (event->button() == Qt::MiddleButton) {
     m_viewer->setCurrentColumn(m_col);
     m_pos       = event->pos();
     m_isPanning = true;
@@ -3710,8 +3710,7 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
         openTransparencyPopup();
 
         // make sure the popup doesn't go off the screen to the right
-        QDesktopWidget *desktop = qApp->desktop();
-        QRect screenRect        = desktop->screenGeometry(app->getMainWindow());
+        QRect screenRect = QApplication::primaryScreen()->geometry();
 
         int popupLeft   = event->globalPos().x() + x;
         int popupRight  = popupLeft + m_columnTransparencyPopup->width();

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1260,9 +1260,9 @@ void XsheetViewer::wheelEvent(QWheelEvent *event) {
   case Qt::MouseEventNotSynthesized: {
     if (0 != (event->modifiers() & Qt::ControlModifier) &&
         event->angleDelta().y() != 0) {
-      QPoint pos(event->pos().x() - m_columnArea->geometry().width() +
+      QPoint pos(event->position().x() - m_columnArea->geometry().width() +
                      m_cellArea->visibleRegion().boundingRect().left(),
-                 event->pos().y());
+                 event->position().y());
       int targetFrame = xyToPosition(pos).frame();
 
       int newFactor =

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -63,7 +63,7 @@ NotePopup::NotePopup(XsheetViewer *viewer, int noteIndex)
   beginVLayout();
 
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(1);
+  layout->setContentsMargins(1, 1, 1, 1);
   layout->setColumnStretch(7, 10);
   layout->setColumnStretch(8, 10);
   int row = 0;
@@ -493,7 +493,7 @@ NoteArea::NoteArea(XsheetViewer *parent, Qt::WindowFlags flags)
   m_newLevelButton->setIcon(createQIcon("newmemo"));
   m_newLevelButton->setToolTip(tr("Add New Level"));
 
-  m_noteButton->getContentsMargins(0, 0, 0, 0);
+  m_noteButton->setContentsMargins(0, 0, 0, 0);
   m_noteButton->setStyleSheet("padding: 0px; margin: 0px;");
   m_noteButton->setObjectName("ToolbarToolButton");
   m_noteButton->setFixedSize(32, 16);
@@ -599,7 +599,7 @@ void NoteArea::createLayout() {
               SLOT(onClickHamburger()));
     }
     QVBoxLayout *lay = new QVBoxLayout();
-    lay->setMargin(5);
+    lay->setContentsMargins(5, 5, 5, 5);
     lay->setSpacing(5);
     lay->addWidget(m_hamburgerButton, 1, Qt::AlignCenter);
     setLayout(lay);
@@ -611,14 +611,14 @@ void NoteArea::createLayout() {
 
   // has two elements: main layout and header panel
   QVBoxLayout *panelLayout = new QVBoxLayout();
-  panelLayout->setMargin(1);
+  panelLayout->setContentsMargins(1, 1, 1, 1);
   panelLayout->setSpacing(0);
   {
     QBoxLayout *mainLayout = new QBoxLayout(QBoxLayout::Direction(
         o->dimension(PredefinedDimension::QBOXLAYOUT_DIRECTION)));
     Qt::AlignmentFlag centerAlign =
         Qt::AlignmentFlag(o->dimension(PredefinedDimension::CENTER_ALIGN));
-    mainLayout->setMargin(1);
+    mainLayout->setContentsMargins(1, 1, 1, 1);
     mainLayout->setSpacing(0);
     {
       mainLayout->addWidget(m_flipOrientationButton, 0, centerAlign);
@@ -630,7 +630,7 @@ void NoteArea::createLayout() {
       mainLayout->addStretch(1);
 
       QHBoxLayout *buttonsLayout = new QHBoxLayout();
-      buttonsLayout->setMargin(0);
+      buttonsLayout->setContentsMargins(0, 0, 0, 0);
       buttonsLayout->setSpacing(0);
       {
         buttonsLayout->addWidget(m_precNoteButton, 0);
@@ -761,13 +761,13 @@ FooterNoteArea::FooterNoteArea(QWidget *parent, XsheetViewer *viewer,
   m_noteButton     = new QToolButton(this);
   m_precNoteButton = new QToolButton(this);
   m_nextNoteButton = new QToolButton(this);
-  m_noteButton->getContentsMargins(0, 0, 0, 0);
+  m_noteButton->setContentsMargins(0, 0, 0, 0);
   m_noteButton->setStyleSheet("padding: 0px; margin: 0px;");
 
-  m_precNoteButton->getContentsMargins(0, 0, 0, 0);
+  m_precNoteButton->setContentsMargins(0, 0, 0, 0);
   m_precNoteButton->setStyleSheet("padding: 0px; margin: 0px;");
 
-  m_nextNoteButton->getContentsMargins(0, 0, 0, 0);
+  m_nextNoteButton->setContentsMargins(0, 0, 0, 0);
   m_nextNoteButton->setStyleSheet("padding: 0px; margin: 0px;");
 
   //-----
@@ -832,7 +832,7 @@ void FooterNoteArea::createLayout() {
   setFixedSize(rect.size());
 
   QHBoxLayout *buttonsLayout = new QHBoxLayout();
-  buttonsLayout->setMargin(0);
+  buttonsLayout->setContentsMargins(0, 0, 0, 0);
   buttonsLayout->setSpacing(0);
   {
     buttonsLayout->addWidget(m_precNoteButton, 0);

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -53,19 +53,19 @@ OnionSkinPopup::OnionSkinPopup(QWidget *parent, bool isVertical)
   m_autoCB->setChecked(true);
 
   QGridLayout *mainLayout = new QGridLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setHorizontalSpacing(6);
   mainLayout->setVerticalSpacing(6);
   {
     if (isVertical) {
       QVBoxLayout *vlayout = new QVBoxLayout;
-      vlayout->setMargin(0);
+      vlayout->setContentsMargins(0, 0, 0, 0);
       vlayout->setSpacing(3);
       {
         vlayout->addWidget(new QLabel(tr("Opacity"), this), 0,
                            Qt::AlignHCenter);
         QHBoxLayout *hlayout = new QHBoxLayout;
-        hlayout->setMargin(0);
+        hlayout->setContentsMargins(0, 0, 0, 0);
         hlayout->setSpacing(3);
         hlayout->setAlignment(Qt::AlignHCenter);
         {
@@ -83,7 +83,7 @@ OnionSkinPopup::OnionSkinPopup(QWidget *parent, bool isVertical)
       mainLayout->addWidget(new QLabel(tr("Opacity:"), this), 0, 0,
                             Qt::AlignRight | Qt::AlignVCenter);
       QHBoxLayout *hlayout = new QHBoxLayout;
-      hlayout->setMargin(0);
+      hlayout->setContentsMargins(0, 0, 0, 0);
       hlayout->setSpacing(3);
       {
         hlayout->addWidget(m_slider);

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1352,7 +1352,7 @@ void RowArea::mousePressEvent(QMouseEvent *event) {
     event->accept();
   }  // left-click
      // pan by middle-drag
-  else if (event->button() == Qt::MidButton) {
+  else if (event->button() == Qt::MiddleButton) {
     m_pos       = event->pos();
     m_isPanning = true;
   }

--- a/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
@@ -413,11 +413,7 @@ static TFilePath getFilePath(const QStringList &l, int &i) {
 //------------------------------------------------------------------------------
 
 void TFarmTask::parseCommandLine(QString commandLine) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList l = commandLine.split(" ", Qt::SkipEmptyParts);
-#else
-  QStringList l = commandLine.split(" ", QString::SkipEmptyParts);
-#endif
   assert(l.size() >= 2);
 
   // serve per skippare il path dell'eseguibile su mac che contiene spazi

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -478,11 +478,7 @@ void Task::run() {
 #if defined(_WIN32)
   process.setNativeArguments(argsStr);
 #else
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   process.setArguments(argsStr.split(" ", Qt::SkipEmptyParts));
-#else
-  process.setArguments(argsStr.split(" ", QString::SkipEmptyParts));
-#endif
 #endif
   process.start();
   process.waitForFinished(-1);

--- a/toonz/sources/toonzlib/boardsettings.cpp
+++ b/toonz/sources/toonzlib/boardsettings.cpp
@@ -333,11 +333,7 @@ void BoardSettings::removeItem(int index) {
   m_items.removeAt(index);
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
 void BoardSettings::swapItems(int i, int j) { m_items.swapItemsAt(i, j); }
-#else
-void BoardSettings::swapItems(int i, int j) { m_items.swap(i, j); }
-#endif
 
 void BoardSettings::saveData(TOStream &os, bool forPreset) {
   if (!forPreset) os.child("active") << (int)((m_active) ? 1 : 0);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -1049,11 +1049,7 @@ QString Preferences::getCurrentStyleSheet() const {
   // to apply an extra adjustment when it is run on the older versions (5.9.x)
   // of Qt
   // Update: confirmed that the bug does not appear at least in Qt 5.12.8
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 9)
-  baseSheetStr += "QMenu::Item{ padding: 3 28 3 28; }";
-#else
   baseSheetStr += "QMenu::Item{ padding: 3 28 3 8; }";
-#endif
 
 // Linux system font size appears a lot smaller than it should be despite
 // setting QApplication's setPixelSize = 12 in main.cpp. We'll correct it using

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -45,7 +45,7 @@
 #include <QPainter>
 #include <QPolygon>
 #include <QThreadStorage>
-#include <QMatrix>
+#include <QTransform>
 
 #include "toonz/stage.h"
 

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -56,7 +56,7 @@
 #include <QPainter>
 #include <QPolygon>
 #include <QThreadStorage>
-#include <QMatrix>
+#include <QTransform>
 #include <QThread>
 #include <QGuiApplication>
 
@@ -418,7 +418,7 @@ void RasterPainter::clearNodes() { m_nodes.clear(); }
 
 //-----------------------------------------------------------------------------
 
-TRasterP RasterPainter::getRaster(int index, QMatrix &matrix) {
+TRasterP RasterPainter::getRaster(int index, QTransform &matrix) {
   if ((int)m_nodes.size() <= index) return TRasterP();
 
   if (m_nodes[index].m_onionMode != Node::eOnionSkinNone) return TRasterP();
@@ -437,7 +437,7 @@ TRasterP RasterPainter::getRaster(int index, QMatrix &matrix) {
   rect = rect * TRect(0, 0, m_dim.lx - 1, m_dim.ly - 1);
 
   TAffine aff = TTranslation(-rect.x0, -rect.y0) * m_nodes[index].m_aff;
-  matrix      = QMatrix(aff.a11, aff.a21, aff.a12, aff.a22, aff.a13, aff.a23);
+  matrix = QTransform(aff.a11, aff.a21, aff.a12, aff.a22, aff.a13, aff.a23);
 
   return m_nodes[index].m_raster;
 }
@@ -720,10 +720,10 @@ void RasterPainter::drawRasterImages(QPainter &p, QPolygon cameraPol) {
     p.resetTransform();
     TRasterP ras = m_nodes[i].m_raster;
     TAffine aff  = TTranslation(-rect.x0, -rect.y0) * flipY * m_nodes[i].m_aff;
-    QMatrix matrix(aff.a11, aff.a21, aff.a12, aff.a22, aff.a13, aff.a23);
+    QTransform matrix(aff.a11, aff.a21, aff.a12, aff.a22, aff.a13, aff.a23);
     QImage image = rasterToQImage(ras);
     if (image.isNull()) continue;
-    p.setMatrix(matrix);
+    p.setWorldTransform(matrix);
     p.drawImage(rect.getP00().x, rect.getP00().y, image);
   }
 

--- a/toonz/sources/toonzlib/trasterimageutils.cpp
+++ b/toonz/sources/toonzlib/trasterimageutils.cpp
@@ -367,11 +367,7 @@ void TRasterImageUtils::addSceneNumbering(const TRasterImageP &ri,
   QString sceneNumberingString =
       QString::fromStdWString(sceneName) + ": " + sceneFrame;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int sceneNumberingWidth = fm.horizontalAdvance(sceneNumberingString);
-#else
-  int sceneNumberingWidth = fm.width(sceneNumberingString);
-#endif
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(255, 255, 255, 255));
   p.drawRect(offset, ly - offset - fontHeight, sceneNumberingWidth + offset * 2,
@@ -386,11 +382,7 @@ void TRasterImageUtils::addSceneNumbering(const TRasterImageP &ri,
   QString globalFrame = QString::number(globalIndex);
   while (globalFrame.size() < 4) globalFrame.push_front("0");
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int gloablNumberingWidth = fm.horizontalAdvance(globalFrame);
-#else
-  int gloablNumberingWidth = fm.width(globalFrame);
-#endif
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(255, 255, 255, 255));
   p.drawRect(lx - 3 * offset - gloablNumberingWidth, ly - offset - fontHeight,
@@ -429,11 +421,7 @@ void TRasterImageUtils::addGlobalNumbering(const TRasterImageP &ri,
   QString globalNumberingString =
       QString::fromStdWString(sceneName) + ": " + globalFrame;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   int globalNumberingWidth = fm.horizontalAdvance(globalNumberingString);
-#else
-  int globalNumberingWidth = fm.width(globalNumberingString);
-#endif
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(255, 255, 255, 255));
   p.drawRect(offset, ly - offset - fontHeight,

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -518,11 +518,7 @@ bool TXshCellColumn::loadCellMarks(std::string tagName, TIStream &is) {
       QString frameStr;
       if (is.getTagParam("id", id)) {
         is >> frameStr;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QStringList frameStrList = frameStr.split(" ", Qt::SkipEmptyParts);
-#else
-        QStringList frameStrList = frameStr.split(" ", QString::SkipEmptyParts);
-#endif
         for (auto fStr : frameStrList) m_cellMarkIds.insert(fStr.toInt(), id);
       }
     }

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1116,7 +1116,7 @@ static TFilePath getLevelPathAndSetNameWithPsdLevelName(
     retfp = TFilePath(
         QString::fromStdWString(retfp.getWideString()).replace("##", "#"));
   }
-  QStringList list = name.split("#", QString::SkipEmptyParts);
+  QStringList list = name.split("#", Qt::SkipEmptyParts);
 
   if (list.size() >= 2 && list.at(1) != "frames") {
     bool hasLayerId;

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -302,7 +302,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
 
   QVBoxLayout *mainLay = new QVBoxLayout();
   mainLay->setSpacing(3);
-  mainLay->setMargin(3);
+  mainLay->setContentsMargins(3, 3, 3, 3);
   {
     QGridLayout *gridLay = new QGridLayout();
     gridLay->setHorizontalSpacing(2);
@@ -353,7 +353,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
 
     QHBoxLayout *resListLay = new QHBoxLayout();
     resListLay->setSpacing(3);
-    resListLay->setMargin(1);
+    resListLay->setContentsMargins(1, 1, 1, 1);
     {
       resListLay->addWidget(m_presetListOm, 1);
       resListLay->addWidget(m_addPresetBtn, 0);
@@ -507,7 +507,7 @@ bool CameraSettingsWidget::parsePresetString(const QString &str, QString &name,
   in order to keep compatibility with default (Harlequin's) reslist.txt
   */
 
-  QStringList tokens = str.split(",", QString::SkipEmptyParts);
+  QStringList tokens = str.split(",", Qt::SkipEmptyParts);
 
   if (!(tokens.count() == 3 ||
         (!forCleanup && tokens.count() == 4) || /*- with "fx x fy" token -*/

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -398,7 +398,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
   ret = ret && connect(m_useOverlaySettingsBtn, SIGNAL(clicked()), this,
                        SLOT(useOverlaySettings()));
 
-  ret = ret && connect(m_presetListOm, SIGNAL(activated(const QString &)),
+  ret = ret && connect(m_presetListOm, SIGNAL(textActivated(const QString &)),
                        SLOT(onPresetSelected(const QString &)));
   ret = ret && connect(m_addPresetBtn, SIGNAL(clicked()), SLOT(addPreset()));
   ret = ret &&

--- a/toonz/sources/toonzqt/cleanupcamerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/cleanupcamerasettingswidget.cpp
@@ -44,7 +44,7 @@ CleanupCameraSettingsWidget::CleanupCameraSettingsWidget() {
 
   //--- layout
   QVBoxLayout *mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(m_cameraWidget);
@@ -52,7 +52,7 @@ CleanupCameraSettingsWidget::CleanupCameraSettingsWidget() {
     QGridLayout *offsetLay = new QGridLayout();
     offsetLay->setHorizontalSpacing(3);
     offsetLay->setVerticalSpacing(3);
-    offsetLay->setMargin(3);
+    offsetLay->setContentsMargins(3, 3, 3, 3);
     {
       offsetLay->addWidget(new QLabel(tr("Y")), 0, 0);
       offsetLay->addWidget(m_offsY, 0, 1);

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -300,7 +300,7 @@ ChannelField::ChannelField(QWidget *parent, const QString &string, int value,
 
   //----layout
   QGridLayout *mainLayout = new QGridLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(3);
   {
     mainLayout->addWidget(channelName, 0, 0);
@@ -448,7 +448,7 @@ ColorField::ColorField(QWidget *parent, bool isAlphaActive, TPixel32 color,
     , m_useStyleEditor(useStyleEditor) {
   setMaximumHeight(squareSize);
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(5);
 
   layout->setSizeConstraint(QLayout::SetFixedSize);
@@ -840,13 +840,13 @@ CleanupColorField::CleanupColorField(QWidget *parent,
   //---- layout
 
   QHBoxLayout *mainLay = new QHBoxLayout();
-  mainLay->setMargin(8);
+  mainLay->setContentsMargins(8, 8, 8, 8);;
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(m_colorSample, 0);
 
     QVBoxLayout *paramLay = new QVBoxLayout();
-    paramLay->setMargin(0);
+    paramLay->setContentsMargins(0, 0, 0, 0);
     paramLay->setSpacing(3);
     {
       paramLay->addWidget(m_brightnessChannel);

--- a/toonz/sources/toonzqt/combohistogram.cpp
+++ b/toonz/sources/toonzqt/combohistogram.cpp
@@ -322,11 +322,11 @@ ChannelHisto::ChannelHisto(int channelIndex, bool *showComparePtr,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(2);
   {
     QHBoxLayout *titleLay = new QHBoxLayout();
-    titleLay->setMargin(0);
+    titleLay->setContentsMargins(0, 0, 0, 0);
     titleLay->setSpacing(2);
     {
       titleLay->addWidget(new QLabel(label, this), 0);
@@ -510,13 +510,13 @@ ComboHistogram::ComboHistogram(QWidget *parent)
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   mainLayout->setSpacing(5);
   {
     mainLayout->addWidget(m_histograms[4]);  // RGB
 
     QHBoxLayout *labelLay = new QHBoxLayout();
-    labelLay->setMargin(0);
+    labelLay->setContentsMargins(0, 0, 0, 0);
     labelLay->setSpacing(0);
     {
       labelLay->addWidget(new QLabel(tr("Picked Color"), this), 0);
@@ -532,7 +532,7 @@ ComboHistogram::ComboHistogram(QWidget *parent)
     mainLayout->addWidget(m_rectAverageRgbLabel, 0, Qt::AlignCenter);
 
     QHBoxLayout *infoParamLay = new QHBoxLayout();
-    infoParamLay->setMargin(5);
+    infoParamLay->setContentsMargins(5, 5, 5, 5);
     infoParamLay->setSpacing(3);
     {
       infoParamLay->addWidget(new QLabel(tr("X:"), this), 1,
@@ -544,7 +544,7 @@ ComboHistogram::ComboHistogram(QWidget *parent)
 
       // range control
       QHBoxLayout *rangeLay = new QHBoxLayout();
-      rangeLay->setMargin(0);
+      rangeLay->setContentsMargins(0, 0, 0, 0);
       rangeLay->setSpacing(0);
       {
         rangeLay->addWidget(m_rangeUpBtn, 0);

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -8,7 +8,7 @@
 
 #include <QTextStream>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 
 //========================================================
 
@@ -1536,8 +1536,7 @@ bool DockLayout::restoreState(const State &state) {
     if (item->m_saveIndex > 0) {
       // Ensure that floating panels are not placed in
       // unavailable positions
-      if ((geoms[j] & QApplication::desktop()->availableGeometry(item))
-              .isEmpty())
+      if ((geoms[j] & item->screen()->availableGeometry()).isEmpty())
         item->move(recoverX += 50, recoverY += 50);
 
       // Set floating appearances

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -1440,11 +1440,7 @@ void DockLayout::writeRegion(Region *r, QString &hierarchy) {
 //! widget has ever been left unchanged or completely restored
 //! as it were when saved. In particular, their ordering must be preserved.
 bool DockLayout::restoreState(const State &state) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList vars = state.second.split(" ", Qt::SkipEmptyParts);
-#else
-  QStringList vars = state.second.split(" ", QString::SkipEmptyParts);
-#endif
   if (vars.size() < 1) return 0;
 
   // Check number of items

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -8,7 +8,6 @@
 #include <QEvent>
 #include <QMouseEvent>
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QScreen>
 
 // STD includes
@@ -81,7 +80,7 @@ inline QRect toRect(const QRectF &rect) {
 
 // Forward declaration
 namespace {
-QDesktopWidget *desktop;
+QScreen *desktop;
 void getClosestAvailableMousePosition(QPoint &globalPos);
 }  // namespace
 
@@ -128,7 +127,7 @@ DockWidget::DockWidget(QWidget *parent, Qt::WindowFlags flags)
   m_decoAllocator = new DockDecoAllocator;
 
   // Make sure the desktop is initialized and known
-  desktop = qApp->desktop();
+  desktop = QApplication::primaryScreen();
 }
 
 //-------------------------------------

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -400,19 +400,11 @@ void DockWidget::maximizeDock() {
 void DockWidget::wheelEvent(QWheelEvent *we) {
   if (m_dragging) {
     if (m_selectedPlace) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       DockPlaceholder *newSelected =
           (we->angleDelta().y() > 0)
               ? m_selectedPlace->parentPlaceholder()
               : m_selectedPlace->childPlaceholder(parentWidget()->mapFromGlobal(
                     we->globalPosition().toPoint()));
-#else
-      DockPlaceholder *newSelected =
-          (we->angleDelta().y() > 0)
-              ? m_selectedPlace->parentPlaceholder()
-              : m_selectedPlace->childPlaceholder(
-                    parentWidget()->mapFromGlobal(we->globalPos()));
-#endif
       if (newSelected != m_selectedPlace) {
         m_selectedPlace->hide();
         newSelected->show();

--- a/toonz/sources/toonzqt/doublefield.cpp
+++ b/toonz/sources/toonzqt/doublefield.cpp
@@ -97,11 +97,11 @@ DoubleValueField::DoubleValueField(QWidget *parent,
 
   //---layout
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(5);
   {
     QVBoxLayout *vLayout = new QVBoxLayout(field);
-    vLayout->setMargin(0);
+    vLayout->setContentsMargins(0, 0, 0, 0);
     vLayout->setSpacing(0);
     {
       vLayout->addWidget(m_lineEdit);

--- a/toonz/sources/toonzqt/doublepairfield.cpp
+++ b/toonz/sources/toonzqt/doublepairfield.cpp
@@ -54,7 +54,7 @@ DoubleValuePairField::DoubleValuePairField(QWidget *parent,
 
   //---- layout
   QHBoxLayout *m_mainLayout = new QHBoxLayout;
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setSpacing(3);
   {
     m_mainLayout->addWidget(m_leftLabel, 1);

--- a/toonz/sources/toonzqt/doublepairfield.cpp
+++ b/toonz/sources/toonzqt/doublepairfield.cpp
@@ -157,13 +157,8 @@ void DoubleValuePairField::paintEvent(QPaintEvent *) {
 void DoubleValuePairField::setLeftText(const QString &text) {
   QString oldText = m_leftLabel->text();
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
   int newLabelSize = fontMetrics().horizontalAdvance(text);
-#else
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
-#endif
   int labelSize    = newLabelSize - oldLabelSize;
   m_leftMargin += labelSize + MARGIN_OFFSET;
 
@@ -176,13 +171,8 @@ void DoubleValuePairField::setLeftText(const QString &text) {
 void DoubleValuePairField::setRightText(const QString &text) {
   QString oldText = m_rightLabel->text();
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
   int newLabelSize = fontMetrics().horizontalAdvance(text);
-#else
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
-#endif
   int labelSize    = newLabelSize - oldLabelSize;
   m_rightMargin += labelSize + MARGIN_OFFSET;
 

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -858,7 +858,7 @@ RadioButtonDialog::RadioButtonDialog(const QString &labelText,
     addWidget(radioButton);
   }
 
-  bool ret = connect(buttonGroup, SIGNAL(buttonClicked(int)),
+  bool ret = connect(buttonGroup, SIGNAL(idClicked(int)),
                      SLOT(onButtonClicked(int)));
 
   endVLayout();
@@ -1029,7 +1029,7 @@ int DVGui::MsgBox(MsgType type, const QString &text,
     buttonGroup->addButton(button, i + 1);
   }
 
-  QObject::connect(buttonGroup, SIGNAL(buttonPressed(int)), &dialog,
+  QObject::connect(buttonGroup, SIGNAL(idPressed(int)), &dialog,
                    SLOT(done(int)));
 
   dialog.raise();
@@ -1079,7 +1079,7 @@ void DVGui::MsgBoxInPopup(MsgType type, const QString &text) {
   button->setDefault(true);
   dialog.addButtonBarWidget(button);
   buttonGroup->addButton(button, 1);
-  QObject::connect(buttonGroup, SIGNAL(buttonPressed(int)), &dialog,
+  QObject::connect(buttonGroup, SIGNAL(idPressed(int)), &dialog,
                    SLOT(done(int)));
 
   while (!messageQueue.empty()) {
@@ -1153,7 +1153,7 @@ int DVGui::MsgBox(const QString &text, const QString &button1Text,
   dialog.addButtonBarWidget(button3);
   buttonGroup->addButton(button3, 3);
 
-  QObject::connect(buttonGroup, SIGNAL(buttonPressed(int)), &dialog,
+  QObject::connect(buttonGroup, SIGNAL(idPressed(int)), &dialog,
                    SLOT(done(int)));
   dialog.raise();
   return dialog.exec();
@@ -1212,7 +1212,7 @@ int DVGui::MsgBox(const QString &text, const QString &button1Text,
   dialog.addButtonBarWidget(button4);
   buttonGroup->addButton(button4, 4);
 
-  QObject::connect(buttonGroup, SIGNAL(buttonPressed(int)), &dialog,
+  QObject::connect(buttonGroup, SIGNAL(idPressed(int)), &dialog,
                    SLOT(done(int)));
   dialog.raise();
   return dialog.exec();
@@ -1273,7 +1273,7 @@ Dialog *DVGui::createMsgBox(MsgType type, const QString &text,
     buttonGroup->addButton(button, i + 1);
   }
 
-  QObject::connect(buttonGroup, SIGNAL(buttonPressed(int)), dialog,
+  QObject::connect(buttonGroup, SIGNAL(idPressed(int)), dialog,
                    SLOT(done(int)));
 
   return dialog;
@@ -1332,7 +1332,7 @@ MessageAndCheckboxDialog *DVGui::createMsgandCheckbox(
 
   QObject::connect(dialogCheckBox, SIGNAL(stateChanged(int)), dialog,
                    SLOT(onCheckboxChanged(int)));
-  QObject::connect(buttonGroup, SIGNAL(buttonPressed(int)), dialog,
+  QObject::connect(buttonGroup, SIGNAL(idPressed(int)), dialog,
                    SLOT(onButtonPressed(int)));
 
   return dialog;

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -28,7 +28,7 @@
 #include <QPainter>
 #include <QRadioButton>
 #include <QThread>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QCheckBox>
 
 #include <algorithm>
@@ -126,7 +126,7 @@ void Separator::paintEvent(QPaintEvent *) {
 
   QRect contents(contentsRect());
 
-  int textWidth = p.fontMetrics().width(m_name);
+  int textWidth = p.fontMetrics().horizontalAdvance(m_name);
 
   p.drawText(contents.left(), 10, m_name);
 
@@ -231,16 +231,17 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
     , m_layoutSpacing(5)
     , m_layoutMargin(0)
     , m_labelWidth(100)
-    , m_name() {
+    , m_name()
+    , m_currentScreen(0) {
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   m_mainFrame = new QFrame(this);
   m_mainFrame->setObjectName("dialogMainFrame");
   m_mainFrame->setMinimumHeight(41);
   m_mainFrame->setFrameStyle(QFrame::StyledPanel);
   m_topLayout = new QVBoxLayout;
-  m_topLayout->setMargin(12);
+  m_topLayout->setContentsMargins(12, 12, 12, 12);
   m_topLayout->setSpacing(m_layoutSpacing);
   m_topLayout->setAlignment(Qt::AlignCenter);
   m_mainFrame->setLayout(m_topLayout);
@@ -257,7 +258,7 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
     m_buttonFrame->setFixedHeight(45);
 
     m_buttonLayout = new QHBoxLayout;
-    m_buttonLayout->setMargin(0);
+    m_buttonLayout->setContentsMargins(0, 0, 0, 0);
     m_buttonLayout->setSpacing(20);
     m_buttonLayout->setAlignment(Qt::AlignHCenter);
 
@@ -303,9 +304,9 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
 
     // try and get active screen
     if (parent != NULL) {
-      m_currentScreen = QApplication::desktop()->screenNumber(parent);
+      m_currentScreen = parent->screen();
     }
-    QRect screen = QApplication::desktop()->availableGeometry(m_currentScreen);
+    QRect screen = m_currentScreen->availableGeometry();
     int x        = values.at(0).toInt();
     int y        = values.at(1).toInt();
 
@@ -361,18 +362,17 @@ void Dialog::hideEvent(QHideEvent *event) {
   int x = pos().rx();
   int y = pos().ry();
   // make sure the dialog is actually visible on a screen
-  int screenCount = QApplication::desktop()->screenCount();
-  int currentScreen;
+  int screenCount = QApplication::screens().size();
+  QScreen  *currentScreen;
   for (int i = 0; i < screenCount; i++) {
-    if (QApplication::desktop()->screenGeometry(i).contains(pos())) {
-      currentScreen = i;
+    if ((currentScreen = QApplication::screenAt(pos()))) {
       break;
     } else {
       // if not - put it back on the main window
       currentScreen = m_currentScreen;
     }
   }
-  QRect screen = QApplication::desktop()->availableGeometry(currentScreen);
+  QRect screen = currentScreen->availableGeometry();
 
   if (x > screen.right() - 50) x  = screen.right() - 50;
   if (x < screen.left()) x        = screen.left();
@@ -398,11 +398,13 @@ void Dialog::beginVLayout() {
   m_isMainVLayout = true;
 
   m_leftVLayout = new QVBoxLayout;
-  m_leftVLayout->setMargin(m_layoutMargin);
+  m_leftVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin,
+                                    m_layoutMargin, m_layoutMargin);
   m_leftVLayout->setSpacing(m_layoutSpacing);
 
   m_rightVLayout = new QVBoxLayout;
-  m_rightVLayout->setMargin(m_layoutMargin);
+  m_rightVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin,
+                                     m_layoutMargin, m_layoutMargin);
   m_rightVLayout->setSpacing(m_layoutSpacing);
 }
 
@@ -415,7 +417,8 @@ void Dialog::endVLayout() {
   m_isMainVLayout = false;
 
   QHBoxLayout *layout = new QHBoxLayout;
-  layout->setMargin(m_layoutMargin);
+  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                             m_layoutMargin);
   layout->setSpacing(m_layoutSpacing);
   layout->setSizeConstraint(QLayout::SetFixedSize);
 
@@ -436,7 +439,8 @@ void Dialog::endVLayout() {
 void Dialog::beginHLayout() {
   m_isMainHLayout = true;
   m_mainHLayout   = new QHBoxLayout;
-  m_mainHLayout->setMargin(m_layoutMargin);
+  m_mainHLayout->setContentsMargins(m_layoutMargin, m_layoutMargin,
+                                    m_layoutMargin, m_layoutMargin);
   m_mainHLayout->setSpacing(m_layoutSpacing);
 }
 
@@ -497,7 +501,8 @@ void Dialog::addWidgets(QWidget *firstW, QWidget *secondW) {
     return;
   }
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setMargin(m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                                 m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addWidget(firstW);
   pairLayout->addWidget(secondW);
@@ -563,7 +568,8 @@ layout containing
                 \b widget and \b layout and add it to horizontal layout.
 */
 void Dialog::addWidgetLayout(QWidget *widget, QLayout *layout) {
-  layout->setMargin(m_layoutMargin);
+  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                             m_layoutMargin);
   layout->setSpacing(m_layoutSpacing);
 
   if (m_isMainVLayout) {
@@ -574,7 +580,8 @@ void Dialog::addWidgetLayout(QWidget *widget, QLayout *layout) {
   }
 
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setMargin(m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                                 m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addWidget(widget);
   pairLayout->addLayout(layout);
@@ -615,9 +622,11 @@ layout containing
                 \b firstL and \b secondL and add it to horizontal layout.
 */
 void Dialog::addLayouts(QLayout *firstL, QLayout *secondL) {
-  firstL->setMargin(m_layoutMargin);
+  firstL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                             m_layoutMargin);
   firstL->setSpacing(m_layoutSpacing);
-  secondL->setMargin(m_layoutMargin);
+  secondL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                              m_layoutMargin);
   secondL->setSpacing(m_layoutSpacing);
 
   if (m_isMainVLayout) {
@@ -628,7 +637,8 @@ void Dialog::addLayouts(QLayout *firstL, QLayout *secondL) {
   }
 
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setMargin(m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                                 m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addLayout(firstL);
   pairLayout->addLayout(secondL);
@@ -716,13 +726,15 @@ int Dialog::getLayoutInsertedSpacing() { return m_layoutSpacing; }
 //-----------------------------------------------------------------------------
 /*! Set to \b margin margin of main part of dialog.
  */
-void Dialog::setTopMargin(int margin) { m_topLayout->setMargin(margin); }
+void Dialog::setTopMargin(int margin) {
+  m_topLayout->setContentsMargins(margin, margin, margin, margin);
+}
 
 //-----------------------------------------------------------------------------
 /*! Set to \b margin margin of button part of dialog.
  */
 void Dialog::setButtonBarMargin(int margin) {
-  m_buttonLayout->setMargin(margin);
+  m_buttonLayout->setContentsMargins(margin, margin, margin, margin);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -305,7 +305,8 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
     // try and get active screen
     if (parent != NULL) {
       m_currentScreen = parent->screen();
-    }
+    } else
+      m_currentScreen = QGuiApplication::primaryScreen();
     QRect screen = m_currentScreen->availableGeometry();
     int x        = values.at(0).toInt();
     int y        = values.at(1).toInt();

--- a/toonz/sources/toonzqt/dvtextedit.cpp
+++ b/toonz/sources/toonzqt/dvtextedit.cpp
@@ -232,7 +232,7 @@ void DvTextEdit::createMiniToolBar() {
 
   QVBoxLayout *m_mainLayout = new QVBoxLayout(m_miniToolBar);
   m_mainLayout->setSizeConstraint(QLayout::SetFixedSize);
-  m_mainLayout->setMargin(2);
+  m_mainLayout->setContentsMargins(2, 2, 2, 2);
   m_mainLayout->setSpacing(2);
   m_mainLayout->addWidget(toolBarUp);
   m_mainLayout->addWidget(toolBarDown);

--- a/toonz/sources/toonzqt/dvtextedit.cpp
+++ b/toonz/sources/toonzqt/dvtextedit.cpp
@@ -197,7 +197,7 @@ void DvTextEdit::createMiniToolBar() {
   m_fontComboBox->setMaximumHeight(20);
   m_fontComboBox->setMinimumWidth(140);
 
-  connect(m_fontComboBox, SIGNAL(activated(const QString &)), this,
+  connect(m_fontComboBox, SIGNAL(textActivated(const QString &)), this,
           SLOT(setTextFamily(const QString &)));
 
   m_sizeComboBox = new QComboBox(toolBarUp);
@@ -209,7 +209,7 @@ void DvTextEdit::createMiniToolBar() {
   for (int size : db.standardSizes())
     m_sizeComboBox->addItem(QString::number(size));
 
-  connect(m_sizeComboBox, SIGNAL(activated(const QString &)), this,
+  connect(m_sizeComboBox, SIGNAL(textActivated(const QString &)), this,
           SLOT(setTextSize(const QString &)));
 
   toolBarUp->addWidget(m_fontComboBox);

--- a/toonz/sources/toonzqt/filefield.cpp
+++ b/toonz/sources/toonzqt/filefield.cpp
@@ -41,7 +41,7 @@ FileField::FileField(QWidget *parent, QString path, bool readOnly,
   setFocusProxy(m_field);
 
   QHBoxLayout *mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(1);
   {
     mainLayout->addWidget(m_field, 5);

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -2026,12 +2026,8 @@ QFrame *FlipConsole::createFpsSlider() {
   m_fpsField  = new DVGui::IntLineEdit(fpsSliderFrame, m_fps, -60, 60);
   m_fpsField->setFixedWidth(40);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   m_fpsLabel->setMinimumWidth(
       m_fpsLabel->fontMetrics().horizontalAdvance("_FPS_24___"));
-#else
-  m_fpsLabel->setMinimumWidth(m_fpsLabel->fontMetrics().width("_FPS_24___"));
-#endif
   m_fpsLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
   m_fpsSlider->setObjectName("ViewerFpsSlider");
   m_fpsSlider->setRange(-60, 60);

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -43,7 +43,7 @@
 #include <QStyle>
 #include <QStylePainter>
 #include <QStyleOption>
-#include <QStyleOptionFrameV3>
+#include <QStyleOptionFrame>
 #include <QSettings>
 #include <QPushButton>
 #include <QScrollBar>

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -488,7 +488,7 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, std::vector<int> gadgetsMask,
 
   if (m_gadgetsMask.size() == 0) return;
 
-  // mainLayout->setMargin(1);
+  // mainLayout->setContentsMargins(1, 1, 1, 1);
   // mainLayout->setSpacing(0);
 
   // create toolbars other than frame slider
@@ -498,7 +498,7 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, std::vector<int> gadgetsMask,
     m_playToolBarContainer = new ToolBarContainer();
 
     QHBoxLayout *hLayout = new QHBoxLayout;
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(0);
     hLayout->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
     {
@@ -1975,7 +1975,7 @@ QFrame *FlipConsole::createFrameSlider() {
   m_currFrameSlider->setValue(0);
 
   m_timeLabel = new QLabel(QString("00:00:00"), frameSliderFrame);
-  m_timeLabel->setFixedWidth(m_timeLabel->fontMetrics().width("00:00:00") + 10);
+  m_timeLabel->setFixedWidth(m_timeLabel->fontMetrics().horizontalAdvance("00:00:00") + 10);
   m_timeLabel->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
   m_timeLabel->setStyleSheet("padding: 0px; margin: 0px;");
 
@@ -1994,7 +1994,7 @@ QFrame *FlipConsole::createFrameSlider() {
   // layout
   QHBoxLayout *frameSliderLayout = new QHBoxLayout();
   frameSliderLayout->setSpacing(5);
-  frameSliderLayout->setMargin(2);
+  frameSliderLayout->setContentsMargins(2, 2, 2, 2);
   {
     frameSliderLayout->addWidget(m_timeLabel, 0);
     frameSliderLayout->addWidget(m_editCurrFrame, 0);
@@ -2037,7 +2037,7 @@ QFrame *FlipConsole::createFpsSlider() {
 
   QHBoxLayout *hLay = new QHBoxLayout();
   hLay->setSpacing(0);
-  hLay->setMargin(0);
+  hLay->setContentsMargins(0, 0, 0, 0);
   {
     hLay->addWidget(m_fpsLabel, 0);
     hLay->addWidget(m_fpsField, 0);

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -553,11 +553,7 @@ void FunctionPanel::drawFrameGrid(QPainter &painter) {
   Ruler ruler;
   ruler.setTransform(m_viewTransform.m11(), m_viewTransform.dx(), -1);
   ruler.setRange(m_valueAxisX, width());
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   ruler.setMinLabelDistance(fm.horizontalAdvance("-8888") + 2);
-#else
-  ruler.setMinLabelDistance(fm.width("-8888") + 2);
-#endif
   ruler.setMinDistance(5);
   ruler.setMinStep(1);
   ruler.compute();
@@ -573,12 +569,8 @@ void FunctionPanel::drawFrameGrid(QPainter &painter) {
     if (isLabel) {
       painter.setPen(m_textColor);
       QString labelText = QString::number(f + 1);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
       painter.drawText(x - fm.horizontalAdvance(labelText) / 2, y - 6,
                        labelText);
-#else
-      painter.drawText(x - fm.width(labelText) / 2, y - 6, labelText);
-#endif
     }
   }
 }
@@ -619,11 +611,7 @@ void FunctionPanel::drawValueGrid(QPainter &painter) {
     if (isLabel) {
       painter.setPen(m_textColor);
       QString labelText = QString::number(v);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
       painter.drawText(std::max(0, x - 5 - fm.horizontalAdvance(labelText)),
-#else
-      painter.drawText(std::max(0, x - 5 - fm.width(labelText)),
-#endif
                        y + fm.height() / 2, labelText);
     }
   }
@@ -1108,11 +1096,7 @@ void FunctionPanel::paintEvent(QPaintEvent *e) {
   QFontMetrics fm(font);
 
   // define ruler sizes
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   m_valueAxisX     = fm.horizontalAdvance("-888.88") + 2;
-#else
-  m_valueAxisX     = fm.width("-888.88") + 2;
-#endif
   m_frameAxisY     = fm.height() + 2;
   m_graphViewportY = m_frameAxisY + 12;
   int ox           = m_valueAxisX;
@@ -1160,12 +1144,8 @@ void FunctionPanel::paintEvent(QPaintEvent *e) {
     int x = frameToX(m_cursor.frame);
     painter.drawLine(x, oy0 + 1, x, oy0 + 10);
     QString text = QString::number(tround(m_cursor.frame) + 1);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
     painter.drawText(x - fm.horizontalAdvance(text) / 2, oy0 + 10 + fm.height(),
                      text);
-#else
-    painter.drawText(x - fm.width(text) / 2, oy0 + 10 + fm.height(), text);
-#endif
 
     TDoubleParam *currentCurve = getCurrentCurve();
     if (currentCurve) {
@@ -1455,11 +1435,7 @@ void FunctionPanel::mouseMoveEvent(QMouseEvent *e) {
         m_curveLabel.text = name.toStdString();
 
         // in order to avoid run off the right-end of visible area
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
         int textWidth = fontMetrics().horizontalAdvance(name) + 30;
-#else
-        int textWidth = fontMetrics().width(name) + 30;
-#endif
         double frame  = xToFrame(width() - textWidth);
 
         m_curveLabel.curvePos = getWinPos(curve, frame).toPoint();
@@ -1505,11 +1481,7 @@ void FunctionPanel::leaveEvent(QEvent *) {
 
 void FunctionPanel::wheelEvent(QWheelEvent *e) {
   double factor = exp(0.002 * (double)e->angleDelta().y());
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   zoom(factor, factor, e->position().toPoint());
-#else
-  zoom(factor, factor, e->pos());
-#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/functionsegmentviewer.cpp
+++ b/toonz/sources/toonzqt/functionsegmentviewer.cpp
@@ -91,7 +91,7 @@ SpeedInOutSegmentPage::SpeedInOutSegmentPage(FunctionSegmentViewer *parent)
   QGridLayout *mainLayout = new QGridLayout();
   mainLayout->setHorizontalSpacing(5);
   mainLayout->setVerticalSpacing(5);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addWidget(new QLabel(tr("First Speed:")), 0, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
@@ -382,7 +382,7 @@ EaseInOutSegmentPage::EaseInOutSegmentPage(bool isPercentage,
 
   QGridLayout *mainLayout = new QGridLayout();
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addWidget(new QLabel(tr("Ease Out:")), 0, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
@@ -502,7 +502,7 @@ FunctionExpressionSegmentPage::FunctionExpressionSegmentPage(
   //---- layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(2);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addSpacing(3);
     mainLayout->addWidget(new QLabel(tr("Expression:")));
@@ -684,14 +684,14 @@ FileSegmentPage::FileSegmentPage(FunctionSegmentViewer *parent)
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addWidget(new QLabel(tr("File Path:")), 0);
     mainLayout->addWidget(m_fileFld);
 
     QGridLayout *bottomLay = new QGridLayout();
     bottomLay->setSpacing(5);
-    bottomLay->setMargin(0);
+    bottomLay->setContentsMargins(0, 0, 0, 0);
     {
       bottomLay->addWidget(new QLabel(tr("Column:")), 0, 0,
                            Qt::AlignRight | Qt::AlignVCenter);
@@ -791,7 +791,7 @@ SimilarShapeSegmentPage::SimilarShapeSegmentPage(FunctionSegmentViewer *parent)
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(2);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addSpacing(3);
     mainLayout->addWidget(new QLabel(tr("Reference Curve:")));
@@ -988,18 +988,18 @@ FunctionSegmentViewer::FunctionSegmentViewer(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   {
     m_topbar                  = new QWidget();
     QVBoxLayout *topbarLayout = new QVBoxLayout();
     topbarLayout->setSpacing(5);
-    topbarLayout->setMargin(0);
+    topbarLayout->setContentsMargins(0, 0, 0, 0);
     {
       topbarLayout->addWidget(m_paramNameLabel);
 
       QHBoxLayout *upperLay = new QHBoxLayout();
       upperLay->setSpacing(3);
-      upperLay->setMargin(0);
+      upperLay->setContentsMargins(0, 0, 0, 0);
       {
         upperLay->addWidget(new QLabel(tr("From"), this), 0);
         upperLay->addWidget(m_fromFld, 1);
@@ -1014,7 +1014,7 @@ FunctionSegmentViewer::FunctionSegmentViewer(QWidget *parent,
 
       QHBoxLayout *bottomLay = new QHBoxLayout();
       bottomLay->setSpacing(3);
-      bottomLay->setMargin(0);
+      bottomLay->setContentsMargins(0, 0, 0, 0);
       {
         bottomLay->addWidget(typeLabel, 0);
         bottomLay->addWidget(m_typeCombo, 1);
@@ -1031,7 +1031,7 @@ FunctionSegmentViewer::FunctionSegmentViewer(QWidget *parent,
     mainLayout->addWidget(applyButton);
 
     QHBoxLayout *moveLay = new QHBoxLayout();
-    moveLay->setMargin(0);
+    moveLay->setContentsMargins(0, 0, 0, 0);
     moveLay->setSpacing(0);
     {
       moveLay->addWidget(m_prevCurveButton, 0);

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -712,7 +712,7 @@ int FunctionSelection::getCommonSegmentType(bool inclusive) {
 QList<int> FunctionSelection::getSelectedKeyIndices(TDoubleParam *curve) {
   for (auto selectedParam : m_selectedKeyframes) {
     if (curve == selectedParam.first) {
-      QList<int> ret = selectedParam.second.toList();
+      QList<int> ret(selectedParam.second.begin(),selectedParam.second.end());
       std::sort(ret.begin(), ret.end());
       return ret;
     }

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -212,7 +212,7 @@ FunctionSheetButtonArea::FunctionSheetButtonArea(QWidget *parent)
   m_syncSizeBtn->setToolTip(tr("Toggle synchronizing zoom with xsheet"));
 
   QVBoxLayout *layout = new QVBoxLayout();
-  layout->setMargin(2);
+  layout->setContentsMargins(2, 2, 2, 2);
   layout->setSpacing(0);
   {
     layout->addStretch();

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -130,7 +130,7 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
           Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup;
 
   m_leftLayout = new QVBoxLayout();
-  m_leftLayout->setMargin(0);
+  m_leftLayout->setContentsMargins(0, 0, 0, 0);
   m_leftLayout->setSpacing(0);
   {
     if (!toolBarOnBottom) m_leftLayout->addWidget(m_toolbar);
@@ -155,7 +155,7 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
   leftPanel->setLayout(m_leftLayout);
 
   QVBoxLayout *rightLayout = new QVBoxLayout();
-  rightLayout->setMargin(0);
+  rightLayout->setContentsMargins(0, 0, 0, 0);
   rightLayout->setSpacing(5);
   {
     rightLayout->addWidget(m_treeView, 1);

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -53,7 +53,7 @@
 #include <QApplication>
 #include <QMenu>
 #include <QGraphicsSceneMouseEvent>
-#include <QDesktopWidget>
+#include <QScreen>
 
 //********************************************************************************
 //    Local namespace
@@ -442,9 +442,9 @@ void FxPalettePainter::paint(QPainter *painter,
   painter->setPen(Qt::NoPen);
 
   if (m_parent->isNormalIconView())
-    painter->drawRoundRect(QRectF(0, 0, m_width, m_height), 35, 99);
+    painter->drawRoundedRect(QRectF(0, 0, m_width, m_height), 35, 99);
   else
-    painter->drawRoundRect(QRectF(0, 0, m_width, m_height), 10, 30);
+    painter->drawRoundedRect(QRectF(0, 0, m_width, m_height), 10, 30);
 
   bool showColumnNumber = Preferences::instance()->isShowColumnNumbersEnabled();
   int rectAdj           = 0;
@@ -1310,7 +1310,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxInputPort:
     case eFxGroupedInPort: {
       QRect targetRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       static QIcon fxPortRedIcon(":Resources/fxport_red.svg");
       static QIcon fxPortPassThroughRedIcon(":Resources/fxport_pt_red.svg");
       QPixmap redPm = (m_isPassThrough)
@@ -1322,7 +1322,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxOutputPort:
     case eFxGroupedOutPort: {
       QRect sourceRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       static QIcon fxPortBlueIcon(":Resources/fxport_blue.svg");
       QPixmap bluePm = fxPortBlueIcon.pixmap(sourceRect.size());
       sourceRect     = QRect(0, 0, bluePm.width(), bluePm.height());
@@ -1346,7 +1346,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxLinkPort:  // LinkPort
     default: {         //ここから！！！
       QRect sourceRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       QPixmap linkPm =
           QIcon(":Resources/schematic_link.svg").pixmap(sourceRect.size());
       painter->drawPixmap(boundingRect().toRect(), linkPm);
@@ -1370,7 +1370,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxLinkPort:  // LinkPort
     {
       QRect sourceRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       QPixmap linkPm = QIcon(":Resources/schematic_link_small.svg")
                            .pixmap(sourceRect.size());
       painter->drawPixmap(boundingRect().toRect(), linkPm);
@@ -2751,7 +2751,7 @@ void FxSchematicNormalFxNode::mouseDoubleClickEvent(
 #endif
   }
   static QFont font(fontName, 10, QFont::Normal);
-  int width = QFontMetrics(font).width(m_name);
+  int width = QFontMetrics(font).horizontalAdvance(m_name);
   QRectF nameArea(0, 0, width, 14);
   if (nameArea.contains(me->pos())) {
     m_nameItem->setPlainText(m_name);
@@ -3734,7 +3734,9 @@ void FxGroupNode::onNameChanged() {
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TFxCommand::renameGroup(m_groupedFxs.toStdList(), m_name.toStdWString(),
+  TFxCommand::renameGroup(
+      std::list<TFxP>(m_groupedFxs.begin(), m_groupedFxs.end()),
+                          m_name.toStdWString(),
                           false, fxScene->getXsheetHandle());
   update();
 }
@@ -3865,7 +3867,7 @@ void FxPassThroughPainter::paint(QPainter *painter,
   if (!m_showName) return;
 
   QFont fnt = painter->font();
-  int width = QFontMetrics(fnt).width(m_name) + 1;
+  int width = QFontMetrics(fnt).horizontalAdvance(m_name) + 1;
   QRectF nameArea(0, 0, width, 14);
 
   if (m_parent->isNormalIconView()) {
@@ -4038,7 +4040,7 @@ void FxSchematicPassThroughNode::mouseDoubleClickEvent(
 #endif
   }
   static QFont font(fontName, 10, QFont::Normal);
-  int width = QFontMetrics(font).width(m_name);
+  int width = QFontMetrics(font).horizontalAdvance(m_name);
   QRectF nameArea(0, 0, width, 14);
 
   m_nameItem->setPlainText(m_name);

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -109,7 +109,7 @@ ParamsPage::ParamsPage(QWidget *parent, ParamViewer *paramViewer)
   setFrameStyle(QFrame::StyledPanel);
 
   m_mainLayout = new QGridLayout(this);
-  m_mainLayout->setMargin(12);
+  m_mainLayout->setContentsMargins(12, 12, 12, 12);
   m_mainLayout->setVerticalSpacing(10);
   m_mainLayout->setHorizontalSpacing(5);
 
@@ -130,7 +130,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
   // metodo, per sicurezza verifico.
   if (isVertical == false && !m_horizontalLayout) {
     m_horizontalLayout = new QHBoxLayout();
-    m_horizontalLayout->setMargin(0);
+    m_horizontalLayout->setContentsMargins(0, 0, 0, 0);
     m_horizontalLayout->setSpacing(5);
   }
 
@@ -236,7 +236,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
     } else if (tagName == "hbox") {
       int currentRow     = m_mainLayout->rowCount();
       m_horizontalLayout = new QHBoxLayout();
-      m_horizontalLayout->setMargin(0);
+      m_horizontalLayout->setContentsMargins(0, 0, 0, 0);
       m_horizontalLayout->setSpacing(5);
       setPageField(is, fx, false);
       m_mainLayout->addLayout(m_horizontalLayout, currentRow, 1, 1, 2);
@@ -252,7 +252,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
           QString str         = QString::fromStdWString(TStringTable::translate(label));
           QCheckBox *checkBox = new QCheckBox(this);
           QHBoxLayout *sepLay = new QHBoxLayout();
-          sepLay->setMargin(0);
+          sepLay->setContentsMargins(0, 0, 0, 0);
           sepLay->setSpacing(5);
           sepLay->addWidget(checkBox, 0);
           sepLay->addWidget(new Separator(str, this),
@@ -301,7 +301,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
         QGridLayout *keepMainLay = m_mainLayout;
         // temporary switch the layout
         m_mainLayout = new QGridLayout();
-        m_mainLayout->setMargin(0);
+        m_mainLayout->setContentsMargins(0, 0, 0, 0);
         m_mainLayout->setVerticalSpacing(10);
         m_mainLayout->setHorizontalSpacing(5);
         m_mainLayout->setColumnStretch(0, 0);
@@ -504,7 +504,7 @@ void ParamsPage::addWidget(QWidget *field, bool isVertical) {
   } else {
     if (!m_horizontalLayout) {
       m_horizontalLayout = new QHBoxLayout();
-      m_horizontalLayout->setMargin(0);
+      m_horizontalLayout->setContentsMargins(0, 0, 0, 0);
       m_horizontalLayout->setSpacing(5);
     }
     m_horizontalLayout->addWidget(field);
@@ -683,11 +683,12 @@ QSize ParamsPage::getPreferredSize() {
 
   updateMaximumPageSize(m_mainLayout, maxLabelWidth, maxWidgetWidth,
                         fieldsHeight);
-  return QSize(maxLabelWidth + maxWidgetWidth +
-                   m_mainLayout->horizontalSpacing() +
-                   2 * m_mainLayout->margin(),
-               fieldsHeight + 2 * m_mainLayout->margin() +
-                   31 /* spacing for the swatch */);
+  int lmargin, tmargin, rmargin, bmargin;
+  m_mainLayout->getContentsMargins(&lmargin, &tmargin, &rmargin, &bmargin);
+  return QSize(
+      maxLabelWidth + maxWidgetWidth + m_mainLayout->horizontalSpacing() +
+          lmargin + rmargin,
+      fieldsHeight + tmargin + bmargin + 31 /* spacing for the swatch */);
 }
 
 //=============================================================================
@@ -729,11 +730,11 @@ ParamsPageSet::ParamsPageSet(QWidget *parent, Qt::WindowFlags flags)
 
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     QHBoxLayout *hLayout = new QHBoxLayout();
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->addSpacing(0);
     {
       hLayout->addWidget(m_tabBar);
@@ -1083,13 +1084,13 @@ ParamViewer::ParamViewer(QWidget *parent, Qt::WindowFlags flags)
   showSwatchButton->setFocusPolicy(Qt::NoFocus);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_tablePageSet, 1);
 
     QHBoxLayout *showPreviewButtonLayout = new QHBoxLayout(this);
-    showPreviewButtonLayout->setMargin(3);
+    showPreviewButtonLayout->setContentsMargins(3, 3, 3, 3);
     showPreviewButtonLayout->setSpacing(3);
     {
       showPreviewButtonLayout->addWidget(showSwatchButton, 0);
@@ -1242,7 +1243,7 @@ FxSettings::FxSettings(QWidget *parent, const TPixel32 &checkCol1,
   addWidget(m_paramViewer);
 
   QVBoxLayout *swatchLayout = new QVBoxLayout(swatchContainer);
-  swatchLayout->setMargin(0);
+  swatchLayout->setContentsMargins(0, 0, 0, 0);
   swatchLayout->setSpacing(0);
   {
     swatchLayout->addWidget(m_viewer, 0, Qt::AlignHCenter);

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -265,15 +265,9 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
           tmpWidget->setVisible(shrink == 1);
         } else {  // modeSensitiveStr != ""
           QList<int> modes;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
           QStringList modeListStr =
               QString::fromStdString(is.getTagAttribute("mode"))
                   .split(',', Qt::SkipEmptyParts);
-#else
-          QStringList modeListStr =
-              QString::fromStdString(is.getTagAttribute("mode"))
-                  .split(',', QString::SkipEmptyParts);
-#endif
           for (QString modeNum : modeListStr) modes.push_back(modeNum.toInt());
           // find the mode combobox
           ModeChangerParamField *modeChanger = nullptr;
@@ -632,11 +626,7 @@ void updateMaximumPageSize(QGridLayout *layout, int &maxLabelWidth,
     QGroupBox *gBox =
         dynamic_cast<QGroupBox *>(layout->itemAtPosition(r, 0)->widget());
     if (label) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
       int tmpWidth = label->fontMetrics().horizontalAdvance(label->text());
-#else
-      int tmpWidth = label->fontMetrics().width(label->text());
-#endif
       if (maxLabelWidth < tmpWidth) maxLabelWidth = tmpWidth;
     }
     /*-- PlugInFxのGroupパラメータのサイズ --*/

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -30,7 +30,7 @@
 #include <QKeyEvent>
 #include <QUrl>
 #include <QFileInfo>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QSvgRenderer>
 #include <QScreen>
 #include <QWindow>
@@ -44,7 +44,7 @@ inline bool hasScreensWithDifferentDevPixRatio() {
   static bool ret     = false;
   static bool checked = false;
   if (!checked) {  // check once
-    int dpr = QApplication::desktop()->devicePixelRatio();
+    int dpr = QApplication::primaryScreen()->devicePixelRatio();
     for (auto screen : QGuiApplication::screens()) {
       if ((int)screen->devicePixelRatio() != dpr) {
         ret = true;
@@ -192,7 +192,7 @@ int getDevicePixelRatio(const QWidget *widget) {
   if (hasScreensWithDifferentDevPixRatio() && widget) {
     return widget->screen()->devicePixelRatio();
   }
-  static int devPixRatio = QApplication::desktop()->devicePixelRatio();
+  static int devPixRatio = QApplication::primaryScreen()->devicePixelRatio();
   return devPixRatio;
 }
 
@@ -777,7 +777,7 @@ QString elideText(const QString &srcText, const QFont &font, int width) {
   QFontMetrics metrix(font);
   int srcWidth = metrix.horizontalAdvance(srcText);
   if (srcWidth < width) return srcText;
-  int tilde = metrix.width("~");
+  int tilde = metrix.horizontalAdvance("~");
   int block = (width - tilde) / 2;
   QString text("");
   int i;

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -190,13 +190,7 @@ QPixmap scalePixmapKeepingAspectRatio(QPixmap pixmap, QSize size,
 
 int getDevicePixelRatio(const QWidget *widget) {
   if (hasScreensWithDifferentDevPixRatio() && widget) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     return widget->screen()->devicePixelRatio();
-#else
-    if (!widget->windowHandle()) widget->winId();
-    if (widget->windowHandle())
-      return widget->windowHandle()->devicePixelRatio();
-#endif
   }
   static int devPixRatio = QApplication::desktop()->devicePixelRatio();
   return devPixRatio;
@@ -781,11 +775,7 @@ bool isReservedFileName_message(const QString &fileName) {
 
 QString elideText(const QString &srcText, const QFont &font, int width) {
   QFontMetrics metrix(font);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int srcWidth = metrix.horizontalAdvance(srcText);
-#else
-  int srcWidth = metrix.width(srcText);
-#endif
   if (srcWidth < width) return srcText;
   int tilde = metrix.width("~");
   int block = (width - tilde) / 2;
@@ -793,21 +783,13 @@ QString elideText(const QString &srcText, const QFont &font, int width) {
   int i;
   for (i = 0; i < srcText.size(); i++) {
     text += srcText.at(i);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     if (metrix.horizontalAdvance(text) > block) break;
-#else
-    if (metrix.width(text) > block) break;
-#endif
   }
   text[i] = '~';
   QString endText("");
   for (i = srcText.size() - 1; i >= 0; i--) {
     endText.push_front(srcText.at(i));
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     if (metrix.horizontalAdvance(endText) > block) break;
-#else
-    if (metrix.width(endText) > block) break;
-#endif
   }
   endText.remove(0, 1);
   text += endText;
@@ -820,11 +802,7 @@ QString elideText(const QString &srcText, const QFontMetrics &fm, int width,
                   const QString &elideSymbol) {
   QString text(srcText);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   for (int i = text.size(); i > 1 && fm.horizontalAdvance(text) > width;)
-#else
-  for (int i = text.size(); i > 1 && fm.width(text) > width;)
-#endif
     text = srcText.left(--i).append(elideSymbol);
 
   return text;

--- a/toonz/sources/toonzqt/hexcolornames.cpp
+++ b/toonz/sources/toonzqt/hexcolornames.cpp
@@ -517,7 +517,7 @@ HexColorNamesEditor::HexColorNamesEditor(QWidget *parent)
                                   QSizePolicy::Preferred);
   m_importButton = new QPushButton(tr("Import"));
   m_exportButton = new QPushButton(tr("Export"));
-  bottomLay->setMargin(8);
+  bottomLay->setContentsMargins(8, 8, 8, 8);
   bottomLay->setSpacing(5);
   bottomLay->addWidget(m_autoCompleteCb);
   bottomLay->addWidget(m_importButton);

--- a/toonz/sources/toonzqt/histogram.cpp
+++ b/toonz/sources/toonzqt/histogram.cpp
@@ -366,7 +366,7 @@ HistogramView::HistogramView(QWidget *parent, QColor color)
   setMinimumHeight(120 + 10 * 2 + 2);  // 10 == margin of internal widget
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(7);
 
   m_histogramGraph = new HistogramGraph(this, color);
@@ -518,7 +518,7 @@ Histogram::Histogram(QWidget *parent) : QWidget(parent) {
   setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   setLayout(mainLayout);
 

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -896,6 +896,14 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
 //*********************************************************************************************
 
 FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
+#if defined(_WIN32)
+  // Allow Lazy Nezumi to hook the canvas
+  setAttribute(Qt::WA_PaintOnScreen);
+  setAttribute(Qt::WA_NoSystemBackground);
+  setAttribute(Qt::WA_NativeWindow);
+  setAttribute(Qt::WA_DontCreateNativeAncestors);
+#endif
+
   QHBoxLayout *layout = new QHBoxLayout(this);
   layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
@@ -1039,7 +1047,6 @@ bool FullScreenWidget::toggleFullScreen(
             this->window()->windowHandle()->setScreen(ptrScreenThisWindowIsOn);
 
             // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
-            this->winId();
             QWindowsWindowFunctions::setHasBorderInFullScreen(
                 this->windowHandle(), true);
 

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -897,7 +897,7 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
 
 FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
 
   setLayout(layout);

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -901,10 +901,6 @@ FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
   layout->setSpacing(0);
 
   setLayout(layout);
-
-#ifdef _WIN32
-  this->winId();
-#endif
 }
 
 //---------------------------------------------------------------------------------
@@ -1043,6 +1039,7 @@ bool FullScreenWidget::toggleFullScreen(
             this->window()->windowHandle()->setScreen(ptrScreenThisWindowIsOn);
 
             // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
+            this->winId();
             QWindowsWindowFunctions::setHasBorderInFullScreen(
                 this->windowHandle(), true);
 

--- a/toonz/sources/toonzqt/infoviewer.cpp
+++ b/toonz/sources/toonzqt/infoviewer.cpp
@@ -302,11 +302,7 @@ void InfoViewerImp::setGeneralFileInfo(const TFilePath &path) {
   setVal(eFileType, getTypeString());
   if (fi.owner() != "") setVal(eOwner, fi.owner());
   setVal(eSize, fileSizeString(fi.size()));
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
   setVal(eCreated, fi.birthTime().toString());
-#else
-  setVal(eCreated, fi.created().toString());
-#endif
   setVal(eModified, fi.lastModified().toString());
   setVal(eLastAccess, fi.lastRead().toString());
   m_separator1.show();

--- a/toonz/sources/toonzqt/insertfxpopup.cpp
+++ b/toonz/sources/toonzqt/insertfxpopup.cpp
@@ -279,7 +279,7 @@ InsertFxPopup::InsertFxPopup(QWidget *parent, Qt::WindowFlags flags)
   QHBoxLayout *searchLay = new QHBoxLayout();
   QLineEdit *searchEdit  = new QLineEdit(this);
 
-  searchLay->setMargin(0);
+  searchLay->setContentsMargins(0, 0, 0, 0);
   searchLay->setSpacing(5);
   searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
   searchLay->addWidget(searchEdit);
@@ -333,7 +333,7 @@ InsertFxPopup::InsertFxPopup(QWidget *parent, Qt::WindowFlags flags)
 
 /*
   QHBoxLayout *buttonLayout = new QHBoxLayout;
-  buttonLayout->setMargin(0);
+  buttonLayout->setContentsMargins(0, 0, 0, 0);
   buttonLayout->setSpacing(5);
   buttonLayout->setAlignment(Qt::AlignHCenter);
 

--- a/toonz/sources/toonzqt/intfield.cpp
+++ b/toonz/sources/toonzqt/intfield.cpp
@@ -283,13 +283,13 @@ IntField::IntField(QWidget *parent, bool isMaxRangeLimited, bool isRollerHide)
     , m_isLinearSlider(true) {
   setObjectName("IntField");
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(5);
 
   QWidget *field = new QWidget(this);
   field->setMaximumWidth(43);
   QVBoxLayout *vLayout = new QVBoxLayout(field);
-  vLayout->setMargin(0);
+  vLayout->setContentsMargins(0, 0, 0, 0);
   vLayout->setSpacing(0);
 
   m_lineEdit = new DVGui::IntLineEdit(field);

--- a/toonz/sources/toonzqt/intpairfield.cpp
+++ b/toonz/sources/toonzqt/intpairfield.cpp
@@ -49,7 +49,7 @@ IntPairField::IntPairField(QWidget *parent, bool isMaxRangeLimited)
 
   //----layout
   QHBoxLayout *m_mainLayout = new QHBoxLayout;
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setSpacing(5);
   {
     m_mainLayout->addWidget(m_leftLabel, 1);

--- a/toonz/sources/toonzqt/intpairfield.cpp
+++ b/toonz/sources/toonzqt/intpairfield.cpp
@@ -153,13 +153,8 @@ void IntPairField::paintEvent(QPaintEvent *) {
 void IntPairField::setLeftText(const QString &text) {
   QPoint pos       = m_leftLabel->pos();
   QString oldText  = m_leftLabel->text();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
   int newLabelSize = fontMetrics().horizontalAdvance(text);
-#else
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
-#endif
   int labelSize    = newLabelSize - oldLabelSize;
   m_leftMargin += labelSize + MARGIN_OFFSET;
   m_leftLabel->setText(text);
@@ -170,13 +165,8 @@ void IntPairField::setLeftText(const QString &text) {
 
 void IntPairField::setRightText(const QString &text) {
   QString oldText  = m_rightLabel->text();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
   int newLabelSize = fontMetrics().horizontalAdvance(text);
-#else
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
-#endif
   int labelSize    = newLabelSize - oldLabelSize;
   m_rightMargin += labelSize + MARGIN_OFFSET;
   m_rightLabel->setText(text);

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -514,11 +514,7 @@ bool LutManager::loadLutFile(const QString& fp) {
 
   // The third line is corrections of values at each LUT grid
   line = locals::readDataLine(stream);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   list = line.split(" ", Qt::SkipEmptyParts);
-#else
-  list        = line.split(" ", QString::SkipEmptyParts);
-#endif
   if (list.size() != m_lut.meshSize) {
     file.close();
     return execWarning(QObject::tr("Failed to Load 3DLUT File."));
@@ -534,11 +530,7 @@ bool LutManager::loadLutFile(const QString& fp) {
       for (int i = 0; i < m_lut.meshSize; ++i)  // b
       {
         line = locals::readDataLine(stream);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         list = line.split(" ", Qt::SkipEmptyParts);
-#else
-        list = line.split(" ", QString::SkipEmptyParts);
-#endif
         if (list.size() != 3) {
           file.close();
           delete[] m_lut.data;

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -158,7 +158,7 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
   }
 
   QHBoxLayout *newPageLayout = new QHBoxLayout(toolBarWidget);
-  newPageLayout->setMargin(0);
+  newPageLayout->setContentsMargins(0, 0, 0, 0);
   newPageLayout->setSpacing(0);
   newPageLayout->addWidget(m_newPageToolbar, 0, Qt::AlignRight);
   newPageWidget->setLayout(newPageLayout);
@@ -166,7 +166,7 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
   createToolBar();
 
   QHBoxLayout *toolBarLayout = new QHBoxLayout(toolBarWidget);
-  toolBarLayout->setMargin(0);
+  toolBarLayout->setContentsMargins(0, 0, 0, 0);
   toolBarLayout->setSpacing(0);
   {
     toolBarLayout->addWidget(m_paletteToolBar, 0, Qt::AlignLeft);
@@ -182,12 +182,12 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
   m_tabBarContainer = new TabBarContainter(this);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     // To add 6px (on the left) before the TabBar
     QHBoxLayout *hLayout = new QHBoxLayout;
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     // hLayout->setAlignment(Qt::AlignLeft);
     // hLayout->addSpacing(6);
     {
@@ -201,7 +201,7 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
     mainLayout->addWidget(m_pageViewerScrollArea, 1);
 
     QHBoxLayout *bottomLayout = new QHBoxLayout;
-    bottomLayout->setMargin(0);
+    bottomLayout->setContentsMargins(0, 0, 0, 0);
     bottomLayout->addWidget(toolbarScrollWidget, 0);
     outerToolbarFrame->setLayout(bottomLayout);
     mainLayout->addWidget(outerToolbarFrame);

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -493,11 +493,7 @@ void PageViewer::drawColorName(QPainter &p, QRect &nameRect, TColorStyle *style,
     QRect rect     = nameRect;
     QPen oldPen    = p.pen();
     TPixel32 color = style->getMainColor();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     int textWidth = QFontMetrics(p.font()).horizontalAdvance(name);
-#else
-    int textWidth = QFontMetrics(p.font()).width(name);
-#endif
     p.setPen(Qt::black);
     if (textWidth < rect.width() - 2)
       p.drawText(rect.adjusted(1,1,1,1), Qt::AlignCenter, name);
@@ -877,12 +873,8 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       tmpFont.setItalic(false);
       p.setFont(tmpFont);
       if (ShowStyleIndex == 1) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
         int indexWidth =
             fontMetrics().horizontalAdvance(QString().setNum(styleIndex)) + 4;
-#else
-        int indexWidth = fontMetrics().width(QString().setNum(styleIndex)) + 4;
-#endif
         QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
                         chipRect.bottomRight());
         p.setPen(Qt::black);

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -637,7 +637,7 @@ ParamField::ParamField(QWidget *parent, QString paramName, const TParamP &param,
     , m_description(QString::fromStdString(param->getDescription())) {
   QString str;
   m_layout = new QHBoxLayout(this);
-  m_layout->setMargin(0);
+  m_layout->setContentsMargins(0, 0, 0, 0);
   m_layout->setSpacing(5);
 }
 
@@ -1131,7 +1131,7 @@ RgbLinkButtons::RgbLinkButtons(QString str1, QString str2, QWidget *parent,
   swapButton->setFixedHeight(21);
 
   QHBoxLayout *lay = new QHBoxLayout();
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
   lay->setSpacing(5);
   {
     lay->addWidget(copyButton, 0);

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -1350,7 +1350,7 @@ EnumParamField::EnumParamField(QWidget *parent, QString name,
     QString str;
     m_om->addItem(str.fromStdString(caption));
   }
-  connect(m_om, SIGNAL(activated(const QString &)), this,
+  connect(m_om, SIGNAL(textActivated(const QString &)), this,
           SLOT(onChange(const QString &)));
   m_layout->addWidget(m_om);
 
@@ -1696,9 +1696,9 @@ FontParamField::FontParamField(QWidget *parent, QString name,
   setLayout(m_layout);
 
   bool ret = true;
-  ret = ret && connect(m_fontCombo, SIGNAL(activated(const QString &)), this,
+  ret = ret && connect(m_fontCombo, SIGNAL(textActivated(const QString &)), this,
                        SLOT(onChange()));
-  ret = ret && connect(m_styleCombo, SIGNAL(activated(const QString &)), this,
+  ret = ret && connect(m_styleCombo, SIGNAL(textActivated(const QString &)), this,
                        SLOT(onChange()));
   ret = ret && connect(m_sizeField, SIGNAL(valueChanged(bool)), this,
                        SLOT(onSizeChange(bool)));
@@ -2427,7 +2427,7 @@ RadioButton_enum::RadioButton_enum(QWidget *parent, QString name,
     m_layout->addWidget(button);
   }
 
-  connect(value_, SIGNAL(buttonClicked(int)), this, SLOT(update_value(int)));
+  connect(value_, SIGNAL(idClicked(int)), this, SLOT(update_value(int)));
 
   setLayout(m_layout);
 }

--- a/toonz/sources/toonzqt/pickrgbutils.cpp
+++ b/toonz/sources/toonzqt/pickrgbutils.cpp
@@ -85,16 +85,10 @@ QRgb pickScreenRGB(const QRect &rect) {
 
 #endif
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QImage img(widget->screen()
                  ->grabWindow(widget->winId(), theRect.x(), theRect.y(),
                               theRect.width(), theRect.height())
                  .toImage());
-#else
-  QImage img(QPixmap::grabWindow(widget->winId(), theRect.x(), theRect.y(),
-                                 theRect.width(), theRect.height())
-                 .toImage());
-#endif
   return meanColor(
       img, QRect(rect.left() - theRect.left(), rect.top() - theRect.top(),
                  rect.width(), rect.height()));

--- a/toonz/sources/toonzqt/pickrgbutils.cpp
+++ b/toonz/sources/toonzqt/pickrgbutils.cpp
@@ -6,7 +6,7 @@
 #include <QPixmap>
 #include <QImage>
 #include <QOpenGLWidget>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QApplication>
 #include <QScreen>
 
@@ -49,17 +49,15 @@ QRgb meanColor(const QImage &img, const QRect &rect) {
 //==============================================================================
 
 QRgb pickRGB(QWidget *widget, const QRect &rect) {
-  QImage img(QPixmap::grabWidget(widget, rect.x(), rect.y(), rect.width(),
-                                 rect.height())
+  QImage img(widget->grab(QRect(rect.x(), rect.y(), rect.width(),
+                                 rect.height()))
                  .toImage());
   return meanColor(img, img.rect());
 }
 
 //------------------------------------------------------------------------------
 
-QRgb pickScreenRGB(const QRect &rect) {
-  QWidget *widget = QApplication::desktop();
-
+QRgb pickScreenRGB(const QRect &rect, QWidget *widget) {
 #ifdef MACOSX
 
   //   #Bugzilla 6514, possibly related to #QTBUG 23516
@@ -70,7 +68,7 @@ QRgb pickScreenRGB(const QRect &rect) {
   // the workaround is to trivially grab the smallest rect including the
   // requested one and a part of the primary screen.
 
-  const QRect &screen0Geom = QApplication::desktop()->screenGeometry(0);
+  const QRect &screen0Geom = QApplication::primaryScreen()->geometry();
 
   int left   = std::min(rect.left(), screen0Geom.right());
   int top    = std::min(rect.top(), screen0Geom.bottom());

--- a/toonz/sources/toonzqt/planeviewer.cpp
+++ b/toonz/sources/toonzqt/planeviewer.cpp
@@ -269,13 +269,8 @@ void PlaneViewer::wheelEvent(QWheelEvent *event) {
     if ((m_gestureActive == true &&
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       TPointD pos(event->position().x() * getDevPixRatio(),
                   height() - event->position().y() * getDevPixRatio());
-#else
-      TPointD pos(event->pos().x() * getDevPixRatio(),
-                  height() - event->pos().y() * getDevPixRatio());
-#endif
       double zoom_par = 1 + event->angleDelta().y() * 0.001;
 
       zoomView(pos.x, pos.y, zoom_par);

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -14,7 +14,7 @@
 #include <QTextBlock>
 #include <QMenuBar>
 #include <QPolygonF>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QClipboard>
 #include "tundo.h"
 #include "toonzqt/menubarcommand.h"

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -20,13 +20,11 @@
 #include "toonzqt/menubarcommand.h"
 #include "toonzqt/gutil.h"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #define ACCEL_KEY(k)                                                           \
   (!QCoreApplication::testAttribute(Qt::AA_DontShowShortcutsInContextMenus)    \
        ? QLatin1Char('\t') +                                                   \
              QKeySequence(k).toString(QKeySequence::NativeText)                \
        : QString())
-#endif
 
 //========================================================
 //
@@ -45,7 +43,6 @@ SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
   setFlag(QGraphicsItem::ItemIsFocusable, true);
   setTextInteractionFlags(Qt::TextEditorInteraction);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   popup = new QMenu();
   popup->setObjectName(QLatin1String("qt_edit_menu"));
 
@@ -73,7 +70,6 @@ SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
   actionSelectAll->setObjectName(QStringLiteral("select-all"));
 
   connect(popup, SIGNAL(aboutToHide()), this, SLOT(onPopupHide()));
-#endif
 
   connect(document(), SIGNAL(contentsChanged()), this,
           SLOT(onContentsChanged()));
@@ -82,9 +78,7 @@ SchematicName::SchematicName(QGraphicsItem *parent, double width, double height)
 //--------------------------------------------------------
 
 SchematicName::~SchematicName() {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   delete popup;
-#endif
 }
 
 //--------------------------------------------------------
@@ -163,7 +157,6 @@ bool SchematicName::eventFilter(QObject *object, QEvent *event) {
 void SchematicName::focusInEvent(QFocusEvent *fe) {
   QGraphicsTextItem::focusInEvent(fe);
   qApp->installEventFilter(this);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   if (!m_refocus) {
     QTextDocument *doc = document();
     QTextCursor cursor(doc->begin());
@@ -171,16 +164,10 @@ void SchematicName::focusInEvent(QFocusEvent *fe) {
     setTextCursor(cursor);
     m_curName = toPlainText();
   }
-#else
-  QTextDocument *doc = document();
-  QTextCursor cursor(doc->begin());
-  cursor.select(QTextCursor::Document);
-#endif
 }
 
 //--------------------------------------------------------
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 void SchematicName::contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) {
   QClipboard *clipboard = QApplication::clipboard();
   QTextCursor cursor    = textCursor();
@@ -285,7 +272,6 @@ void SchematicName::onSelectAll() {
   cursor.select(QTextCursor::Document);
   setTextCursor(cursor);
 }
-#endif
 
 //========================================================
 //

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -502,11 +502,7 @@ void SchematicSceneViewer::wheelEvent(QWheelEvent *me) {
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
       double factor = exp(delta * 0.001);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       changeScale(me->position().toPoint(), factor);
-#else
-      changeScale(me->pos(), factor);
-#endif
       m_panning = false;
     }
   }

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -884,7 +884,7 @@ SchematicViewer::SchematicViewer(QWidget *parent)
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_viewer, 1);
@@ -892,7 +892,7 @@ SchematicViewer::SchematicViewer(QWidget *parent)
     QFrame *bottomFrame = new QFrame(this);
     bottomFrame->setObjectName("SchematicBottomFrame");
     QHBoxLayout *horizontalLayout = new QHBoxLayout();
-    horizontalLayout->setMargin(0);
+    horizontalLayout->setContentsMargins(0, 0, 0, 0);
     horizontalLayout->setSpacing(0);
     {
       horizontalLayout->addWidget(m_commonToolbar);

--- a/toonz/sources/toonzqt/screenboard.cpp
+++ b/toonz/sources/toonzqt/screenboard.cpp
@@ -1,7 +1,7 @@
 
 
 #include <QPaintEvent>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QApplication>
 #include <QMetaObject>
 #include <QCursor>
@@ -178,8 +178,6 @@ void ScreenBoard::releaseMouse() {
 
 // Refresh the screen widgets pool, depending on stored drawings
 void ScreenBoard::reallocScreenWidgets() {
-  QDesktopWidget *desktop = QApplication::desktop();
-
   int i;
   int screensCount = QGuiApplication::screens().count();
 

--- a/toonz/sources/toonzqt/spectrumfield.cpp
+++ b/toonz/sources/toonzqt/spectrumfield.cpp
@@ -329,7 +329,7 @@ SpectrumField::SpectrumField(QWidget *parent, TPixel32 color)
   setFixedHeight(60);
 
   QVBoxLayout *layout = new QVBoxLayout();
-  layout->setMargin(m_margin);
+  layout->setContentsMargins(m_margin, m_margin, m_margin, m_margin);
   layout->setSpacing(m_spacing);
 
   m_spectrumbar = new SpectrumBar(this, color);

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -591,7 +591,7 @@ SpreadsheetViewer::SpreadsheetViewer(QWidget *parent)
 
   //---- layout
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
   {
     layout->addWidget(m_columnScrollArea, 0, 1);

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -147,7 +147,7 @@ void ColumnPainter::paint(QPainter *painter,
   }
 
   if (levelType == PLT_XSHLEVEL)
-    painter->drawRoundRect(0, 0, m_width, m_height, 32, 99);
+    painter->drawRoundedRect(0, 0, m_width, m_height, 32, 99);
   else
     painter->drawRect(0, 0, m_width, m_height);
 
@@ -652,7 +652,7 @@ void SplinePainter::paint(QPainter *painter,
 
   painter->setBrush(viewer->getSplineColor());
   painter->setPen(Qt::NoPen);
-  painter->drawRoundRect(QRectF(0, 0, m_width, m_height), 20, 99);
+  painter->drawRoundedRect(QRectF(0, 0, m_width, m_height), 20, 99);
   if (m_parent->isOpened()) {
     // Draw the pixmap
     painter->setBrush(Qt::NoBrush);
@@ -765,7 +765,7 @@ void StageSchematicNodePort::paint(QPainter *painter,
     painter->drawText(boundingRect(), text, textOption);
   } else {
     QRect imgRect(2, 2, 14, 14);
-    QRect sourceRect = scene->views()[0]->matrix().mapRect(imgRect);
+    QRect sourceRect = scene->views()[0]->transform().mapRect(imgRect);
     QPixmap pixmap;
 
     if (getType() == eStageParentPort || getType() == eStageParentGroupPort) {
@@ -921,7 +921,7 @@ void StageSchematicSplinePort::paint(QPainter *painter,
                                      const QStyleOptionGraphicsItem *option,
                                      QWidget *widget) {
   QRect sourceRect =
-      scene()->views()[0]->matrix().mapRect(boundingRect().toRect());
+      scene()->views()[0]->transform().mapRect(boundingRect().toRect());
   QPixmap pixmap;
 
   if (!m_parent->isParentPort()) {

--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -1218,7 +1218,7 @@ StudioPaletteViewer::StudioPaletteViewer(QWidget *parent,
   // First Splitter Widget
   QWidget *treeWidget      = new QWidget(this);
   QVBoxLayout *treeVLayout = new QVBoxLayout(treeWidget);
-  treeVLayout->setMargin(0);
+  treeVLayout->setContentsMargins(0, 0, 0, 0);
   treeVLayout->setSpacing(0);
 
   m_studioPaletteTreeViewer = new StudioPaletteTreeViewer(

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -1748,7 +1748,7 @@ PlainColorPage::PlainColorPage(QWidget *parent)
   // SLOT(onWheelSliderReleased()));
   // connect( m_verticalSlider,		SIGNAL(sliderReleased()),	this,
   // SLOT(onWheelSliderReleased()));
-  // connect(channelButtonGroup, SIGNAL(buttonClicked(int)), this,
+  // connect(channelButtonGroup, SIGNAL(idClicked(int)), this,
   // SLOT(setWheelChannel(int)));
 }
 

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -944,7 +944,7 @@ void HexagonalColorWheel::mouseReleaseEvent(QMouseEvent *event) {
 void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
   QLineF p(m_wp[0] + m_wheelPosition, QPointF(pos));
   QLineF horizontal(0, 0, 1, 0);
-  float theta = (p.dy() < 0) ? p.angle(horizontal) : 360 - p.angle(horizontal);
+  float theta = (p.dy() < 0) ? p.angleTo(horizontal) : 360 - p.angleTo(horizontal);
   float phi   = theta;
   while (phi >= 60.0f) phi -= 60.0f;
   phi -= 30.0f;
@@ -1291,7 +1291,7 @@ ColorSliderBar::ColorSliderBar(QWidget *parent, Qt::Orientation orientation)
     layout = new QVBoxLayout(this);
 
   layout->setSpacing(0);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->addWidget(first, 0, Qt::AlignCenter);
   layout->addWidget(m_colorSlider, 1);
   layout->addWidget(last, 0, Qt::AlignCenter);
@@ -1397,7 +1397,7 @@ ColorChannelControl::ColorChannelControl(ColorChannel channel, QWidget *parent)
   m_label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
 
   m_field->setObjectName("colorSliderField");
-  m_field->setFixedWidth(fontMetrics().width('0') * 4);
+  m_field->setFixedWidth(fontMetrics().horizontalAdvance('0') * 4);
   m_field->setMinimumHeight(7);
 
   addButton->setObjectName("colorSliderAddButton");
@@ -1418,7 +1418,7 @@ ColorChannelControl::ColorChannelControl(ColorChannel channel, QWidget *parent)
   subButton->setFocusPolicy(Qt::NoFocus);
 
   QHBoxLayout *mainLayout = new QHBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(1);
   {
     mainLayout->addWidget(m_label, 0);
@@ -1681,21 +1681,21 @@ PlainColorPage::PlainColorPage(QWidget *parent)
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(0);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   {
     QHBoxLayout *wheelLayout = new QHBoxLayout();
-    wheelLayout->setMargin(5);
+    wheelLayout->setContentsMargins(5, 5, 5, 5);
     wheelLayout->setSpacing(0);
     { wheelLayout->addWidget(m_hexagonalColorWheel); }
     m_wheelFrame->setLayout(wheelLayout);
     m_vSplitter->addWidget(m_wheelFrame);
 
     QVBoxLayout *slidersLayout = new QVBoxLayout();
-    slidersLayout->setMargin(0);
+    slidersLayout->setContentsMargins(0, 0, 0, 0);
     slidersLayout->setSpacing(0);
     {
       QVBoxLayout *hsvLayout = new QVBoxLayout();
-      hsvLayout->setMargin(4);
+      hsvLayout->setContentsMargins(4, 4, 4, 4);
       hsvLayout->setSpacing(4);
       {
         hsvLayout->addWidget(m_channelControls[eHue]);
@@ -1706,14 +1706,14 @@ PlainColorPage::PlainColorPage(QWidget *parent)
       slidersLayout->addWidget(m_hsvFrame, 3);
 
       QVBoxLayout *alphaLayout = new QVBoxLayout();
-      alphaLayout->setMargin(4);
+      alphaLayout->setContentsMargins(4, 4, 4, 4);
       alphaLayout->setSpacing(4);
       { alphaLayout->addWidget(m_channelControls[eAlpha]); }
       m_alphaFrame->setLayout(alphaLayout);
       slidersLayout->addWidget(m_alphaFrame, 1);
 
       QVBoxLayout *rgbLayout = new QVBoxLayout();
-      rgbLayout->setMargin(4);
+      rgbLayout->setContentsMargins(4, 4, 4, 4);
       rgbLayout->setSpacing(4);
       {
         rgbLayout->addWidget(m_channelControls[eRed]);
@@ -1932,7 +1932,7 @@ void StyleChooserPage::paintEvent(QPaintEvent *) {
 
   QPainter p(this);
   // p.setRenderHint(QPainter::SmoothPixmapTransform);
-  bool origAA = p.testRenderHint(QPainter::HighQualityAntialiasing);
+  bool origAA = p.testRenderHint(QPainter::Antialiasing);
   bool origS  = p.testRenderHint(QPainter::SmoothPixmapTransform);
   if (m_chipPerRow == 0 || getChipCount() == 0) return;
 
@@ -1978,10 +1978,10 @@ void StyleChooserPage::paintEvent(QPaintEvent *) {
         QPen checkPen(Qt::red);
         checkPen.setWidthF(1.5);
         p.setPen(checkPen);
-        if (!origAA) p.setRenderHint(QPainter::HighQualityAntialiasing, true);
+        if (!origAA) p.setRenderHint(QPainter::Antialiasing, true);
         if (!origS) p.setRenderHint(QPainter::SmoothPixmapTransform, true);
         p.drawPath(checkmark);
-        p.setRenderHint(QPainter::HighQualityAntialiasing, origAA);
+        p.setRenderHint(QPainter::Antialiasing, origAA);
         p.setRenderHint(QPainter::SmoothPixmapTransform, origS);
       }
 
@@ -3627,7 +3627,7 @@ SettingBox::SettingBox(QWidget *parent, int index)
 {
         QHBoxLayout* hLayout = new QHBoxLayout(this);
         hLayout->setSpacing(5);
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         hLayout->addSpacing(10);
         m_name = new QLabel(this);
         m_name->setFixedSize(82,20);
@@ -3727,7 +3727,7 @@ SettingsPage::SettingsPage(QWidget *parent)
   setWidget(paramsContainer);
 
   QVBoxLayout *paramsContainerLayout = new QVBoxLayout(this);
-  paramsContainerLayout->setMargin(10);
+  paramsContainerLayout->setContentsMargins(10, 10, 10, 10);;
   paramsContainerLayout->setSpacing(10);
   paramsContainer->setLayout(paramsContainerLayout);
 
@@ -3742,7 +3742,7 @@ SettingsPage::SettingsPage(QWidget *parent)
 
   // Prepare the style parameters layout
   m_paramsLayout = new QGridLayout;
-  m_paramsLayout->setMargin(0);
+  m_paramsLayout->setContentsMargins(0, 0, 0, 0);
   m_paramsLayout->setVerticalSpacing(8);
   m_paramsLayout->setHorizontalSpacing(5);
   paramsContainerLayout->addLayout(m_paramsLayout);
@@ -4228,11 +4228,11 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
 
   /* ------- layout ------- */
   QGridLayout *mainLayout = new QGridLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     QHBoxLayout *hLayout = new QHBoxLayout;
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     {
       hLayout->addSpacing(0);
       hLayout->addWidget(m_styleBar);
@@ -4396,7 +4396,7 @@ QFrame *StyleEditor::createBottomWidget() {
 
   m_autoApplyWidget = new QWidget(this);
   QHBoxLayout *autoApplyLayout = new QHBoxLayout;
-  autoApplyLayout->setMargin(0);
+  autoApplyLayout->setContentsMargins(0, 0, 0, 0);
   autoApplyLayout->setSpacing(0);
   {
     autoApplyLayout->addWidget(m_autoButton);
@@ -4408,17 +4408,17 @@ QFrame *StyleEditor::createBottomWidget() {
 
   /* ------ layout ------ */
   QHBoxLayout *mainLayout = new QHBoxLayout;
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_autoApplyWidget);
 
     QVBoxLayout *colorLay = new QVBoxLayout();
-    colorLay->setMargin(0);
+    colorLay->setContentsMargins(0, 0, 0, 0);
     colorLay->setSpacing(0);
     {
       QHBoxLayout *chipLay = new QHBoxLayout();
-      chipLay->setMargin(0);
+      chipLay->setContentsMargins(0, 0, 0, 0);
       chipLay->setSpacing(0);
       {
         chipLay->addWidget(m_newColor, 1);
@@ -4432,7 +4432,7 @@ QFrame *StyleEditor::createBottomWidget() {
     mainLayout->addLayout(colorLay, 1);
 
     QVBoxLayout *hexLay = new QVBoxLayout();
-    hexLay->setMargin(0);
+    hexLay->setContentsMargins(0, 0, 0, 0);
     hexLay->setSpacing(0);
     {
       hexLay->addWidget(m_hexLineEdit);
@@ -4502,12 +4502,12 @@ QFrame *StyleEditor::createTexturePage() {
 
   /* ------ layout ------ */
   QVBoxLayout *textureOutsideLayout = new QVBoxLayout();
-  textureOutsideLayout->setMargin(0);
+  textureOutsideLayout->setContentsMargins(0, 0, 0, 0);
   textureOutsideLayout->setSpacing(0);
   textureOutsideLayout->setSizeConstraint(QLayout::SetNoConstraint);
   {
     QVBoxLayout *textureLayout = new QVBoxLayout();
-    textureLayout->setMargin(0);
+    textureLayout->setContentsMargins(0, 0, 0, 0);
     textureLayout->setSpacing(0);
     textureLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -4516,7 +4516,7 @@ QFrame *StyleEditor::createTexturePage() {
       std::vector<QPushButton *>::iterator itB      = m_textureButtons.begin();
       for (; itP != m_texturePages.end(); itP++, itL++, itB++) {
         QHBoxLayout *setLabelLay = new QHBoxLayout();
-        setLabelLay->setMargin(0);
+        setLabelLay->setContentsMargins(0, 0, 0, 0);
         setLabelLay->setSpacing(3);
         {
           setLabelLay->addWidget(*itB, 0);
@@ -4536,7 +4536,7 @@ QFrame *StyleEditor::createTexturePage() {
     textureOutsideLayout->addWidget(m_textureArea);
 
     QHBoxLayout *searchLayout = new QHBoxLayout();
-    searchLayout->setMargin(2);
+    searchLayout->setContentsMargins(2, 2, 2, 2);
     searchLayout->setSpacing(0);
     searchLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -4574,12 +4574,12 @@ QFrame *StyleEditor::createVectorPage() {
 
   /* ------ layout ------ */
   QVBoxLayout *vectorOutsideLayout = new QVBoxLayout();
-  vectorOutsideLayout->setMargin(0);
+  vectorOutsideLayout->setContentsMargins(0, 0, 0, 0);
   vectorOutsideLayout->setSpacing(0);
   vectorOutsideLayout->setSizeConstraint(QLayout::SetNoConstraint);
   {
     QVBoxLayout *vectorLayout = new QVBoxLayout();
-    vectorLayout->setMargin(0);
+    vectorLayout->setContentsMargins(0, 0, 0, 0);
     vectorLayout->setSpacing(0);
     vectorLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -4588,7 +4588,7 @@ QFrame *StyleEditor::createVectorPage() {
       std::vector<QPushButton *>::iterator itB      = m_vectorButtons.begin();
       for (; itP != m_vectorPages.end(); itP++, itL++, itB++) {
         QHBoxLayout *setLabelLay = new QHBoxLayout();
-        setLabelLay->setMargin(0);
+        setLabelLay->setContentsMargins(0, 0, 0, 0);
         setLabelLay->setSpacing(3);
         {
           setLabelLay->addWidget(*itB, 0);
@@ -4608,7 +4608,7 @@ QFrame *StyleEditor::createVectorPage() {
     vectorOutsideLayout->addWidget(m_vectorArea);
 
     QHBoxLayout *searchLayout = new QHBoxLayout();
-    searchLayout->setMargin(2);
+    searchLayout->setContentsMargins(2, 2, 2, 2);
     searchLayout->setSpacing(0);
     searchLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -4647,12 +4647,12 @@ QFrame *StyleEditor::createRasterPage() {
 
   /* ------ layout ------ */
   QVBoxLayout *rasterOutsideLayout = new QVBoxLayout();
-  rasterOutsideLayout->setMargin(0);
+  rasterOutsideLayout->setContentsMargins(0, 0, 0, 0);
   rasterOutsideLayout->setSpacing(0);
   rasterOutsideLayout->setSizeConstraint(QLayout::SetNoConstraint);
   {
     QVBoxLayout *rasterLayout = new QVBoxLayout();
-    rasterLayout->setMargin(0);
+    rasterLayout->setContentsMargins(0, 0, 0, 0);
     rasterLayout->setSpacing(0);
     rasterLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -4661,7 +4661,7 @@ QFrame *StyleEditor::createRasterPage() {
       std::vector<QPushButton *>::iterator itB      = m_rasterButtons.begin();
       for (; itP != m_rasterPages.end(); itP++, itL++, itB++) {
         QHBoxLayout *setLabelLay = new QHBoxLayout();
-        setLabelLay->setMargin(0);
+        setLabelLay->setContentsMargins(0, 0, 0, 0);
         setLabelLay->setSpacing(3);
         {
           setLabelLay->addWidget(*itB, 0);
@@ -4681,7 +4681,7 @@ QFrame *StyleEditor::createRasterPage() {
     rasterOutsideLayout->addWidget(m_rasterArea);
 
     QHBoxLayout *searchLayout = new QHBoxLayout();
-    searchLayout->setMargin(2);
+    searchLayout->setContentsMargins(2, 2, 2, 2);
     searchLayout->setSpacing(0);
     searchLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -7242,7 +7242,7 @@ NewStyleSetPopup::NewStyleSetPopup(StylePageType pageType, QWidget *parent)
   connect(okBtn, SIGNAL(clicked()), this, SLOT(createStyleSet()));
   connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   {
     m_buttonLayout->addStretch();
@@ -7251,11 +7251,11 @@ NewStyleSetPopup::NewStyleSetPopup(StylePageType pageType, QWidget *parent)
   }
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(10);
   {
     QGridLayout *upperLayout = new QGridLayout();
-    upperLayout->setMargin(5);
+    upperLayout->setContentsMargins(5, 5, 5, 5);
     upperLayout->setHorizontalSpacing(5);
     upperLayout->setVerticalSpacing(10);
     {

--- a/toonz/sources/toonzqt/styleindexlineedit.cpp
+++ b/toonz/sources/toonzqt/styleindexlineedit.cpp
@@ -15,13 +15,8 @@ using namespace DVGui;
 StyleIndexLineEdit::StyleIndexLineEdit() : m_pltHandle(0) {
   // style index will not be more than 4096, but a longer text
   // "current" may be input instead of style id + chip width + margin
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   int currentWidth = std::max(fontMetrics().horizontalAdvance("current"),
                               fontMetrics().horizontalAdvance(tr("current")));
-#else
-  int currentWidth = std::max(fontMetrics().width("current"),
-                              fontMetrics().width(tr("current")));
-#endif
   setMaximumWidth(currentWidth + 30);
   setFixedHeight(20);
 }

--- a/toonz/sources/toonzqt/stylenameeditor.cpp
+++ b/toonz/sources/toonzqt/stylenameeditor.cpp
@@ -48,14 +48,14 @@ NewWordDialog::NewWordDialog(QWidget* parent) {
 
   // layout
   QVBoxLayout* mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(new QLabel(tr("Enter new word"), this), 0,
                        Qt::AlignLeft | Qt::AlignVCenter);
     mainLay->addWidget(m_lineEdit, 0);
     QHBoxLayout* buttonsLay = new QHBoxLayout();
-    buttonsLay->setMargin(3);
+    buttonsLay->setContentsMargins(3, 3, 3, 3);
     buttonsLay->setSpacing(20);
     {
       buttonsLay->addSpacing(1);
@@ -179,7 +179,7 @@ EasyInputArea::EasyInputArea(QWidget* parent) : QWidget(parent) {
   loadList();
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(3);
   for (int a = 0; a < WORD_COLUMN_AMOUNT; a++) {
     m_scrollArea[a] = new QScrollArea(this);
@@ -187,7 +187,7 @@ EasyInputArea::EasyInputArea(QWidget* parent) : QWidget(parent) {
 
     QFrame* wordPanel       = new QFrame(this);
     QGridLayout* buttonsLay = new QGridLayout();
-    buttonsLay->setMargin(3);
+    buttonsLay->setContentsMargins(3, 3, 3, 3);
     buttonsLay->setSpacing(3);
     {
       int row = 0;
@@ -373,11 +373,11 @@ StyleNameEditor::StyleNameEditor(QWidget* parent)
   easyInputArea->setFocusPolicy(Qt::NoFocus);
 
   // QVBoxLayout* mainLayout = new QVBoxLayout();
-  m_topLayout->setMargin(10);
+  m_topLayout->setContentsMargins(10, 10, 10, 10);;
   m_topLayout->setSpacing(5);
   {
     QHBoxLayout* inputLayout = new QHBoxLayout();
-    inputLayout->setMargin(0);
+    inputLayout->setContentsMargins(0, 0, 0, 0);
     inputLayout->setSpacing(3);
     {
       inputLayout->addWidget(new QLabel(tr("Style Name"), this), 0);
@@ -386,7 +386,7 @@ StyleNameEditor::StyleNameEditor(QWidget* parent)
     m_topLayout->addLayout(inputLayout, 0);
 
     QHBoxLayout* buttonLayout = new QHBoxLayout();
-    buttonLayout->setMargin(0);
+    buttonLayout->setContentsMargins(0, 0, 0, 0);
     buttonLayout->setSpacing(3);
     {
       buttonLayout->addWidget(m_okButton);
@@ -398,7 +398,7 @@ StyleNameEditor::StyleNameEditor(QWidget* parent)
     m_topLayout->addSpacing(5);
 
     QHBoxLayout* labelLay = new QHBoxLayout();
-    labelLay->setMargin(0);
+    labelLay->setContentsMargins(0, 0, 0, 0);
     labelLay->setSpacing(3);
     {
       labelLay->addWidget(new QLabel(tr("Easy Inputs"), this), 1,

--- a/toonz/sources/toonzqt/swatchviewer.cpp
+++ b/toonz/sources/toonzqt/swatchviewer.cpp
@@ -784,13 +784,8 @@ void SwatchViewer::wheelEvent(QWheelEvent *event) {
     if ((m_gestureActive == true &&
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       TPoint center(event->position().x() - width() / 2,
                     -event->position().y() + height() / 2);
-#else
-      TPoint center(event->pos().x() - width() / 2,
-                    -event->pos().y() + height() / 2);
-#endif
       zoom(center, exp(0.001 * event->angleDelta().y()));
     }
   }

--- a/toonz/sources/toonzqt/tdockwindows.cpp
+++ b/toonz/sources/toonzqt/tdockwindows.cpp
@@ -37,7 +37,7 @@ TMainWindow::TMainWindow(QWidget *parent, Qt::WindowFlags flags)
 
   // Set a vertical layout to include menu bars
   QVBoxLayout *vlayout = new QVBoxLayout;
-  vlayout->setMargin(0);
+  vlayout->setContentsMargins(0, 0, 0, 0);
   vlayout->setSpacing(4);
   setLayout(vlayout);
 
@@ -192,7 +192,7 @@ void TDockWidget::setFloatingAppearance() {
   if (m_titlebar) {
     // If has a custom title bar, impose a margin to the layout
     // to provide a frame.
-    layout()->setMargin(m_margin);
+    layout()->setContentsMargins(m_margin, m_margin, m_margin, m_margin);
 
     if (!m_floating)  // was docked
     {
@@ -212,7 +212,7 @@ void TDockWidget::setFloatingAppearance() {
 
 void TDockWidget::setDockedAppearance() {
   // No layout margin is visible when docked
-  layout()->setMargin(0);
+  layout()->setContentsMargins(0, 0, 0, 0);
 
   if (m_floating)  // was floating
   {
@@ -240,8 +240,9 @@ int TDockWidget::isResizeGrip(QPoint p) {
 
   int marginType = 0;
   QRect geom(QPoint(0, 0), QPoint(width(), height()));
-  int margin = layout()->margin();
-  QRect contGeom(geom.adjusted(margin, margin, -margin, -margin));
+  int lmargin, tmargin, rmargin, bmargin;
+  layout()->getContentsMargins(&lmargin, &tmargin, &rmargin, &bmargin);
+  QRect contGeom(geom.adjusted(lmargin, tmargin, -rmargin, -bmargin));
 
   if (geom.contains(p) && !contGeom.contains(p)) {
     if (p.x() < 15) marginType |= leftMargin;

--- a/toonz/sources/toonzqt/tmessageviewer.cpp
+++ b/toonz/sources/toonzqt/tmessageviewer.cpp
@@ -138,11 +138,11 @@ TMessageViewer::TMessageViewer(QWidget *parent) : QFrame(parent) {
   setFrameStyle(QFrame::StyledPanel);
   setObjectName("OnePixelMarginFrame");
   QVBoxLayout *vLayout = new QVBoxLayout();
-  vLayout->setMargin(0);
+  vLayout->setContentsMargins(0, 0, 0, 0);
   QFrame *fr = new QFrame();
 
   QHBoxLayout *hLayout = new QHBoxLayout();
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   fr->setLayout(hLayout);
   fr->setFixedHeight(24);
   fr->setStyleSheet("background-color: rgb(210,210,210); color: black;");

--- a/toonz/sources/toonzqt/tonecurvefield.cpp
+++ b/toonz/sources/toonzqt/tonecurvefield.cpp
@@ -894,11 +894,11 @@ ToneCurveField::ToneCurveField(QWidget *parent,
   //------ layout
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     QHBoxLayout *channelListLayout = new QHBoxLayout();
-    channelListLayout->setMargin(0);
+    channelListLayout->setContentsMargins(0, 0, 0, 0);
     channelListLayout->setSpacing(0);
     channelListLayout->setAlignment(Qt::AlignCenter);
     {
@@ -914,12 +914,12 @@ ToneCurveField::ToneCurveField(QWidget *parent,
     mainLayout->addLayout(channelListLayout, 0);
 
     QGridLayout *bottomLayout = new QGridLayout();
-    bottomLayout->setMargin(0);
+    bottomLayout->setContentsMargins(0, 0, 0, 0);
     bottomLayout->setHorizontalSpacing(5);
     bottomLayout->setVerticalSpacing(0);
     {
       QVBoxLayout *currentValLayout = new QVBoxLayout();
-      currentValLayout->setMargin(0);
+      currentValLayout->setContentsMargins(0, 0, 0, 0);
       currentValLayout->setSpacing(0);
       currentValLayout->setAlignment(Qt::AlignLeft);
       {


### PR DESCRIPTION
This PR makes the following changes:

- Windows builds have been migrated to Qt 5.15.2. (macOS and Linux already use 5.15)
  - This uses a custom Qt 5.15.2 version built with WinTab support by @shun-iwasawa (see below)
  - Build instructions have been updated
- Changed the C++ standard from C++11 to C++17 (required by Qt6)
  - Fixed some code that did not meet C++17 standards
- Removed all macros for compiling with older versions of Qt.
  - This change requires building on a minimum of Qt 5.15.2 going forward
- Replaced deprecated Qt classes and methods as of 5.15.2 (preparation for Qt6)
- Replaced almost all obsolete Qt classes and methods through the latest 5.15 version. (preparation for Qt6)

------
### Local Windows Builders
For those using local builds or developing for T2D, you will need to redo/update your build environments as follows after this is merged:
- Git pull tahoma2d/master into your fork's master branch.
  - I suggest rebasing any active branches in your fork against the updated master
- Download and install Shun-iwasawa's custom Qt5.15.2 library from https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab. See build instructions for more information.
- Redo the CMake step in the build instructions