### PR TITLE
Fix invisible drawing guides

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -820,6 +820,7 @@ void FullColorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 void FullColorBrushTool::draw() {
   if (TRasterImageP ri = TRasterImageP(getImage(false))) {
     if (m_isStraight) {
+      tglColor(TPixel32::Red);
       tglDrawSegment(m_firstPoint, m_lastPoint);
     }
     // If toggled off, don't draw brush outline

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2516,6 +2516,7 @@ void RectanglePrimitive::draw() {
       areAlmostEqual(m_selectingRect.x0, m_selectingRect.x1) ||
       areAlmostEqual(m_selectingRect.y0, m_selectingRect.y1)) {
 //    tglColor(m_isEditing ? m_color : TPixel32::Green);
+    tglColor(TPixel32::Red);
 
     if (m_rectangle.hasSymmetryBrushes()) {
       double pixelSize = m_tool->getPixelSize();
@@ -3939,7 +3940,8 @@ void PolygonPrimitive::draw() {
     return;
   }
 
-  tglColor(m_isEditing ? m_color : TPixel32::Green);
+//  tglColor(m_isEditing ? m_color : TPixel32::Green);
+  tglColor(TPixel32::Red);
 
   int edgeCount = m_param->m_edgeCount.getValue();
   if (edgeCount == 0) return;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2377,6 +2377,7 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
 void ToonzRasterBrushTool::draw() {
   if (m_isStraight) {
+    tglColor(TPixel32::Red);
     tglDrawSegment(m_firstPoint, m_lastPoint);
   }
   if (m_minThick == 0 && m_maxThick == 0 &&


### PR DESCRIPTION
This fixes an issue with the following drawing guides being invisible when the both the canvas' `Camera Box` and `Raster Bounding Box` are disabled:

- Raster brush tool's straight line guide
- Smart Raster brush tool's straight line guide
- Geometry Tool's Rectangle and Polygon guide