### PR TITLE
Link libdeflate for Linux builds

### DIFF
--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -6,6 +6,7 @@ sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev
 sudo apt-get install -y nasm yasm libgnutls28-dev libunistring-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libfreetype6-dev libopencore-amrnb-dev libopencore-amrwb-dev libspeex-dev libsoxr-dev libopenjp2-7-dev
 sudo apt-get install -y python3-pip
 sudo apt-get install -y build-essential libgirepository1.0-dev autotools-dev intltool gettext libtool patchelf autopoint libusb-1.0-0 libusb-1.0-0-dev
+sudo apt-get install -y libdeflate-dev
 
 pip3 install --upgrade pip
 pip3 install numpy

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -541,6 +541,8 @@ elseif(BUILD_ENV_UNIXLIKE)
         find_library(GPHOTO2_PORT_LIB gphoto2_port)
         message("**************** gphoto2_port lib:" ${GPHOTO2_PORT_LIB})
     endif()
+	
+	find_library(DEFLATE_LIB deflate)
 endif()
 
 

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -164,6 +164,7 @@ elseif(BUILD_ENV_UNIXLIKE)
     # Generic Unix
     set(EXTRA_LIBS
         ${TNZLIBS}
+        ${DEFLATE_LIB}
     )
 
     if(BUILD_TARGET_WIN)


### PR DESCRIPTION
Something changed in one of the package dependencies that is now installing libdeflate onto the Linux build environments in GitHub. This causes Linux builds to fail with the same messages as found in #1248.  We're still building using OpenEXR 2.3 so it appears somethings else we are currently building with now requires libdeflate.

This replaces PR #1274, and hopefully fixes #1248, which was the original attempt to fix linux builds but wasn't needed at the time since github builds were not failing.

I will merge as soon as I see that all checks have passed.