### PR TITLE
Fix hidden column folder move

### DIFF
--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -286,12 +286,14 @@ Set column color tag to \b colorTag.
   void removeFromAllFolders();
   int folderDepth();
 
-  TXshColumn *getFolderColumn() const;
-  bool isFolderCamstandVisible() const;
-  bool isFolderPreviewVisible() const;
-  bool isFolderLocked() const;
-  UCHAR getFolderOpacity() const;
-  int getFolderColorFilterId() const;
+  TXshColumn *getParentFolder(int position = -1) const;
+  bool isParentFolderCamstandVisible() const;
+  bool isParentFolderPreviewVisible() const;
+  bool isParentFolderLocked() const;
+  UCHAR getParentFolderOpacity() const;
+  int getParentFolderColorFilterId() const;
+
+  bool isColumnVisible();
 
   bool loadFolderInfo(std::string tagName, TIStream &is);
   void saveFolderInfo(TOStream &os);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2692,7 +2692,7 @@ void ColumnTransparencyPopup::setColumn(TXshColumn *column) {
           SLOT(onValueChanged(const QString &)));
 
   m_slider->setEnabled(true);
-  if (column->getFolderOpacity() != 255) m_slider->setEnabled(false);
+  if (column->getParentFolderOpacity() != 255) m_slider->setEnabled(false);
 
   m_filterColorCombo->clear();
   // initialize color filter combo box
@@ -2715,7 +2715,8 @@ void ColumnTransparencyPopup::setColumn(TXshColumn *column) {
       m_filterColorCombo->findData(m_column->getColorFilterId()));
 
   m_filterColorCombo->setEnabled(true);
-  if (column->getFolderColorFilterId()) m_filterColorCombo->setEnabled(false);
+  if (column->getParentFolderColorFilterId())
+    m_filterColorCombo->setEnabled(false);
 
   m_maskGroupBox->blockSignals(true);
   m_invertMask->blockSignals(true);
