### PR TITLE
Fix missing undo with temp tool release

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -337,6 +337,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 
     if (TApp::instance()->getCurrentTool()->isToolBusy())
       TApp::instance()->getCurrentTool()->setToolBusy(false);
+    if (toolHandle->getTool() && !toolHandle->getTool()->isUndoable())
+      toolHandle->getTool()->setCanUndo(true);
 #else
     if (m_tabletState == StartStroke || m_tabletState == OnStroke) {
       m_tabletState = Released;
@@ -1125,6 +1127,8 @@ void SceneViewer::resetTabletStatus() {
   m_buttonClicked = false;
   if (TApp::instance()->getCurrentTool()->isToolBusy())
     TApp::instance()->getCurrentTool()->setToolBusy(false);
+  TTool *tool = TApp::instance()->getCurrentTool()->getTool();
+  if (tool && !tool->isUndoable()) tool->setCanUndo(true);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes #1642 

As explained in the issue, while actively using a tool (drawing, erasing, etc) then temporarily interrupt the action to move, zoom or rotate the canvas, when you lift the pen (or mouse button) without switching back, the prior tool's action becomes undoable.

Added logic when lifting pen/releasing mouse button while moving, zooming or rotating the canvas with the temp shortcut, the prior tool is also notified of the release so it can complete whatever action it was in the middle of. 

Additionally fixed a few places where the "canUndo" flag isn't reset when the "toolBusy" flag is reset.

