### PR TITLE
Fix color wheel pointer position

### DIFF
--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -944,8 +944,9 @@ void HexagonalColorWheel::mouseReleaseEvent(QMouseEvent *event) {
 void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
   QLineF p(m_wp[0] + m_wheelPosition, QPointF(pos));
   QLineF horizontal(0, 0, 1, 0);
-  float theta = (p.dy() < 0) ? p.angleTo(horizontal) : 360 - p.angleTo(horizontal);
-  float phi   = theta;
+  float theta =
+      (p.dy() < 0) ? 360 - p.angleTo(horizontal) : horizontal.angleTo(p);
+  float phi = theta;
   while (phi >= 60.0f) phi -= 60.0f;
   phi -= 30.0f;
   // d is a length from center to edge of the wheel when saturation = 100


### PR DESCRIPTION
This fixes #1476 caused by replacing a deprecated function as part of #1456