### PR TITLE
Install and link libdeflate (macOS)

### DIFF
--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -16,4 +16,4 @@ rm -f '/usr/local/bin/python3.12-config'
 brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz gsed
 #brew install dav1d
 brew install meson ninja
-brew install automake autoconf gettext pkg-config libtool libusb-compat gd libexif
+brew install automake autoconf gettext pkg-config libtool libusb-compat gd libexif libdeflate

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -480,6 +480,8 @@ elseif(BUILD_ENV_APPLE)
         find_library(GPHOTO2_PORT_LIB gphoto2_port)
         message("**************** gphoto2_port lib:" ${GPHOTO2_PORT_LIB})
     endif()
+
+    find_library(DEFLATE_LIB deflate)
 elseif(BUILD_ENV_UNIXLIKE)
     if(BUILD_TARGET_WIN)
         find_library(GL_LIB opengl32)
@@ -557,7 +559,7 @@ elseif(BUILD_ENV_UNIXLIKE)
         message("**************** gphoto2_port lib:" ${GPHOTO2_PORT_LIB})
     endif()
 	
-	find_library(DEFLATE_LIB deflate)
+    find_library(DEFLATE_LIB deflate)
 endif()
 
 

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -159,6 +159,7 @@ elseif(BUILD_ENV_APPLE)
         ${CARBON_LIB}
         ${CORE_SERVICES_LIB}
         ${QD_LIB}
+        ${DEFLATE_LIB}		
     )
 elseif(BUILD_ENV_UNIXLIKE)
     # Generic Unix


### PR DESCRIPTION
Similar to Linux builds a few months ago (PR #1517), a change in one of the brew'd packages now requires T2D builds to be compiled with `libdeflate`.

This will brew in the dependency and update the builds to include it;

I will merge as soon as I see that all checks have passed.