### PR TITLE
Raster/MyPaint style brush Smooth option

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -52,6 +52,7 @@
 
 TEnv::IntVar FullcolorBrushMinSize("FullcolorBrushMinSize", 1);
 TEnv::IntVar FullcolorBrushMaxSize("FullcolorBrushMaxSize", 5);
+TEnv::DoubleVar FullcolorBrushSmooth("FullcolorBrushSmooth", 0);
 TEnv::IntVar FullcolorPressureSensitivity("FullcolorPressureSensitivity", 1);
 TEnv::DoubleVar FullcolorBrushHardness("FullcolorBrushHardness", 100);
 TEnv::DoubleVar FullcolorMinOpacity("FullcolorMinOpacity", 100);
@@ -121,6 +122,7 @@ public:
 FullColorBrushTool::FullColorBrushTool(std::string name)
     : TTool(name)
     , m_thickness("Size", 1, 1000, 1, 5, false)
+    , m_smooth("Smooth:", 0, 50, 0)
     , m_pressure("Pressure", true)
     , m_opacity("Opacity", 0, 100, 100, 100, true)
     , m_hardness("Hardness:", 0, 100, 100)
@@ -144,9 +146,10 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_thickness.setNonLinearSlider();
 
   m_prop.bind(m_thickness);
-  m_prop.bind(m_hardness);
-  m_prop.bind(m_opacity);
   m_prop.bind(m_modifierSize);
+  m_prop.bind(m_hardness);
+  m_prop.bind(m_smooth);
+  m_prop.bind(m_opacity);
   m_prop.bind(m_modifierOpacity);
   m_prop.bind(m_modifierEraser);
   m_prop.bind(m_modifierLockAlpha);
@@ -189,6 +192,7 @@ void FullColorBrushTool::onColorStyleChanged() {
 
 void FullColorBrushTool::updateTranslation() {
   m_thickness.setQStringName(tr("Size"));
+  m_smooth.setQStringName(tr("Smooth:"));
   m_pressure.setQStringName(tr("Pressure"));
   m_opacity.setQStringName(tr("Opacity"));
   m_hardness.setQStringName(tr("Hardness:"));
@@ -398,6 +402,15 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   if (!updateRect.isEmpty())
     ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
 
+  std::vector<TThickPoint> pts;
+  if (m_smooth.getValue() == 0) {
+    pts.push_back(point);
+  } else {
+    m_smoothStroke.beginStroke(m_smooth.getValue());
+    m_smoothStroke.addPoint(point);
+    m_smoothStroke.getSmoothPoints(pts);
+  }
+
   TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
   TRectD invalidateRect = convert(m_strokeSegmentRect) - rasCenter;
   invalidateRect += TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
@@ -599,17 +612,30 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
   else
     pressure = m_enabledPressure ? e.m_pressure : 1.0;
 
-  m_strokeSegmentRect.empty();
-  m_toonz_brush->strokeTo(point, pressure, restartBrushTimer());
-  TRect updateRect = m_strokeSegmentRect * ras->getBounds();
-  if (!updateRect.isEmpty())
-    ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
+  std::vector<TThickPoint> pts;
+  if (m_smooth.getValue() == 0) {
+    pts.push_back(point);
+  } else {
+    m_smoothStroke.addPoint(point);
+    m_smoothStroke.getSmoothPoints(pts);
+  }
+  invalidateRect.empty();
+  double brushTimer = restartBrushTimer();
+  for (size_t i = 0; i < pts.size(); ++i) {
+    const TThickPoint &thickPoint = pts[i];
+    m_strokeSegmentRect.empty();
+    m_toonz_brush->strokeTo(thickPoint, pressure, brushTimer);
+    TRect updateRect = m_strokeSegmentRect * ras->getBounds();
+    if (!updateRect.isEmpty())
+      ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
 
-  TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
-  invalidateRect = convert(m_strokeSegmentRect) - rasCenter;
-  invalidateRect += TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
-  invalidateRect +=
-      TRectD(previousBrushPos - thickOffset, previousBrushPos + thickOffset);
+    TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
+    invalidateRect += convert(m_strokeSegmentRect) - rasCenter;
+    invalidateRect +=
+        TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
+    invalidateRect +=
+        TRectD(previousBrushPos - thickOffset, previousBrushPos + thickOffset);
+  }
   invalidate(invalidateRect.enlarge(2.0));
 }
 
@@ -643,18 +669,33 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
     pressure = m_oldPressure;
   }
 
