### PR TITLE
Fix stylus event processing (Part 2)

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -408,7 +408,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     // call the fake leave event if the pen is hovering the viewer edge
     if (!isHoveringInsideViewer) onLeave();
 #endif
-    if (e->button() != Qt::NoButton) e->accept();
+    if (e->buttons() != Qt::NoButton) e->accept();
   } break;
   default:
     break;
@@ -520,6 +520,13 @@ void SceneViewer::onMove(const TMouseEvent &event) {
   // in case mouseReleaseEvent is not called, finish the action for the previous
   // button first.
   if (m_mouseButton != Qt::NoButton && event.m_buttons == Qt::NoButton) {
+#ifdef _WIN32
+    // Somehow, even though we are actively dragging QT sometimes loses the
+    // button being pressed but still think there is pressure. This causes the
+    // stylus to relase. Don't treat these as valid pen events because the
+    // pressure values appear incorrect. Skip it insteead.
+    if (event.m_isTablet && event.m_pressure != 0.0) return;
+#endif
     TMouseEvent preEvent = event;
     preEvent.m_button    = m_mouseButton;
     onRelease(preEvent);

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -364,7 +364,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     }
 #endif
     QPointF curPos = e->posF() * getDevPixRatio();
-#if defined(_WIN32)
+
     // Use the application attribute Qt::AA_CompressTabletEvents instead of the
     // delay timer
     // 21/4/2021 High frequent tablet event caused slowness when deforming with
@@ -379,16 +379,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
         m_isBusyOnTabletMove = true;
         QTimer::singleShot(20, this, SLOT(releaseBusyOnTabletMove()));
       }
-#else
-    // It seems that the tabletEvent is called more often than mouseMoveEvent.
-    // So I fire the interval timer in order to limit the following process
-    // to be called in 50fps in maximum.
-    if (curPos != m_lastMousePos && !m_isBusyOnTabletMove) {
-      m_isBusyOnTabletMove = true;
-      TMouseEvent mouseEvent;
-      initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
-      QTimer::singleShot(20, this, SLOT(releaseBusyOnTabletMove()));
-#endif
+
       // cancel stroke to prevent drawing while floating
       // 23/1/2018 There is a case that the pressure becomes zero at the start
       // and the end of stroke. For such case, stroke should not be cancelled.


### PR DESCRIPTION
Qt5.15 is generating stylus move (TableMove) events differently on 2 different Windows laptop-tablet than it used to when we were on Qt5.9.  Using the customized version of Qt5.15 seems to also be playing a small role in some situations as well.  This appears to be an issue with how the WinTab drivers is generating events, and some of these issues may not be present with users that have separate graphics tablets.

This PR will address the following issues which fixes it in my system but shouldn't impact graphics tablet users:

- **Single tap causing 2 taps (base Qt5.15 issue; Windows only)**

Doing a simple tap on the canvas produces a TabletPress+TableRelease followed immediately by a MousePress+MouseRelease instead of these events being interleaved like i was i Qt5.9.  Because of this, it acts like it's tapped 2x (not double-click) and causes issues with `arc`, `multi-arc` and `polyline` modes. 

Added logic to ignore the MousePress if we just processed a TabletRelease.

- **Loss of pen pressure when using WinTab (Custom Qt5.15 issue; Windows only)**

On my 1 laptop-tablet, it appears the TabletMove events randomly are missing that the button is pressed (active drawing) and as such immediately turns off stylus drawing.   Then a MousePress event shows up and reinitializes drawing from mouse instead of stylus and ignores all pressure coming from valid stylus events.

Added logic to ignore TableMove events that has pressure but no button press.  I determined I cannot use the pressure in these bad stylus events because it incorrect. 

- **Drawing circles starts off with a flat line (Not a Qt related issue, impacts all OS)**

The current logic for processing stylus moves only processes TabletMove events every 20ms due to the volume of these events being generated.  This logic was added many years ago to address an extreme lag issue with scaling Raster images, however the way it was implemented affected all tools. It is also the source of some users complaints about drawing experience.

Recently introduced/modified logic for Windows TabletMove events corrects this issue and made drawing feel more fluid.  I've unified the logic so it applies to all OSes.  I've verified it helps with Linux builds but I don't have a mac to check.
