### PR TITLE
Undo/Redo Touch Gestures

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -98,6 +98,9 @@ public:
                     header)     */
   };
 
+  enum GestureUndoMethod { TwoFingerTap, ThreeFingerDragLeft };
+  enum GestureRedoMethod { ThreeFingerTap, ThreeFingerDragRight };
+
   enum SnappingTarge { SnapStrokes, SnapGuides, SnapAll };
 
   enum PathAliasPriority {
@@ -534,6 +537,12 @@ public:
   }
 
   // Tablet tab
+  GestureUndoMethod getGestureUndoMethod() const {
+    return GestureUndoMethod(getIntValue(gestureUndoMethod));
+  }
+  GestureRedoMethod getGestureRedoMethod() const {
+    return GestureRedoMethod(getIntValue(gestureRedoMethod));
+  }
   bool isWinInkEnabled() const { return getBoolValue(winInkEnabled); }
   bool isQtNativeWinInkEnabled() const {
     return getBoolValue(useQtNativeWinInk);

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -203,6 +203,8 @@ enum PreferencesItemId {
   // Touch / Tablet Settings
   // TounchGestureControl // Touch Gesture is a checkable command and not in
   // preferences.ini
+  gestureUndoMethod,
+  gestureRedoMethod,
   winInkEnabled,
   // This option will be shown & available only when WITH_WINTAB is defined
   useQtNativeWinInk,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1501,6 +1501,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Touch / Tablet Settings
       // TounchGestureControl // Touch Gesture is a checkable command and not in
       // preferences.ini
+      {gestureUndoMethod, tr("Undo Gesture:")},
+      {gestureRedoMethod, tr("Redo Gesture:")},
       {winInkEnabled, tr("Enable Windows Ink Support* (EXPERIMENTAL)")},
       {useQtNativeWinInk,
        tr("Use Qt's Native Windows Ink Support*\n(CAUTION: This options is for "
@@ -1612,7 +1614,13 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
         {tr("Expression "), 7},
         {tr("File"), 8}}},
       {animatedGuidedDrawing,
-       {{tr("Arrow Markers"), 0}, {tr("Animated Guide"), 1}}}};
+       {{tr("Arrow Markers"), 0}, {tr("Animated Guide"), 1}}},
+      {gestureUndoMethod,
+       {{tr("2-Finger Tap"), Preferences::TwoFingerTap},
+        {tr("3-Finger Drag Left"), Preferences::ThreeFingerDragLeft}}},
+      {gestureRedoMethod,
+       {{tr("3-Finger Tap"), Preferences::ThreeFingerTap},
+        {tr("3-Finger Drag Right"), Preferences::ThreeFingerDragRight}}}};
   assert(comboItemsTable.contains(id));
   return comboItemsTable.value(id, QList<ComboBoxItem>());
 }
@@ -2407,9 +2415,6 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
 
   QAction* touchAction =
       CommandManager::instance()->getAction(MI_TouchGestureControl);
-  CheckBox* enableTouchGestures =
-      new CheckBox(tr("Enable Touch Gesture Controls"));
-  enableTouchGestures->setChecked(touchAction->isChecked());
 
   QPushButton* viewerEventLogBtn =
       new QPushButton(tr("Open Viewer Event Log"));
@@ -2418,8 +2423,22 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
   QGridLayout* lay = new QGridLayout();
   setupLayout(lay);
 
-  lay->addWidget(enableTouchGestures, 0, 0, 1, 2);
-  lay->addWidget(viewerEventLogBtn, 0, 3, 1, 1);
+  QGroupBox* touchGesturesBox =
+      new QGroupBox(tr("Enable Touch Gesture Controls"), this);
+  touchGesturesBox->setCheckable(true);
+  touchGesturesBox->setChecked(touchAction->isChecked());
+  QGridLayout* touchGestureslay = new QGridLayout();
+  setupLayout(touchGestureslay, 5);
+  touchGesturesBox->setLayout(touchGestureslay);
+  {
+    insertUI(gestureUndoMethod, touchGestureslay,
+             getComboItemList(gestureUndoMethod));
+    insertUI(gestureRedoMethod, touchGestureslay,
+             getComboItemList(gestureRedoMethod));
+  }
+
+  lay->addWidget(touchGesturesBox, 0, 0, 1, 2);
+  lay->addWidget(viewerEventLogBtn, 0, 3, 2, 1, Qt::AlignTop);
   if (winInkAvailable) insertUI(winInkEnabled, lay);
 #ifdef WITH_WINTAB
   insertUI(useQtNativeWinInk, lay);
@@ -2430,10 +2449,10 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
   widget->setLayout(lay);
 
   bool ret = true;
