### PR TITLE
Appimage fix: Allow to pass filename as argument for Tahoma binary

### DIFF
--- a/toonz/sources/scripts/AppRun
+++ b/toonz/sources/scripts/AppRun
@@ -11,4 +11,4 @@ echo "CAMLIBS: $CAMLIBS"
 export IOLIBS=`find $APPDIR/usr/lib/libgphoto2_port -mindepth 1 -type d`
 echo "IOLIBS: $IOLIBS"
 
-$APPDIR/usr/bin/Tahoma2D
+$APPDIR/usr/bin/Tahoma2D "$@"


### PR DESCRIPTION
When filename is passed as argument Tahoma will open specified file after launch.

This is useful if we associate .tnz files with Tahoma 2D.