### PR TITLE
Fix multi-screen detection issues

### DIFF
--- a/toonz/sources/include/tools/screenpicker.h
+++ b/toonz/sources/include/tools/screenpicker.h
@@ -14,6 +14,7 @@ class ScreenPicker final : public QObject, public DVGui::ScreenBoard::Drawing {
 
   QPoint m_start;
   QRect m_geometry;
+  QWidget *m_widget;
 
   bool m_mousePressed, m_mouseGrabbed;
 

--- a/toonz/sources/include/toonzqt/pickrgbutils.h
+++ b/toonz/sources/include/toonzqt/pickrgbutils.h
@@ -63,9 +63,9 @@ inline QRgb pickRGB(QOpenGLWidget *widget, const QPoint &pos) {
 \warning In general, grabbing an area outside the screen is not safe.
          This depends on the underlying window system.
 */
-QRgb DVAPI pickScreenRGB(const QRect &rect);
-inline QRgb pickScreenRGB(const QPoint &pos) {
-  return pickScreenRGB(QRect(pos.x(), pos.y(), 1, 1));
+QRgb DVAPI pickScreenRGB(const QRect &rect, QWidget *widget);
+inline QRgb pickScreenRGB(const QPoint &pos, QWidget *widget) {
+  return pickScreenRGB(QRect(pos.x(), pos.y(), 1, 1), widget);
 }
 
 #endif  // PICK_RGB_UTILS_H

--- a/toonz/sources/tnztools/screenpicker.cpp
+++ b/toonz/sources/tnztools/screenpicker.cpp
@@ -16,6 +16,8 @@
 #include <QCoreApplication>
 #include <QCursor>
 #include <QTimer>
+#include <QScreen>
+#include <QApplication>
 
 #include "tools/screenpicker.h"
 
@@ -93,6 +95,12 @@ void ScreenPicker::mouseReleaseEvent(QWidget *widget, QMouseEvent *me) {
 
   QPoint pos(widget->mapToGlobal(me->pos()));
   m_geometry = QRect(QRect(m_start, QSize(1, 1)) | QRect(pos, QSize(1, 1)));
+  m_widget   = widget;
+  if (widget->screen() != QApplication::primaryScreen()) {
+    m_geometry.adjust(
+        -widget->screen()->geometry().x(), -widget->screen()->geometry().y(),
+        -widget->screen()->geometry().x(), -widget->screen()->geometry().y());
+  }
 
   // TimerEvents execution is delayed until all other events have been
   // processed.
@@ -108,7 +116,7 @@ void ScreenPicker::pick() {
   // Process them before picking.
   QCoreApplication::processEvents();
 
-  QColor color(pickScreenRGB(m_geometry));
+  QColor color(pickScreenRGB(m_geometry, m_widget));
   RGBPicker::setCurrentColorWithUndo(
       TPixel32(color.red(), color.green(), color.blue()));
 

--- a/toonz/sources/toonz/aboutpopup.cpp
+++ b/toonz/sources/toonz/aboutpopup.cpp
@@ -1,6 +1,7 @@
 #include "aboutpopup.h"
 #include "tenv.h"
 #include "tsystem.h"
+#include "tapp.h"
 
 #include <QPushButton>
 #include <QLabel>
@@ -8,6 +9,7 @@
 #include <QScreen>
 #include <QTextEdit>
 #include <QDesktopServices>
+#include <QMainWindow>
 
 AboutClickableLabel::AboutClickableLabel(QWidget* parent, Qt::WindowFlags f)
     : QLabel(parent) {
@@ -23,7 +25,7 @@ void AboutClickableLabel::mousePressEvent(QMouseEvent* event) {
 AboutPopup::AboutPopup(QWidget* parent)
     : DVGui::Dialog(parent, true, true, "About Tahoma2D") {
   setFixedWidth(360);
-  setFixedHeight(350);
+  setFixedHeight(383);
 
   setWindowTitle(tr("About Tahoma2D"));
   setTopMargin(0);
@@ -44,7 +46,6 @@ AboutPopup::AboutPopup(QWidget* parent)
 
   QLabel* blankLabel = new QLabel(this);
   blankLabel->setText(tr(" "));
-  blankLabel->setWordWrap(true);
 
   mainLayout->addWidget(blankLabel);
 
@@ -115,4 +116,15 @@ AboutPopup::AboutPopup(QWidget* parent)
   button->setDefault(true);
   addButtonBarWidget(button);
   connect(button, SIGNAL(clicked()), this, SLOT(accept()));
+}
+
+void AboutPopup::showEvent(QShowEvent *event) {
+
+  // center window
+  QScreen* currentScreen         = TApp::instance()->getMainWindow()->screen();
+  QPoint activeMonitorCenter     = currentScreen->availableGeometry().center();
+  QPoint thisPopupCenter         = this->rect().center();
+  QPoint centeredOnActiveMonitor = activeMonitorCenter - thisPopupCenter;
+  this->move(centeredOnActiveMonitor);
+
 }

--- a/toonz/sources/toonz/aboutpopup.h
+++ b/toonz/sources/toonz/aboutpopup.h
@@ -38,6 +38,9 @@ class AboutPopup final : public DVGui::Dialog {
 
 public:
   AboutPopup(QWidget* parent);
+
+protected:
+  void showEvent(QShowEvent *) override;
 };
 
 #endif  // ABOUTPOPUP_H

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2815,13 +2815,13 @@ double SceneViewer::getZoomScaleFittingWithScreen() {
 
   // get the image size to be rendered
 
-  if (isPreviewEnabled())
+  if (isPreviewEnabled()) {
     imgSize = TApp::instance()
                   ->getCurrentScene()
                   ->getScene()
                   ->getCurrentCamera()
                   ->getRes();
-  else if (TApp::instance()->getCurrentFrame()->isEditingLevel()) {
+  } else if (TApp::instance()->getCurrentFrame()->isEditingLevel()) {
     TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
     if (!sl || sl->getType() == PLI_XSHLEVEL || sl->getImageDpi() == TPointD())
       return 0.0;
@@ -2842,7 +2842,7 @@ double SceneViewer::getZoomScaleFittingWithScreen() {
   // add small margin on the edge of the image
   int margin = 20;
   // get the desktop resolution
-  QRect rec = QApplication::primaryScreen()->geometry();
+  QRect rec = screen()->geometry();
 
   // fit to either direction
   int moni_x = rec.width() - (margin * 2);

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -418,7 +418,7 @@ void StartupPopup::showEvent(QShowEvent *) {
   // clear items if they exist first
   refreshRecentScenes();
   // center window
-  QScreen *currentScreen = QApplication::primaryScreen();
+  QScreen *currentScreen = TApp::instance()->getMainWindow()->screen();
   QPoint activeMonitorCenter = currentScreen->availableGeometry().center();
   QPoint thisPopupCenter         = this->rect().center();
   QPoint centeredOnActiveMonitor = activeMonitorCenter - thisPopupCenter;

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3655,7 +3655,7 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
         openTransparencyPopup();
 
         // make sure the popup doesn't go off the screen to the right
-        QRect screenRect = QApplication::primaryScreen()->geometry();
+        QRect screenRect = screen()->geometry();
 
         int popupLeft   = event->globalPos().x() + x;
         int popupRight  = popupLeft + m_columnTransparencyPopup->width();

--- a/toonz/sources/toonzqt/pickrgbutils.cpp
+++ b/toonz/sources/toonzqt/pickrgbutils.cpp
@@ -9,6 +9,7 @@
 #include <QScreen>
 #include <QApplication>
 #include <QScreen>
+#include <QWidget>
 
 #include "toonzqt/pickrgbutils.h"
 
@@ -57,7 +58,9 @@ QRgb pickRGB(QWidget *widget, const QRect &rect) {
 
 //------------------------------------------------------------------------------
 
-QRgb pickScreenRGB(const QRect &rect) {
+QRgb pickScreenRGB(const QRect &rect, QWidget *widget) {
+  QScreen *screen = widget->screen();
+
 #ifdef MACOSX
 
   //   #Bugzilla 6514, possibly related to #QTBUG 23516
@@ -83,7 +86,7 @@ QRgb pickScreenRGB(const QRect &rect) {
 
 #endif
 
-  QImage img(QApplication::primaryScreen()
+  QImage img(screen
                  ->grabWindow(0, theRect.x(), theRect.y(),
                               theRect.width(), theRect.height())
                  .toImage());


### PR DESCRIPTION
For those with multiple monitors, this fixes an issue with detecting the current screen or the screen where the T2D's main application is.

The following have been corrected/updated:
- RGB Picker Tool - Pick Screen mode
  - Adjusts the coordinates based on the screen it picks from.
- Full screen viewer Zoom In/Out using shortcuts (Preview and Level Edit mode)
  - Uses the current screen's dimensions instead of the system's primary screen dimensions for some adjustments
- Timeline/Xsheet column config button popup
  - Uses the current screen's dimensions instead of the system's primary screen dimensions to determine if it needs to move the config popup
- Startup popup
  - Startup popup will always open in the middle of the main T2D window, regardless of which screen T2D is in
- About popup
  - About popup will always open in the middle of the main T2D window, regardless of which screen T2D is in.  (This is new)

The issues were caused by changes made in #1456 where a deprecated method was replaced.