### PR TITLE
Fix pinching at end of line

### DIFF
--- a/toonz/sources/tnzext/LinearPotential.cpp
+++ b/toonz/sources/tnzext/LinearPotential.cpp
@@ -22,7 +22,10 @@ void ToonzExt::LinearPotential::setParameters_(const TStroke *ref, double par,
   leftFactor_ = lengthAtParam_;
 
   // lunghezza dal pto di click alla fine
-  rightFactor_ = strokeLength_ - lengthAtParam_;
+  if (areAlmostEqual(strokeLength_, lengthAtParam_, 0.001))
+    rightFactor_ = 0.0;
+  else
+    rightFactor_ = strokeLength_ - lengthAtParam_;
 
   // considero come intervallo di mapping [-range,range].
   //  4 ha come valore c.a. 10exp-6

--- a/toonz/sources/tnzext/NotSymmetricBezierPotential.cpp
+++ b/toonz/sources/tnzext/NotSymmetricBezierPotential.cpp
@@ -59,7 +59,10 @@ void ToonzExt::NotSymmetricBezierPotential::setParameters_(const TStroke *ref,
                     actionLength_ * 0.5);  // lengthAtParam_ / strokeLength_;
 
   // lunghezza dal pto di click alla fine
-  rightFactor_ = min(strokeLength_ - lengthAtParam_, actionLength_ * 0.5);
+  if (areAlmostEqual(strokeLength_, lengthAtParam_, 0.001))
+    rightFactor_ = 0.0;
+  else
+    rightFactor_ = min(strokeLength_ - lengthAtParam_, actionLength_ * 0.5);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnzext/NotSymmetricExpPotential.cpp
+++ b/toonz/sources/tnzext/NotSymmetricExpPotential.cpp
@@ -71,7 +71,10 @@ void ToonzExt::NotSymmetricExpPotential::setParameters_(const TStroke *ref,
                     actionLength_ * 0.5);  // lengthAtParam_ / strokeLength_;
 
   // lunghezza dal pto di click alla fine
-  rightFactor_ = min(strokeLength_ - lengthAtParam_, actionLength_ * 0.5);
+  if (areAlmostEqual(strokeLength_, lengthAtParam_, 0.001))
+    rightFactor_ = 0.0;
+  else
+    rightFactor_ = min(strokeLength_ - lengthAtParam_, actionLength_ * 0.5);
 
   // considero come intervallo di mapping [-range,range].
   //  4 ha come valore c.a. 10exp-6

--- a/toonz/sources/tnzext/SquarePotential.cpp
+++ b/toonz/sources/tnzext/SquarePotential.cpp
@@ -23,7 +23,10 @@ void ToonzExt::SquarePotential::setParameters_(const TStroke *ref, double par,
                     actionLength_ * 0.5);  // lengthAtParam_ / strokeLength_;
 
   // lunghezza dal pto di click alla fine
-  rightFactor_ = min(strokeLength_ - lengthAtParam_, actionLength_ * 0.5);
+  if (areAlmostEqual(strokeLength_, lengthAtParam_, 0.001))
+    rightFactor_ = 0.0;
+  else
+    rightFactor_ = min(strokeLength_ - lengthAtParam_, actionLength_ * 0.5);
 
   // considero come intervallo di mapping [-range,range].
   //  4 ha come valore c.a. 10exp-6


### PR DESCRIPTION
This fixes #1601 

Due to an infinitesimal fractional calculation difference at the end of some lines, the Pinch tool thinks it's not quite at the end and so pinches the line really close to the end instead of the end itself

Added check that if we're close enough to the end, we'll treat it as the end and pinch accordingly.