### PR TITLE
Fix Flow Paint Brush Iwa Fx Swatch Crash

### DIFF
--- a/toonz/sources/toonzqt/swatchviewer.cpp
+++ b/toonz/sources/toonzqt/swatchviewer.cpp
@@ -1058,8 +1058,10 @@ SwatchViewer::ContentRender::ContentRender(TRasterFx *fx, int frame,
   m_info.m_cameraBox = TRectD(-0.5 * TPointD(m_size.lx, m_size.ly),
                               TDimensionD(m_size.lx, m_size.ly));
 
-  if (m_fx->getAlias(m_frame, m_info).find("plasticDeformerFx") !=
-          std::string::npos &&
+  if ((m_fx->getAlias(m_frame, m_info).find("plasticDeformerFx") !=
+           std::string::npos ||
+       m_fx->getAlias(m_frame, m_info).find("iwa_FlowPaintBrushFx") !=
+           std::string::npos) &&
       QThread::currentThread() == qGuiApp->thread()) {
     m_info.m_offScreenSurface.reset(new QOffscreenSurface());
     m_info.m_offScreenSurface->setFormat(QSurfaceFormat::defaultFormat());


### PR DESCRIPTION
This fixes a crash reported in the T2D Discord that happens when you turn on the `Preview` or `Camera Preview` in the `Flow Paint Brush Iwa` Fx's `Swatch Viewer`.

Crash was caused when rendering to an offline GL Context but no surface created for it to use.  A surface is now created.