### PR TITLE
Fix level strip empty space selection and commands

### DIFF
--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -111,7 +111,8 @@ public:
     CTRL_SELECT,
     START_DRAG_SELECT,
     DRAG_SELECT,
-    ONLY_SELECT
+    ONLY_SELECT,
+    SELECT_EMPTY_SPACE
   };
   void select(int index, SelectionMode mode = SIMPLE_SELECT);
 

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -1764,7 +1764,7 @@ void FilmstripCmd::paste(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
 //-----------------------------------------------------------------------------
 
 void FilmstripCmd::merge(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
-  if (!sl || sl->isReadOnly() || sl->isSubsequence()) return;
+  if (!sl || sl->isReadOnly() || sl->isSubsequence() || !frames.size()) return;
 
   std::vector<TFrameId> oldLevelFrameId;
   sl->getFids(oldLevelFrameId);
@@ -2080,7 +2080,7 @@ public:
 //-----------------------------------------------------------------------------
 
 void FilmstripCmd::reverse(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
-  if (!sl || sl->isSubsequence() || sl->isReadOnly()) return;
+  if (!sl || sl->isSubsequence() || sl->isReadOnly() || !frames.size()) return;
   performReverse(sl, frames);
   TUndoManager::manager()->add(new FilmstripReverseUndo(sl, frames));
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
@@ -2169,7 +2169,7 @@ public:
 //-----------------------------------------------------------------------------
 
 void FilmstripCmd::swing(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
-  if (!sl || sl->isSubsequence() || sl->isReadOnly()) return;
+  if (!sl || sl->isSubsequence() || sl->isReadOnly() || !frames.size()) return;
   performSwing(sl, frames);
   TUndoManager::manager()->add(new FilmstripSwingUndo(sl, frames));
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
@@ -2285,7 +2285,7 @@ public:
 
 void FilmstripCmd::step(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
                         int step) {
-  if (!sl || sl->isSubsequence() || sl->isReadOnly()) return;
+  if (!sl || sl->isSubsequence() || sl->isReadOnly() || !frames.size()) return;
   QApplication::setOverrideCursor(Qt::WaitCursor);
   StepFilmstripUndo *undo = new StepFilmstripUndo(sl, frames, step);
   stepFilmstripFrames(sl, frames, step);
@@ -2381,7 +2381,7 @@ public:
 
 void FilmstripCmd::each(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
                         int each) {
-  if (!sl || sl->isSubsequence() || sl->isReadOnly()) return;
+  if (!sl || sl->isSubsequence() || sl->isReadOnly() || !frames.size()) return;
   std::map<TFrameId, QString> deletedFrames =
       eachFilmstripFrames(sl, frames, each);
   TUndoManager::manager()->add(

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -141,17 +141,18 @@ void TFilmstripSelection::updateInbetweenRange() {
 void TFilmstripSelection::select(const TFrameId &fid, bool selected) {
   TApp *app = TApp::instance();
 
-  if (selected)
+  TXshSimpleLevel *sl = app->getCurrentLevel()->getSimpleLevel();
+
+  if (selected) {
+    if (sl && !sl->getFrame(fid, false)) return;
     m_selectedFrames.insert(fid);
-  else
+  } else
     m_selectedFrames.erase(fid);
 
   updateInbetweenRange();
 
   TTool *tool = app->getCurrentTool()->getTool();
   if (tool) tool->setSelectedFrames(m_selectedFrames);
-
-  TXshSimpleLevel *sl = app->getCurrentLevel()->getSimpleLevel();
 }
 
 //-----------------------------------------------------------------------------
@@ -286,6 +287,7 @@ void TFilmstripSelection::deleteFrames() {
       DVGui::warning(QObject::tr("Can't delete the last drawing in a level."));
       return;
     }
+    if (!m_selectedFrames.size()) return;
     // find highest numbered frame
     int highestFrame = -1;
     TFrameId fid;
@@ -329,7 +331,14 @@ void TFilmstripSelection::clearFrames() {
 
 void TFilmstripSelection::insertEmptyFrames() {
   TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
-  if (sl) FilmstripCmd::insert(sl, m_selectedFrames, true);
+  if (sl) {
+    if (!m_selectedFrames.size() && sl && sl->getFrameCount()) {
+      TFrameId fid = sl->getLastFid().getNumber() + 1;
+      m_selectedFrames.insert(fid);
+    }
+
+    FilmstripCmd::insert(sl, m_selectedFrames, true);
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This will fix the following issues in Level Strip

- When clicking in any spot in empty area in the Level Strip, it will "select" the 1st empty area just after the last actual frame
- Commands that normally requite a frame will not work in or will ignore an empty space if it is "selected".  Exceptions: `Insert` and paste commands