-  ret = ret && connect(enableTouchGestures, SIGNAL(clicked(bool)), touchAction,
+  ret = ret && connect(touchGesturesBox, SIGNAL(clicked(bool)), touchAction,
                        SLOT(setChecked(bool)));
-  ret = ret && connect(touchAction, SIGNAL(triggered(bool)),
-                       enableTouchGestures, SLOT(setChecked(bool)));
+  ret = ret && connect(touchAction, SIGNAL(triggered(bool)), touchGesturesBox,
+                       SLOT(setChecked(bool)));
   ret = ret && connect(viewerEventLogBtn, SIGNAL(clicked()), this,
                        SLOT(onOpenViewerEventLog()));
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2448,6 +2448,12 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
   if (winInkAvailable) insertFootNote(lay);
   widget->setLayout(lay);
 
+#ifdef MACOSX
+  // Can only support 3-finger swipe undo/redo gestures for now
+  m_controlIdMap.key(gestureUndoMethod)->setEnabled(false);
+  m_controlIdMap.key(gestureRedoMethod)->setEnabled(false);
+#endif
+
   bool ret = true;
   ret = ret && connect(touchGesturesBox, SIGNAL(clicked(bool)), touchAction,
                        SLOT(setChecked(bool)));

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -888,6 +888,7 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
   grabGesture(Qt::SwipeGesture);
   grabGesture(Qt::PanGesture);
   grabGesture(Qt::PinchGesture);
+  grabGesture(Qt::TapGesture);
 
   setUpdateBehavior(QOpenGLWidget::PartialUpdate);
 

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -100,6 +100,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
   bool m_rotating                        = false;
   bool m_zooming                         = false;
   bool m_panning                         = false;
+  int m_touchPoints                      = 0;
 
   // These are for mouse based zoom, rotate, pan
   int m_mouseRotating   = 0;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1192,6 +1192,8 @@ void SceneViewer::gestureEvent(QGestureEvent *e) {
     m_gestureActive = true;
   } else if (QGesture *pan = e->gesture(Qt::PanGesture)) {
     m_gestureActive = true;
+  } else if (QGesture *pan = e->gesture(Qt::TapGesture)) {
+    m_gestureActive = true;
   }
   if (QGesture *pinch = e->gesture(Qt::PinchGesture)) {
     QPinchGesture *gesture = static_cast<QPinchGesture *>(pinch);

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1308,7 +1308,6 @@ void SceneViewer::touchEvent(QTouchEvent *e, int type) {
         m_touchPoints = 100;  // This will block undo/redo action
       }
     } else if (e->touchPoints().count() == 3) {
-
       QPointF newPoint = e->touchPoints().at(0).pos();
       if ((m_undoPoint.x() - newPoint.x()) > 100 &&
           Preferences::instance()->getGestureUndoMethod() ==
@@ -1347,6 +1346,7 @@ bool SceneViewer::event(QEvent *e) {
   case QEvent::TabletMove:
   case QEvent::TabletRelease:
   case QEvent::TouchBegin:
+  case QEvent::TouchUpdate:
   case QEvent::TouchEnd:
   case QEvent::TouchCancel:
   case QEvent::Gesture:

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -4,6 +4,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QTabletEvent>
+#include <QGestureEvent>
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QApplication>
@@ -275,8 +276,45 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
 
   case QEvent::Gesture: {
     if (!m_eventCheckBox[VIEWEREVENT::Gesture]->isChecked()) return;
+    QGestureEvent *ge = dynamic_cast<QGestureEvent *>(e);
+    QString action;
+    for (int i = 0; i < ge->gestures().count(); i++) {
+      if (i > 0) action += ",";
+      QGesture *g = ge->gestures()[i];
+      switch (g->gestureType()) {
+      case Qt::GestureType::PanGesture:
+        action += "pan";
+        break;
+      case Qt::GestureType::SwipeGesture:
+        action += "swipe";
+        break;
+      case Qt::GestureType::PinchGesture:
+        action += "pinch";
+        break;
+      case Qt::GestureType::TapGesture:
+        action += "tap";
+        break;
+      default:
+        action += "unknown";
+        break;
+      }
+      switch (g->state()) {
+      case Qt::GestureState::GestureStarted:
+        action += "-started";
+        break;
+      case Qt::GestureState::GestureUpdated:
+        action += "-updated";
+        break;
+      case Qt::GestureState::GestureFinished:
+        action += "-finished";
+        break;
+      case Qt::GestureState::GestureCanceled:
+        action += "-cancelled";
+        break;
+      }
+    }
 
-    eventMsg = tr("Gesture encountered");
+    eventMsg = tr("Gesture encountered (%1)").arg(action);
   } break;
 
   case QEvent::MouseButtonPress: {

--- a/toonz/sources/toonz/viewereventlogpopup.h
+++ b/toonz/sources/toonz/viewereventlogpopup.h
@@ -3,6 +3,8 @@
 #ifndef VIEWER_EVENT_LOG_H
 #define VIEWER_EVENT_LOG_H
 
+#include "saveloadqsettings.h"
+
 #include <QSplitter>
 #include <QEvent>
 
@@ -13,16 +15,31 @@ class QPushButton;
 //**************************************************************
 //    Viewer Event Log Popup
 //**************************************************************
+enum VIEWEREVENT {
+  Enter = 0,
+  Leave,
+  TabletPress,
+  TabletMove,
+  TabletRelease,
+  TouchBegin,
+  TouchUpdate,
+  TouchEnd,
+  TouchCancel,
+  Gesture,
+  MouseButtonPress,
+  MouseMove,
+  MouseButtonRelease,
+  MouseButtonDblClick,
+  KeyPress,
+  KeyRelease,
+  Count
+};
 
 class ViewerEventLogPopup final : public QSplitter {
   Q_OBJECT
 
   QTextEdit *m_eventLog;
-  QCheckBox *m_eventEnter, *m_eventLeave, *m_eventTabletPress,
-      *m_eventTabletMove, *m_eventTabletRelease, *m_eventTouchBegin,
-      *m_eventTouchEnd, *m_eventTouchCancel, *m_eventGesture,
-      *m_eventMouseButtonPress, *m_eventMouseMove, *m_eventMouseButtonRelease,
-      *m_eventMouseButtonDblClick, *m_eventKeyPress, *m_eventKeyRelease;
+  QCheckBox *m_toggleAllOnOff, *m_eventCheckBox[VIEWEREVENT::Count];
 
   QPushButton *m_pauseBtn;
 
@@ -30,6 +47,8 @@ class ViewerEventLogPopup final : public QSplitter {
   int m_lastMsgCount;
 
   bool m_logging;
+
+  int m_eventCount;
 
 public:
   ViewerEventLogPopup(QWidget *parent = 0);
@@ -42,6 +61,8 @@ public slots:
   void onPauseButtonPressed();
   void onCopyButtonPressed();
   void onClearButtonPressed();
+  void onToggleAllOnOff();
+  void onEventFilterUpdated();
 };
 
 //**************************************************************

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -682,6 +682,10 @@ void Preferences::definePreferenceItems() {
   // Touch / Tablet Settings
   // TounchGestureControl // Touch Gesture is a checkable command and not in
   // preferences.ini
+  define(gestureUndoMethod, "gestureUndoMethod", QMetaType::Int,
+         (int)TwoFingerTap);
+  define(gestureRedoMethod, "gestureRedoMethod", QMetaType::Int,
+         (int)ThreeFingerTap);
   define(winInkEnabled, "winInkEnabled", QMetaType::Bool, false);
   // This option will be shown & available only when WITH_WINTAB is defined
   define(useQtNativeWinInk, "useQtNativeWinInk", QMetaType::Bool, false);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -291,6 +291,12 @@ void Preferences::load() {
     setValue(CurrentLanguageName, "English");
 
   TImageWriter::setBackgroundColor(getColorValue(rasterBackgroundColor));
+
+#ifdef MACOSX
+  // Can only support 3-finger swipe undo/redo gestures for now
+  setValue(gestureUndoMethod, GestureUndoMethod::ThreeFingerDragLeft);
+  setValue(gestureRedoMethod, GestureRedoMethod::ThreeFingerDragRight);
+#endif
 }
 
 //-----------------------------------------------------------------
@@ -682,10 +688,19 @@ void Preferences::definePreferenceItems() {
   // Touch / Tablet Settings
   // TounchGestureControl // Touch Gesture is a checkable command and not in
   // preferences.ini
+#ifdef MACOSX
+  // Currently 2/3 fingre tapping doesn't work on macOS for either touchpad or
+  // touchscreen. For now, force to only use 3-finger swping
+  define(gestureUndoMethod, "gestureUndoMethod", QMetaType::Int,
+         (int)ThreeFingerDragLeft);
+  define(gestureRedoMethod, "gestureRedoMethod", QMetaType::Int,
+         (int)ThreeFingerDragRight);
+#else
   define(gestureUndoMethod, "gestureUndoMethod", QMetaType::Int,
          (int)TwoFingerTap);
   define(gestureRedoMethod, "gestureRedoMethod", QMetaType::Int,
          (int)ThreeFingerTap);
+#endif  // !MACOS
   define(winInkEnabled, "winInkEnabled", QMetaType::Bool, false);
   // This option will be shown & available only when WITH_WINTAB is defined
   define(useQtNativeWinInk, "useQtNativeWinInk", QMetaType::Bool, false);


### PR DESCRIPTION
Discovered that Tahoma2D has Undo/Redo Touch Gestures for touchscreens (windows) and touchpads (macs). The original method uses 3-finger swipe Left (Undo) or Right (Redo).

This will add and additional option for how to invoke Undo/Redo using a 2-finger Tap (Undo) and 3-finger Tap (Redo) matching the undo/redo gestures in other apps and can be changed in Preferences:
![image](https://github.com/user-attachments/assets/35c4e687-7abc-4b3e-8c9d-2eabc2ed4ed0)

Mac Users:  The 2/3-finger tapping methods do not currently work on macOS using either touchpad or touchscreen.
