### PR TITLE
[WIP] Block codec DLL files that cause crashes

### DIFF
--- a/toonz/sources/include/dllblacklist.h
+++ b/toonz/sources/include/dllblacklist.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifndef DDLBLACKLIST_H
+#define DDLBLACKLIST_H
+
+#ifdef _WIN32
+
+// Blacklist entries must be all lowercase
+std::vector<QString> dllBlackList = {"lvcod64.dll", "ff_vfw.dll"};
+
+bool isDLLBlacklisted(QString dll) {
+  // Added blacklisted DLLS known to cause crashes
+  bool blacklisted = false;
+  for (int x = 0; x < dllBlackList.size(); x++) {
+    blacklisted = dll.toLower().contains(dllBlackList[x]);
+    if (blacklisted) break;
+  }
+
+  return blacklisted;
+}
+
+#endif
+
+#endif

--- a/toonz/sources/toonzlib/avicodecrestrictions.cpp
+++ b/toonz/sources/toonzlib/avicodecrestrictions.cpp
@@ -2,6 +2,7 @@
 
 #include "avicodecrestrictions.h"
 #include "tconvert.h"
+#include "dllblacklist.h"
 #include <windows.h>
 #include <vfw.h>
 
@@ -205,7 +206,7 @@ QMap<std::wstring, bool> AviCodecRestrictions::getUsableCodecs(
   ICINFO icinfo;
   memset(&icinfo, 0, sizeof(ICINFO));
 
-  char descr[2048], name[2048];
+  char descr[2048], name[2048], driver[2048];
   DWORD fccType = 0;
 
   BITMAPINFO inFmt;
@@ -227,9 +228,12 @@ QMap<std::wstring, bool> AviCodecRestrictions::getUsableCodecs(
                           sizeof(descr), 0, 0);
       WideCharToMultiByte(CP_ACP, 0, icinfo.szName, -1, name, sizeof(name), 0,
                           0);
+      WideCharToMultiByte(CP_ACP, 0, icinfo.szDriver, -1, driver,
+                          sizeof(driver), 0, 0); 
       // Give up to load codecs once the blackmagic codec is found -
       // as it seems to cause crash for unknown reasons (issue #138)
-      if (strstr(descr, "Blackmagic") != 0) break;
+      if (isDLLBlacklisted(QString(driver)) || strstr(descr, "Blackmagic") != 0)
+        break;
 
       std::wstring compressorName;
       compressorName =


### PR DESCRIPTION
This should prevent crashes when T2D attempts to search for an AVI codec to use and encounters specific DLLs known to cause crashes at startup:

- C:\Windows\System32\lvcod64.dll     (Logitech codec)
- C:\Windows\System32\ff_vfw.dll        (ffdshow codec)

The logic actually ignores path and only look for the actual filename.

As I cannot verify this works, this ticket will remain in WIP status until someone with the problem can verify the artifact does resolve the problem.

