### PR TITLE
Fix explicit holds created in implicit mode

### DIFF
--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -1750,6 +1750,7 @@ bool StopMotion::importImage() {
     for (int i = 0; i < m_captureNumberOfFrames; i++) {
       xsh->insertCells(row + i, col);
       xsh->setCell(row + i, col, TXshCell(sl, fid));
+      if (Preferences::instance()->isImplicitHoldEnabled()) break;
     }
     app->getCurrentColumn()->setColumnIndex(col);
     if (getReviewTimeDSec() == 0 || m_isTimeLapse)
@@ -1796,6 +1797,7 @@ bool StopMotion::importImage() {
     for (int i = 0; i < m_captureNumberOfFrames; i++) {
       xsh->insertCells(row + i, foundCol);
       xsh->setCell(row + i, foundCol, TXshCell(sl, fid));
+      if (Preferences::instance()->isImplicitHoldEnabled()) break;
     }
     app->getCurrentColumn()->setColumnIndex(foundCol);
     if (getReviewTimeDSec() == 0 || m_isTimeLapse)
@@ -1812,6 +1814,7 @@ bool StopMotion::importImage() {
     }
     for (int i = 0; i < m_captureNumberOfFrames; i++) {
       xsh->setCell(row + i, col, TXshCell(sl, fid));
+      if (Preferences::instance()->isImplicitHoldEnabled()) break;
     }
     app->getCurrentColumn()->setColumnIndex(col);
     if (getReviewTimeDSec() == 0 || m_isTimeLapse)

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -4256,9 +4256,10 @@ void TCellSelection::convertToToonzRaster() {
   TUndoManager::manager()->add(undo);
 
   // expose the new frames in the column
+  bool implicitMode = Preferences::instance()->isImplicitHoldEnabled();
   for (i = 0; i < totalImages; i++) {
     for (int k = r0; k <= r1; k++) {
-      TXshCell oldCell = xsh->getCell(k, c0);
+      TXshCell oldCell = xsh->getCell(k, c0, !implicitMode);
       TXshCell newCell(sl, newFids[i]);
       if (oldCell.getFrameId() == frameIds[i]) {
         xsh->setCell(k, col, newCell);

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -1028,10 +1028,11 @@ bool VectorizerPopup::apply() {
       TXsheet *xsheet = TApp::instance()->getCurrentXsheet()->getXsheet();
       xsheet->insertColumn(newIndexColumn);
 
+      bool implicitMode = Preferences::instance()->isImplicitHoldEnabled();
       int r, c;
       for (c = c0; c <= c1; c++) {
         for (r = r0; r <= r1; r++) {
-          TXshCell cell = xsheet->getCell(r, c);
+          TXshCell cell = xsheet->getCell(r, c, !implicitMode);
           TXshSimpleLevel *level =
               (!cell.isEmpty()) ? cell.getSimpleLevel() : 0;
           if (level != sl) continue;

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -406,12 +406,18 @@ public:
       int col = m_col + c;
       xsh->insertCells(r0, col, count);
       int r;
+      TXshCell prevCell = xsh->getCell(r0, c);
       for (r = r0; r <= r1; r++) {
-        int k = (r - m_row) * m_colCount + c;
-        if (isSoundColumn)
+        int k         = (r - m_row) * m_colCount + c;
+        TXshCell cell = m_cells[k];
+        if (isSoundColumn ||
+            (Preferences::instance()->isImplicitHoldEnabled() &&
+             prevCell == cell))
           xsh->setCell(r, col, TXshCell());
-        else
-          xsh->setCell(r, col, m_cells[k]);
+        else {
+          xsh->setCell(r, col, cell);
+          prevCell = cell;
+        }
       }
     }
   }
@@ -786,11 +792,18 @@ public:
         if (column && column->getFolderColumn()) continue;
         bool isSoundColumn = (column && column->getSoundColumn());
         if (m_insert) xsh->insertCells(m_r1 + 1, m_c0 + c, dr);
-        for (int r = m_r1 + 1; r <= r1; r++)
-          if (isSoundColumn)
+        TXshCell prevCell = xsh->getCell(m_r1, c);
+        for (int r = m_r1 + 1; r <= r1; r++) {
+          TXshCell cell = m_columns[c].generate(r);
+          if (isSoundColumn ||
+              (Preferences::instance()->isImplicitHoldEnabled() &&
+               prevCell == cell))
             xsh->setCell(r, m_c0 + c, TXshCell());
-          else
-            xsh->setCell(r, m_c0 + c, m_columns[c].generate(r));
+          else {
+            xsh->setCell(r, m_c0 + c, cell);
+            prevCell = cell;
+          }
+        }
       }
     }
     m_r1 = r1;

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -771,9 +771,11 @@ bool TXsheet::incrementCells(int r0, int c0, int r1, int c1,
         TXshCell cell(0, TFrameId::NO_FRAME);
         forUndo.push_back(std::pair<TRect, TXshCell>(
             TRect(i + 1, j, i + 1 + numCells - 1, j), cell));
-        for (int k = 1; k <= numCells; k++) {
-          TXshCell cell = getCell(CellPosition(i, j), false);
-          setCell(i + k, j, cell);
+        if (!Preferences::instance()->isImplicitHoldEnabled()) {
+          for (int k = 1; k <= numCells; k++) {
+            TXshCell cell = getCell(CellPosition(i, j), false);
+            setCell(i + k, j, cell);
+          }
         }
         i += numCells;
         r1 += numCells;
@@ -1015,7 +1017,9 @@ int TXsheet::reframeCells(int r0, int r1, int col, int step, int withBlank) {
     if (useImplicitHold && !level) level = getCell(i, col).m_level;
     for (int i1 = 0; i1 < step; i1++) {
       // Cell is empty, find last level
-      if (cells[k].isEmpty() || (useImplicitHold && i1 > 0))
+      if (cells[k].isEmpty() ||
+          (useImplicitHold &&
+           (i1 > 0 || (k == 0 && i == r0 && getCell(i, col, false).isEmpty()))))
         clearCells(i + i1, col);
       else
         setCell(i + i1, col, cells[k]);


### PR DESCRIPTION
This fixes the following actions where explicit holds are created while in implicit mode:

- Stop Motion when capturing on 2s 3s, etc
- `Autoexpose` when there are gaps in the number sequence
- `Reframe` when the first cell in the selection is an implicit cell
- Cell exposure extender 
- `Convert to Vectors...`
- `Vector to Smart Raster`