### PR TITLE
Relative Drawing Onion Skin Mode

### DIFF
--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -46,11 +46,6 @@ public:
     ENABLED_WITHOUT_GHOST_MOVEMENTS
   };
 
-  enum RelativeSkinMode {
-    FRAMES,
-    DRAWING
-  };
-
 public:
   OnionSkinMask();
 
@@ -70,8 +65,7 @@ public:
     return m_dos.size();
   }  //!< Returns the Drawing OS frames count
   int getRosCount() const {
-    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? getMosCount()
-                                                          : getDosCount();
+    return m_isRelativeFrameMode ? getMosCount() : getDosCount();
   }
 
   int getMos(int index) const {
@@ -90,8 +84,7 @@ public:
   }
 
   int getRos(int index) const {
-    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? getMos(index)
-                                                          : getDos(index);
+    return m_isRelativeFrameMode ? getMos(index) : getDos(index);
   }
 
   void setMos(int drow, bool on);  //!< Sets a Mobile OS frame shifted by drow
@@ -102,7 +95,7 @@ public:
   void setDos(int drow,
               bool on);  //!< Sets a Drawing OS frame to the specified xsheet row
   void setRos(int drow, bool on) {
-    if (m_relativeSkinMode == RelativeSkinMode::FRAMES)
+    if (m_isRelativeFrameMode)
       setMos(drow, on);
     else
       setDos(drow, on);
@@ -115,31 +108,28 @@ public:
   void setDosOpacity(int drow, double opacity);
   double getDosOpacity(int drow);
   void setRosOpacity(int drow, double opacity) {
-    if (m_relativeSkinMode == RelativeSkinMode::FRAMES)
+    if (m_isRelativeFrameMode)
       setMosOpacity(drow, opacity);
     else
       setDosOpacity(drow, opacity);
   }
   double getRosOpacity(int drow) {
-    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? getMosOpacity(drow)
-                                                          : getDosOpacity(drow);
+    return m_isRelativeFrameMode ? getMosOpacity(drow) : getDosOpacity(drow);
   }
 
   bool isMos(int drow);
   bool isFos(int row);
   bool isDos(int drow);
   bool isRos(int drow) {
-    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? isMos(drow)
-                                                          : isDos(drow);
+    return m_isRelativeFrameMode ? isMos(drow) : isDos(drow);
   }
 
   bool getMosRange(int &drow0, int &drow1) const;
   bool getDosRange(int &drow0, int &drow1) const;
 
   bool isEmpty() const {
-    return ((m_relativeSkinMode == RelativeSkinMode::FRAMES && m_mos.empty()) ||
-            (m_relativeSkinMode == RelativeSkinMode::DRAWING &&
-             m_dos.empty())) &&
+    return ((m_isRelativeFrameMode && m_mos.empty()) ||
+            (!m_isRelativeFrameMode && m_dos.empty())) &&
            m_fos.empty();
   }
 
@@ -206,10 +196,8 @@ since underlying onion-skinned drawings must be visible.
   void removeGhostFlipKey(int key) { m_ghostFlipKeys.removeAll(key); }
   void clearGhostFlipKey() { m_ghostFlipKeys.clear(); }
 
-  bool isRelativeFrameMode() {
-    return m_relativeSkinMode == RelativeSkinMode::FRAMES;
-  }
-  void setRelativeSkinMode(RelativeSkinMode mode) { m_relativeSkinMode = mode; }
+  bool isRelativeFrameMode() const { return m_isRelativeFrameMode; }
+  void setRelativeFrameMode(bool on);
 
 private:
   std::vector<std::pair<int, double>> m_fos,
@@ -229,7 +217,7 @@ private:
 
   bool m_LightTableStatus;
 
-  RelativeSkinMode m_relativeSkinMode;
+  bool m_isRelativeFrameMode;
 };
 
 //***************************************************************************

--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -6,6 +6,7 @@
 // TnzCore includes
 #include "tcommon.h"
 #include "tgeometry.h"
+#include "txsheet.h"
 
 #include <QList>
 
@@ -45,13 +46,19 @@ public:
     ENABLED_WITHOUT_GHOST_MOVEMENTS
   };
 
+  enum RelativeSkinMode {
+    FRAMES,
+    DRAWING
+  };
+
 public:
   OnionSkinMask();
 
   void clear();
 
   //! Fills in the output vector with the absolute frames to be onion-skinned.
