### PR TITLE
Fix Stylus event processing

### DIFF
--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -125,6 +125,8 @@ class FillTool final : public QObject, public TTool {
 
   int m_firstFrameIdx, m_lastFrameIdx;
 
+  bool m_filledOnPress;
+
 public:
   FillTool(int targetType);
 

--- a/toonz/sources/tnztools/fullcolorfilltool.h
+++ b/toonz/sources/tnztools/fullcolorfilltool.h
@@ -42,6 +42,8 @@ class FullColorFillTool final : public QObject, public TTool {
   TFrameId m_firstFrameId, m_veryFirstFrameId;
   int m_firstFrameIdx, m_lastFrameIdx;
 
+  bool m_filledOnPress;
+
 public:
   FullColorFillTool();
 
@@ -55,6 +57,7 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
+  void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override;
 
   void resetMulti();
   bool onPropertyChanged(std::string propertyName) override;

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -412,11 +412,12 @@ int main(int argc, char *argv[]) {
 
   // Enable to render smooth icons on high dpi monitors
   a.setAttribute(Qt::AA_UseHighDpiPixmaps);
+
 #if defined(_WIN32)
   // Compress tablet events with application attributes instead of implementing
   // the delay-timer by ourselves
   a.setAttribute(Qt::AA_CompressHighFrequencyEvents);
-  a.setAttribute(Qt::AA_CompressTabletEvents);
+//  a.setAttribute(Qt::AA_CompressTabletEvents);
 #endif
 
 #ifdef _WIN32

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -324,7 +324,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       onContextMenu(e->pos(), e->globalPos());
     }
 #endif
-
+    e->accept();
   } break;
   case QEvent::TabletRelease: {
 #ifdef MACOSX
@@ -346,6 +346,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     } else
       m_tabletEvent = false;
 #endif
+    e->accept();
   } break;
   case QEvent::TabletMove: {
 #ifdef MACOSX
@@ -383,9 +384,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     // So I fire the interval timer in order to limit the following process
     // to be called in 50fps in maximum.
     if (curPos != m_lastMousePos && !m_isBusyOnTabletMove) {
-#ifndef LINUX
       m_isBusyOnTabletMove = true;
-#endif
       TMouseEvent mouseEvent;
       initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
       QTimer::singleShot(20, this, SLOT(releaseBusyOnTabletMove()));
@@ -400,12 +399,6 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
         m_tabletState       = Released;
         mouseEvent.m_button = Qt::LeftButton;
         onRelease(mouseEvent);
-      } else if (m_tabletState == StartStroke) {
-        // Single tap of stylus still records TableMoves before TabletRelease.
-        // Skip the 1st TabletMove to give time for TabletRelease to show up
-        // This way we don't try to do a LeftButtonDrag operation (i.e. normal
-        // fill) too soon.
-        m_tabletState = OnStroke;
       } else {
         m_tabletMove = true;
         onMove(mouseEvent);  // m_tabletState is set to OnStrole here
@@ -415,6 +408,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     // call the fake leave event if the pen is hovering the viewer edge
     if (!isHoveringInsideViewer) onLeave();
 #endif
+    if (e->button() != Qt::NoButton) e->accept();
   } break;
   default:
     break;


### PR DESCRIPTION
This PR makes some modification to stylus event processing to address the following issues.

- Fixes "floaty" feeling when drawing (impacts future v1.5 only)
   - User was feeling a slight lag in drawing making it feel a little off and causing drawing errors.  I believe this was due to the compression of stylus events which might have been dropping too many movement points.  Removed the stylus event compression appears to have corrected it.
- Alternate fix for #1240 to prevent accidental normal fills when tapping
   - The original fix ignored the 1st tablet move event following a press event.  This didn't fix the issue for users whose tablet generated multiple move events before the release when tapping to fill. I think this was happening because the fill from the stylus press would pause processing events too much that when it regained control, the mouse appeared to have jumped to a different position and created 1 or more move events at the new location before the release.  Additionally, the prior fix caused the start of an arc to have a flat line.  It was more obvious the faster you tried to draw complete circles.
   - Reverted the prior fix and modified the fill tool.  The 1st drag-fill event after the initial press-fill will be ignored and the click point  switched to the current mouse position so subsequent drag-fills at the same exact point are ignored.
- Fix raster/smart raster selection tool deformation lag on Linux builds
   - Partially reverses a change made in #640 that was supposed to fix a stylus drawing issue with geometry tool's arc/multi-arc on Linux builds only.  A better fix was actually made by a Linux hover-move fix ported from OT so it was safe to remove the prior change.
- Fix issue stylus drawing with geometry tool's arc/multi-arc on Windows builds (impacts v1.4.4 only)
  - Some tablets need a tablet event accepted response which was removed entirely in a Linux hover-move fix ported from OT. This broke it for T2D Windows builds...for me at least.
  - Readded tablet accept response for press, release and drag-move events.  Hover-move events won't return any tablet response.
  - NOTE: I still have this issue with v1.5 on my system.  The accepted response doesn't appear to be acknowledged on my system so the stylus press/release is immediately followed by a mouse press-release. Will need to find an alternate fix for others that may have the same problem.