### PR TITLE
Fix current frame changing on column selection

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3360,7 +3360,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
             if (!(event->modifiers() & Qt::ControlModifier) &&
                 !(event->modifiers() & Qt::ShiftModifier)) {
               // Switch to column and allow immediate drag
-              setDragTool(XsheetGUI::DragTool::makeSelectionTool(m_viewer));
+              setDragTool(XsheetGUI::DragTool::makeColumnSelectionTool(m_viewer));
               // Before switching drag tool, trigger column selection switch notification
               m_viewer->dragToolClick(event);
               isInDragArea = true;


### PR DESCRIPTION
This fixes an issue where the current frame randomly changes to a different frame when clicking on a column header.  This only happens when drag bars are disabled.

Related to changes made in #1330