-  void getAll(int currentRow, std::vector<int> &output) const;
+  void getAll(int currentRow, std::vector<std::pair<int, double>> &output,
+              TXsheet *xsh, int col) const;
 
   int getMosCount() const {
     return m_mos.size();
@@ -59,6 +66,13 @@ public:
   int getFosCount() const {
     return m_fos.size();
   }  //!< Returns the Fixed OS frames count
+  int getDosCount() const {
+    return m_dos.size();
+  }  //!< Returns the Drawing OS frames count
+  int getRosCount() const {
+    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? getMosCount()
+                                                          : getDosCount();
+  }
 
   int getMos(int index) const {
     assert(0 <= index && index < (int)m_mos.size());
@@ -70,22 +84,64 @@ public:
     return m_fos[index].first;
   }
 
+  int getDos(int index) const {
+    assert(0 <= index && index < (int)m_dos.size());
+    return m_dos[index].first;
+  }
+
+  int getRos(int index) const {
+    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? getMos(index)
+                                                          : getDos(index);
+  }
+
   void setMos(int drow, bool on);  //!< Sets a Mobile OS frame shifted by drow
                                    //! around current xsheet frame
   void setFos(int row,
               bool on);  //!< Sets a Fixed OS frame to the specified xsheet row
 
+  void setDos(int drow,
+              bool on);  //!< Sets a Drawing OS frame to the specified xsheet row
+  void setRos(int drow, bool on) {
+    if (m_relativeSkinMode == RelativeSkinMode::FRAMES)
+      setMos(drow, on);
+    else
+      setDos(drow, on);
+  }
+
   void setMosOpacity(int drow, double opacity);
   double getMosOpacity(int drow);
   void setFosOpacity(int row, double opacity);
   double getFosOpacity(int row);
+  void setDosOpacity(int drow, double opacity);
+  double getDosOpacity(int drow);
+  void setRosOpacity(int drow, double opacity) {
+    if (m_relativeSkinMode == RelativeSkinMode::FRAMES)
+      setMosOpacity(drow, opacity);
+    else
+      setDosOpacity(drow, opacity);
+  }
+  double getRosOpacity(int drow) {
+    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? getMosOpacity(drow)
+                                                          : getDosOpacity(drow);
+  }
 
   bool isMos(int drow);
   bool isFos(int row);
+  bool isDos(int drow);
+  bool isRos(int drow) {
+    return m_relativeSkinMode == RelativeSkinMode::FRAMES ? isMos(drow)
+                                                          : isDos(drow);
+  }
 
   bool getMosRange(int &drow0, int &drow1) const;
+  bool getDosRange(int &drow0, int &drow1) const;
 
-  bool isEmpty() const { return m_mos.empty() && m_fos.empty(); }
+  bool isEmpty() const {
+    return ((m_relativeSkinMode == RelativeSkinMode::FRAMES && m_mos.empty()) ||
+            (m_relativeSkinMode == RelativeSkinMode::DRAWING &&
+             m_dos.empty())) &&
+           m_fos.empty();
+  }
 
   bool isEnabled() const { return m_enabled; }
   void enable(bool on) { m_enabled = on; }
@@ -150,9 +206,15 @@ since underlying onion-skinned drawings must be visible.
   void removeGhostFlipKey(int key) { m_ghostFlipKeys.removeAll(key); }
   void clearGhostFlipKey() { m_ghostFlipKeys.clear(); }
 
+  bool isRelativeFrameMode() {
+    return m_relativeSkinMode == RelativeSkinMode::FRAMES;
+  }
+  void setRelativeSkinMode(RelativeSkinMode mode) { m_relativeSkinMode = mode; }
+
 private:
   std::vector<std::pair<int, double>> m_fos,
-      m_mos;                      //!< Fixed and Mobile Onion Skin indices and opacity
+      m_mos, m_dos;               //!< Fixed, Mobile (relative frames mode), Drawing Onion Skin
+                                  //!< indices and opacity
   bool m_enabled;                 //!< Whether onion skin is enabled
   bool m_wholeScene;              //!< Whether the OS works on the entire scene
   bool m_everyFrame;              //!< Whether the OS renders every frame or only on new exposures.
@@ -166,6 +228,8 @@ private:
                                // display the corresponding ghost
 
   bool m_LightTableStatus;
+
+  RelativeSkinMode m_relativeSkinMode;
 };
 
 //***************************************************************************

--- a/toonz/sources/include/toonz/stage.h
+++ b/toonz/sources/include/toonz/stage.h
@@ -78,14 +78,14 @@ DVAPI void visit(Visitor &visitor, ToonzScene *scene, TXsheet *xsh, int row);
 //-----------------------------------------------------------------------------
 
 DVAPI void visit(Visitor &visitor, TXshSimpleLevel *level, const TFrameId &fid,
-                 const OnionSkinMask &osm, bool isPlaying,
+                 const OnionSkinMask &osm, bool isPlaying, TXsheet *xsh,
                  int isGuidedDrawingEnabled = 0, int guidedBackStroke = -1,
                  int guidedFrontStroke = -1);
 
 //-----------------------------------------------------------------------------
 
 DVAPI void visit(Visitor &visitor, TXshLevel *level, const TFrameId &fid,
-                 const OnionSkinMask &osm, bool isPlaying,
+                 const OnionSkinMask &osm, bool isPlaying, TXsheet *xsh,
                  double isGuidedDrawingEnabled = 0.0, int guidedBackStroke = -1,
                  int guidedFrontStroke = -1);
 

