### PR TITLE
Fix ZoomIn Viewer shortcut processing

### DIFF
--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -851,18 +851,20 @@ ShortcutZoomer::ShortcutZoomer(QWidget *zoomingWidget)
 //--------------------------------------------------------------------------
 
 bool ShortcutZoomer::exec(QKeyEvent *event) {
+  int key = event->key();
+  if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt)
+    return false;
+
+  if (event->modifiers() & Qt::KeypadModifier)
+    key = key |
+          event->modifiers() &
+              (~0xf0000000);  // Ignore if the key is a numpad key
+
   int zoomInKey, zoomOutKey, viewResetKey, zoomFitKey, showHideFullScreenKey,
       actualPixelSize, flipX, flipY, zoomReset, rotateReset, positionReset;
   getViewerShortcuts(zoomInKey, zoomOutKey, viewResetKey, zoomFitKey,
                      showHideFullScreenKey, actualPixelSize, flipX, flipY,
                      zoomReset, rotateReset, positionReset);
-
-  int key = event->key();
-  if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt)
-    return false;
-
-  key = key | event->modifiers() &
-                  (~0xf0000000);  // Ignore if the key is a numpad key
 
   return (key == showHideFullScreenKey)
              ? toggleFullScreen()


### PR DESCRIPTION
The default shortcut for `Zoom In` is `+`.  For those with a number pad on their keyboard, using the `+` works fine. For those without a numpad, we need to use `Shift+=` to get the `+`.but this does not work in the viewer.

Corrected some old (and odd) logic that modified the key, trying to account for number pad keys even though it was not being used.  The original logic caused any zooming type shortcuts with `Shift` to not work.  Now this logic is only applied if it detects a number pad key was used.
