### PR TITLE
Add option to increase the size of the Edit & Control Point Editor tool widgets.

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -370,6 +370,9 @@ public:
   bool isMagnetNonLinearSliderEnabled() const {
     return getBoolValue(magnetNonLinearSliderEnabled);
   }
+  int isToolScaled() const { 
+    return getBoolValue(toolScale); 
+  }
 
   // Xsheet  tab
   QString getXsheetLayoutPreference() const {

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -121,6 +121,7 @@ enum PreferencesItemId {
   useCtrlAltToResizeBrush,
   temptoolswitchtimer,
   magnetNonLinearSliderEnabled,
+  toolScale,
 
   //----------
   // Xsheet

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -19,6 +19,7 @@
 #include "toonz/tobjecthandle.h"
 #include "toonz/stage2.h"
 #include "toonz/tstageobject.h"
+#include "toonz/preferences.h"
 
 #include "toonzqt/tselectionhandle.h"
 
@@ -303,7 +304,8 @@ void ControlPointEditorTool::drawControlPoint() {
   TPixel color_handle   = TPixel(96, 64, 201);
   int controlPointCount = m_controlPointEditorStroke.getControlPointCount();
 
-  double pix    = getPixelSize() * 2.0f;
+  double toolScale = Preferences::instance()->isToolScaled() ? 2 : 1;
+  double pix    = getPixelSize() * 2.0f * toolScale;
   double pix1_5 = 1.5 * pix, pix2 = pix + pix, pix2_5 = pix1_5 + pix,
          pix3 = pix2 + pix, pix3_5 = pix2_5 + pix, pix4 = pix3 + pix;
 

--- a/toonz/sources/tnztools/selectiontool.cpp
+++ b/toonz/sources/tnztools/selectiontool.cpp
@@ -11,6 +11,7 @@
 #include "tools/cursors.h"
 #include "toonz/stage2.h"
 #include "toonz/tobjecthandle.h"
+#include "toonz/preferences.h"
 
 #include <QKeyEvent>
 
@@ -952,7 +953,8 @@ void SelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
 
   FourPoints bbox = getBBox();
 
-  double pixelSize = getPixelSize();
+  double toolSize = Preferences::instance()->isToolScaled() ? 3 : 1;
+  double pixelSize = getPixelSize() * toolSize;
   if (!bbox.isEmpty()) {
     double maxDist  = 17 * pixelSize;
     double maxDist2 = maxDist * maxDist;
@@ -1041,7 +1043,7 @@ void SelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
         m_what     = DEFORM;
       }
       return;
-    }
+    } 
     TPointD hpos = bbox.getP10() - TPointD(14 * pixelSize, 15 * pixelSize);
     TRectD rect(hpos - TPointD(14 * pixelSize, 5 * pixelSize),
                 hpos + TPointD(14 * pixelSize, 5 * pixelSize));
@@ -1268,7 +1270,8 @@ void SelectionTool::drawCommandHandle(const TImage *image) {
 
   if (!isSelectionEditable()) return;
 
-  double pixelSize = getPixelSize();
+  double toolScale = Preferences::instance()->isToolScaled() ? 3 : 1;
+  double pixelSize = getPixelSize() * toolScale;
   if (!isLevelType() && !isSelectedFramesType()) {
     TPointD c = getCenter() + TPointD(-pixelSize, +pixelSize);
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1397,6 +1397,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
        tr("Temporary Tool Switch Shortcut Hold Time (ms):")},
       {magnetNonLinearSliderEnabled,
        tr("Magnet Tool Size Slider - Non-Linear mode*")},
+      {toolScale, tr("Increase Selection and Control Point Editor Tool Widget Size (For 4k Displays)")},
 
       // Xsheet
       {xsheetLayoutPreference, tr("Xsheet Header Layout*:")},
@@ -2143,6 +2144,7 @@ QWidget* PreferencesPopup::createToolsPage() {
     insertUI(useCtrlAltToResizeBrush, lay);
   insertUI(temptoolswitchtimer, lay);
   insertUI(magnetNonLinearSliderEnabled, lay);
+  insertUI(toolScale, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -564,6 +564,7 @@ void Preferences::definePreferenceItems() {
          std::numeric_limits<int>::max());
   define(magnetNonLinearSliderEnabled, "magnetNonLinearSliderEnabled",
          QMetaType::Bool, false);
+  define(toolScale, "toolScale", QMetaType::Bool, false);
 
   // Xsheet
   define(xsheetLayoutPreference, "xsheetLayoutPreference", QMetaType::QString,


### PR DESCRIPTION
I added an option to increase the size of the Edit & Control Point Editor tool widgets. The Edit Tool widget will increase by 3x, the Control Point Editor by 2x when enabled.

Please give this a once over to check that I've done this correctly.