### PR TITLE
Fix Exporting/Importing OCA folder

### DIFF
--- a/toonz/sources/toonz/ocaio.cpp
+++ b/toonz/sources/toonz/ocaio.cpp
@@ -691,6 +691,9 @@ void ImportOCACommand::execute() {
     importEnabled = (ret == 1);
   }
 
+  // Check if this is a directory or the actual file
+  if (TFileStatus(fp).isDirectory()) fp = fp + fp.withoutParentDir();
+
   QString ocafile           = fp.getQString();
   OCAInputData ocaInputData = OCAInputData(0, false, false);
   QJsonObject ocaObject;


### PR DESCRIPTION
This corrects OCA Export and Import as follows:

- Export:  Per OCA specs, the actual OCA file and directory containing the image files are now created inside a folder of the same name as the actual OCA file (i.e `C:\OCA Exports\myscene.oca\myscene.oca`)
  - Change the name of the subdirectory containing the level files to be the name of the export + "_files" (i.e `C:\OCA Exports\myscene.oca\myscene_files`)

- Import: Handles importing an OCA folder or an actual OCA file.
  - In case of folder, it looks for the actual OCA file of the same name within the selected folder.