### PR TITLE
Fix max fill depth calculations

### DIFF
--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -1047,7 +1047,7 @@ void fullColorFill(const TRaster32P &ras, const FillParameters &params,
   TPointD m_firstPoint, m_clickPoint;
 
   // convert fillDepth range from [0 - 15] to [0 - 255]
-  fillDepth = ((15 - fillDepth) << 4) | (15 - fillDepth);
+  fillDepth = (fillDepth << 4) | fillDepth;
 
   std::stack<FillSeed> seeds;
   std::map<int, std::vector<std::pair<int, int>>> segments;

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -510,6 +510,8 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
   int paint = params.m_styleId;
   int fillDepth =
       params.m_shiftFill ? params.m_maxFillDepth : params.m_minFillDepth;
+  if (xsheet)  // convert fillDepth range from [0 - 15] to [0 - 255]
+    fillDepth = (fillDepth << 4) | fillDepth;
   TRasterCM32P tempRaster, cr, refCMRaster;
   int styleIndex                                 = GAP_CLOSE_TEMP;
   int fakeStyleIndex                             = GAP_CLOSE_USED;


### PR DESCRIPTION
Fixing the following 2 issues...

- In v1.4 I had reversed the meaning of Raster's fill depth due to what I perceived were backward results when compared to Smart Raster fills.

After further review with different examples, the original way was correct, but the fill results don't quite match how Smart Raster fills using similar drawings and the same fill depth settings.  Will review this difference at a later time.

- When Smart Raster refer visible is used, it uses a flattened  and rasterized image to do the fill.  Fixed the fill depth value calculation needs to use the Raster logic rather than the Smart Raster logic otherwise the results are reversed.

