### PR TITLE
Fix unexposed clipping mask frame hiding exposed level frame

### DIFF
--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -708,7 +708,8 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
       if (column->isCamstandVisible() ||
           includeUnvisible)  // se l'"occhietto" non e' chiuso
       {
-        if (column->isMask())  // se e' una maschera (usate solo in tab pro)
+        if (column->isMask() && !column->isCellEmpty(row) &&
+            !xsh->getCell(row, c).getFrameId().isStopFrame())
         {
           if (column->canRenderMask())
             addCellWithOnionSkin(players, scene, xsh, row, c, level,


### PR DESCRIPTION
This fixes a bug where a clipped level's exposed frame is not drawn at all in Normal viewer mode  if there are no clipping mask frames or a clipping mask stop hold frame exposed below it.  This is not an issue with Preview/Render.
