### PR TITLE
Fix context menu in rename fields

### DIFF
--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -774,6 +774,7 @@ protected:
   StyleEditor *m_editor;
 
   bool m_validatingName;
+  bool m_contextMenuActive;
 
 public:
   RenameStyleSet(QWidget *parent);
@@ -786,6 +787,7 @@ public:
 
 protected:
   void focusOutEvent(QFocusEvent *) override;
+  void contextMenuEvent(QContextMenuEvent *) override;
 
 protected slots:
   void renameSet();

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -756,7 +756,7 @@ void ChangeObjectHandle::selectCurrent(const QString &text) {
 //-----------------------------------------------------------------------------
 
 RenameColumnField::RenameColumnField(QWidget *parent, XsheetViewer *viewer)
-    : QLineEdit(parent), m_col(-1) {
+    : QLineEdit(parent), m_col(-1), m_contextMenuActive(false) {
   setFixedSize(20, 20);
   connect(this, SIGNAL(returnPressed()), SLOT(renameColumn()));
 }
@@ -795,6 +795,7 @@ void RenameColumnField::show(const QRect &rect, int col) {
   setText(QString(name.c_str()));
   selectAll();
 
+  m_contextMenuActive = false;
   QWidget::show();
   raise();
   setFocus();
@@ -823,6 +824,8 @@ void RenameColumnField::renameColumn() {
 //-----------------------------------------------------------------------------
 
 void RenameColumnField::focusOutEvent(QFocusEvent *e) {
+  if (m_contextMenuActive) return;
+
   std::wstring newName = text().toStdWString();
   if (!newName.empty())
     renameColumn();
@@ -830,6 +833,14 @@ void RenameColumnField::focusOutEvent(QFocusEvent *e) {
     hide();
 
   QLineEdit::focusOutEvent(e);
+}
+
+//-----------------------------------------------------------------------------
+
+void RenameColumnField::contextMenuEvent(QContextMenuEvent *e) {
+  m_contextMenuActive = true;
+  QLineEdit::contextMenuEvent(e);
+  m_contextMenuActive = false;
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -149,6 +149,8 @@ class RenameColumnField final : public QLineEdit {
 
   TXsheetHandle *m_xsheetHandle;
 
+  bool m_contextMenuActive;
+
 public:
   RenameColumnField(QWidget *parent, XsheetViewer *viewer);
   ~RenameColumnField() {}
@@ -161,6 +163,7 @@ public:
 
 protected:
   void focusOutEvent(QFocusEvent *) override;
+  void contextMenuEvent(QContextMenuEvent *) override;
 
 protected slots:
   void renameColumn();

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -7375,7 +7375,8 @@ void ClickableLabel::mousePressEvent(QMouseEvent *event) {
 // RenameStyleSet
 //-----------------------------------------------------------------------------
 
-RenameStyleSet::RenameStyleSet(QWidget *parent) : QLineEdit(parent) {
+RenameStyleSet::RenameStyleSet(QWidget *parent)
+    : QLineEdit(parent), m_contextMenuActive(false) {
   m_editor = dynamic_cast<StyleEditor *>(parent);
 
   setFixedSize(200, 20);
@@ -7404,7 +7405,8 @@ void RenameStyleSet::show(const QRect &rect) {
   setText(name);
   selectAll();
 
-  m_validatingName = false;
+  m_validatingName    = false;
+  m_contextMenuActive = false;
   QWidget::show();
   raise();
   setFocus();
@@ -7443,6 +7445,8 @@ void RenameStyleSet::renameSet() {
 //-----------------------------------------------------------------------------
 
 void RenameStyleSet::focusOutEvent(QFocusEvent *e) {
+  if (m_contextMenuActive) return;
+
   if (!m_validatingName) {
     std::wstring newName = text().toStdWString();
     if (!newName.empty())
@@ -7452,4 +7456,12 @@ void RenameStyleSet::focusOutEvent(QFocusEvent *e) {
   }
 
   QLineEdit::focusOutEvent(e);
+}
+
+//-----------------------------------------------------------------------------
+
+void RenameStyleSet::contextMenuEvent(QContextMenuEvent *e) {
+  m_contextMenuActive = true;
+  QLineEdit::contextMenuEvent(e);
+  m_contextMenuActive = false;
 }


### PR DESCRIPTION
This fixes an issue where a renaming action is canceled when trying to bring up a context menu within the rename field.

This applies to the following
- Renaming column names in the `Timeline`/`Xsheet`
- Renaming style sets in the `Style Editor`