-  m_strokeSegmentRect.empty();
-  m_toonz_brush->strokeTo(point, pressure, restartBrushTimer());
-  m_toonz_brush->endStroke();
-  TRect updateRect = m_strokeSegmentRect * ras->getBounds();
-  if (!updateRect.isEmpty())
-    ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
+  std::vector<TThickPoint> pts;
+  if (m_smooth.getValue() == 0 || m_isStraight) {
+    pts.push_back(point);
+  } else {
+    m_smoothStroke.addPoint(point);
+    m_smoothStroke.endStroke();
+    m_smoothStroke.getSmoothPoints(pts);
+  }
+  TRectD invalidateRect;
+  double brushTimer = restartBrushTimer();
+  for (size_t i = 0; i < pts.size(); ++i) {
+    const TThickPoint &thickPoint = pts[i];
 
-  TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
-  TRectD invalidateRect = convert(m_strokeSegmentRect) - rasCenter;
-  invalidateRect += TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
-  invalidateRect +=
-      TRectD(previousBrushPos - thickOffset, previousBrushPos + thickOffset);
+    m_strokeSegmentRect.empty();
+    m_toonz_brush->strokeTo(point, pressure, brushTimer);
+    if (i == pts.size() - 1) m_toonz_brush->endStroke();
+    TRect updateRect = m_strokeSegmentRect * ras->getBounds();
+    if (!updateRect.isEmpty())
+      ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
+
+    TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
+    invalidateRect += convert(m_strokeSegmentRect) - rasCenter;
+    invalidateRect +=
+        TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
+    invalidateRect +=
+        TRectD(previousBrushPos - thickOffset, previousBrushPos + thickOffset);
+  }
   invalidate(invalidateRect.enlarge(2.0));
 
   if (m_toonz_brush) {
@@ -877,6 +918,7 @@ bool FullColorBrushTool::onPropertyChanged(std::string propertyName) {
 
   FullcolorBrushMinSize        = m_thickness.getValue().first;
   FullcolorBrushMaxSize        = m_thickness.getValue().second;
+  FullcolorBrushSmooth         = m_smooth.getValue();
   FullcolorPressureSensitivity = m_pressure.getValue();
   FullcolorBrushHardness       = m_hardness.getValue();
   FullcolorMinOpacity          = m_opacity.getValue().first;
@@ -933,6 +975,7 @@ void FullColorBrushTool::loadPreset() {
   {
     m_thickness.setValue(
         TIntPairProperty::Value(std::max((int)preset.m_min, 1), preset.m_max));
+    m_smooth.setValue(preset.m_smooth, true);
     m_hardness.setValue(preset.m_hardness, true);
     m_opacity.setValue(
         TDoublePairProperty::Value(preset.m_opacityMin, preset.m_opacityMax));
@@ -953,6 +996,7 @@ void FullColorBrushTool::addPreset(QString name) {
 
   preset.m_min               = m_thickness.getValue().first;
   preset.m_max               = m_thickness.getValue().second;
+  preset.m_smooth            = m_smooth.getValue();
   preset.m_hardness          = m_hardness.getValue();
   preset.m_opacityMin        = m_opacity.getValue().first;
   preset.m_opacityMax        = m_opacity.getValue().second;
@@ -992,6 +1036,7 @@ void FullColorBrushTool::removePreset() {
 void FullColorBrushTool::loadLastBrush() {
   m_thickness.setValue(
       TIntPairProperty::Value(FullcolorBrushMinSize, FullcolorBrushMaxSize));
+  m_smooth.setValue(FullcolorBrushSmooth);
   m_pressure.setValue(FullcolorPressureSensitivity ? 1 : 0);
   m_opacity.setValue(
       TDoublePairProperty::Value(FullcolorMinOpacity, FullcolorMaxOpacity));

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -402,12 +402,13 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   if (!updateRect.isEmpty())
     ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
 
+  TThickPoint thickPoint(point, pressure);
   std::vector<TThickPoint> pts;
   if (m_smooth.getValue() == 0) {
-    pts.push_back(point);
+    pts.push_back(thickPoint);
   } else {
     m_smoothStroke.beginStroke(m_smooth.getValue());
-    m_smoothStroke.addPoint(point);
+    m_smoothStroke.addPoint(thickPoint);
     m_smoothStroke.getSmoothPoints(pts);
   }
 
@@ -612,19 +613,20 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
   else
     pressure = m_enabledPressure ? e.m_pressure : 1.0;
 
+  TThickPoint thickPoint(point, pressure);
   std::vector<TThickPoint> pts;
   if (m_smooth.getValue() == 0) {
-    pts.push_back(point);
+    pts.push_back(thickPoint);
   } else {
-    m_smoothStroke.addPoint(point);
+    m_smoothStroke.addPoint(thickPoint);
     m_smoothStroke.getSmoothPoints(pts);
   }
   invalidateRect.empty();
   double brushTimer = restartBrushTimer();
   for (size_t i = 0; i < pts.size(); ++i) {
-    const TThickPoint &thickPoint = pts[i];
+    const TThickPoint &thickPoint2 = pts[i];
     m_strokeSegmentRect.empty();
-    m_toonz_brush->strokeTo(thickPoint, pressure, brushTimer);
+    m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, brushTimer);
     TRect updateRect = m_strokeSegmentRect * ras->getBounds();
     if (!updateRect.isEmpty())
       ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
@@ -669,21 +671,21 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
     pressure = m_oldPressure;
   }
 
+  TThickPoint thickPoint(point, pressure);
   std::vector<TThickPoint> pts;
   if (m_smooth.getValue() == 0 || m_isStraight) {
-    pts.push_back(point);
+    pts.push_back(thickPoint);
   } else {
-    m_smoothStroke.addPoint(point);
+    m_smoothStroke.addPoint(thickPoint);
     m_smoothStroke.endStroke();
     m_smoothStroke.getSmoothPoints(pts);
   }
   TRectD invalidateRect;
   double brushTimer = restartBrushTimer();
   for (size_t i = 0; i < pts.size(); ++i) {
-    const TThickPoint &thickPoint = pts[i];
-
+    const TThickPoint &thickPoint2 = pts[i];
     m_strokeSegmentRect.empty();
-    m_toonz_brush->strokeTo(point, pressure, brushTimer);
+    m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, brushTimer);
     if (i == pts.size() - 1) m_toonz_brush->endStroke();
     TRect updateRect = m_strokeSegmentRect * ras->getBounds();
     if (!updateRect.isEmpty())

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -87,6 +87,7 @@ protected:
   TPropertyGroup m_prop;
 
   TIntPairProperty m_thickness;
+  TDoubleProperty m_smooth;
   TBoolProperty m_pressure;
   TDoublePairProperty m_opacity;
   TDoubleProperty m_hardness;
@@ -109,6 +110,8 @@ protected:
   TRaster32P m_workRaster;
 
   TRect m_strokeRect, m_strokeSegmentRect, m_lastRect;
+
+  SmoothStroke m_smoothStroke;
 
   MyPaintToonzBrush *m_toonz_brush;
   QElapsedTimer m_brushTimer;

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2176,8 +2176,9 @@ void BrushToolOptionsBox::filterControls() {
   for (QMap<std::string, QLabel *>::iterator it = m_labels.begin();
        it != m_labels.end(); it++) {
     bool isModifier = (it.key().substr(0, 8) == "Modifier");
-    bool isCommon   = (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
-                     it.key() == "Preset:" || it.key() == "Grid");
+    bool isCommon =
+        (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
+         it.key() == "Preset:" || it.key() == "Grid" || it.key() == "Smooth:");
     bool visible = isCommon || (isModifier == showModifiers);
     it.value()->setVisible(visible);
   }
@@ -2185,8 +2186,9 @@ void BrushToolOptionsBox::filterControls() {
   for (QMap<std::string, ToolOptionControl *>::iterator it = m_controls.begin();
        it != m_controls.end(); it++) {
     bool isModifier = (it.key().substr(0, 8) == "Modifier");
-    bool isCommon   = (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
-                     it.key() == "Preset:" || it.key() == "Grid");
+    bool isCommon =
+        (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
+         it.key() == "Preset:" || it.key() == "Grid" || it.key() == "Smooth:");
     bool visible = isCommon || (isModifier == showModifiers);
     if (QWidget *widget = dynamic_cast<QWidget *>(it.value()))
       widget->setVisible(visible);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1433,12 +1433,13 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
       }
       m_lastRect = m_strokeRect;
 
+      TThickPoint thickPoint(point, pressure);
       std::vector<TThickPoint> pts;
       if (m_smooth.getValue() == 0) {
-        pts.push_back(point);
+        pts.push_back(thickPoint);
       } else {
         m_smoothStroke.beginStroke(m_smooth.getValue());
-        m_smoothStroke.addPoint(point);
+        m_smoothStroke.addPoint(thickPoint);
         m_smoothStroke.getSmoothPoints(pts);
       }
 
@@ -1787,20 +1788,21 @@ void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
     double pressure =
         m_pressure.getValue() && e.isTablet() ? e.m_pressure : 0.5;
 
+    TThickPoint thickPoint(point, pressure);
     std::vector<TThickPoint> pts;
     if (m_smooth.getValue() == 0) {
-      pts.push_back(point);
+      pts.push_back(thickPoint);
     } else {
-      m_smoothStroke.addPoint(point);
+      m_smoothStroke.addPoint(thickPoint);
       m_smoothStroke.getSmoothPoints(pts);
     }
 
     invalidateRect.empty();
     double brushTimer = restartBrushTimer();
     for (size_t i = 0; i < pts.size(); ++i) {
-      const TThickPoint &thickPoint = pts[i];
+      const TThickPoint &thickPoint2 = pts[i];
       m_strokeSegmentRect.empty();
-      m_toonz_brush->strokeTo(thickPoint, pressure, brushTimer);
+      m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, brushTimer);
       TRect updateRect = m_strokeSegmentRect * ras->getBounds();
       if (!updateRect.isEmpty()) {
         // ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
@@ -1975,21 +1977,22 @@ void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
     TPointD point(pos + rasCenter);
     double pressure = m_pressure.getValue() ? pressureVal : 0.5;
 
+    TThickPoint thickPoint(point, pressure);
     std::vector<TThickPoint> pts;
     if (m_smooth.getValue() == 0 || m_isStraight) {
-      pts.push_back(point);
+      pts.push_back(thickPoint);
     } else {
-      m_smoothStroke.addPoint(point);
+      m_smoothStroke.addPoint(thickPoint);
       m_smoothStroke.endStroke();
       m_smoothStroke.getSmoothPoints(pts);
     }
     TRectD invalidateRect;
     double brushTimer = restartBrushTimer();
     for (size_t i = 0; i < pts.size(); ++i) {
-      const TThickPoint &thickPoint = pts[i];
+      const TThickPoint &thickPoint2 = pts[i];
 
       m_strokeSegmentRect.empty();
-      m_toonz_brush->strokeTo(thickPoint, pressure, brushTimer);
+      m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, brushTimer);
       if (i == pts.size() - 1) m_toonz_brush->endStroke();
       TRect updateRect = m_strokeSegmentRect * ras->getBounds();
       if (!updateRect.isEmpty()) {

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -935,9 +935,9 @@ ToonzRasterBrushTool::ToonzRasterBrushTool(std::string name, int targetType)
 
   m_prop[0].bind(m_rasThickness);
   m_prop[0].bind(m_hardness);
+  m_prop[0].bind(m_modifierSize);
   m_prop[0].bind(m_smooth);
   m_prop[0].bind(m_drawOrder);
-  m_prop[0].bind(m_modifierSize);
   m_prop[0].bind(m_modifierLockAlpha);
   m_prop[0].bind(m_pencil);
   m_pencil.setId("PencilMode");
@@ -1433,6 +1433,15 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
       }
       m_lastRect = m_strokeRect;
 
+      std::vector<TThickPoint> pts;
+      if (m_smooth.getValue() == 0) {
+        pts.push_back(point);
+      } else {
+        m_smoothStroke.beginStroke(m_smooth.getValue());
+        m_smoothStroke.addPoint(point);
+        m_smoothStroke.getSmoothPoints(pts);
+      }
+
       TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
       invalidateRect = convert(m_strokeSegmentRect) - rasCenter;
       invalidateRect +=
@@ -1778,22 +1787,36 @@ void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
     double pressure =
         m_pressure.getValue() && e.isTablet() ? e.m_pressure : 0.5;
 
-    m_strokeSegmentRect.empty();
-    m_toonz_brush->strokeTo(point, pressure, restartBrushTimer());
-    TRect updateRect = m_strokeSegmentRect * ras->getBounds();
-    if (!updateRect.isEmpty()) {
-      // ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
-      m_toonz_brush->updateDrawing(ras, m_backupRas, m_strokeSegmentRect,
-                                   m_styleId, m_modifierLockAlpha.getValue());
+    std::vector<TThickPoint> pts;
+    if (m_smooth.getValue() == 0) {
+      pts.push_back(point);
+    } else {
+      m_smoothStroke.addPoint(point);
+      m_smoothStroke.getSmoothPoints(pts);
     }
-    m_lastRect = m_strokeRect;
 
-    TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
-    invalidateRect = convert(m_strokeSegmentRect) - rasCenter;
-    invalidateRect +=
-        TRectD(centeredPos - thickOffset, centeredPos + thickOffset);
-    invalidateRect +=
-        TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
+    invalidateRect.empty();
+    double brushTimer = restartBrushTimer();
+    for (size_t i = 0; i < pts.size(); ++i) {
+      const TThickPoint &thickPoint = pts[i];
+      m_strokeSegmentRect.empty();
+      m_toonz_brush->strokeTo(thickPoint, pressure, brushTimer);
+      TRect updateRect = m_strokeSegmentRect * ras->getBounds();
+      if (!updateRect.isEmpty()) {
+        // ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
+        m_toonz_brush->updateDrawing(ras, m_backupRas, m_strokeSegmentRect,
+                                     m_styleId, m_modifierLockAlpha.getValue());
+      }
+
+      m_lastRect = m_strokeRect;
+
+      TPointD thickOffset(m_maxCursorThick * 0.5, m_maxCursorThick * 0.5);
+      invalidateRect += convert(m_strokeSegmentRect) - rasCenter;
+      invalidateRect +=
+          TRectD(centeredPos - thickOffset, centeredPos + thickOffset);
+      invalidateRect +=
+          TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
+    }
   } else if (m_cmRasterBrush &&
              (m_hardness.getValue() == 100 || m_pencil.getValue())) {
     /*-- Pencilモードでなく、Hardness=100 の場合のブラシサイズを1段階下げる
@@ -1952,19 +1975,33 @@ void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
     TPointD point(pos + rasCenter);
     double pressure = m_pressure.getValue() ? pressureVal : 0.5;
 
-    m_strokeSegmentRect.empty();
-    m_toonz_brush->strokeTo(point, pressure, restartBrushTimer());
-    m_toonz_brush->endStroke();
-    TRect updateRect = m_strokeSegmentRect * ras->getBounds();
-    if (!updateRect.isEmpty()) {
-      // ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
-      m_toonz_brush->updateDrawing(ras, m_backupRas, m_strokeSegmentRect,
-                                   m_styleId, m_modifierLockAlpha.getValue());
+    std::vector<TThickPoint> pts;
+    if (m_smooth.getValue() == 0 || m_isStraight) {
+      pts.push_back(point);
+    } else {
+      m_smoothStroke.addPoint(point);
+      m_smoothStroke.endStroke();
+      m_smoothStroke.getSmoothPoints(pts);
     }
-    TPointD thickOffset(m_maxCursorThick * 0.5,
-                        m_maxCursorThick * 0.5);  // TODO
-    TRectD invalidateRect = convert(m_strokeSegmentRect) - rasCenter;
-    invalidateRect += TRectD(pos - thickOffset, pos + thickOffset);
+    TRectD invalidateRect;
+    double brushTimer = restartBrushTimer();
+    for (size_t i = 0; i < pts.size(); ++i) {
+      const TThickPoint &thickPoint = pts[i];
+
+      m_strokeSegmentRect.empty();
+      m_toonz_brush->strokeTo(thickPoint, pressure, brushTimer);
+      if (i == pts.size() - 1) m_toonz_brush->endStroke();
+      TRect updateRect = m_strokeSegmentRect * ras->getBounds();
+      if (!updateRect.isEmpty()) {
+        // ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
+        m_toonz_brush->updateDrawing(ras, m_backupRas, m_strokeSegmentRect,
+                                     m_styleId, m_modifierLockAlpha.getValue());
+      }
+      TPointD thickOffset(m_maxCursorThick * 0.5,
+                          m_maxCursorThick * 0.5);  // TODO
+      invalidateRect += convert(m_strokeSegmentRect) - rasCenter;
+      invalidateRect += TRectD(pos - thickOffset, pos + thickOffset);
+    }
     invalidate(invalidateRect.enlarge(2.0));
 
     if (m_toonz_brush) {


### PR DESCRIPTION
This adds the `Smooth` brush setting to the Raster Brush tool.

Smooth setting is also available for MyPaint styles in Raster and Smart Raster tools. This smooth setting is independent of MyPaint style's `Slow Tracking Position` setting and is applied before it.