### PR TITLE
Fix zoom out with small movements

### DIFF
--- a/toonz/sources/tnztools/viewtools.cpp
+++ b/toonz/sources/tnztools/viewtools.cpp
@@ -15,7 +15,7 @@ namespace {
 //-----------------------------------------------------------------------------
 
 class ZoomTool final : public TTool {
-  int m_oldY;
+  double m_oldY;
   TPointD m_center;
   bool m_dragging;
   double m_factor;
@@ -41,7 +41,7 @@ public:
     invalidate();
   }
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override {
-    int d    = m_oldY - e.m_pos.y;
+    double d = m_oldY - e.m_pos.y;
     m_oldY   = e.m_pos.y;
     double f = exp(-d * 0.01);
     m_factor = f;

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -113,7 +113,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
   TPointD m_center;
   bool m_dragging;
   // zoom variables
-  int m_oldY;
+  double m_oldY;
   double m_factor;
   // rotate variables
   double m_angle;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -2014,7 +2014,7 @@ void SceneViewer::mousePan(const TMouseEvent &e) {
 //-----------------------------------------------------------------------------
 
 void SceneViewer::mouseZoom(const TMouseEvent &e) {
-  int d    = m_oldY - e.m_pos.y;
+  double d = m_oldY - e.m_pos.y;
   m_oldY   = e.m_pos.y;
   double f = exp(-d * 0.01);
   m_factor = f;


### PR DESCRIPTION
This fixes #1643 

When making small movements to Zoom Out (drag down), the calculations dropped precision causing small changes to be ignored. This oddly was not impacting Zoom In (drag up) operations.

Changed the types on variables used in the calculations to maintain precision.