### PR TITLE
Fix implicit getCells in column range

### DIFF
--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -191,9 +191,16 @@ void TXshCellColumn::getCells(int row, int rowCount, TXshCell cells[],
   TXshCell *endDstCell = dstCell + dst;
   while (dstCell < endDstCell) *dstCell++ = emptyCell;
   endDstCell += n;
+  TXshCell tmpCell;
   while (dstCell < endDstCell) {
     TXshCell cell = m_cells[src];
-    if (cell.isEmpty() && implicitLookup) cell = getCell(src + dst);
+    if (implicitLookup) {
+      if (cell.isEmpty() && src > 0 &&
+          !tmpCell.isEmpty()) {
+        cell = tmpCell;
+      } else if (!cell.getFrameId().isStopFrame())
+        tmpCell = cell;
+    }
     *dstCell++ = cell;
     src++;
   }


### PR DESCRIPTION
While working on a new feature, I encountered an implicit hold bug when getting a range of column cells.  The implicit cells returned may not  be the correct one.

This fixes the issue I found which, based on it's usage, might have only impacted merging columns.