### PR TITLE
Change eraser tools resize binding to CTRL+ALT in Normal Mode only.

### DIFF
--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -1140,20 +1140,15 @@ void FullColorEraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
   } locals = {this};
 
-  switch (e.getModifiersMask()) {
-  case TMouseEvent::ALT_KEY: {
+  if (m_eraseType.getValue() == NORMALERASE && e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed()) {
     // User wants to alter the maximum brush size
     const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
     locals.addMinMaxSeparate(m_size, min, max);
-    break;
-  }
-
-  default:
+  } else { 
     m_brushPos = pos;
-    break;
   }
 
   m_mousePos = pos;

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -2252,20 +2252,15 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
   } locals = {this};
 
-  switch (e.getModifiersMask()) {
-  case TMouseEvent::ALT_KEY: {
+  if (m_eraseType.getValue() == NORMALERASE && e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed()) {
     // User wants to alter the maximum brush size
     const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
     locals.addMinMaxSeparate(m_toolSize, min, max);
-    break;
-  }
-
-  default:
+  } else { 
     m_brushPos = fixMousePos(pos);
-    break;
   }
 
   m_mousePos = pos;

--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -1386,20 +1386,15 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
   } locals = {this};
 
-  switch (e.getModifiersMask()) {
-  case TMouseEvent::ALT_KEY: {
+  if (m_eraseType.getValue() == NORMAL_ERASE && e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed()) {
     // User wants to alter the maximum brush size
     const TPointD &diff = m_windowMousePos - -e.m_pos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
 
     locals.addMinMaxSeparate(m_toolSize, min, max);
-    break;
-  }
-
-  default:
+  } else {
     m_brushPos = pos;
-    break;
   }
 
   m_oldMousePos = m_mousePos = pos;


### PR DESCRIPTION
Change eraser tools resize binding to CTRL+ALT in Normal Mode only. 

This should help reduce accidentally triggering a resize when attempting to execute another shortcut. The CTRL+ALT resize binding is consistent with the brush tools (when enabled.)