### PR TITLE
Fix used style detection for Fill and Style Picker tools

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2624,6 +2624,11 @@ void FillTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
     if (params.m_fillType == LINES && m_targetType == TTool::ToonzImage)
       m_normalLineFillTool->leftButtonDown(pos, e);
     else {
+      int fillMode =
+          params.m_fillType == AREAS ? 0 : params.m_fillType == LINES ? 1 : 2;
+      int currentStyleId = pick(getImage(false), pos, -1, fillMode);
+      if (currentStyleId == -1 || currentStyleId == params.m_styleId) return;
+
       applyFill(getImage(true), pos, params, e.isShiftPressed(),
              m_level.getPointer(), getCurrentFid(), m_autopaintLines.getValue(),
              m_closeRasterGaps.getIndex() > 0, m_closeRasterGaps.getIndex() > 1,
@@ -2675,22 +2680,13 @@ void FillTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     if (m_clickPoint == pos) return;
     TImageP img = getImage(true);
     int styleId = params.m_styleId;
-    if (TVectorImageP vi = img) {
-      TRegion *r = vi->getRegion(pos);
-      if (r && r->getStyle() == styleId) return;
-    } else if (TToonzImageP ti = img) {
-      TRasterCM32P ras = ti->getRaster();
-      if (!ras) return;
-      TPointD center = ras->getCenterD();
-      TPoint ipos    = convert(pos + center);
-      if (!ras->getBounds().contains(ipos)) return;
-      TPixelCM32 pix = ras->pixels(ipos.y)[ipos.x];
-      if (pix.getPaint() == styleId) {
-        invalidate();
-        return;
-      }
-      //TSystem::outputDebug("ok. pix=" + std::to_string(pix.getTone()) + "," +
-      //                     std::to_string(pix.getPaint()));
+    TVectorImageP vi = img;
+    TToonzImageP ti  = img;
+    if (vi || ti) {
+      int fillMode =
+          params.m_fillType == AREAS ? 0 : params.m_fillType == LINES ? 1 : 2;
+      int currentStyleId = pick(img, pos, -1, fillMode);
+      if (currentStyleId == -1 || currentStyleId == styleId) return;
     } else
       return;
     int closeStyleIndex = m_closeStyleIndex.getStyleIndex();
@@ -2980,7 +2976,8 @@ void FillTool::draw() {
 
 //-----------------------------------------------------------------------------
 
-int FillTool::pick(const TImageP &image, const TPointD &pos, const int frame) {
+int FillTool::pick(const TImageP &image, const TPointD &pos, const int frame,
+                   const int mode) {
   TToonzImageP ti  = image;
   TVectorImageP vi = image;
   if (!ti && !vi) return 0;
@@ -3003,7 +3000,7 @@ int FillTool::pick(const TImageP &image, const TPointD &pos, const int frame) {
     pickPos.y /= dpiScale.y;
   }
   // thin stroke can be picked with 10 pixel range
-  return picker.pickStyleId(pickPos, 10.0, scale2);
+  return picker.pickStyleId(pickPos, 10.0, scale2, mode);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -150,7 +150,8 @@ public:
   void draw() override;
 
   // if frame = -1 it uses current frame
-  int pick(const TImageP &image, const TPointD &pos, const int frame = -1);
+  int pick(const TImageP &image, const TPointD &pos, const int frame = -1,
+           const int mode = 2);
   int pickOnionColor(const TPointD &pos);
 
   void onEnter() override;

--- a/toonz/sources/tnztools/stylepickertool.cpp
+++ b/toonz/sources/tnztools/stylepickertool.cpp
@@ -222,8 +222,8 @@ void StylePickerTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   int subsampling = level->getImageSubsampling(getCurrentFid());
   StylePicker picker(getViewer()->viewerWidget(), image);
   TPointD pickPos(TScale(1.0 / subsampling) * pos + TPointD(-0.5, -0.5));
-  int inkStyleId = picker.pickStyleId(pickPos, 10.0, scale2, 1);
-  int paintStyleId = picker.pickStyleId(pickPos, 10.0, scale2, 0);
+  int inkStyleId   = std::max(picker.pickStyleId(pickPos, 10.0, scale2, 1), 0);
+  int paintStyleId = std::max(picker.pickStyleId(pickPos, 10.0, scale2, 0), 0);
   int tone = picker.pickTone(pickPos);
   controller->notifyStylePassivePicked(inkStyleId, paintStyleId, tone);
 }


### PR DESCRIPTION
This PR unifies the logic used in the Fill tool and the Style Picker tool to detect the style under the cursor.

This was initially done because the logic in the Fill tool was causing multiple fill actions to be record whenever the stylus moved over a `Line`.  As I was working on fixing it, I noticed some issues with the Style Picker tool not always picking the right style depending on the mode.

The Fill tool, in `Normal` mode would only check for styles used in regions under the cursor.  Because of this, whenever it crossed over a `Line`, it wouldn't detect any style and try to fill it creating multiple fill actions that didn't do anything. Since the Fill tool already used Style Picker logic for non-`Normal` modes, I modified the logic to use the same one.

As I was fixing the Fill tool, I noticed the Style Picker logic was not correctly accounting for the picking `Mode` and would return the wrong information so fixed that as well.