### PR TITLE
Fix invalid path error/project creation crash

### DIFF
--- a/toonz/sources/include/toonz/tproject.h
+++ b/toonz/sources/include/toonz/tproject.h
@@ -31,6 +31,8 @@ class DVAPI TProject final {
 
   FilePathProperties *m_fpProp;
 
+  bool m_isLoaded;
+
 public:
   // default folders names
   static const std::string Inputs;
@@ -95,7 +97,9 @@ public:
 
   static bool isAProjectPath(const TFilePath &fp);
 
-private:
+  bool isLoaded() const { return m_isLoaded; }
+
+  private:
   // not implemented
   TProject(const TProject &src);
   TProject &operator=(const TProject &);

--- a/toonz/sources/toonz/cleanupsettingsmodel.cpp
+++ b/toonz/sources/toonz/cleanupsettingsmodel.cpp
@@ -60,7 +60,7 @@ public:
       folderPath = folderPath.getParentDir();
     else {
       auto currentProject = TProjectManager::instance()->getCurrentProject();
-      if (currentProject)
+      if (currentProject->isLoaded())
         folderPath =
             currentProject->decode(currentProject->getFolder(TProject::Inputs));
     }

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -1036,7 +1036,7 @@ void DvDirTreeView::editCurrentVersionControlNode() {
         TProjectManager::instance()->projectFolderToProjectPath(path);
 
     auto currentProject = TProjectManager::instance()->getCurrentProject();
-    if (!currentProject) return;
+    if (!currentProject->isLoaded()) return;
     TFilePath sceneFolder =
         currentProject->decode(currentProject->getFolder(TProject::Scenes));
     TFilePath scenesDescPath = sceneFolder + "scenes.xml";
@@ -1090,7 +1090,7 @@ void DvDirTreeView::unlockCurrentVersionControlNode() {
         TProjectManager::instance()->projectFolderToProjectPath(path);
 
     auto currentProject = TProjectManager::instance()->getCurrentProject();
-    if (!currentProject) return;
+    if (!currentProject->isLoaded()) return;
     TFilePath sceneFolder =
         currentProject->decode(currentProject->getFolder(TProject::Scenes));
     TFilePath scenesDescPath = sceneFolder + "scenes.xml";
@@ -1143,7 +1143,7 @@ void DvDirTreeView::revertCurrentVersionControlNode() {
         TProjectManager::instance()->projectFolderToProjectPath(path);
     auto currentProject =
         TProjectManager::instance()->getCurrentProject();
-    if (!currentProject) return;
+    if (!currentProject->isLoaded()) return;
     TFilePath sceneFolder =
         currentProject->decode(currentProject->getFolder(TProject::Scenes));
     TFilePath scenesDescPath = sceneFolder + "scenes.xml";

--- a/toonz/sources/toonz/exportscenepopup.cpp
+++ b/toonz/sources/toonz/exportscenepopup.cpp
@@ -703,7 +703,7 @@ TFilePath ExportScenePopup::createNewProject() {
   auto project = std::make_shared<TProject>();
 
   auto currentProject = pm->getCurrentProject();
-  assert(currentProject);
+  assert(currentProject->isLoaded());
   int i;
   for (i = 0; i < (int)currentProject->getFolderCount(); i++)
     project->setFolder(currentProject->getFolderName(i),

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1913,7 +1913,7 @@ bool IoCmd::loadScene(ToonzScene &scene, const TFilePath &scenePath,
   scene.load(scenePath);
   // import if needed
   auto currentProject = TProjectManager::instance()->getCurrentProject();
-  if (!scene.getProject()) return false;
+  if (!scene.getProject()->isLoaded()) return false;
   if (scene.getProject()->getProjectPath() !=
       currentProject->getProjectPath()) {
     ResourceImportDialog resourceLoader;
@@ -2047,7 +2047,7 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
     // import if needed
     TProjectManager *pm      = TProjectManager::instance();
     auto currentProject = pm->getCurrentProject();
-    if (!scene->getProject() ||
+    if (!scene->getProject()->isLoaded() ||
         scene->getProject()->getProjectPath() !=
             currentProject->getProjectPath()) {
       ResourceImportDialog resourceLoader;
@@ -2070,8 +2070,7 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   }
   printf("%s:%s end load:\n", __FILE__, __FUNCTION__);
   auto project = scene->getProject();
-  if (!project) {
-    project = std::make_shared<TProject>();
+  if (!project->isLoaded()) {
     project->setFolder("project", scenePath);
     scene->setProject(project);
   }

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -601,7 +601,7 @@ void ProjectCreatePopup::createProject() {
     return;
   }
 
-  auto project            = std::shared_ptr<TProject>();
+  auto project = std::make_shared<TProject>();
   updateProjectFromFields(project);
   auto currentProject = pm->getCurrentProject();
   project->setSceneProperties(currentProject->getSceneProperties());

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -328,6 +328,7 @@ void ToonzScene::clear() {
 void ToonzScene::setProject(std::shared_ptr<TProject> project) {
   assert(project);
   m_project = project;
+  if (!m_project) m_project = std::make_shared<TProject>();
 }
 
 //-----------------------------------------------------------------------------
@@ -1395,7 +1396,7 @@ TFilePath ToonzScene::codeFilePath(const TFilePath &path) const {
     return fp;
   }
 
-  if (project)
+  if (project->isLoaded())
     for (int i = 0; i < project->getFolderCount(); i++) {
       TFilePath folderName("+" + project->getFolderName(i));
       TFilePath folderPath = decodeFilePath(folderName);
@@ -1430,7 +1431,7 @@ bool ToonzScene::codeFilePathWithSceneFolder(TFilePath &path) const {
 TFilePath ToonzScene::getDefaultLevelPath(int levelType,
                                           std::wstring levelName) const {
   auto project = getProject();
-  assert(project);
+  assert(project->isLoaded());
   TFilePath levelPath;
   switch (levelType) {
   case TZI_XSHLEVEL:
@@ -1514,7 +1515,7 @@ TFilePath ToonzScene::decodeSavePath(TFilePath path) const {
 
 bool ToonzScene::isExternPath(const TFilePath &fp) const {
   auto project = m_project;
-  assert(project);
+  assert(project->isLoaded());
   for (int i = 0; i < project->getFolderCount(); i++) {
     if (project->getFolderName(i) == "scenes") continue;
 

--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -327,7 +327,8 @@ TProject::TProject()
     : m_name()
     , m_path()
     , m_sprop(new TSceneProperties())
-    , m_fpProp(new FilePathProperties()) {}
+    , m_fpProp(new FilePathProperties())
+    , m_isLoaded(false) {}
 
 //-------------------------------------------------------------------
 
@@ -748,6 +749,7 @@ void TProject::load(const TFilePath &projectPath) {
   }
 
   setUseSubScenePath(useSubScenePath);
+  m_isLoaded = true;
 }
 
 //-------------------------------------------------------------------
@@ -1056,10 +1058,11 @@ TFilePath TProjectManager::getCurrentProjectPath() {
    current project path.
 */
 std::shared_ptr<TProject> TProjectManager::getCurrentProject() {
-  if (!currentProject) {
+  if (!currentProject) currentProject = std::make_shared<TProject>();
+
+  if (!currentProject->isLoaded()) {
     TFilePath fp = getCurrentProjectPath();
     assert(TProject::isAProjectPath(fp));
-    currentProject = std::make_shared<TProject>();
     currentProject->load(fp);
 
     // update TFilePath condition on loading the current project


### PR DESCRIPTION
This fixes 2 issues related to the OT Patch `Remove TSmartObject from TProject ` recently applied in PR #1535 

- `is an invalid path` error when saving a scene after opening a scene in another project
- Crash when creating a new project