### PR TITLE
Reenable arrow keys as shortcuts and fixes

### DIFF
--- a/toonz/sources/include/toonzqt/menubarcommand.h
+++ b/toonz/sources/include/toonzqt/menubarcommand.h
@@ -156,7 +156,6 @@ public:
   int getKeyFromId(CommandId id);
   void setShortcut(QAction *action, std::string shortcutString,
                    bool keepDefault = true);
-  bool canUseShortcut(QString shortcut);
   QAction *getAction(CommandId id, bool createIfNeeded = false);
 
   // createAction creates a new independent QAction with text and shortcut

--- a/toonz/sources/tnztools/perspectivetool.h
+++ b/toonz/sources/tnztools/perspectivetool.h
@@ -488,6 +488,9 @@ public:
   void onProjectSwitched() override;
   void onProjectChanged() override;
 
+  // returns true if the pressed key is recognized and processed.
+  bool isEventAcceptable(QEvent *e) override;
+
 protected:
   TPropertyGroup m_prop;
   std::vector<PerspectiveGridToolOptionBox *> m_toolOptionsBox;

--- a/toonz/sources/tnztools/symmetrytool.cpp
+++ b/toonz/sources/tnztools/symmetrytool.cpp
@@ -666,6 +666,55 @@ void SymmetryTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
   m_isRotating     = false;
 }
 
