### PR TITLE
Fix RGB Picker Tool's Pick Screen

### DIFF
--- a/toonz/sources/include/tools/screenpicker.h
+++ b/toonz/sources/include/tools/screenpicker.h
@@ -17,8 +17,6 @@ class ScreenPicker final : public QObject, public DVGui::ScreenBoard::Drawing {
 
   bool m_mousePressed, m_mouseGrabbed;
 
-  QWidget *m_pickWidget;
-
 public:
   ScreenPicker(QWidget *parent = 0);
 

--- a/toonz/sources/include/toonzqt/pickrgbutils.h
+++ b/toonz/sources/include/toonzqt/pickrgbutils.h
@@ -63,9 +63,9 @@ inline QRgb pickRGB(QOpenGLWidget *widget, const QPoint &pos) {
 \warning In general, grabbing an area outside the screen is not safe.
          This depends on the underlying window system.
 */
-QRgb DVAPI pickScreenRGB(const QRect &rect, QWidget *widget);
-inline QRgb pickScreenRGB(const QPoint &pos, QWidget *widget) {
-  return pickScreenRGB(QRect(pos.x(), pos.y(), 1, 1), widget);
+QRgb DVAPI pickScreenRGB(const QRect &rect);
+inline QRgb pickScreenRGB(const QPoint &pos) {
+  return pickScreenRGB(QRect(pos.x(), pos.y(), 1, 1));
 }
 
 #endif  // PICK_RGB_UTILS_H

--- a/toonz/sources/tnztools/screenpicker.cpp
+++ b/toonz/sources/tnztools/screenpicker.cpp
@@ -94,8 +94,6 @@ void ScreenPicker::mouseReleaseEvent(QWidget *widget, QMouseEvent *me) {
   QPoint pos(widget->mapToGlobal(me->pos()));
   m_geometry = QRect(QRect(m_start, QSize(1, 1)) | QRect(pos, QSize(1, 1)));
 
-  m_pickWidget = widget;
-
   // TimerEvents execution is delayed until all other events have been
   // processed.
   // In particular, we want to pick after the screen refreshes
@@ -110,7 +108,7 @@ void ScreenPicker::pick() {
   // Process them before picking.
   QCoreApplication::processEvents();
 
-  QColor color(pickScreenRGB(m_geometry, m_pickWidget));
+  QColor color(pickScreenRGB(m_geometry));
   RGBPicker::setCurrentColorWithUndo(
       TPixel32(color.red(), color.green(), color.blue()));
 

--- a/toonz/sources/toonzqt/pickrgbutils.cpp
+++ b/toonz/sources/toonzqt/pickrgbutils.cpp
@@ -57,7 +57,7 @@ QRgb pickRGB(QWidget *widget, const QRect &rect) {
 
 //------------------------------------------------------------------------------
 
-QRgb pickScreenRGB(const QRect &rect, QWidget *widget) {
+QRgb pickScreenRGB(const QRect &rect) {
 #ifdef MACOSX
 
   //   #Bugzilla 6514, possibly related to #QTBUG 23516
@@ -83,8 +83,8 @@ QRgb pickScreenRGB(const QRect &rect, QWidget *widget) {
 
 #endif
 
-  QImage img(widget->screen()
-                 ->grabWindow(widget->winId(), theRect.x(), theRect.y(),
+  QImage img(QApplication::primaryScreen()
+                 ->grabWindow(0, theRect.x(), theRect.y(),
                               theRect.width(), theRect.height())
                  .toImage());
   return meanColor(


### PR DESCRIPTION
This fixes `RGB Picker Tool`'s `Pick Screen` not working after updating for Qt5.15 (#1456)


