### PR TITLE
Fix crash opening PLI (Vector) files and folders

### DIFF
--- a/toonz/sources/common/timage/tlevel.cpp
+++ b/toonz/sources/common/timage/tlevel.cpp
@@ -11,7 +11,8 @@ TLevel::TLevel()
     : TSmartObject(m_classCode)
     , m_name("")
     , m_table(new Table())
-    , m_palette(0) {}
+    , m_palette(0)
+    , m_partialLoad(false) {}
 
 //-------------------------------------------------
 

--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -1943,6 +1943,7 @@ void autoclose(double factor, vector<VIStroke *> &s, int ii, int jj,
 //-----------------------------------------------------------------------------
 
 TPointD inline getTangent(const IntersectedStroke &item) {
+  if (!item.m_edge.m_s) return TPointD();
   return (item.m_gettingOut ? 1 : -1) *
          item.m_edge.m_s->getSpeed(item.m_edge.m_w0, item.m_gettingOut);
 }
@@ -2484,6 +2485,8 @@ static TRegion *findRegion(VIList<Intersection> &intList, Intersection *p1,
       }
 
     } while (!p2->m_nextIntersection);
+
+    if (!p2->m_edge.m_s) continue;
 
     nextp1 = p2->m_nextIntersection;
     nextp2 = p2->m_nextStroke;

--- a/toonz/sources/image/pli/pli_io.cpp
+++ b/toonz/sources/image/pli/pli_io.cpp
@@ -747,6 +747,14 @@ void ParsedPliImp::loadInfo(bool readPlt, TPalette *&palette,
   // palette = new TPalette();
   // for (int i=0; i<256; i++)
   //  palette->getPage(0)->addStyle(TPixel::Black);
+
+  // File is missing frames!  Load what we can.
+  // Last frame is likely an unusable image. Allow to load in case it was also
+  // the 1st frame, so we don't crash.
+  if (m_framesNumber > m_frameOffsInFile.size()) {
+    m_framesNumber = m_frameOffsInFile.size();
+    throw TException("Not all frames loaded.");
+  }
 }
 
 /*=====================================================================*/

--- a/toonz/sources/image/pli/tiio_pli.cpp
+++ b/toonz/sources/image/pli/tiio_pli.cpp
@@ -811,7 +811,17 @@ TLevelP TLevelReaderPli::loadInfo() {
         (majorVersionNumber != 5 || minorVersionNumber < 5))
       return m_level;
     TPalette *palette = 0;
-    m_pli->loadInfo(m_readPalette, palette, m_contentHistory);
+    try {
+      m_pli->loadInfo(m_readPalette, palette, m_contentHistory);
+    } catch (TException &e) {
+      QString msg = QString::fromStdString(::to_string(e.getMessage()));
+      if (msg.contains("Not all frames loaded"))
+        m_level->setPartialLoad(true);
+      else
+        throw e;
+    } catch (...) {
+      throw;
+    }
     if (palette) m_level->setPalette(palette);
 
     for (int i = 0; i < m_pli->getFrameCount(); i++)

--- a/toonz/sources/include/tlevel.h
+++ b/toonz/sources/include/tlevel.h
@@ -30,6 +30,8 @@ private:
   Table *m_table;
   TPalette *m_palette;
 
+  bool m_partialLoad;
+
 public:
   TLevel();
   ~TLevel();
@@ -66,6 +68,9 @@ public:
 
   TPalette *getPalette();
   void setPalette(TPalette *);
+
+  void setPartialLoad(bool partial) { m_partialLoad = partial; }
+  bool isPartialLoad() { return m_partialLoad; }
 };
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -885,7 +885,8 @@ item.m_validInfo = true;*/
 //! calculated by using a dedicated thread and therefore cannot be simply
 //! classified as *valid* or *invalid* infos...
 void FileBrowser::readFrameCount(Item &item) {
-  if (TFileType::isViewable(TFileType::getInfo(item.m_path))) {
+  if (!item.m_isFolder &&
+      TFileType::isViewable(TFileType::getInfo(item.m_path))) {
     if (isMultipleFrameType(item.m_path.getType()))
       item.m_frameCount = m_frameCountReader.getFrameCount(item.m_path);
     else

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1228,6 +1228,16 @@ void TXshSimpleLevel::load() {
     lr->setUseExactPath(getScene()->isLoading());
 
     TLevelP level = lr->loadInfo();
+    if (level->isPartialLoad()) {
+      QString msg =
+          QString(
+              "File '%1' partially loaded. Not all frames were found. Possible "
+              "file corruption. Loaded what could be found.\nRecommend "
+              "replacing any bad frames in Level Strip and saving.")
+              .arg(QString::fromStdWString(m_path.getWideString()));
+      QMessageBox::warning(0, "File load warning", msg);
+      setDirtyFlag(true);
+    }
     if (level->getFrameCount() > 0) {
       const TImageInfo *info = lr->getImageInfo(level->begin()->first);
 


### PR DESCRIPTION
This fixes 3 issues regarding opening files/folders with a .PLI extension

- **Prevent crash opening partially corrupted PLI files (missing frames)**

Sometimes a PLI file is partially corrupted in such a way that it's missing the last few frames.  This leads to a crash when it tries to work with the number of frames indicated in the file but not all were loaded.

Added logic to detect when the number of frames read is less than what was indicated in the file.  Rather than failing, it will keep whatever it was able to read. Usually the corrupted frame is the last frame missing an image. A warning is displayed and the level is immediately flagged as dirty so that the user is forced to deal with it when saving.

- **Prevent crash opening folder named with .PLI extension**

When the browser or any dialog that accesses the user's drive encountered a folder that ends with `.PLI`, it would crash when it failed to open and read it to get image information.  Theoretically this could happen with any supported image file, but some handle the error properly.

Logic added to only open browser items to get image information if it is not a folder.

- **Prevent crash loading region information in PLI file (strokeless edge)**

There are some scenarios where the region information in the PLI file contains edge information with no stroke.  In some cases this cause a crash.

Added logic to ignore edge information if it is missing stroke information.  This primarily seems to impact loading files that have this scenario.  I don't know what normally causes this scenario so I am not sure what impact the change will have during normal vector drawing/filling operations.