--- a/toonz/sources/tnztools/hooktool.cpp
+++ b/toonz/sources/tnztools/hooktool.cpp
@@ -341,14 +341,16 @@ void HookTool::draw() {
   TXshSimpleLevel *level  = 0;
 
   OnionSkinMask osm = app->getCurrentOnionSkin()->getOnionSkinMask();
-  std::vector<int> os;
+  std::vector<std::pair<int, double>> os;
 
   if (isEditingScene())
-    osm.getAll(getFrame(), os);
+    osm.getAll(getFrame(), os, getXsheet(),
+               app->getCurrentColumn()->getColumnIndex());
   else {
     level = app->getCurrentLevel()->getSimpleLevel();
     assert(level);
-    osm.getAll(level->guessIndex(fid), os);
+    osm.getAll(level->guessIndex(fid), os, getXsheet(),
+               app->getCurrentColumn()->getColumnIndex());
   }
 
   int i;
@@ -356,10 +358,10 @@ void HookTool::draw() {
     for (i = 0; i < (int)os.size(); i++) {
       if (isEditingScene()) {
         const TXshCell &cell = getXsheet()->getCell(
-            os[i], app->getCurrentColumn()->getColumnIndex());
+            os[i].first, app->getCurrentColumn()->getColumnIndex());
         drawHooks(hookSet, cell.getFrameId(), true);
       } else {
-        const TFrameId &fid2 = level->index2fid(os[i]);
+        const TFrameId &fid2 = level->index2fid(os[i].first);
         drawHooks(hookSet, fid2, true);
       }
     }

--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -1936,10 +1936,11 @@ void PlasticTool::drawOnionSkinSkeletons_build(double pixelSize) {
   const OnionSkinMask &os =
       TTool::getApplication()->getCurrentOnionSkin()->getOnionSkinMask();
 
-  std::vector<int> osRows;
+  std::vector<std::pair<int, double>> osRows;
   int currentRow = ::row();
 
-  os.getAll(currentRow, osRows);
+  os.getAll(currentRow, osRows, getXsheet(),
+            TTool::getApplication()->getCurrentColumn()->getColumnIndex());
 
   TStageObject *obj = ::stageObject();
 
@@ -1948,16 +1949,16 @@ void PlasticTool::drawOnionSkinSkeletons_build(double pixelSize) {
 
   int r, rCount = int(osRows.size());
   for (r = 0; r != rCount; ++r) {
-    assert(osRows[r] != currentRow);
+    assert(osRows[r].first != currentRow);
 
-    double sdFrame = obj->paramsTime(double(osRows[r] - 1));
+    double sdFrame = obj->paramsTime(double(osRows[r].first - 1));
     int skelId     = m_sd->skeletonId(sdFrame);
 
     UCHAR &skelAlpha = skelAlphas[skelId];
 
     UCHAR alpha =
         255 -
-        UCHAR(255.0 * OnionSkinMask::getOnionSkinFade(osRows[r] - currentRow));
+        UCHAR(255.0 * OnionSkinMask::getOnionSkinFade(osRows[r].first - currentRow));
     skelAlpha = std::max(skelAlpha, alpha);
   }
 
@@ -1976,24 +1977,25 @@ void PlasticTool::drawOnionSkinSkeletons_animate(double pixelSize) {
   const OnionSkinMask &os =
       TTool::getApplication()->getCurrentOnionSkin()->getOnionSkinMask();
 
-  std::vector<int> osRows;
+  std::vector<std::pair<int, double>> osRows;
   int currentRow = ::row();
 
-  os.getAll(currentRow, osRows);
+  os.getAll(currentRow, osRows, getXsheet(),
+            TTool::getApplication()->getCurrentColumn()->getColumnIndex());
 
   TStageObject *obj = ::stageObject();
 
   int r, rCount = int(osRows.size());
   for (r = 0; r != rCount; ++r) {
-    assert(osRows[r] != currentRow);
+    assert(osRows[r].first != currentRow);
 
-    double sdFrame = obj->paramsTime(double(osRows[r] - 1));
+    double sdFrame = obj->paramsTime(double(osRows[r].first - 1));
 
     PlasticSkeleton skel;
     m_sd->storeDeformedSkeleton(m_sd->skeletonId(sdFrame), sdFrame, skel);
 
     UCHAR alpha = 255 - 255.0 * OnionSkinMask::getOnionSkinFade(
-                                    abs(osRows[r] - currentRow));
+                                    abs(osRows[r].first - currentRow));
     drawSkeleton(skel, pixelSize, alpha);
   }
 }

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1173,9 +1173,9 @@ void TTool::Viewer::getGuidedFrameIdx(int *backIdx, int *frontIdx) {
   TFrameHandle *currentFrame = getApplication()->getCurrentFrame();
 
   int cidx     = currentFrame->getFrameIndex();
-  int mosBack  = 0;
-  int mosFront = 0;
-  int mosCount = osMask.getMosCount();
+  int rosBack  = 0;
+  int rosFront = 0;
+  int rosCount = osMask.getRosCount();
   int fosBack  = -1;
   int fosFront = -1;
   int fosCount = osMask.getFosCount();
@@ -1183,18 +1183,18 @@ void TTool::Viewer::getGuidedFrameIdx(int *backIdx, int *frontIdx) {
   // Find onion-skinned drawing that is being used for guided auto inbetween
   if (Preferences::instance()->getGuidedDrawingType() == 1) {
     // Get closest moving unionskin
-    for (int i = 0; i < mosCount; i++) {
-      int cmos = osMask.getMos(i);
+    for (int i = 0; i < rosCount; i++) {
+      int cmos = osMask.getRos(i);
       if (cmos == 0) continue;  // skip current
-      if (cmos < 0 && (!mosBack || cmos > mosBack)) mosBack = cmos;
-      if (cmos > 0 && (!mosFront || cmos < mosFront)) mosFront = cmos;
+      if (cmos < 0 && (!rosBack || cmos > rosBack)) rosBack = cmos;
+      if (cmos > 0 && (!rosFront || cmos < rosFront)) rosFront = cmos;
     }
-    if (mosBack) *backIdx = mosBack + cidx;
-    if (mosFront) *frontIdx = mosFront + cidx;
+    if (rosBack) *backIdx = rosBack + cidx;
+    if (rosFront) *frontIdx = rosFront + cidx;
 
     // Get closest fixed onionskin
     for (int i = 0; i < fosCount; i++) {
-      int cfos = osMask.getFos(i);
+      int cfos = osMask.getRos(i);
       if (cfos == cidx) continue;  // skip current
       if (cfos < cidx && (fosBack == -1 || cfos > fosBack)) fosBack = cfos;
       if (cfos > cidx && (fosFront == -1 || cfos < fosFront)) fosFront = cfos;
@@ -1211,18 +1211,18 @@ void TTool::Viewer::getGuidedFrameIdx(int *backIdx, int *frontIdx) {
   } else if (Preferences::instance()->getGuidedDrawingType() ==
              2) {  // Furthest drawing
                    // Get moving unionskin
-    for (int i = 0; i < mosCount; i++) {
-      int cmos = osMask.getMos(i);
+    for (int i = 0; i < rosCount; i++) {
+      int cmos = osMask.getRos(i);
       if (cmos == 0) continue;  // skip current
-      if (cmos < 0 && (!mosBack || cmos < mosBack)) mosBack = cmos;
-      if (cmos > 0 && (!mosFront || cmos > mosFront)) mosFront = cmos;
+      if (cmos < 0 && (!rosBack || cmos < rosBack)) rosBack = cmos;
+      if (cmos > 0 && (!rosFront || cmos > rosFront)) rosFront = cmos;
     }
-    if (mosBack) *backIdx = mosBack + cidx;
-    if (mosFront) *frontIdx = mosFront + cidx;
+    if (rosBack) *backIdx = rosBack + cidx;
+    if (rosFront) *frontIdx = rosFront + cidx;
 
     // Get fixed onionskin
     for (int i = 0; i < fosCount; i++) {
-      int cfos = osMask.getFos(i);
+      int cfos = osMask.getRos(i);
       if (cfos == cidx) continue;  // skip current
       if (cfos < cidx && (fosBack == -1 || cfos < fosBack)) fosBack = cfos;
       if (cfos > cidx && (fosFront == -1 || cfos > fosFront)) fosFront = cfos;

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1194,7 +1194,7 @@ void TTool::Viewer::getGuidedFrameIdx(int *backIdx, int *frontIdx) {
 
     // Get closest fixed onionskin
     for (int i = 0; i < fosCount; i++) {
-      int cfos = osMask.getRos(i);
+      int cfos = osMask.getFos(i);
       if (cfos == cidx) continue;  // skip current
       if (cfos < cidx && (fosBack == -1 || cfos > fosBack)) fosBack = cfos;
       if (cfos > cidx && (fosFront == -1 || cfos < fosFront)) fosFront = cfos;
@@ -1222,7 +1222,7 @@ void TTool::Viewer::getGuidedFrameIdx(int *backIdx, int *frontIdx) {
 
     // Get fixed onionskin
     for (int i = 0; i < fosCount; i++) {
-      int cfos = osMask.getRos(i);
+      int cfos = osMask.getFos(i);
       if (cfos == cidx) continue;  // skip current
       if (cfos < cidx && (fosBack == -1 || cfos < fosBack)) fosBack = cfos;
       if (cfos > cidx && (fosFront == -1 || cfos > fosFront)) fosFront = cfos;

--- a/toonz/sources/toonz/onionskinmaskgui.cpp
+++ b/toonz/sources/toonz/onionskinmaskgui.cpp
@@ -148,13 +148,13 @@ void OnioniSkinMaskGUI::OnionSkinSwitcher::clearOS() {
 
 void OnioniSkinMaskGUI::OnionSkinSwitcher::enableRelativeFrameMode() {
   OnionSkinMask osm = getMask();
-  osm.setRelativeSkinMode(osm.FRAMES);
+  osm.setRelativeFrameMode(true);
   setMask(osm);
 }
 
 void OnioniSkinMaskGUI::OnionSkinSwitcher::enableRelativeDrawingMode() {
   OnionSkinMask osm = getMask();
-  osm.setRelativeSkinMode(osm.DRAWING);
+  osm.setRelativeFrameMode(false);
   setMask(osm);
 }
 

--- a/toonz/sources/toonz/onionskinmaskgui.h
+++ b/toonz/sources/toonz/onionskinmaskgui.h
@@ -34,6 +34,7 @@ public:
   bool isActive() const;
   bool isWholeScene() const;
   bool isEveryFrame() const;
+  bool isRelativeFrameMode() const;
 
 public slots:
   void activate();
@@ -44,7 +45,10 @@ public slots:
   void setNewExposure();
   void clearFOS();
   void clearMOS();
+  void clearDOS();
   void clearOS();
+  void enableRelativeFrameMode();
+  void enableRelativeDrawingMode();
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2316,8 +2316,8 @@ void SceneViewer::drawScene() {
       Stage::visit(painter, app->getCurrentLevel()->getLevel(),
                    app->getCurrentFrame()->getFid(),
                    app->getCurrentOnionSkin()->getOnionSkinMask(),
-                   frameHandle->isPlaying(), useGuidedDrawing, guidedBackStroke,
-                   guidedFrontStroke);
+                   frameHandle->isPlaying(), xsh, useGuidedDrawing,
+                   guidedBackStroke, guidedFrontStroke);
     } else {
       std::pair<TXsheet *, int> xr;
       int xsheetLevel = 0;
@@ -3432,14 +3432,14 @@ int SceneViewer::posToRow(const TPointD &p, double distance,
   Stage::Picker picker(getViewMatrix(), pos, m_visualSettings,
                        getDevPixRatio());
   picker.setMinimumDistance(distance);
-
+  
+  TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
   if (app->getCurrentFrame()->isEditingLevel()) {
     Stage::visit(picker, app->getCurrentLevel()->getLevel(),
                  app->getCurrentFrame()->getFid(), osm,
-                 app->getCurrentFrame()->isPlaying(), false);
+                 app->getCurrentFrame()->isPlaying(), xsh, false);
   } else {
     ToonzScene *scene      = app->getCurrentScene()->getScene();
-    TXsheet *xsh           = app->getCurrentXsheet()->getXsheet();
     int frame              = app->getCurrentFrame()->getFrame();
     int currentColumnIndex = app->getCurrentColumn()->getColumnIndex();
 

--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -11,6 +11,7 @@
 // forward declaration
 class XsheetViewer;
 class QMenu;
+class TXsheet;
 
 namespace XsheetGUI {
 
@@ -34,7 +35,8 @@ class OnionSkinPopup final : public QWidget {
 
 public:
   OnionSkinPopup(QWidget *parent, bool isVertical = true);
-  void setOnionSkinData(int currentRow, int os, bool isFixed);
+  void setOnionSkinData(int currentRow, int os, bool isFixed, TXsheet *xsh,
+                        int currentCol);
 
 protected:
   // void mouseMoveEvent ( QMouseEvent * e );

--- a/toonz/sources/toonzlib/onionskinmask.cpp
+++ b/toonz/sources/toonzlib/onionskinmask.cpp
@@ -59,13 +59,14 @@ double inline getIncrement(int paperThickness) {
 
 TEnv::IntVar WholeScene("OnionSkinWholeScene", 0);
 TEnv::IntVar EveryFrame("OnionSkinEveryFrame", 1);
+TEnv::IntVar RelativeFrameMode("OnionSkinRelativeFrameMode", 1);
 
 OnionSkinMask::OnionSkinMask() {
   m_enabled = false;
   m_wholeScene = WholeScene;
   m_everyFrame = EveryFrame;
   m_LightTableStatus = false;
-  m_relativeSkinMode = RelativeSkinMode::FRAMES;
+  m_isRelativeFrameMode = RelativeFrameMode;
 }
 
 void OnionSkinMask::clear() {
@@ -88,17 +89,16 @@ void OnionSkinMask::clear() {
 void OnionSkinMask::getAll(int currentRow,
                            std::vector<std::pair<int, double>> &output,
                            TXsheet *xsh, int col) const {
-  bool framesMode = m_relativeSkinMode == RelativeSkinMode::FRAMES;
-
   output.clear();
-  output.reserve(m_fos.size() + (framesMode ? m_mos.size() : m_dos.size()));
+  output.reserve(m_fos.size() +
+                 (m_isRelativeFrameMode ? m_mos.size() : m_dos.size()));
 
   std::vector<std::pair<int, double>>::const_iterator fosIt(m_fos.begin()), fosEnd(m_fos.end());
   std::vector<std::pair<int, double>> dos2mos;
   std::vector<std::pair<int, double>>::const_iterator dosIt(m_dos.begin()),
       dosEnd(m_dos.end());
 
-  if (!framesMode && xsh && col >= 0) {
+  if (!m_isRelativeFrameMode && xsh && col >= 0) {
     // Translate relative drawing position to frame drawing position
     int r0, r1;
     int n = xsh->getCellRange(col, r0, r1);
@@ -146,8 +146,8 @@ void OnionSkinMask::getAll(int currentRow,
   }
 
   std::vector<std::pair<int, double>>::const_iterator rosIt(
-      framesMode ? m_mos.begin() : dos2mos.begin()),
-      rosEnd(framesMode ? m_mos.end() : dos2mos.end());
+      m_isRelativeFrameMode ? m_mos.begin() : dos2mos.begin()),
+      rosEnd(m_isRelativeFrameMode ? m_mos.end() : dos2mos.end());
 
   for (; fosIt != fosEnd && rosIt != rosEnd;) {
     int fos = fosIt->first;
@@ -393,6 +393,11 @@ void OnionSkinMask::setShiftTraceGhostAff(int index, const TAffine &aff) {
 void OnionSkinMask::setShiftTraceGhostCenter(int index, const TPointD &center) {
   assert(0 <= index && index < 2);
   m_ghostCenter[index] = center;
+}
+
+void OnionSkinMask::setRelativeFrameMode(bool on) {
+  m_isRelativeFrameMode = on;
+  RelativeFrameMode     = m_isRelativeFrameMode;
 }
 
 //***************************************************************************

--- a/toonz/sources/toonzlib/onionskinmask.cpp
+++ b/toonz/sources/toonzlib/onionskinmask.cpp
@@ -10,6 +10,8 @@
 
 #include "toonz/onionskinmask.h"
 
+#include "toonz/txshcell.h"
+
 //*****************************************************************************************
 //    Macros
 //*****************************************************************************************
@@ -63,11 +65,13 @@ OnionSkinMask::OnionSkinMask() {
   m_wholeScene = WholeScene;
   m_everyFrame = EveryFrame;
   m_LightTableStatus = false;
+  m_relativeSkinMode = RelativeSkinMode::FRAMES;
 }
 
 void OnionSkinMask::clear() {
   m_fos.clear();
   m_mos.clear();
+  m_dos.clear();
 
   m_shiftTraceStatus = DISABLED;
 
@@ -81,35 +85,101 @@ void OnionSkinMask::clear() {
 
 //-------------------------------------------------------------------
 
-void OnionSkinMask::getAll(int currentRow, std::vector<int> &output) const {
+void OnionSkinMask::getAll(int currentRow,
+                           std::vector<std::pair<int, double>> &output,
+                           TXsheet *xsh, int col) const {
+  bool framesMode = m_relativeSkinMode == RelativeSkinMode::FRAMES;
+
   output.clear();
-  output.reserve(m_fos.size() + m_mos.size());
+  output.reserve(m_fos.size() + (framesMode ? m_mos.size() : m_dos.size()));
 
-  std::vector<std::pair<int, double>>::const_iterator fosIt, fosEnd(m_fos.end());
-  std::vector<std::pair<int, double>>::const_iterator mosIt,
-      mosEnd(m_mos.end());
+  std::vector<std::pair<int, double>>::const_iterator fosIt(m_fos.begin()), fosEnd(m_fos.end());
+  std::vector<std::pair<int, double>> dos2mos;
+  std::vector<std::pair<int, double>>::const_iterator dosIt(m_dos.begin()),
+      dosEnd(m_dos.end());
 
-  for (fosIt = m_fos.begin(), mosIt = m_mos.begin();
-       fosIt != fosEnd && mosIt != mosEnd;) {
-    int fos = fosIt->first, mos = mosIt->first + currentRow;
+  if (!framesMode && xsh && col >= 0) {
+    // Translate relative drawing position to frame drawing position
+    int r0, r1;
+    int n = xsh->getCellRange(col, r0, r1);
+    std::vector<TXshCell> cells(n);
+    bool useImplicit = Preferences::instance()->isImplicitHoldEnabled();
+    xsh->getCells(r0, col, n, &cells[0]);
+    TXshCell startCell = xsh->getCell(currentRow, col);
+    for (; dosIt != dosEnd;) {
+      int r             = currentRow - r0;
+      TXshCell prevCell = startCell;
+      if (r >= n)  // after last cell
+        r = n - 1;
+      else if (r < 0)  // Before the 1st cell
+        r = 0;
+      if (prevCell.getFrameId().isStopFrame()) prevCell = TXshCell();
 
-    if (fos < mos) {
-      if (fos != currentRow) output.push_back(fos);
+      int x = dosIt->first;
+      if (x < 0) {
+        // Find Previous Drawings
+        for (; r >= 0; r--) {
+          if (cells[r].isEmpty() || cells[r].getFrameId().isStopFrame())
+            continue;
+          if (cells[r] != prevCell) {
+            prevCell = cells[r];
+            x++;
+            if (!x) break;
+          }
+        }
+      } else if (x > 0) {
+        // Find Next Drawings
+        for (; r < n; r++) {
+          if (cells[r].isEmpty() || cells[r].getFrameId().isStopFrame())
+            continue;
+          if (cells[r] != prevCell) {
+            prevCell = cells[r];
+            x--;
+            if (!x) break;
+          }
+        }
+      }
+      if (r >= 0 && r < n)
+        dos2mos.push_back(std::make_pair((r + r0 - currentRow), dosIt->second));
+      ++dosIt;
+    }
+  }
+
+  std::vector<std::pair<int, double>>::const_iterator rosIt(
+      framesMode ? m_mos.begin() : dos2mos.begin()),
+      rosEnd(framesMode ? m_mos.end() : dos2mos.end());
+
+  for (; fosIt != fosEnd && rosIt != rosEnd;) {
+    int fos = fosIt->first;
+    int ros = rosIt->first + currentRow;
+
+    if (fos < ros) {
+      if (fos != currentRow)
+        output.push_back(std::make_pair(fos, fosIt->second));
 
       ++fosIt;
     } else {
-      if (mos != currentRow) output.push_back(mos);
+      double opacity = rosIt->second;
+      if (fos == ros) {
+        double fosFade = fosIt->second;
+        double rosFade = rosIt->second;
+        opacity        = fosFade == -1.0
+                      ? rosFade
+                      : (rosFade == -1 ? fosFade : std::min(fosFade, rosFade));
+      }
+      if (ros != currentRow) output.push_back(std::make_pair(ros, opacity));
 
-      ++mosIt;
+      ++rosIt;
     }
   }
 
   for (; fosIt != fosEnd; ++fosIt)
-    if (fosIt->first != currentRow) output.push_back(fosIt->first);
+    if (fosIt->first != currentRow)
+      output.push_back(std::make_pair(fosIt->first, fosIt->second));
 
-  for (; mosIt != mosEnd; ++mosIt) {
-    int mos = mosIt->first + currentRow;
-    if (mos != currentRow) output.push_back(mos);
+  for (; rosIt != rosEnd; ++rosIt) {
+    int ros = rosIt->first + currentRow;
+    if (ros != currentRow) output.push_back(std::make_pair(ros, rosIt->second));
   }
 }
 
@@ -144,6 +214,24 @@ void OnionSkinMask::setFos(int row, bool on) {
       m_fos.insert(r, std::make_pair(row, -1));
   } else {
     if (r != m_fos.end() && r->first == row) m_fos.erase(r);
+  }
+}
+
+//-------------------------------------------------------------------
+
+void OnionSkinMask::setDos(int drow, bool on) {
+  assert(drow != 0);
+
+  std::vector<std::pair<int, double>>::iterator r;
+  for (r = m_dos.begin(); r != m_dos.end(); r++) {
+    if (r->first >= drow) break;
+  }
+
+  if (on) {
+    if (r == m_dos.end() || r->first != drow)
+      m_dos.insert(r, std::make_pair(drow, -1));
+  } else {
+    if (r != m_dos.end() && r->first == drow) m_dos.erase(r);
   }
 }
 
@@ -193,6 +281,28 @@ double OnionSkinMask::getFosOpacity(int drow) {
 
 //-------------------------------------------------------------------
 
+void OnionSkinMask::setDosOpacity(int drow, double opacity) {
+  std::vector<std::pair<int, double>>::iterator r;
+  for (r = m_dos.begin(); r != m_dos.end(); r++) {
+    if (r->first == drow) {
+      r->second = opacity;
+      break;
+    }
+  }
+}
+
+//-------------------------------------------------------------------
+
+double OnionSkinMask::getDosOpacity(int drow) {
+  std::vector<std::pair<int, double>>::iterator r;
+  for (r = m_dos.begin(); r != m_dos.end(); r++)
+    if (r->first == drow) return r->second;
+
+  return -1.0;
+}
+
+//-------------------------------------------------------------------
+
 bool OnionSkinMask::isFos(int row) {
   std::vector<std::pair<int, double>>::iterator r;
   for (r = m_fos.begin(); r != m_fos.end(); r++)
@@ -213,12 +323,34 @@ bool OnionSkinMask::isMos(int drow) {
 
 //-------------------------------------------------------------------
 
+bool OnionSkinMask::isDos(int drow) {
+  std::vector<std::pair<int, double>>::iterator r;
+  for (r = m_dos.begin(); r != m_dos.end(); r++)
+    if (r->first == drow) return true;
+
+  return false;
+}
+
+//-------------------------------------------------------------------
+
 bool OnionSkinMask::getMosRange(int &drow0, int &drow1) const {
   if (m_mos.empty()) {
     drow0 = 0, drow1 = -1;
     return false;
   } else {
     drow0 = m_mos.front().first, drow1 = m_mos.back().first;
+    return true;
+  }
+}
+
+//-------------------------------------------------------------------
+
+bool OnionSkinMask::getDosRange(int &drow0, int &drow1) const {
+  if (m_dos.empty()) {
+    drow0 = 0, drow1 = -1;
+    return false;
+  } else {
+    drow0 = m_dos.front().first, drow1 = m_dos.back().first;
     return true;
   }
 }
@@ -298,14 +430,14 @@ void OnionSkinMaskModifier::click(int row, bool isFos) {
     }
   } else {
     int drow = row - m_curRow;
-    if (drow != 0 && m_curMask.isEnabled() && m_curMask.isMos(drow)) {
+    if (drow != 0 && m_curMask.isEnabled() && m_curMask.isRos(drow)) {
       m_status = 4;  // spegnere mos
-      m_curMask.setMos(drow, false);
+      m_curMask.setRos(drow, false);
     } else if (drow == 0) {
       m_status = 8 + 4 + 1;  // accendere mos; partito da 0
     } else {
       if (!m_curMask.isEnabled()) m_curMask.enable(true);
-      m_curMask.setMos(drow, true);
+      m_curMask.setRos(drow, true);
       m_status = 4 + 1;  // accendere mos;
     }
   }
@@ -331,7 +463,7 @@ void OnionSkinMaskModifier::drag(int row) {
         m_curMask.clear();
         m_curMask.enable(true);
       }
-      if (r != m_curRow) m_curMask.setMos(r - m_curRow, (m_status & 1) != 0);
+      if (r != m_curRow) m_curMask.setRos(r - m_curRow, (m_status & 1) != 0);
     } else
       m_curMask.setFos(r, (m_status & 1) != 0);
   }
@@ -354,6 +486,8 @@ void OnionSkinMaskModifier::release(int row) {
         m_curMask.setMos(-1, true);
         m_curMask.setMos(-2, true);
         m_curMask.setMos(-3, true);
+        m_curMask.setDos(-1, true);
+        m_curMask.setDos(1, true);
       }
     }
   }


### PR DESCRIPTION
Current Onion Skin has 2 basic modes, Fixed and Relative.  This new feature will essentially split the Relative Onion Skin into 2 modes:
- Frames (current; default)
- Drawings (new)

You can switch between these modes using in the Frames context menu like so:
![image](https://github.com/user-attachments/assets/fb789fdf-1878-4136-aff3-9384c344311d)

The relative marker shapes indicate the mode you are in, Circle = Frame, Square = Drawing.

In Frame Onion Skin Mode, the relative marker will show the frame that the mark is actually on. Relative Drawing Onion Skin Mode is different  in that setting a relative skin marker will display a specific drawing before/after the current frame..  The distance away from the current frame determines which drawing away from the current frame to show, i.e. 1 away-1st drawing, 2 away-2nd drawing, etc

![image](https://github.com/user-attachments/assets/fe7985f8-ec24-40ce-9c58-9e2f42cbcd47)

In the image, the current drawing is Drawing 4.  The selected markers means that the onion skins will be shown for drawings 1, 2, 3 and 5, 6, 7 even though they are spaced apart.