### PR TITLE
Relocate/Rename FX Browser menu command

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2160,8 +2160,6 @@ void MainWindow::defineActions() {
                          "delete_lines");
   createMenuXsheetAction(MI_MergeColumns, QT_TR_NOOP("&Merge Levels"), "",
                          "merge_levels");
-  createMenuXsheetAction(MI_InsertFx, QT_TR_NOOP("&New FX..."), "Ctrl+F",
-                         "fx_logo");
   createMenuXsheetAction(MI_NewOutputFx, QT_TR_NOOP("&New Output"), "Alt+O",
                          "output");
   createMenuXsheetAction(MI_InsertSceneFrame, QT_TR_NOOP("Insert Frame"), "",
@@ -2452,6 +2450,8 @@ void MainWindow::defineActions() {
                           "", "studiopalette");
   createMenuWindowsAction(MI_OpenSchematic, QT_TR_NOOP("&Schematic"), "",
                           "schematic");
+  createMenuWindowsAction(MI_InsertFx, QT_TR_NOOP("&FX Browser"), "Ctrl+F",
+                          "fx_logo");
   createMenuWindowsAction(MI_FxParamEditor, QT_TR_NOOP("&FX Editor"), "Ctrl+K",
                           "fx_settings");
   createMenuWindowsAction(MI_OpenCleanupSettings,

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -431,7 +431,6 @@ void TopBar::loadMenubar() {
   addMenuItem(sceneMenu, MI_DeleteMatchLines);
   addMenuItem(sceneMenu, MI_DeleteInk);
   sceneMenu->addSeparator();
-  addMenuItem(sceneMenu, MI_InsertFx);
   addMenuItem(sceneMenu, MI_NewOutputFx);
   sceneMenu->addSeparator();
   addMenuItem(sceneMenu, MI_InsertSceneFrame);
@@ -674,6 +673,7 @@ void TopBar::loadMenubar() {
   addMenuItem(windowsMenu, MI_OpenTimelineView);
   addMenuItem(windowsMenu, MI_OpenFunctionEditor);
   addMenuItem(windowsMenu, MI_OpenSchematic);
+  addMenuItem(windowsMenu, MI_InsertFx);
   addMenuItem(windowsMenu, MI_FxParamEditor);
   addMenuItem(windowsMenu, MI_OpenFilmStrip);
   addMenuItem(windowsMenu, MI_OpenLocator);


### PR DESCRIPTION
Now that the FX Browser is dockable as a result of #1419, the menu option `Scene` -> `New FX...` that normally brings up this window is now found as `Panels` -> `FX Browser`