### PR TITLE
Fix ffmpeg MP4/MOV color space

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ff_mov.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ff_mov.cpp
@@ -94,9 +94,28 @@ TLevelWriterFFMov::~TLevelWriterFFMov() {
   postIArgs << "yuva444p10le";
   postIArgs << "-profile:v";
   postIArgs << "4";
-  postIArgs << "-s";
-  postIArgs << QString::number(outLx) + "x" + QString::number(outLy);
-  postIArgs << "-b";
+/* KONERO_VERSION
+  postIArgs << "-vf";
+  postIArgs << "scale=" + QString::number(outLx) + "x" +
+                   QString::number(outLy) +
+                   ":in_color_matrix=bt709:out_color_matrix=bt709";
+*/
+// RODNEY VERSION
+  postIArgs << "-vf";
+  postIArgs
+      << "scale=" + QString::number(outLx) + "x" + QString::number(outLy) +
+             "," +
+             "colorspace=all=bt709:iall=bt601-6-625:fast=1";  // Adding color
+                                                              // space
+                                                              // conversion
+  postIArgs << "-color_primaries";
+  postIArgs << "bt709";
+  postIArgs << "-color_trc";
+  postIArgs << "bt709";
+  postIArgs << "-colorspace";
+  postIArgs << "bt709";
+//
+  postIArgs << "-b:v";
   postIArgs << QString::number(finalBitrate) + "k";
 
   ffmpegWriter->runFfmpeg(preIArgs, postIArgs, false, false, true);

--- a/toonz/sources/image/ffmpeg/tiio_mp4.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.cpp
@@ -86,9 +86,11 @@ TLevelWriterMp4::~TLevelWriterMp4() {
 
   postIArgs << "-pix_fmt";
   postIArgs << "yuv420p";
-  postIArgs << "-s";
-  postIArgs << QString::number(outLx) + "x" + QString::number(outLy);
-  postIArgs << "-b";
+  postIArgs << "-vf";
+  postIArgs << "scale=" + QString::number(outLx) + "x" +
+                   QString::number(outLy) +
+                   ":in_color_matrix=bt709:out_color_matrix=bt709";
+  postIArgs << "-b:v";
   postIArgs << QString::number(finalBitrate) + "k";
   if (Ffmpeg::checkCodecs("libopenh264")) {
     postIArgs << "-c:v";

--- a/toonz/sources/image/ffmpeg/tiio_mp4.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.cpp
@@ -86,10 +86,27 @@ TLevelWriterMp4::~TLevelWriterMp4() {
 
   postIArgs << "-pix_fmt";
   postIArgs << "yuv420p";
+/* KONERO_VERSION
   postIArgs << "-vf";
   postIArgs << "scale=" + QString::number(outLx) + "x" +
                    QString::number(outLy) +
                    ":in_color_matrix=bt709:out_color_matrix=bt709";
+*/
+// RODNEY VERSION
+  postIArgs << "-vf";
+  postIArgs
+      << "scale=" + QString::number(outLx) + "x" + QString::number(outLy) +
+             "," +
+             "colorspace=all=bt709:iall=bt601-6-625:fast=1";  // Adding color
+                                                              // space
+                                                              // conversion
+  postIArgs << "-color_primaries";
+  postIArgs << "bt709";
+  postIArgs << "-color_trc";
+  postIArgs << "bt709";
+  postIArgs << "-colorspace";
+  postIArgs << "bt709";
+//
   postIArgs << "-b:v";
   postIArgs << QString::number(finalBitrate) + "k";
   if (Ffmpeg::checkCodecs("libopenh264")) {


### PR DESCRIPTION
This fixes an issue with MP4/MOV renders through ffmpeg having their colors look muted (or desaturated, or something other than actual).

Thanks to @RodneyBaker 's investigation and some testing, he found right ffmpeg parameters to correct the color of MP4 renders through ffmpeg.
```
  postIArgs << "-pix_fmt";
  postIArgs << "yuv420p";
  postIArgs << "-b:v";
  postIArgs << QString::number(finalBitrate) + "k";
  postIArgs << "-vf";
  postIArgs << "scale=" + QString::number(outLx) + "x" + QString::number(outLy) + ",";
  postIArgs << "colorspace=all=bt709:iall=bt601-6-625:fast=1"; // Adding color space conversion
  postIArgs << "-color_primaries";
  postIArgs << "bt709";
  postIArgs << "-color_trc";
  postIArgs << "bt709";
  postIArgs << "-colorspace";
  postIArgs << "bt709";
```

@konero also provided a slightly different set of ffmpeg parameters to use.
```
  postIArgs << "-pix_fmt";
  postIArgs << "yuv420p";
  postIArgs << "-vf";
  postIArgs << "scale=" + QString::number(outLx) + "x" + QString::number(outLy) + ":in_color_matrix=bt709:out_color_matrix=bt709";
  postIArgs << "-b:v";
  postIArgs << QString::number(finalBitrate) + "k";
```
I wound up using @RodneyBaker's version, but have added both of them as co-authors in the commit. Thank you both for this fix.

This fix, though appears to be good for Windows renders, doesn't quite fix macOS renders.  It does, however, seem shift the color closer to what T2D displays in macOS.  Further investigation for parameters better suited for macOS needs to be done.