### PR TITLE
Fix Drag/Drop Fx Plugin

### DIFF
--- a/toonz/sources/toonzqt/insertfxpopup.cpp
+++ b/toonz/sources/toonzqt/insertfxpopup.cpp
@@ -180,7 +180,7 @@ void FxTree::mousePressEvent(QMouseEvent *event) {
   // Let's use FxsData to transfer to schematic
   FxsData *fxData = new FxsData();
   QList<TFxP> fxList;
-  fxList.append(fx);
+  fxList.append(fx->clone());
   fxData->setFxs(fxList, QList<TFxCommand::Link>(), QList<int>(), 0);
 
   QMimeData *mimeData = new QMimeData;


### PR DESCRIPTION
This fixes a reported crash when rendering using an Fx Plugin.

This only occurred when the fx plugin was dragged/dropped from the Fx Browser to the Fx Schematic implemented in #1419. 