+//-----------------------------------------------------------------------------
+
+// returns true if the pressed key is recognized and processed in the tool
+// instead of triggering the shortcut command.
+bool SymmetryTool::isEventAcceptable(QEvent *e) {
+  if (!isEnabled()) return false;
+  // arrow keys will be used for moving the selected points
+  QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
+  // shift + arrow will not be recognized for now
+  if (keyEvent->modifiers() & Qt::ShiftModifier) return false;
+  int key = keyEvent->key();
+  return (key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left ||
+          key == Qt::Key_Right);
+}
+
+//----------------------------------------------------------------------------------------------
+
+bool SymmetryTool::keyDown(QKeyEvent *event) {
+  TPointD delta;
+
+  switch (event->key()) {
+  case Qt::Key_Up:
+    delta.y = 1;
+    break;
+  case Qt::Key_Down:
+    delta.y = -1;
+    break;
+  case Qt::Key_Left:
+    delta.x = -1;
+    break;
+  case Qt::Key_Right:
+    delta.x = 1;
+    break;
+  default:
+    return false;
+    break;
+  }
+
+  m_undo = new SymmetryObjectUndo(m_symmetryObj, this);
+
+  m_symmetryObj.shiftSymmetryObject(delta);
+  m_undo->setRedoData(m_symmetryObj);
+
+  TUndoManager::manager()->add(m_undo);
+  m_undo = 0;
+
+  return true;
+}
+
 //----------------------------------------------------------------------------------------------
 
 void SymmetryTool::invalidateControl() {

--- a/toonz/sources/tnztools/symmetrytool.h
+++ b/toonz/sources/tnztools/symmetrytool.h
@@ -227,6 +227,7 @@ public:
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
+  bool keyDown(QKeyEvent *event) override;
 
   bool onPropertyChanged(std::string propertyName) override;
 
@@ -267,6 +268,9 @@ public:
   void loadLastSymmetry();
 
   void loadTool() override;
+
+  // returns true if the pressed key is recognized and processed.
+  bool isEventAcceptable(QEvent *e) override;
 
 protected:
   TPropertyGroup m_prop;

--- a/toonz/sources/tnztools/trackertool.cpp
+++ b/toonz/sources/tnztools/trackertool.cpp
@@ -807,7 +807,7 @@ bool TrackerTool::keyDown(QKeyEvent *event) {
   case Qt::Key_Left:
     delta.x = -1;
     break;
-  case Qt::Key_0:
+  case Qt::Key_Right:
     delta.x = 1;
     break;
   case Qt::Key_PageUp:  // converto in Hook

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -153,11 +153,29 @@ void ShortcutViewer::onEditingFinished() {
     for (int i = 0; i < seqCount; i++) {
       QKeySequence tmpKeys = QKeySequence(k1, (i >= 1 ? k2 : 0),
                                           (i >= 2 ? k3 : 0), (i >= 3 ? k4 : 0));
+
+      QString msg;
+      if (i == 0 &&
+          (tmpKeys.toString() == "Left" || tmpKeys.toString() == "Up" ||
+           tmpKeys.toString() == "Down" || tmpKeys.toString() == "Right")) {
+        msg = tr("Using '%1' arrow %2 may block navigation or movement "
+                 "operations in certain panels.\nUse anyway?")
+                  .arg(tmpKeys.toString())
+                  .arg(seqCount > 1 ? tr("to start of a shortcut sequence")
+                                    : tr("as a shortcut"));
+        int ret = DVGui::MsgBox(msg, tr("Yes"), tr("No"), 1);
+        activateWindow();
+        if (ret == 2 || ret == 0) {
+          setKeySequence(m_action->shortcut());
+          setFocus();
+          return;
+        }
+      }
+
       QAction *oldAction =
           cm->getActionFromShortcut(tmpKeys.toString().toStdString());
       if (oldAction == m_action) return;
       if (oldAction) {
-        QString msg;
         if (seqCount == (i + 1)) {
           msg = tr("'%1' is already assigned to '%2'\nAssign to '%3'?")
                     .arg(tmpKeys.toString())

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -119,15 +119,6 @@ void ShortcutViewer::keyPressEvent(QKeyEvent *event) {
       return;
     }
 
-    // Block the arrows
-    int ctl = modifiers | Qt::CTRL;
-    if ((modifiers == Qt::NoModifier) &&
-        (key == Qt::Key_Left || key == Qt::Key_Right || key == Qt::Key_Up ||
-         key == Qt::Key_Down)) {
-      event->ignore();
-      return;
-    }
-
     // If "Use Numpad and Tab keys for Switching Styles" option is activated,
     // then prevent to assign such keys
     if (Preferences::instance()->isUseNumpadForSwitchingStylesEnabled() &&

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -98,7 +98,6 @@ CommandManager::Node *CommandManager::getNode(CommandId id,
 void CommandManager::setShortcut(CommandId id, QAction *action,
                                  std::string shortcutString) {
   QString shortcutQString = QString::fromStdString(shortcutString);
-  if (!canUseShortcut(shortcutQString)) shortcutQString = "";
   if (shortcutQString != "")
     action->setShortcut(QKeySequence(shortcutQString));
   else
@@ -138,24 +137,12 @@ void CommandManager::define(CommandId id, CommandType type,
   // user defined shortcuts will be loaded afterwards in loadShortcuts()
   QString defaultShortcutQString =
       QString::fromStdString(defaultShortcutString);
-  if (!canUseShortcut(defaultShortcutQString)) defaultShortcutQString = "";
   if (!defaultShortcutQString.isEmpty()) {
     qaction->setShortcut(QKeySequence(defaultShortcutQString));
     m_shortcutTable[defaultShortcutString] = node;
   }
 
   if (type == ToolCommandType) updateToolTip(qaction);
-}
-
-//---------------------------------------------------------
-
-bool CommandManager::canUseShortcut(QString shortcut) {
-  shortcut = shortcut.toLower();
-  if (shortcut == "left" || shortcut == "up" || shortcut == "right" ||
-      shortcut == "down") {
-    return false;
-  }
-  return true;
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR does the following:

- Reallow the use of arrows keys as shortcuts
- Adds a warning that arrow keys as shortcuts or shortcut sequences that begins with an arrow key may block navigation and movement operations in certain panels
- Fixed `Perspective Tool` as follows:
  - Updated logic so arrow keys always move selected perspective objects even if they key is assigned as a shortcut to do something else
  - Updated undo logic for perspective object movements done via arrow keys
- Fixed `Symmetry Tool` as follows:
  - Added logic to move symmetry guide position with arrow keys.
- Fixed `Tracker Tool` as follows:
  - Replaced Key `0` with `Right` Arrow key for shifting tracker objects to the right.
