### PR TITLE
Fix Cleanup Palette switching issues

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2082,6 +2082,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   if (app->getCurrentLevel() && app->getCurrentLevel()->getSimpleLevel())
     palette = app->getCurrentLevel()->getSimpleLevel()->getPalette();
   app->getCurrentPalette()->setPalette(palette);
+  // In case cleanup palette is showing, switch to level palette
+  app->getPaletteController()->editLevelPalette();
   app->getCurrentXsheet()->notifyXsheetSoundChanged();
   app->getCurrentObject()->setIsSpline(false);
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -39,6 +39,7 @@
 #include "toonz/txshsimplelevel.h"
 #include "toonz/tproject.h"
 #include "toonz/scriptengine.h"
+#include "toonz/palettecontroller.h"
 
 // TnzSound includes
 #include "tnzsound.h"
@@ -894,6 +895,9 @@ int main(int argc, char *argv[]) {
 #endif
 
   a.installEventFilter(TApp::instance());
+
+  // In case cleanup palette loaded last, switch to level palette
+  TApp::instance()->getPaletteController()->editLevelPalette();
 
   int ret = a.exec();
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -905,8 +905,7 @@ CleanupColorFieldEditorController::CleanupColorFieldEditorController()
     : m_currentColorField(0)
     , m_colorFieldHandle(new TPaletteHandle)
     , m_palette(new TPalette) {
-  std::wstring name = L"EmptyColorFieldPalette";
-  m_palette->setPaletteName(name);
+  m_palette->setIsCleanupPalette(true);
   m_colorFieldHandle->setPalette(m_palette.getPointer(), 1);
   DVGui::CleanupColorField::setEditorController(this);
 }
@@ -927,8 +926,11 @@ void CleanupColorFieldEditorController::edit(
 
   m_blackColor = dynamic_cast<TBlackCleanupStyle *>(fieldStyle);
   if (m_blackColor) {
-    m_palette->setStyle(1, new TSolidColorStyle);
-    m_palette->getStyle(1)->setMainColor(fieldStyle->getColorParamValue(1));
+    m_palette->setStyle(1, new TBlackCleanupStyle);
+    m_palette->getStyle(1)->setColorParamValue(
+        0, fieldStyle->getColorParamValue(0));
+    m_palette->getStyle(1)->setColorParamValue(
+        1, fieldStyle->getColorParamValue(1));
   } else {
     m_palette->setStyle(1, new TColorCleanupStyle);
 
@@ -961,9 +963,12 @@ void CleanupColorFieldEditorController::onColorStyleChanged() {
 
   TColorStyle *style = m_palette->getStyle(1);
   if (m_blackColor) {
-    if (m_currentColorField->getOutputColor() == style->getMainColor()) return;
+    if (m_currentColorField->getColor() == style->getColorParamValue(0) &&
+        m_currentColorField->getOutputColor() == style->getColorParamValue(1))
+      return;
 
-    m_currentColorField->setOutputColor(style->getMainColor());
+    m_currentColorField->setColor(style->getColorParamValue(0));
+    m_currentColorField->setOutputColor(style->getColorParamValue(1));
   } else {
     if (m_currentColorField->getColor() == style->getMainColor() &&
         m_currentColorField->getOutputColor() == style->getColorParamValue(1))

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -4821,6 +4821,7 @@ void StyleEditor::hideEvent(QHideEvent *) {
   disconnect(m_paletteHandle, 0, this, 0);
   if (m_cleanupPaletteHandle) disconnect(m_cleanupPaletteHandle, 0, this, 0);
   disconnect(m_paletteController, 0, this, 0);
+  m_paletteController->editLevelPalette();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -1584,7 +1584,8 @@ void ColorParameterSelector::clear() {
   if (isVisible()) {
     hide();
     update();
-    qApp->processEvents();
+// Can cause crash when palette switching if stylus used to switch columns
+//    qApp->processEvents();
   }
 }
 


### PR DESCRIPTION
This fixes the following issues related to switching to/from cleanup palette when there is a `Cleanup Settings` panel docked in any room or a cleanup palette is showng in the `Style Editor`.

- Fixes a crash that occurs when a cleanup palette is showing in the style editor and a pen is used to switch columns on the timeline/xsheet.
- When clicking on a color selector in the `Cleanup Settings` panel, the `Style Editor` now loads a temporary cleanup palette so you can change both color parameters instead of a level palette that only allowed you to change 1 parameter.
- On initial startup, the default level palette for the user's preferred level type will be displayed in the `Style Editor` instead of a cleanup palette.
- When loading a scene, if a cleanup palette was displayed, the `Style Editor` will now switch to showing the level palette.
- When the `Style Editor` is closed and currently showing a cleanup palette, it will switch back to level palette.