### PR TITLE
Fix Qt::AA_UseDesktopOpenGL setting (Windows only)

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -333,6 +333,12 @@ int main(int argc, char *argv[]) {
   // constructed. Available from Qt 5.6.
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
+#ifdef Q_OS_WIN
+  //	Since currently Tahoma does not work with OpenGL of software or
+  // angle,	force Qt to use desktop OpenGL
+  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL, true);
+#endif
+
   QApplication a(argc, argv);
 
 #ifdef MACOSX
@@ -368,14 +374,6 @@ int main(int argc, char *argv[]) {
   };
 
   a.installNativeEventFilter(new OSXMouseDragFilter);
-#endif
-
-#ifdef Q_OS_WIN
-  //	Since currently Tahoma does not work with OpenGL of software or
-  // angle,	force Qt to use desktop OpenGL
-  // FIXME: This options should be called before constructing the application.
-  // Thus, ANGLE seems to be enabled as of now.
-  a.setAttribute(Qt::AA_UseDesktopOpenGL, true);
 #endif
 
   // Some Qt objects are destroyed badly without a living qApp. So, we must


### PR DESCRIPTION
The Qt::AA_UseDesktopOpenGL attribute must be set before the instantiation of the application but since OT went opensource, it has always been set incorrectly afterwards.  As such T2D (and OT) have apparently been using ANGLE rather than OpenGL.

I've moved the setting of this attribute to the correct position.

I'm not sure of the full impact of this change, however when I compared against the recent nightly I did notice my preview renders of a scene composed with only vector levels were faster.

Additional testing is needed to check for any negative effects of this change.  Possible this change may affect users in different ways depending on their system.

EDIT: The change of location doesn't appear to have any impact when building on Qt5.9, still used by T2D's fix releases.  As such, this will only be applied to v1.5.