### PR TITLE
Fix pasting raster selection in xsheet/timeline cell

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -9,6 +9,7 @@
 #include "toonz/imagepainter.h"
 #include "toonz/tapplication.h"
 #include "tools/cursors.h"
+#include "tpalette.h"
 
 // TnzCore includes
 #include "tcommon.h"
@@ -549,6 +550,8 @@ transformation.
   void setAlignMethod(int method) { m_alignMethod = method; }
   int getAlignMethod() { return m_alignMethod; }
  
+  void removeTouchedImageIfNeeded(const TPaletteP &oldPalette);
+
 public:
   struct CellOps {
     int r0;

--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -746,7 +746,10 @@ void StrokeSelection::paste() {
   }
 
   TVectorImageP tarImg = TImageP(tool->touchImage());
-  if (!tarImg) return;
+  if (!tarImg) {
+    tool->removeTouchedImageIfNeeded(0);
+    return;
+  }
   TPaletteP palette       = tarImg->getPalette();
   TPaletteP oldPalette    = new TPalette();
   if (palette) oldPalette = palette->clone();
@@ -762,7 +765,8 @@ void StrokeSelection::paste() {
         level, tool->getCurrentFid(), indexSet, oldPalette, m_sceneHandle,
         tool->m_isFrameCreated, tool->m_isLevelCreated));
     m_updateSelectionBBox = isPaste;
-  }
+  } else
+    tool->removeTouchedImageIfNeeded(oldPalette);
   tool->notifyImageChanged();
   tool->getApplication()
       ->getPaletteController()

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -370,6 +370,8 @@ TImage *TTool::touchImage(bool forDuplicate) {
   // Stop frames cannot be modified
   if (cell.getFrameId().isStopFrame()) return 0;
 
+  if (cell.getChildLevel()) return 0;
+
   TXshSimpleLevel *sl = cell.getSimpleLevel();
 
   if (sl) {

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -35,6 +35,7 @@
 #include "toonz/palettecontroller.h"
 #include "toonz/tonionskinmaskhandle.h"
 #include "toutputproperties.h"
+#include "toonz/levelset.h"
 
 // TnzCore includes
 #include "tvectorimage.h"
@@ -1577,4 +1578,60 @@ void TTool::flipGuideStrokeDirection(int mode) {
   sl->setDirtyFlag(true);
   getViewer()->invalidateAll();
   m_application->getCurrentLevel()->notifyLevelChange();
+}
+
+//-------------------------------------------------------------------------------------------------------------
+
+void TTool::removeTouchedImageIfNeeded(const TPaletteP &oldPalette) {
+  TXshSimpleLevel *sl =
+      m_application->getCurrentLevel()->getLevel()->getSimpleLevel();
+  if (!sl) return;
+
+  TFrameId frameId = getCurrentFid();
+
+  int col = m_application->getCurrentColumn()->getColumnIndex();
+  int row = m_application->getCurrentFrame()->getFrameIndex();
+
+  if (m_isFrameCreated) {
+    sl->eraseFrame(frameId);
+    if (!m_application->getCurrentFrame()->isEditingLevel()) {
+      TXsheet *xsh = m_application->getCurrentXsheet()->getXsheet();
+      TXshCell cell;
+      for (const TTool::CellOps &cellOps : TTool::m_cellsData) {
+        if (cellOps.type == TTool::CellOps::ExistingToNew)
+          cell = xsh->getCell(cellOps.r0 - 1, col);
+        for (int r = cellOps.r0; r <= cellOps.r1; r++)
+          xsh->setCell(r, col, cell);
+      }
+      if (TTool::m_cellsData.size() < 1) {
+        xsh->setCell(row, col, cell);
+      }
+    }
+    if (m_isLevelCreated) {
+      TLevelSet *levelSet =
+          m_application->getCurrentScene()->getScene()->getLevelSet();
+      if (levelSet) {
+        levelSet->removeLevel(sl);
+        m_application->getCurrentScene()->notifyCastChange();
+      }
+    }
+  }
+  if (oldPalette.getPointer()) {
+    sl->getPalette()->assign(oldPalette->clone());
+    m_application->getPaletteController()
+        ->getCurrentLevelPalette()
+        ->notifyPaletteChanged();
+  }
+  if (m_isLevelRenumbererd) {
+    TXsheet *xsh = m_application->getCurrentScene()->getScene()->getTopXsheet();
+    std::vector<TXshChildLevel *> childLevels;
+    ToolUtils::doUpdateXSheet(sl, m_newFids, m_oldFids, xsh, childLevels);
+    sl->renumber(m_oldFids);
+    m_application->getCurrentXsheet()->notifyXsheetChanged();
+  }
+  if (m_isFrameCreated || m_isLevelCreated)
+    m_application->getCurrentLevel()->notifyLevelChange();
+  m_isFrameCreated     = false;
+  m_isLevelCreated     = false;
+  m_isLevelRenumbererd = false;
 }

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -692,7 +692,7 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
   TApp *app      = TApp::instance();
   TXsheet *xsh   = app->getCurrentXsheet()->getXsheet();
   TXshCell cell  = xsh->getCell(row, col);
-  if(xsh->getColumn(col)->getFolderColumn()){
+  if (col < 0 || xsh->getColumn(col)->getFolderColumn()) {
     DVGui::error(
         QObject::tr("It is not possible to paste image on the current cell."));
     return false;

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -557,7 +557,7 @@ bool pasteStrokesInCellWithoutUndo(
   } else {
     vi = cell.getImage(true);
     sl = cell.getSimpleLevel();
-    if (sl->getType() == OVL_XSHLEVEL && sl->getPath().isUneditable())
+    if (!sl || (sl->getType() == OVL_XSHLEVEL && sl->getPath().isUneditable()))
       return false;
     fid = cell.getFrameId();
     if (!vi) {

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -692,6 +692,12 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
   TApp *app      = TApp::instance();
   TXsheet *xsh   = app->getCurrentXsheet()->getXsheet();
   TXshCell cell  = xsh->getCell(row, col);
+  if(xsh->getColumn(col)->getFolderColumn()){
+    DVGui::error(
+        QObject::tr("It is not possible to paste image on the current cell."));
+    return false;
+  }
+
   TImageP img;
   TXshSimpleLevel *sl = 0;
   TFrameId fid(1);

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -372,6 +372,9 @@ void TApp::updateXshLevel() {
                                           ->m_levels.at(0)
                                           ->getSoundLevel());
       }
+    } else if (xsheet->getColumn(column) &&
+               xsheet->getColumn(column)->getFolderColumn()) {
+      getCurrentSelection()->setSelection(0);
     } else if (xsheet && column >= 0 && frame >= 0 &&
                !xsheet->isColumnEmpty(column)) {
       TXshCell cell = xsheet->getCell(frame, column);


### PR DESCRIPTION
This fixes issues related to pasting image selections in certain xsheet/timeline cells.

This is done by selecting a part of an image and then clicking on a xsheet/timeline cell in order to either add it to that image or create a new frame with the selection. 

The issues correct are as follows:
1. This fixes #1573 
Since cells are not allowed in folder columns, this will throw an error message to the user and cancel the paste action.
2. Fixes pasting selection in a non-image cell (camera, sound, palette, mesh, etc) that causes a crash similar to the issue mentioned above
3. Fixes an issue where pasting selection fails, usually pasting raster into vector/smart raster, but creates a new frame that is not undoable
4. Block pasting selection in a sub-scene cell which clears an existing frame that cannot be undone.