### PR TITLE
Fix pasting external clipboard image

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -780,6 +780,11 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
     // Don't know why.
     cell = xsh->getCell(row, col);
     sl   = cell.getSimpleLevel();
+    if (!sl) {
+      DVGui::error(QObject::tr(
+          "It is not possible to paste image on the current cell."));
+      return false;
+    }
     fid  = cell.getFrameId();
     img  = cell.getImage(true);
     if (!img->getPalette()) {

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2370,19 +2370,19 @@ void TCellSelection::pasteCells() {
       TXshSimpleLevel *sl   = xsh->getCell(r0, c0).getSimpleLevel();
       if (!sl && r0 > 0) sl = xsh->getCell(r0 - 1, c0).getSimpleLevel();
       bool newLevel         = false;
+      if (!sl &&
+          (xsh->isColumnEmpty(c0) || xsh->getColumn(c0)->getLevelColumn()))
+        newLevel = true;      
       TRasterImageP ri(img);
       if (clipImage.height() > 0) {
         // This stuff is only if we have a pasted image from outside Tahoma
 
-        // check the size of the incoming image
-        bool tooBig = false;
-
+        bool checkImgSize = false;
+        double w, h;
         if (sl && sl->getType() == OVL_XSHLEVEL) {
           // offer to make a new level or paste in place
-          if (sl && (sl->getResolution().lx < clipImage.width() ||
-                     sl->getResolution().ly < clipImage.height())) {
-            tooBig = true;
-          }
+          w = sl->getResolution().lx;
+          h = sl->getResolution().ly;
 
           QString question =
               QObject::tr("Paste in place or create a new level?");
@@ -2408,13 +2408,8 @@ void TCellSelection::pasteCells() {
             TApp::instance()->getCurrentColumn()->setColumn(col);
             TApp::instance()->getCurrentFrame()->setFrame(r0);
             newLevel = true;
-          } else {
-            if (tooBig) {
-              clipImage =
-                  clipImage.scaled(sl->getResolution().lx,
-                                   sl->getResolution().ly, Qt::KeepAspectRatio);
-            }
-          }
+          } else
+            checkImgSize = true;
         } else if (sl) {
           // not on a raster level
           // find an empty column
@@ -2427,6 +2422,34 @@ void TCellSelection::pasteCells() {
           TApp::instance()->getCurrentColumn()->setColumn(col);
           TApp::instance()->getCurrentFrame()->setFrame(r0);
           newLevel = true;
+        }
+
+        if (newLevel) {
+          // We need to scale it to the default raster size if too big
+          double dpi, dpiY;
+          Preferences *pref = Preferences::instance();
+          if (pref->isNewLevelSizeToCameraSizeEnabled()) {
+            ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+            TDimensionD camSize = scene->getCurrentCamera()->getSize();
+            w                   = camSize.lx;
+            h                   = camSize.ly;
+            dpi                 = scene->getCurrentCamera()->getDpi().x;
+            dpiY                = scene->getCurrentCamera()->getDpi().y;
+          } else {
+            w    = pref->getDefLevelWidth();
+            h    = pref->getDefLevelHeight();
+            dpi  = pref->getDefLevelDpi();
+            dpiY = dpi;
+          }
+
+          w            = tround(w * dpi);
+          h            = tround(h * dpiY);
+          checkImgSize = true;
+        }
+
+        // Scale down image to fit level if too big
+        if (checkImgSize && (w < clipImage.width() || h < clipImage.height())) {
+          clipImage = clipImage.scaled(w, h, Qt::KeepAspectRatio);
         }
 
         // create variables to go into the Full Color Raster Selection data

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -692,7 +692,8 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
   TApp *app      = TApp::instance();
   TXsheet *xsh   = app->getCurrentXsheet()->getXsheet();
   TXshCell cell  = xsh->getCell(row, col);
-  if (col < 0 || xsh->getColumn(col)->getFolderColumn()) {
+  if (col < 0 ||
+      (xsh->getColumn(col) && xsh->getColumn(col)->getFolderColumn())) {
     DVGui::error(
         QObject::tr("It is not possible to paste image on the current cell."));
     return false;


### PR DESCRIPTION
This fixes the following issues reported to pasting an external clipboard image

- Fixes a crash when trying to paste into a Smart Raster or Vector level. (Issue caused by logiced added for new Folder feature)
- Fixes a crash when trying to paste into an empty cell of a non-image type column (Text, Sound, etc).
- When pasting creates a new level, the clipboard image will be scaled down to the default level size if it is too big to fit in it