### PR TITLE
Timeline duplicate created after original in Level Strip

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -321,8 +321,10 @@ public:
       bool toBeModified,
       int subsampling = 0);  //!< Returns the image to be edited by the tool.
 
-  static TImage *touchImage();  //!< Returns a pointer to the actual image - the
-                                //!  one of the frame that has been selected.
+  static TImage *touchImage(
+      bool forDuplicate =
+          false);  //!< Returns a pointer to the actual image - the
+                   //!  one of the frame that has been selected.
 
   /*! \details      This function is necessary since tools are created before
 the main

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -3316,7 +3316,7 @@ void TCellSelection::duplicateFrame(int row, int col, bool multiple) {
     Preferences::instance()->setValue(EnableCreationInHoldCells, true, false);
   //------------------
 
-  TImage *img = toolHandle->getTool()->touchImage();
+  TImage *img = toolHandle->getTool()->touchImage(true);
   if (!img) {
     //----- Restore previous states of autocreation
     if (!isAutoCreateEnabled)


### PR DESCRIPTION
The `Duplicate` behavior in the `Level Strip` always creates the duplicate immediately after the original frame, renumbering everything after it.

The `Duplicate` behavior in the `Timeline`/`Xsheet` duplicates after the highest frame number anywhere left of the original frame being duplicated.  For example, if you had frames exposed in the order  3, 1, 2, 4 and you duplicate frame  1, frame 4 is renumbered to 5 and the duplicate is created in frame 4 because the last highest frame number was frame 3. (result: 3, 1, 4, 2, 5)  NOTE: This is actually the normal frame number assignment behavior for `Create Blank Drawing` and autocreation of a new drawing frame.

This PR will modify the duplicate logic from the Timeline/Xsheet to match the Level Strip and always immediately create the duplicate right after the original frame, renumbering everything after it.