### PR TITLE
Fix pen tap leaving max size dot

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -373,8 +373,11 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   if (getApplication()->getCurrentLevelStyle()->getTagId() ==
       4001)  // mypaint brush case
     pressure = m_enabledPressure && e.isTablet() ? e.m_pressure : 0.5;
-  else
-    pressure    = m_enabledPressure ? e.m_pressure : 1.0;
+  else {
+    pressure = m_enabledPressure && e.isTablet() ? e.m_pressure : 1.0;
+    if (m_enabledPressure && e.m_pressure == 1.0)
+      pressure = 0.1;
+  }
   m_oldPressure = pressure;
 
   m_tileSet   = new TTileSetFullColor(ras->getSize());
@@ -668,8 +671,11 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   if (getApplication()->getCurrentLevelStyle()->getTagId() ==
       4001)  // mypaint brush case
     pressure = m_enabledPressure && e.isTablet() ? e.m_pressure : 0.5;
-  else
-    pressure = m_enabledPressure ? e.m_pressure : 1.0;
+  else {
+    pressure = m_enabledPressure && e.isTablet() ? e.m_pressure : 1.0;
+    if (m_enabledPressure && e.m_pressure == 1.0)
+      pressure = 0.1;
+  }
   if (m_isStraight) {
     pressure = m_oldPressure;
   }


### PR DESCRIPTION
This fixes an issue on Raster levels where dots are drawing using the max size when tapping on the canvas with a stylus. 

Added similar logic found in other brushes to use the smallest size.

This started happening after #1459 which now always draws a dot, sometimes too faint to see, whenever tapping the canvas.