### PR TITLE
Clip with Vector Strokes

### DIFF
--- a/toonz/sources/common/tvrender/tglregions.cpp
+++ b/toonz/sources/common/tvrender/tglregions.cpp
@@ -420,8 +420,11 @@ void tglDrawMask(const TVectorRenderData &rd1, const TVectorImage *vim) {
     assert(vPalette);
     rd.m_palette = vPalette;
   }
-  for (i = 0; i < vim->getRegionCount(); i++)
-    tglDraw(rd, vim->getRegion(i), false);
+// Expand clipping mask to strokes too, not just filled regions
+//  for (i = 0; i < vim->getRegionCount(); i++)
+//    tglDraw(rd, vim->getRegion(i), false);
+
+  tglDraw(rd, vim);
 
   glPopAttrib();
 }


### PR DESCRIPTION
Current vector based clipping masks will only clip based on a filled region, up to and including the centerline of the strokes that make the fill. 

This change enhances Clipping Masks to include the entirety of vector stroke as well.  With this, you can even just clip with vector strokes and no filled region.