### PR TITLE
Allow to run packaging script from any dir

### DIFF
--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -2,7 +2,8 @@
 source /opt/qt515/bin/qt515-env.sh
 
 echo ">>> Temporary install of Tahoma2D"
-export BUILDDIR=$(pwd)/toonz/build
+SCRIPTPATH=`dirname "$0"`
+export BUILDDIR=$SCRIPTPATH/../../toonz/build
 cd $BUILDDIR
 sudo make install
 


### PR DESCRIPTION
Previously you can only run packaging script when your current working directory is a root of repository.

This change allows  to run packaging script from any dir.