### PR TITLE
[WIP] macOS 2/3-fingered Touchpad Tap Gesture

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2451,12 +2451,6 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
   if (winInkAvailable) insertFootNote(lay);
   widget->setLayout(lay);
 
-#ifdef MACOSX
-  // Can only support 3-finger swipe undo/redo gestures for now
-  m_controlIdMap.key(gestureUndoMethod)->setEnabled(false);
-  m_controlIdMap.key(gestureRedoMethod)->setEnabled(false);
-#endif
-
   bool ret = true;
   ret = ret && connect(touchGesturesBox, SIGNAL(clicked(bool)), touchAction,
                        SLOT(setChecked(bool)));

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1309,6 +1309,19 @@ void SceneViewer::touchEvent(QTouchEvent *e, int type) {
         panQt(centerDelta.toPoint());
         m_touchPoints = 100;  // This will block undo/redo action
       }
+#ifdef MACOS
+      else {
+        // For macs: Might be using 2-finger touchpad tap to undo
+        if (Preferences::instance()->getGestureRedoMethod() ==
+            Preferences::TwoFingerTap) {
+          // Make it look like a gesture from touchscreen
+          m_gestureActive = true;
+          m_touchDevice   = QTouchDevice::TouchScreen;
+          // macOS will generate ButtonPress/Release on a successful 2-finger
+          // tap
+        }
+      }
+#endif
     } else if (e->touchPoints().count() == 3) {
       QPointF newPoint = e->touchPoints().at(0).pos();
       if ((m_undoPoint.x() - newPoint.x()) > 100 &&
@@ -1325,6 +1338,25 @@ void SceneViewer::touchEvent(QTouchEvent *e, int type) {
         m_undoPoint = newPoint;
         m_touchPoints = 100;  // This will block undo/redo action
       }
+#ifdef MACOS
+      // For macs: Might be using 3-finger touchpad tap to redo
+      if (m_touchDevice == QTouchDevice::TouchPad &&
+          Preferences::instance()->getGestureRedoMethod() ==
+          Preferences::ThreeFingerTap) {
+        // Make it look like a gesture from touchscreen
+        m_gestureActive = true;
+        m_touchDevice   = QTouchDevice::TouchScreen;
+
+        // macOS does not generate ButtonPress/Release on a successful 3-finger
+        // tap. Let's create it
+        QMouseEvent fakePress(QEvent::MouseButtonPress, m_firstPanPoint,
+                                Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+        QApplication::instance()->sendEvent(this, &fakePress);
+        QMouseEvent fakeRelease(QEvent::MouseButtonRelease, m_firstPanPoint,
+                                Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+        QApplication::instance()->sendEvent(this, &fakeRelease);
+      }
+#endif
     }
   }
   if (type == QEvent::TouchEnd || type == QEvent::TouchCancel) {

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -291,12 +291,6 @@ void Preferences::load() {
     setValue(CurrentLanguageName, "English");
 
   TImageWriter::setBackgroundColor(getColorValue(rasterBackgroundColor));
-
-#ifdef MACOSX
-  // Can only support 3-finger swipe undo/redo gestures for now
-  setValue(gestureUndoMethod, GestureUndoMethod::ThreeFingerDragLeft);
-  setValue(gestureRedoMethod, GestureRedoMethod::ThreeFingerDragRight);
-#endif
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
This is an attempt to allow Undo/Redo actions using 2/3-finger tap gesture on macOS touchpads, similar to the one introduced in #1584 

Normally 2/3-fingered tap Undo/Redo requires Qt's Touch events, Gesture events and Mouse Press/Release events. Tap gestures are not generated on macOS touchpads, for some reason, so it works without them as follows:

- 2-fingered tap:
  - macOS touchpad automatically triggers a mouse Press and Release after a 2-fingered tap.  Logic will flag the touch as a gesture from a touchscreen to allow the existing logic to handle the Undo
- 3-fingered tap:
  - macOS touchpad doesn't do anything with this, so the logic will not only flag the touch as a gesture from a touchscreen, but also trigger a mouse Press and Release event to allow the existing logic to handle the Redo
