### PR TITLE
Fix hdiutil resource busy

### DIFF
--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -192,18 +192,25 @@ cd $TOONZDIR
 
 # Due to random ERROR: Bundle creation error: "hdiutil: create failed - Resource busy\n"
 # We'll try to create the DMG a few times
-'
-let X=5
-while [ $X -gt 0 ]
+
+let MAXTRY=10
+
+for TRY in $(seq 1 $MAXTRY)
 do
+   if [ $TRY -gt  1 ]
+   then
+      echo ">>> DMG file creation failed.  Retrying $TRY/$MAXTRY..."
+   fi
+
     $QTDIR/bin/macdeployqt Tahoma2D.app -dmg -verbose=0
     if [ -f Tahoma2D.dmg ]
     then
+       echo ">>> DMG file created successfully"
        mv Tahoma2D.dmg ../Tahoma2D-portable-osx.dmg
        exit 0
     fi
-    let X=$X-1
 done
 
+echo ">>> DMG file creation failed after too many attempts. Aborting!"
 exit 1
 

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -187,7 +187,23 @@ cp -R stuff $TOONZDIR/Tahoma2D.app/tahomastuff
 chmod -R 777 $TOONZDIR/Tahoma2D.app/tahomastuff
 
 find $TOONZDIR/Tahoma2D.app/tahomastuff -name .gitkeep -exec rm -f {} \;
-   
-$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma2D.app -dmg -verbose=0
 
-mv $TOONZDIR/Tahoma2D.dmg $TOONZDIR/../Tahoma2D-portable-osx.dmg
+cd $TOONZDIR
+
+# Due to random ERROR: Bundle creation error: "hdiutil: create failed - Resource busy\n"
+# We'll try to create the DMG a few times
+'
+let X=5
+while [ $X -gt 0 ]
+do
+    $QTDIR/bin/macdeployqt Tahoma2D.app -dmg -verbose=0
+    if [ -f Tahoma2D.dmg ]
+    then
+       mv Tahoma2D.dmg ../Tahoma2D-portable-osx.dmg
+       exit 0
+    fi
+    let X=$X-1
+done
+
+exit 1
+


### PR DESCRIPTION
This fixes a rather random but more frequent issue creating the DMG file on macOS 13 (Ventura).  This issue appears to affect a number of repos on github.

In prior macOS versions, I rarely encountered the following error when generating the DMG file.

`ERROR: Bundle creation error: "hdiutil: create failed - Resource busy\n"`

This was usually resolved by just rerunning the job.  However, since moving to Ventura, this has suddenly become significantly more frequent and requires rerunning multiple times.  One time it took me 6 reruns.

Until a better solution presents itself, I've added logic to reattempt to create the DMG file every time it fails.  It will try up to 10x before giving up completely.