### PR TITLE
Increase initial 3D Viewer scale

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -837,7 +837,7 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
     , m_viewMode(SCENE_VIEWMODE)
     , m_pos(0, 0)
     , m_pan3D(TPointD(0, 0))
-    , m_zoomScale3D(0.1)
+    , m_zoomScale3D(1.0)
     , m_theta3D(20)
     , m_phi3D(30)
     , m_dpiScale(TPointD(1, 1))
@@ -3101,12 +3101,12 @@ void SceneViewer::resetSceneViewer() {
 
   m_pos         = QPoint(0, 0);
   m_pan3D       = TPointD(0, 0);
-  m_zoomScale3D = 0.1;
   m_theta3D     = 20;
   m_phi3D       = 30;
   m_isFlippedX  = false;
   m_isFlippedY  = false;
   fitToCameraOutline();
+  m_zoomScale3D = 1.0;
   emit onZoomChanged();
   emit onFlipHChanged(m_isFlippedX);
   emit onFlipVChanged(m_isFlippedY);
@@ -3191,7 +3191,7 @@ void SceneViewer::setActualPixelSize() {
 
   m_pos         = QPoint(0, 0);
   m_pan3D       = TPointD(0, 0);
-  m_zoomScale3D = 0.1;
+  m_zoomScale3D = 1.0;
   m_theta3D     = 20;
   m_phi3D       = 30;
   emit onZoomChanged();


### PR DESCRIPTION
When switching to 3D view, the initial scale is very small and I find myself always having to zoom in quite a bit to get to a usable view.  Resetting the 3D view also scales it back down to the small size.

I've increased the initial 3D view scale to something more usable.