### PR TITLE
Fix extend cells creating explicit holds in implicit mode

### DIFF
--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -792,7 +792,7 @@ public:
         if (column && column->getFolderColumn()) continue;
         bool isSoundColumn = (column && column->getSoundColumn());
         if (m_insert) xsh->insertCells(m_r1 + 1, m_c0 + c, dr);
-        TXshCell prevCell = xsh->getCell(m_r1, c);
+        TXshCell prevCell = xsh->getCell(m_r1, m_c0 + c);
         for (int r = m_r1 + 1; r <= r1; r++) {
           TXshCell cell = m_columns[c].generate(r);
           if (isSoundColumn ||


### PR DESCRIPTION
This fixes an issue where explicit holds are created for columns other than column 1 when extending cells while in Implicit Mode.