### PR TITLE
Update to custom rhubarb v1.13.0

### DIFF
--- a/ci-scripts/linux/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/linux/tahoma-get3rdpartyapps.sh
@@ -23,6 +23,6 @@ if [ -d rhubarb ]
 then
    rm -rf rhubarb ]
 fi
-wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.3/rhubarb-lip-sync-tahoma2d-linux.zip
+wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.13.0/rhubarb-lip-sync-tahoma2d-linux.zip
 unzip rhubarb-lip-sync-tahoma2d-linux.zip -d rhubarb
 

--- a/ci-scripts/osx/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/osx/tahoma-get3rdpartyapps.sh
@@ -23,6 +23,6 @@ if [ -d rhubarb ]
 then
    rm -rf rhubarb
 fi
-wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.3/rhubarb-lip-sync-tahoma2d-osx.zip
+wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.13.0/rhubarb-lip-sync-tahoma2d-osx.zip
 unzip rhubarb-lip-sync-tahoma2d-osx.zip -d rhubarb
 

--- a/ci-scripts/windows/tahoma-get3rdpartyapps.bat
+++ b/ci-scripts/windows/tahoma-get3rdpartyapps.bat
@@ -15,7 +15,7 @@ rename ffmpeg-5.0.0-win64-static-lgpl ffmpeg
 echo ">>> Getting Rhubarb Lip Sync"
 
 IF EXIST rhubarb rmdir /S /Q rhubarb
-curl -fsSL -o rhubarb-lip-sync-tahoma2d-win.zip https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.10.3/rhubarb-lip-sync-tahoma2d-win.zip
+curl -fsSL -o rhubarb-lip-sync-tahoma2d-win.zip https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.13.0/rhubarb-lip-sync-tahoma2d-win.zip
 7z x rhubarb-lip-sync-tahoma2d-win.zip
 rename rhubarb-lip-sync-tahoma2d-win rhubarb
 


### PR DESCRIPTION
This will update build packages to use the custom Rhubarb v1.13.0 which contains support for lower frame rates.

The prior custom Rhubarb version (v1.10.3) had custom changes for supporting 32-bit PCM WAV files but I had inadvertently lost the custom change to work with frame rates < 24fps.

The baseline v1.13.0 now has better support for 32-bit PCM WAV files and other formats so T2D's custom changes are no longer needed.  Reintroduced T2D's custom change to work with frame rates < 24fps.


The following comment from DanielSWolf (Rhubarb maintainer) should be kept in mind, especially when using with frame rates < 24 fps:

> Currently, Rhubarb always uses 100fps internally (for technical reasons). To achieve any other frame rate, output frames are simply discarded. This is far from ideal, because it can lead to whole parts of the animation being dropped when the frame rate is reduced too much. This is why I set the minimum to 24fps.
