### PR TITLE
Fix palette viewer's Save Palette/Save Palette As options

### DIFF
--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -653,14 +653,12 @@ void PaletteViewer::createSavePaletteToolBar() {
 
     // overwrite palette
     QAction *savePalette =
-        new QAction(createQIcon("save", false, true), tr("&Save Palette"),
-                    m_savePaletteToolBar);
+        CommandManager::instance()->getAction("MI_OverwritePalette");
     m_viewMode->addAction(savePalette);
 
     // save palette as
     QAction *saveAsPalette =
-        new QAction(createQIcon("saveas", false, true), tr("&Save Palette As"),
-                    m_savePaletteToolBar);
+        CommandManager::instance()->getAction("MI_SavePaletteAs");
     m_viewMode->addAction(saveAsPalette);
 
     // save as default palette


### PR DESCRIPTION
This fixes #1524 

Reverted an OT change ported in v1.4 that prevented the `Save Palette` and `Save Palette As` options from working in T2D.  The OT are not need because T2D's `Palette` viewer layout is different from OT's so the changes are unnecessary.