### PR TITLE
Fix displaying plastic deformed level in Linux

### DIFF
--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -195,7 +195,7 @@ DrawableTextureDataP texture_utils::getTextureData(const TXsheet *xsh,
 
   // Render the xsheet on the specified bbox
   bool masked = TStencilControl::instance()->isMaskEnabled();
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
   // Must move masks aside when building texture
   if (masked) TStencilControl::instance()->stashMask();
   xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -53,7 +53,7 @@ TOfflineGL *currentOfflineGL = 0;
 
 #include <QProgressDialog>
 
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
 #include <QSurfaceFormat>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
@@ -820,7 +820,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
   TRect clipRect(ras->getBounds());
 
 // fix for plastic tool applied to subxsheet
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
   QSurfaceFormat format;
   format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
@@ -837,7 +837,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
   ogl.makeCurrent();
 #endif
   {
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
     std::unique_ptr<QOpenGLFramebufferObject> fb(
         new QOpenGLFramebufferObject(ras->getLx(), ras->getLy()));
     fb->setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
@@ -868,7 +868,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 
     painter.flushRasterImages();
     glFlush();
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
     QImage img =
         fb->toImage().scaled(QSize(ras->getLx(), ras->getLy()),
                              Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
@@ -887,7 +887,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
     TRop::over(ras, ogl.getRaster());
 #endif
   }
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
   glMatrixMode(GL_MODELVIEW), glPopMatrix();
   glMatrixMode(GL_PROJECTION), glPopMatrix();
 


### PR DESCRIPTION
This fixes #1560 

The existing Windows and Linux logic for displaying plastic deformed levels causes a opengl context switch to and from the main context. This isn't a problem for Windows builds but appears to be an issue for Linux builds, in particular, when displaying a mesh deformed sub-scene. I also think this causes another Linux issue where the canvas refresh is messed up after switching in/out of preview mode when there is a deformed sub-scene.

macOS uses different logic to handle plastic deformed levels.  It uses an offline context to build the deformed image and transfers it back to the main context.  I've extended this logic to Linux builds which fixes the original reported issue.  I think this also helps with the canvas refresh issue I was seeing and might help with other seemingly random issues that have been reported.