### PR TITLE
Skip Stop Holds with Next/Previous Drawing

### DIFF
--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -77,7 +77,9 @@ public:
     int frameCount = xsh->getFrameCount();
     while (row < frameCount) {
       row++;
-      if (xsh->getCell(row, col).isEmpty()) continue;
+      if (xsh->getCell(row, col).isEmpty() ||
+          xsh->getCell(row, col).getFrameId().isStopFrame())
+        continue;
       if (xsh->getCell(row, col) != cell) {
         TApp::instance()->getCurrentFrame()->setFrame(row);
 
@@ -107,7 +109,9 @@ public:
     // Get *last* cell in previous uniform cell block
     while (row >= 0) {
       row--;
-      if (xsh->getCell(row, col).isEmpty()) continue;
+      if (xsh->getCell(row, col).isEmpty() ||
+          xsh->getCell(row, col).getFrameId().isStopFrame())
+        continue;
       if (xsh->getCell(row, col) != cell) {
         cell = xsh->getCell(row, col);
         break;


### PR DESCRIPTION
Fixes Next/Previous Drawing commands to ignore Stop Holds.