### PR TITLE
Fix raster eraser crash

### DIFF
--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -731,6 +731,8 @@ void FullColorEraserTool::leftButtonUp(const TPointD &pos,
   TRasterImageP ri        = (TRasterImageP)getImage(true);
   if (!ri) return;
   if (m_eraseType.getValue() == NORMALERASE) {
+    if (!m_brush) return;
+
     int maxThick  = m_size.getValue().second;
     int thickness = (m_pressure.getValue() && e.isTablet())
                         ? computeThickness(e.m_pressure, m_size)
@@ -757,10 +759,8 @@ void FullColorEraserTool::leftButtonUp(const TPointD &pos,
       invalidate(invalidateRect.enlarge(2) - rasCenter);
     }
 
-    if (m_brush) {
-      delete m_brush;
-      m_brush = 0;
-    }
+    delete m_brush;
+    m_brush = 0;
 
     m_workRaster->unlock();
     double opacity  = m_opacity.getValue() * 0.01;


### PR DESCRIPTION
This fixes #1321, fixes #1403, fixes #1473, fixes #1523, fixes #1565, fixes #1621 (and maybe others?) which occurs with Raster Eraser in `Normal` mode.

Based on what I can guess from the logs/dump files, It appears at times the raster eraser `leftButtonUp` "event" is being called again after eraser has already been stopped. When this happens, the existing logic doesn't handle the fact the eraser brush is gone and crashes.

This is more likely to occur when using a stylus than a mouse, though I couldn't cause this to happen at all on my system.  Some may be more prone to this than others depending on tablet, settins and other factors that I cannot easly duplicate.

Added a simple statement to ignore the event if the eraser brush has already been cleared. 