### PR TITLE
Revert "Fix Smart Raster Freehand/Polyline Fill"

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -1060,12 +1060,11 @@ void fillAreaWithUndo(const TImageP &img, const TRectD &area, TStroke *stroke,
       for (int tempX = 0; tempX < tempRaster->getLx();
            tempX++, tempPix++, keepPix++) {
 
-        if (tempPix->getInk() < IGNORECOLORSTYLE) {
-          keepPix->setInk(tempPix->getInk());
+        if (tempPix->getInk() >= IGNORECOLORSTYLE || tempPix->getPaint() >= IGNORECOLORSTYLE) {
+          continue;
         }
-        if (tempPix->getPaint() < IGNORECOLORSTYLE) {
-          keepPix->setPaint(tempPix->getPaint());
-        }
+        keepPix->setInk(tempPix->getInk());
+        keepPix->setPaint(tempPix->getPaint());
         keepPix->setTone(tempPix->getTone());
       }
     }


### PR DESCRIPTION
This fixes #1640 by reverting the Smart Raster Freehand/Polyline Fill fix made in #1606.

The original Smart Raster Freehand/Polyline issue that was report appears to be caused by a different issue.