@@ -3593,7 +3594,7 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
   if (m_doOnRelease != 0) {
     TXshColumn *column = xsh->getColumn(m_col);
     if (m_doOnRelease == ToggleTransparency) {
-      if (column->isFolderCamstandVisible()) {
+      if (column->isParentFolderCamstandVisible()) {
         column->setCamstandVisible(!column->isCamstandVisible());
         // sync eye button
         if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
@@ -3602,11 +3603,11 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
           app->getCurrentXsheet()->notifyXsheetSoundChanged();
       }
     } else if (m_doOnRelease == TogglePreviewVisible) {
-      if (column->isFolderPreviewVisible()) {
+      if (column->isParentFolderPreviewVisible()) {
         column->setPreviewVisible(!column->isPreviewVisible());
       }
     } else if (m_doOnRelease == ToggleLock) {
-      if (!column->isFolderLocked()) {
+      if (!column->isParentFolderLocked()) {
         column->lock(!column->isLocked());
       }
     } else if (m_doOnRelease == OpenSettings) {

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1960,10 +1960,11 @@ public:
       int newCol = m_firstCol + offset;
 
       // Dropping into folder
-      if (!m_addToFolder.isEmpty() && offset > 0 && xsh->getColumn(m_targetCol)->getFolderColumn() &&
+      if (!m_addToFolder.isEmpty() && offset && xsh->getColumn(m_targetCol)->getFolderColumn() &&
           xsh->getColumn(m_targetCol)->getFolderColumn()->getFolderColumnFolderId() == m_addToFolder.back()) {
         xsh->openCloseFolder(m_targetCol, true);
-        newCol--;
+        if (offset > 0)
+          newCol--;
       }
 
       if (newCol < 0) return;
@@ -1975,10 +1976,10 @@ public:
       for (it = vOldIndices.rbegin(); it != vOldIndices.rend(); it++, i++) {
         newIndices.insert(newCol + i);
 
-        TXshColumn *column = xsh->getColumn(*it);
+        TXshColumn *column        = xsh->getColumn(*it);
         QStack<int> folderIdStack = column->getFolderIdStack();
         vOldFolders.insert(vOldFolders.begin(), folderIdStack);
-  
+
         if (subfolder >= 0 && !column->isContainedInFolder(subfolder)) {
           folderList.pop();
           if (folderList.size())

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1741,16 +1741,48 @@ public:
   }
   void undo() const override {
     moveColumns(m_newIndices, m_oldIndices, m_oldFolders);
+
     TSelection *selection =
         TApp::instance()->getCurrentSelection()->getSelection();
     if (selection) selection->selectNone();
+
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (std::set<int>::iterator it = m_oldIndices.begin();
+         it != m_oldIndices.end(); ++it) {
+      TXshColumn *column   = xsh->getColumn(*it);
+      bool isColumnVisible = column->isColumnVisible();
+      for (auto o : Orientations::all()) {
+        ColumnFan *columnFan = xsh->getColumnFan(o);
+        if (isColumnVisible)
+          columnFan->show(*it);
+        else
+          columnFan->hide(*it);
+      }
+    }
+
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   }
   void redo() const override {
     moveColumns(m_oldIndices, m_newIndices, m_newFolders);
+
     TSelection *selection =
         TApp::instance()->getCurrentSelection()->getSelection();
     if (selection) selection->selectNone();
+
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (std::set<int>::iterator it = m_newIndices.begin();
+         it != m_newIndices.end(); ++it) {
+      TXshColumn *column   = xsh->getColumn(*it);
+      bool isColumnVisible = column->isColumnVisible();
+      for (auto o : Orientations::all()) {
+        ColumnFan *columnFan = xsh->getColumnFan(o);
+        if (isColumnVisible)
+          columnFan->show(*it);
+        else
+          columnFan->hide(*it);
+      }
+    }
+
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   }
   int getSize() const override {
@@ -2000,8 +2032,19 @@ public:
 
       selection->selectNone();
       for (std::set<int>::iterator it = newIndices.begin();
-           it != newIndices.end(); ++it)
+           it != newIndices.end(); ++it) {
         selection->selectColumn(*it, true);
+
+        TXshColumn *column = xsh->getColumn(*it);
+        bool isColumnVisible = column->isColumnVisible();
+        for (auto o : Orientations::all()) {
+          ColumnFan *columnFan = xsh->getColumnFan(o);
+          if (isColumnVisible)
+            columnFan->show(*it);
+          else
+            columnFan->hide(*it);
+        }
+      }
 
       TUndoManager::manager()->add(new ColumnMoveUndo(
           oldIndices, vOldFolders, newIndices, vNewFolders));

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -685,7 +685,7 @@ void TXshColumn::setCamstandNextState() {
 //-----------------------------------------------------------------------------
 
 bool TXshColumn::isCamstandVisible() const {
-  if (!isFolderCamstandVisible()) return false;
+  if (!isParentFolderCamstandVisible()) return false;
   return (m_status & eCamstandVisible) == 0;
 }
 
@@ -717,7 +717,7 @@ void TXshColumn::setCamstandVisible(bool on) {
 //-----------------------------------------------------------------------------
 
 UCHAR TXshColumn::getOpacity() const {
-  UCHAR folderOpacity = getFolderOpacity();
+  UCHAR folderOpacity = getParentFolderOpacity();
 
   return folderOpacity == 255 ? m_opacity : folderOpacity;
 }
@@ -725,7 +725,7 @@ UCHAR TXshColumn::getOpacity() const {
 //-----------------------------------------------------------------------------
 
 int TXshColumn::getColorFilterId() const {
-  int folderColorFilterId = getFolderColorFilterId();
+  int folderColorFilterId = getParentFolderColorFilterId();
 
   return !folderColorFilterId ? m_colorFilterId : folderColorFilterId;
 }
@@ -733,7 +733,7 @@ int TXshColumn::getColorFilterId() const {
 //-----------------------------------------------------------------------------
 
 bool TXshColumn::isPreviewVisible() const {
-  if (!isFolderPreviewVisible()) return false;
+  if (!isParentFolderPreviewVisible()) return false;
   return (m_status & ePreviewVisible) == 0;
 }
 
@@ -750,7 +750,7 @@ void TXshColumn::setPreviewVisible(bool on) {
 //-----------------------------------------------------------------------------
 
 bool TXshColumn::isLocked() const {
-  if (isFolderLocked()) return true;
+  if (isParentFolderLocked()) return true;
   return (m_status & eLocked) != 0;
 }
 
@@ -895,7 +895,7 @@ int TXshColumn::folderDepth() { return m_folderId.size(); }
 
 //-----------------------------------------------------------------------------
 
-TXshColumn *TXshColumn::getFolderColumn() const {
+TXshColumn *TXshColumn::getParentFolder(int position) const {
   TXsheet *xsh = getXsheet();
   if (!xsh) return 0;
 
@@ -905,7 +905,7 @@ TXshColumn *TXshColumn::getFolderColumn() const {
     TXshColumn *folderColumn = xsh->getColumn(i);
     if (folderColumn->getFolderColumn() &&
         folderColumn->getFolderColumn()->getFolderColumnFolderId() ==
-            getFolderId())
+            getFolderId(position))
       return folderColumn;
     if (!folderColumn->isInFolder()) break;
   }
@@ -914,47 +914,60 @@ TXshColumn *TXshColumn::getFolderColumn() const {
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isFolderCamstandVisible() const {
+bool TXshColumn::isParentFolderCamstandVisible() const {
   if (m_folderId.isEmpty()) return true;
-  TXshColumn *column = getFolderColumn();
+  TXshColumn *column = getParentFolder();
 
   return column ? column->isCamstandVisible() : true;
 }
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isFolderPreviewVisible() const {
+bool TXshColumn::isParentFolderPreviewVisible() const {
   if (m_folderId.isEmpty()) return true;
-  TXshColumn *column = getFolderColumn();
+  TXshColumn *column = getParentFolder();
 
   return column ? column->isPreviewVisible() : true;
 }
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isFolderLocked() const {
+bool TXshColumn::isParentFolderLocked() const {
   if (m_folderId.isEmpty()) return false;
-  TXshColumn *column = getFolderColumn();
+  TXshColumn *column = getParentFolder();
 
   return column ? column->isLocked() : false;
 }
 
 //-----------------------------------------------------------------------------
 
-UCHAR TXshColumn::getFolderOpacity() const {
+UCHAR TXshColumn::getParentFolderOpacity() const {
   if (m_folderId.isEmpty()) return 255;
-  TXshColumn *column = getFolderColumn();
+  TXshColumn *column = getParentFolder();
 
   return column ? column->getOpacity() : 255;
 }
 
 //-----------------------------------------------------------------------------
 
-int TXshColumn::getFolderColorFilterId() const {
+int TXshColumn::getParentFolderColorFilterId() const {
   if (m_folderId.isEmpty()) return 0;
-  TXshColumn *column = getFolderColumn();
+  TXshColumn *column = getParentFolder();
 
   return column ? column->getColorFilterId() : 0;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::isColumnVisible() {
+  if (m_folderId.isEmpty()) return true;
+
+  for (int i = 0; i < m_folderId.size(); i++) {
+    TXshColumn *folder = getParentFolder(i);
+    if (folder && !folder->getFolderColumn()->isExpanded()) return false;
+  }
+
+  return true;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the following issues related to moving hidden columns when a Folder is close

- When dropping into a closed folder that is below/left of the moved column, the folder will auto-expand similar to when dropping into a folder above/right of the moved column
- When columns in a closed folder are somehow selected and moved outside of the folder, the column remains forever hidden on the timeline/xsheet.  This now check's the column's visibility based on what and where it is dropped and will make the column visible or hidden if needed.