### PR TITLE
Add MSVC DLLs to Windows Package

### DIFF
--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -50,6 +50,9 @@ IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC" set
 
 %QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe --opengl
 
+xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.29.30133\x64\Microsoft.VC142.CRT Tahoma2D
+xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.29.30133\x64\Microsoft.VC142.OpenMP Tahoma2D
+
 del /A- /S Tahoma2D\tahomastuff\*.gitkeep
 
 IF EXIST ..\..\thirdparty\apps\ffmpeg\bin (


### PR DESCRIPTION
This fixes the Windows releases to include VCRUNTIME140.dll, MSVCP140 and supporting MSVC DLLs.

Some newer systems do not have these necessary DLLs by default and cause T2D to crash on startup. They used to be included with the release but stopped with v1.2 for some unknown reason.