### PR TITLE
Fix GitHub action errors and warnings

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           ci-scripts/linux/tahoma-buildpkg.sh
           mv toonz/build/Tahoma2D-linux.tar.gz toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Tahoma2D-linux-${{ matrix.compiler }}.tar.gz
           path: toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -59,11 +59,11 @@ jobs:
           ci-scripts/osx/tahoma-build.sh
       - name: Create Package
         run: bash ./ci-scripts/osx/tahoma-buildpkg.sh
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Tahoma2D-portable-osx.dmg
           path: toonz/build/Tahoma2D-portable-osx.dmg
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Tahoma2D-install-osx.pkg
           path: toonz/build/Tahoma2D-install-osx.pkg

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -42,11 +42,11 @@ jobs:
           ci-scripts\windows\tahoma-buildpkg.bat
           mkdir artifact
           cp -r toonz\build\Tahoma2D artifact
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Tahoma2D-portable-win
           path: artifact
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Tahoma2D-install-win.exe
           path: toonz\build\Tahoma2D-install-win.exe

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -3,7 +3,7 @@ brew update
 # Remove symlink to bin/2to3 in order for latest python to install
 rm -f '/usr/local/bin/2to3'
 # Remove synlink to nghttp2 in order for latest curl to install
-brew unlink nghttp2
+#brew unlink nghttp2
 brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz gsed
 #brew install dav1d
 brew install meson ninja


### PR DESCRIPTION
This corrects the following Github Action errors and warnings:

- All build environments: Deprecation notice for Upload-Action - Upgraded from v1 to v4.
- macOS Build: No such keg: /usr/local/Cellar/nghttp2 - A dependency install workaround is no longer needed so I removed the unlink nghttp2 command in the script.
