### PR TITLE
Fix display of mesh deformed clipping mask

### DIFF
--- a/toonz/sources/include/ext/meshutils.h
+++ b/toonz/sources/include/ext/meshutils.h
@@ -125,7 +125,8 @@ DVAPI void tglDraw(
     const TAffine
         &meshToTexAffine,  //!< Transform from mesh to texture coordinates.
     const PlasticDeformerDataGroup
-        &deformerDatas  //!< Data structure of a deformation of the input image.
+        &deformerDatas,  //!< Data structure of a deformation of the input image.
+    bool isMask
     );
 
 #endif  // MESHUTILS_H

--- a/toonz/sources/include/toonz/textureutils.h
+++ b/toonz/sources/include/toonz/textureutils.h
@@ -31,7 +31,8 @@ namespace texture_utils {
 //! Returns the OpenGL data of a loaded texture corresponding to sl's content
 //! at fid with specified subsampling.
 DrawableTextureDataP getTextureData(const TXshSimpleLevel *sl,
-                                    const TFrameId &fid, int subsampling);
+                                    const TFrameId &fid, int subsampling,
+                                    bool isMask);
 
 //! Invalidates any currently stored texture associated with sl at the specified
 //! fid.

--- a/toonz/sources/tnzext/meshutils.cpp
+++ b/toonz/sources/tnzext/meshutils.cpp
@@ -317,8 +317,8 @@ void tglDrawRigidity(const TMeshImage &image, double minColor[4],
 //***********************************************************************************************
 
 void tglDraw(const TMeshImage &meshImage, const DrawableTextureData &texData,
-             const TAffine &meshToTexAff,
-             const PlasticDeformerDataGroup &group) {
+             const TAffine &meshToTexAff, const PlasticDeformerDataGroup &group,
+             bool isMask) {
   typedef MeshTexturizer::TextureData::TileData TileData;
 
   // Prepare OpenGL
@@ -448,7 +448,7 @@ GL_SRC_ALPHA, while the latter uses GL_ONE. The result is a PREMULTIPLIED image.
            drawEd2 = (ed2.facesCount() < 2);
 
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-      glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
+      if (!isMask) glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
 
       glBegin(GL_LINES);
       {
@@ -472,7 +472,7 @@ GL_SRC_ALPHA, while the latter uses GL_ONE. The result is a PREMULTIPLIED image.
       glEnd();
 
       glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-      glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+      if(!isMask) glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
 
       glBegin(GL_LINES);
       {
@@ -497,7 +497,7 @@ GL_SRC_ALPHA, while the latter uses GL_ONE. The result is a PREMULTIPLIED image.
 
       // Finally, draw the face
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-      glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
+      if (!isMask) glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
 
       glBegin(GL_TRIANGLES);
       {
@@ -508,7 +508,7 @@ GL_SRC_ALPHA, while the latter uses GL_ONE. The result is a PREMULTIPLIED image.
       glEnd();
 
       glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-      glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+      if (!isMask) glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
 
       glBegin(GL_TRIANGLES);
       {

--- a/toonz/sources/toonzlib/plasticdeformerfx.cpp
+++ b/toonz/sources/toonzlib/plasticdeformerfx.cpp
@@ -408,7 +408,7 @@ void PlasticDeformerFx::doCompute(TTile &tile, double frame,
     glEnable(GL_BLEND);
     glEnable(GL_TEXTURE_2D);
 
-    tglDraw(*mi, *texData, meshToTextureAff, *dataGroup);
+    tglDraw(*mi, *texData, meshToTextureAff, *dataGroup, info.m_applyMask);
 
     // Retrieve drawing and copy to output tile
 

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -224,7 +224,7 @@ public:
                   \b TXshChildLevel, recall \b addFrame().
   */
   void addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh, int row,
-               int col, int level, int subSheetColIndex = -1);
+               int col, int level, bool isMask, int subSheetColIndex = -1);
 
   /*! Verify if onion-skin is active and recall \b addCell().
   \n	Compute the distance between each cell with active onion-skin and
@@ -234,7 +234,7 @@ public:
                   with argument current cell.
   */
   void addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
-                            int row, int col, int level,
+                            int row, int col, int level, bool isMask,
                             int subSheetColIndex = -1);
 
   /*!Recall \b addCellWithOnionSkin() for each cell of row \b row.*/
@@ -323,7 +323,8 @@ void StageBuilder::dumpAll(std::ostream &out) {
 //-----------------------------------------------------------------------------
 
 void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
-                           int row, int col, int level, int subSheetColIndex) {
+                           int row, int col, int level, bool isMask,
+                           int subSheetColIndex) {
   // Local functions
   struct locals {
     static inline bool isMeshDeformed(TXsheet *xsh, TStageObject *obj,
@@ -423,9 +424,9 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     player.m_opacity             = column->getOpacity();
     player.m_filterColor =
         scene->getProperties()->getColorFilterColor(column->getColorFilterId());
-    player.m_isMask              = column->isMask();
-    player.m_isInvertedMask      = column->isInvertedMask();
-    player.m_canRenderMask       = column->canRenderMask();
+    player.m_isMask              = isMask;
+    player.m_isInvertedMask      = isMask ? column->isInvertedMask() : false;
+    player.m_canRenderMask       = isMask ? column->canRenderMask() : false;
 
     if (m_subXSheetStack.empty()) {
       player.m_z         = columnZ;
@@ -560,7 +561,8 @@ static bool alreadyAdded(TXsheet *xsh, int row, int index,
 
 void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
                                         TXsheet *xsh, int row, int col,
-                                        int level, int subSheetColIndex) {
+                                        int level, bool isMask,
+                                        int subSheetColIndex) {
   struct locals {
     static inline bool hasOnionSkinnedMeshParent(StageBuilder *sb, TXsheet *xsh,
                                                  int col) {
@@ -601,7 +603,7 @@ void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
           (cell.getSimpleLevel() == 0 ||
            xsh->getCell(r, col).getSimpleLevel() == cell.getSimpleLevel())) {
         m_shiftTraceGhostId = FIRST_GHOST;
-        addCell(players, scene, xsh, r, col, level, subSheetColIndex);
+        addCell(players, scene, xsh, r, col, level, isMask, subSheetColIndex);
       }
 
       r = row + m_onionSkinMask.getShiftTraceGhostFrameOffset(1);
@@ -609,13 +611,13 @@ void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
           (cell.getSimpleLevel() == 0 ||
            xsh->getCell(r, col).getSimpleLevel() == cell.getSimpleLevel())) {
         m_shiftTraceGhostId = SECOND_GHOST;
-        addCell(players, scene, xsh, r, col, level, subSheetColIndex);
+        addCell(players, scene, xsh, r, col, level, isMask, subSheetColIndex);
       }
 
       // draw current working frame
       if (!cell.isEmpty()) {
         m_shiftTraceGhostId = TRACED;
-        addCell(players, scene, xsh, row, col, level, subSheetColIndex);
+        addCell(players, scene, xsh, row, col, level, isMask, subSheetColIndex);
         m_shiftTraceGhostId = NO_GHOST;
       }
     }
@@ -624,12 +626,12 @@ void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
       int flipKey = m_onionSkinMask.getGhostFlipKey();
       if (flipKey == Qt::Key_F1) {
         int r = row + m_onionSkinMask.getShiftTraceGhostFrameOffset(0);
-        addCell(players, scene, xsh, r, col, level, subSheetColIndex);
+        addCell(players, scene, xsh, r, col, level, isMask, subSheetColIndex);
       } else if (flipKey == Qt::Key_F3) {
         int r = row + m_onionSkinMask.getShiftTraceGhostFrameOffset(1);
-        addCell(players, scene, xsh, r, col, level, subSheetColIndex);
+        addCell(players, scene, xsh, r, col, level, isMask, subSheetColIndex);
       } else
-        addCell(players, scene, xsh, row, col, level, subSheetColIndex);
+        addCell(players, scene, xsh, row, col, level, isMask, subSheetColIndex);
     }
   } else if (locals::doStandardOnionSkin(this, xsh, level, col)) {
     std::vector<int> rows;
@@ -654,19 +656,20 @@ void StageBuilder::addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene,
         m_fade         = fosFade == -1.0
                      ? mosFade
                      : (mosFade == -1 ? fosFade : std::min(fosFade, mosFade));
-        addCell(players, scene, xsh, rows[i], col, level, subSheetColIndex);
+        addCell(players, scene, xsh, rows[i], col, level, isMask,
+                subSheetColIndex);
       }
 #endif
     }
 
     m_onionSkinDistance = 0;
     m_fade              = 0.0;
-    addCell(players, scene, xsh, row, col, level, subSheetColIndex);
+    addCell(players, scene, xsh, row, col, level, isMask, subSheetColIndex);
 
     m_onionSkinDistance = c_noOnionSkin;
     m_fade              = -1.0;
   } else
-    addCell(players, scene, xsh, row, col, level, subSheetColIndex);
+    addCell(players, scene, xsh, row, col, level, isMask, subSheetColIndex);
 }
 
 //-----------------------------------------------------------------------------
@@ -711,7 +714,7 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         if (column->isMask())  // se e' una maschera (usate solo in tab pro)
         {
           if (column->canRenderMask())
-            addCellWithOnionSkin(players, scene, xsh, row, c, level,
+            addCellWithOnionSkin(players, scene, xsh, row, c, level, false,
                                  subSheetColIndex);
           isMask = true;
           std::vector<int> saveMasks;
@@ -719,12 +722,12 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
           int maskIndex   = m_maskPool.size();
           PlayerSet *mask = new PlayerSet();
           m_maskPool.push_back(mask);
-          addCellWithOnionSkin(*mask, scene, xsh, row, c, level);
+          addCellWithOnionSkin(*mask, scene, xsh, row, c, level, true);
           std::stable_sort(mask->begin(), mask->end(), PlayerLt());
           saveMasks.swap(m_masks);
           m_masks.push_back(maskIndex);
         } else
-          addCellWithOnionSkin(players, scene, xsh, row, c, level,
+          addCellWithOnionSkin(players, scene, xsh, row, c, level, false,
                                subSheetColIndex);
       }
     }

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -81,7 +81,7 @@ DrawableTextureDataP Stage::Player::texture() const {
   if (m_sl) {
     // Ask the sLevel directly
     return texture_utils::getTextureData(
-        m_sl, m_fid, -1);  // -1 stands for 'current subsampling'
+        m_sl, m_fid, -1, m_isMask);  // -1 stands for 'current subsampling'
   }
 
   // The level is supposedly a sub-xsheet one. It means we have to build the

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -1649,7 +1649,7 @@ void onPlasticDeformedImage(TStageObject *playerObj,
   // Applying modulation by the specified transparency parameter
 
   glColor4d(pixScale[3], pixScale[3], pixScale[3], pixScale[3]);
-  tglDraw(*mi, *texData, meshToTextureAff, *dataGroup);
+  tglDraw(*mi, *texData, meshToTextureAff, *dataGroup, player.m_isMask);
 
   glDisable(GL_TEXTURE_2D);
 

--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -112,8 +112,9 @@ TRasterImageP getTexture(const TXshSimpleLevel *sl, const TFrameId &fid,
 
 DrawableTextureDataP texture_utils::getTextureData(const TXshSimpleLevel *sl,
                                                    const TFrameId &fid,
-                                                   int subsampling) {
-  const std::string &texId = sl->getImageId(fid);
+                                                   int subsampling,
+                                                   bool isMask) {
+  const std::string &texId = sl->getImageId(fid) + (isMask ? "masked" : "");
 
   // Now, we must associate a texture
   DrawableTextureDataP data(


### PR DESCRIPTION
This fixes an issue with mesh deformed clipping masks displaying the original mask image in a corrupted manner regardless if the mask was actually marked to be rendered.

This issue is/was only seen in normal viewing mode.  Preview/Renders displayed mesh deformed clipping masks correctly.