### PR TITLE
Fix dragging camera cell

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3832,9 +3832,10 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
     } else {
       bool hasDragBar = Preferences::instance()->isShowDragBarsEnabled();
 
-      bool isInDragArea = o->rect(PredefinedRect::DRAG_AREA)
-                              .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
-                              .contains(mouseInCell);
+      bool isInDragArea =
+          col < 0 ? false : o->rect(PredefinedRect::DRAG_AREA)
+                                .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
+                                .contains(mouseInCell);
       bool isSoundPreviewArea =
           isSoundColumn &&
           o->rect(PredefinedRect::PREVIEW_TRACK)


### PR DESCRIPTION
This fixes a bug introduced with #1330.  When using drag bars, if you click and drag the camera cell where a drag bar would normally be found in other column cells, it causes a blank column to appear next to it.

Corrected the logic to ignore the drag bar area for camera column cells