### PR TITLE
Fix palette style animation keys management

### DIFF
--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -209,6 +209,7 @@ void TPalette::Page::removeStyle(int indexInPage, bool flagOnly) {
   assert(0 <= styleId && styleId < m_palette->getStyleCount());
   assert(m_palette->m_styles[styleId].first == this);
   m_palette->m_styles[styleId].first = 0;
+  m_palette->m_styleAnimationTable.erase(styleId);
   if (!flagOnly)
     m_palette->m_styles[styleId].second =
         TColorStyleP(new TSolidColorStyle(TPixel32::Black));
@@ -299,6 +300,14 @@ TColorStyle *TPalette::getStyle(int index) const {
 
 //-------------------------------------------------------------------
 
+StyleAnimation TPalette::getStyleAnimation(int styleId) const {
+  StyleAnimationTable::const_iterator sat = m_styleAnimationTable.find(styleId);
+  if (sat == m_styleAnimationTable.end()) return StyleAnimation();
+  return sat->second;
+}
+
+//-------------------------------------------------------------------
+
 int TPalette::getStyleInPagesCount() const {
   int styleInPagesCount = 0;
   for (int i = 0; i < getStyleCount(); i++)
@@ -368,6 +377,16 @@ void TPalette::setStyle(int styleId, TColorStyle *style) {
 
 void TPalette::setStyle(int styleId, const TPixelRGBM32 &color) {
   setStyle(styleId, new TSolidColorStyle(color));
+}
+
+//-------------------------------------------------------------------
+
+void TPalette::setStyleAnimation(int styleId, StyleAnimation styleAnimation) {
+  if (!styleAnimation.size()) {
+    m_styleAnimationTable.erase(styleId);
+    return;
+  }
+  m_styleAnimationTable[styleId] = styleAnimation;
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/include/tpalette.h
+++ b/toonz/sources/include/tpalette.h
@@ -81,6 +81,9 @@ ASAP.
 
 \sa The TColorStyle class.
 */
+typedef std::map<int, TColorStyleP> StyleAnimation;  //!< Style keyframes list.
+typedef std::map<int, StyleAnimation>
+    StyleAnimationTable;  //!< Style keyframes list per style id.
 
 class DVAPI TPalette final : public TPersist, public TSmartObject {
   DECLARE_CLASS_CODE
@@ -176,11 +179,6 @@ public:
   };
 
 private:
-  typedef std::map<int, TColorStyleP>
-      StyleAnimation;  //!< Style keyframes list.
-  typedef std::map<int, StyleAnimation>
-      StyleAnimationTable;  //!< Style keyframes list per style id.
-
   friend class Page;
 
 private:
@@ -256,6 +254,7 @@ public:
   TColorStyle *getStyle(int styleId)
       const;  //!< Returns a pointer to the color style with the specified id,
               //!  or \p 0 if said id is not stored in the palette.
+  StyleAnimation getStyleAnimation(int styleId) const;
   int getStyleCount() const {
     return (int)m_styles.size();
   }  //!< Returns the number of the color styles in the palette.
@@ -284,7 +283,8 @@ public:
       TColorStyle *style);  //!< Replaces the style with the specified style id.
   void setStyle(int styleId, const TPixelRGBM32 &color);  //!< Replaces the
                                                           //! style with the
-  //! specified style id.
+                                                          //! specified style id.
+  void setStyleAnimation(int styleId, StyleAnimation styleAnimation);
 
   int getPageCount() const;  //!< Returns the pages count.
 

--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -198,6 +198,7 @@ public:
     TPalette::Page *dstPage = m_palette->getPage(m_dstPageIndex);
     assert(dstPage);
     std::vector<int> styles;
+    StyleAnimationTable styleAnimations;
     int count = m_srcIndicesInPage.size();
     int h     = m_dstIndexInPage;
     std::set<int>::const_iterator i;
@@ -210,13 +211,18 @@ public:
     assert(h + count - 1 <= dstPage->getStyleCount());
     int k;
     for (k = 0; k < count; k++) {
-      styles.push_back(dstPage->getStyleId(h));
+      int styleId = dstPage->getStyleId(h);
+      styles.push_back(styleId);
+      styleAnimations.insert(
+          std::make_pair(styleId, m_palette->getStyleAnimation(styleId)));
       dstPage->removeStyle(h, true);
     }
     k = 0;
     for (i = m_srcIndicesInPage.begin(); i != m_srcIndicesInPage.end();
-         ++i, ++k)
+         ++i, ++k) {
       srcPage->insertStyle(*i, styles[k]);
+      m_palette->setStyleAnimation(styles[k], styleAnimations[styles[k]]);
+    }
 
     m_paletteHandle->notifyPaletteChanged();
   }
@@ -227,17 +233,23 @@ public:
     assert(dstPage);
 
     std::vector<int> styles;
+    StyleAnimationTable styleAnimations;
     std::set<int>::const_reverse_iterator i;
     std::vector<int>::iterator j;
     int k = m_dstIndexInPage;
     for (i = m_srcIndicesInPage.rbegin(); i != m_srcIndicesInPage.rend(); ++i) {
       int index = *i;
       if (m_dstPageIndex == m_srcPageIndex && index < k) k--;
-      styles.push_back(srcPage->getStyleId(index));
+      int styleId = srcPage->getStyleId(index);
+      styles.push_back(styleId);
+      styleAnimations.insert(
+          std::make_pair(styleId, m_palette->getStyleAnimation(styleId)));
       srcPage->removeStyle(index, true);
     }
-    for (j = styles.begin(); j != styles.end(); ++j)
+    for (j = styles.begin(); j != styles.end(); ++j) {
       dstPage->insertStyle(k, *j);
+      m_palette->setStyleAnimation(*j, styleAnimations[*j]);
+    }
     m_palette->setDirtyFlag(true);
     m_paletteHandle->notifyPaletteChanged();
   }

--- a/toonz/sources/toonzqt/styledata.cpp
+++ b/toonz/sources/toonzqt/styledata.cpp
@@ -18,8 +18,10 @@ StyleData::~StyleData() {
 
 //-----------------------------------------------------------------------------
 
-void StyleData::addStyle(int styleIndex, TColorStyle *style) {
+void StyleData::addStyle(int styleIndex, TColorStyle *style,
+                         StyleAnimation styleAnimation) {
   m_styles.push_back(std::make_pair(styleIndex, style));
+  m_styleAnimationTable.insert(std::make_pair(styleIndex, styleAnimation));
 }
 
 //-----------------------------------------------------------------------------
@@ -27,6 +29,16 @@ void StyleData::addStyle(int styleIndex, TColorStyle *style) {
 TColorStyle *StyleData::getStyle(int index) const {
   assert(0 <= index && index < (int)m_styles.size());
   return m_styles[index].second;
+}
+
+//-----------------------------------------------------------------------------
+
+StyleAnimation StyleData::getStyleAnimation(int styleId) const {
+  StyleAnimationTable::const_iterator sat = m_styleAnimationTable.find(styleId);
+
+  if (sat == m_styleAnimationTable.end()) return StyleAnimation();
+
+  return sat->second;
 }
 
 //-----------------------------------------------------------------------------
@@ -41,6 +53,7 @@ int StyleData::getStyleIndex(int index) const {
 StyleData *StyleData::clone() const {
   StyleData *data = new StyleData();
   for (int i = 0; i < getStyleCount(); i++)
-    data->addStyle(getStyleIndex(i), getStyle(i)->clone());
+    data->addStyle(getStyleIndex(i), getStyle(i)->clone(),
+                   getStyleAnimation(getStyleIndex(i)));
   return data;
 }

--- a/toonz/sources/toonzqt/styledata.h
+++ b/toonz/sources/toonzqt/styledata.h
@@ -16,6 +16,8 @@ class TColorStyle;
 
 class StyleData final : public DvMimeData {
   std::vector<std::pair<int, TColorStyle *>> m_styles;
+  StyleAnimationTable
+      m_styleAnimationTable;  //!< Table of style animations (per style).
 
 public:
   StyleData();
@@ -23,10 +25,12 @@ public:
 
   StyleData *clone() const override;
 
-  void addStyle(int styleIndex, TColorStyle *style);  // gets ownership
+  void addStyle(int styleIndex, TColorStyle *style,
+                StyleAnimation styleAnimation);  // gets ownership
 
   int getStyleCount() const { return (int)m_styles.size(); }
   TColorStyle *getStyle(int index) const;
+  StyleAnimation getStyleAnimation(int styleId) const;
   int getStyleIndex(int index) const;
 };
 


### PR DESCRIPTION
This fixes issues with a palette's style animation keys that become irrevocably lost when moved or when pasted after copy/cut.  It also fixes when the keys incorrectly remain after a style is cut or deleted and are unknowingly applied to the next newly added style.
