### PR TITLE
Ignore Auto-Stretch while in Implicit Mode

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -478,10 +478,12 @@ TImage *TTool::touchImage(bool forDuplicate) {
     // find the last not-empty cell before the current one (a) and the first
     // after (b)
     int a = row - 1, b = row + 1;
-    while (a >= r0 && xsh->getCell(a, col).isEmpty()) a--;
-    while (b <= r1 && xsh->getCell(b, col).isEmpty()) b++;
-
-    if (a >= r0 && xsh->getCell(a, col).getFrameId().isStopFrame()) a = r0 - 1;
+    while (a >= r0 && (xsh->getCell(a, col).isEmpty() ||
+                       xsh->getCell(a, col).getFrameId().isStopFrame()))
+      a--;
+    while (b <= r1 && (xsh->getCell(b, col).isEmpty() ||
+                       xsh->getCell(b, col).getFrameId().isStopFrame()))
+      b++;
 
     // find the level we must attach to
     if (a >= r0) {

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -310,7 +310,7 @@ TImage *TTool::touchImage(bool forDuplicate) {
 
   bool isAutoCreateEnabled        = pref->isAutoCreateEnabled();
   bool animationSheetEnabled      = pref->isAnimationSheetEnabled();
-  bool isAutoStretchEnabled       = pref->isAutoStretchEnabled();
+  bool isAutoStretchEnabled       = pref->isImplicitHoldEnabled() ? false : pref->isAutoStretchEnabled();
   bool isAutoRenumberEnabled      = pref->isAutorenumberEnabled();
   bool isCreateInHoldCellsEnabled =
       isAutoCreateEnabled && pref->isCreationInHoldCellsEnabled();

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -3057,7 +3057,7 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
     xsh->getCellRange(col, r0, r1);
     for (int r = std::min(r1, row); r > r0; r--) {
       TXshCell cell = xsh->getCell(r, col);
-      if (cell.isEmpty()) continue;
+      if (cell.isEmpty() || cell.getFrameId().isStopFrame()) continue;
       level = cell.m_level.getPointer();
       if (!level) continue;
       break;


### PR DESCRIPTION
When in Implicit Mode, the Auto-Stretch setting is completely ignored. 

This corrects an issue when creating a new frame between a Stop Hold frame and an Exposed frame creating explicit frames between the new frame and other frames.