### PR TITLE
Update Chocolatey boost install for Windows build

### DIFF
--- a/ci-scripts/windows/tahoma-install.bat
+++ b/ci-scripts/windows/tahoma-install.bat
@@ -1,5 +1,5 @@
 choco install opencv --version=4.5.1
-choco install boost-msvc-14.2
+choco install boost-msvc-14.2 --version=1.74.0
 
 mkdir thirdparty\qt
 


### PR DESCRIPTION
The default Chocolatey install of Boost has been updated from version 1.74 to 1.86 which is breaking current Windows builds.

Updating the script to force loading the prior version for now.

Will merge this immediately once I confirm a success Windows build has been created.