### PR TITLE
Fix Export Current Scene popup folder tree

### DIFF
--- a/toonz/sources/toonz/exportscenepopup.cpp
+++ b/toonz/sources/toonz/exportscenepopup.cpp
@@ -404,7 +404,8 @@ void ExportSceneTreeViewDelegate::paint(QPainter *painter,
   QPixmap px = node->getPixmap(m_treeView->isExpanded(index));
   if (!px.isNull()) {
     int x = rect.left();
-    int y = rect.top() + (rect.height() - px.height()) / 2;
+    int y =
+        rect.top() + (rect.height() - px.height() / px.devicePixelRatio()) / 2;
     painter->drawPixmap(QPoint(x, y), px);
   }
   rect.adjust(pnode ? 31 : 22, 0, 0, 0);


### PR DESCRIPTION
This shifts the icons into the correct position on the folder tree in the `Export Current Scene` popup.