### PR TITLE
Fix delete from stage schematic crash

### DIFF
--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -303,8 +303,8 @@ void SchematicScenePanel::onDeleteStageObjects(
 
   TApp *app = TApp::instance();
   TStageObjectCmd::deleteSelection(
-      std::vector<TStageObjectId>(selection->getObjects().toVector().begin(),
-                  selection->getObjects().toVector().end()),
+      std::vector<TStageObjectId>(selection->getObjects().begin(),
+                                  selection->getObjects().end()),
       std::list<QPair<TStageObjectId, TStageObjectId>>(
           selection->getLinks().begin(), selection->getLinks().end()),
       std::list<int>(selection->getSplines().begin(),


### PR DESCRIPTION
This fixes a crash when deleting a column, peg bar, etc... from the stage schematic.

Related to changes from #1456.