### PR TITLE
Update macOS build environment to Ventura

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   macOS:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 brew update
-# Remove symlink to bin/2to3 in order for latest python to install
+# Remove symlink in order for latest python to install
+rm -f '/usr/local/bin/python3'
+rm -f '/usr/local/bin/python3.12'
 rm -f '/usr/local/bin/2to3'
+rm -f '/usr/local/bin/2to3-3.12'
+rm -f '/usr/local/bin/idle3'
+rm -f '/usr/local/bin/idle3.12'
+rm -f '/usr/local/bin/pydoc3'
+rm -f '/usr/local/bin/pydoc3.12'
+rm -f '/usr/local/bin/python3-config'
+rm -f '/usr/local/bin/python3.12-config'
 # Remove synlink to nghttp2 in order for latest curl to install
 #brew unlink nghttp2
 brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz gsed


### PR DESCRIPTION
Github is deprecating the macOS 12 (Monterey) environment on 12/3 and Homebrew recently stopped supporting releases on Monterey causing qt@5 and some other libraries to take several hours to build from source.  All this just before v1.5 release!

This change will update to build on macOS 13 (Ventura).