### PR TITLE
Fix Create Blank Drawing making new level after Stop Frame

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -478,10 +478,12 @@ TImage *TTool::touchImage(bool forDuplicate) {
     // find the last not-empty cell before the current one (a) and the first
     // after (b)
     int a = row - 1, b = row + 1;
-    while (a >= r0 && xsh->getCell(a, col).isEmpty()) a--;
-    while (b <= r1 && xsh->getCell(b, col).isEmpty()) b++;
-
-    if (a >= r0 && xsh->getCell(a, col).getFrameId().isStopFrame()) a = r0 - 1;
+    while (a >= r0 && (xsh->getCell(a, col).isEmpty() ||
+                       xsh->getCell(a, col).getFrameId().isStopFrame()))
+      a--;
+    while (b <= r1 && (xsh->getCell(b, col).isEmpty() ||
+                       xsh->getCell(b, col).getFrameId().isStopFrame()))
+      b++;
 
     // find the level we must attach to
     if (a >= r0) {

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -3057,7 +3057,7 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
     xsh->getCellRange(col, r0, r1);
     for (int r = std::min(r1, row); r > r0; r--) {
       TXshCell cell = xsh->getCell(r, col);
-      if (cell.isEmpty()) continue;
+      if (cell.isEmpty() || cell.getFrameId().isStopFrame()) continue;
       level = cell.m_level.getPointer();
       if (!level) continue;
       break;


### PR DESCRIPTION
This fixes an issue where `Create Blank Drawing` creates a brand new level when created in an empty cell after a Stop Frame instead of creating another frame for the existing level.