### PR TITLE
Clip ZeraryFx Columns

### DIFF
--- a/toonz/sources/include/toonz/txshzeraryfxcolumn.h
+++ b/toonz/sources/include/toonz/txshzeraryfxcolumn.h
@@ -88,6 +88,8 @@ Return \b TZeraryColumnFx.
    * icon. */
   void updateIcon() {}
 
+  std::vector<TXshColumn *> getColumnMasks();
+
 private:
   // not implemented
   TXshZeraryFxColumn &operator=(const TXshZeraryFxColumn &);

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1895,7 +1895,25 @@ void TZeraryColumnFx::setZeraryFx(TFx *fx) {
 
 std::string TZeraryColumnFx::getAlias(double frame,
                                       const TRenderSettings &info) const {
-  return "TZeraryColumnFx[" + m_fx->getAlias(frame, info) + "]";
+  std::string rdata = "";
+
+  if (m_zeraryFxColumn) {
+    std::vector<TXshColumn *> masks = m_zeraryFxColumn->getColumnMasks();
+    if (masks.size()) {
+      std::string maskAlias = "masked";
+      for (int i = 0; i < masks.size(); i++) {
+        TXshLevelColumn *mask = masks[i]->getLevelColumn();
+        if (!mask) break;
+
+        if (mask->isInvertedMask()) maskAlias += "inv";
+        if (mask->canRenderMask()) maskAlias += "render";
+        break;
+      }
+      rdata += "," + maskAlias;
+    }
+  }
+
+  return "TZeraryColumnFx[" + m_fx->getAlias(frame, info) + rdata + "]";
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -241,4 +241,25 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
 
 //-----------------------------------------------------------------------------
 
+std::vector<TXshColumn *> TXshZeraryFxColumn::getColumnMasks() {
+  std::vector<TXshColumn *> masks;
+
+  if (m_index <= 0) return masks;
+
+  TXsheet *xsh = getXsheet();
+  for (int i = m_index - 1; i >= 0; i--) {
+    TXshColumn *mcol = xsh->getColumn(i);
+
+    if (!mcol || mcol->isEmpty()) break;
+    if (mcol->getColumnType() == TXshColumn::eMeshType)
+      continue;  // ignore mesh levels
+    if (!mcol->isMask() || !mcol->isPreviewVisible()) break;
+    masks.push_back(mcol);
+  }
+
+  return masks;
+}
+
+//-----------------------------------------------------------------------------
+
 PERSIST_IDENTIFIER(TXshZeraryFxColumn, "zeraryFxColumn")


### PR DESCRIPTION
This enhancement allows user to apply a Clipping Mask against any Zerary Fx (column based fx), like checkboard, gradients, clouds, etc.

Per normal fx viewing, you'll need to be in `Preview` mode in order to see the effect of the clipping mask on the fx.
