### PR TITLE
Fix Smart Raster Freehand/Polyline Fill

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -1060,11 +1060,12 @@ void fillAreaWithUndo(const TImageP &img, const TRectD &area, TStroke *stroke,
       for (int tempX = 0; tempX < tempRaster->getLx();
            tempX++, tempPix++, keepPix++) {
 
-        if (tempPix->getInk() >= IGNORECOLORSTYLE || tempPix->getPaint() >= IGNORECOLORSTYLE) {
-          continue;
+        if (tempPix->getInk() < IGNORECOLORSTYLE) {
+          keepPix->setInk(tempPix->getInk());
         }
-        keepPix->setInk(tempPix->getInk());
-        keepPix->setPaint(tempPix->getPaint());
+        if (tempPix->getPaint() < IGNORECOLORSTYLE) {
+          keepPix->setPaint(tempPix->getPaint());
+        }
         keepPix->setTone(tempPix->getTone());
       }
     }


### PR DESCRIPTION
This fixes a reported issue where fills of lines were not happening when using `Freehand` or `Polyline` in `Line` mode.  This only appears to have impacted Smart Raster fills.

Stopped working with v1.4.  Needed to partially reverse a change that was made to stop coloring gap close lines beyond the fill area. Remains to be seen if the original change was needed.  Will need to handle that separately if the issue returns.