### PR TITLE
Fix vector skeleton/animate tool crash

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -3287,7 +3287,7 @@ int SceneViewer::pick(const TPointD &point) {
   // (to exploit the bug: open the FxEditor preview and then select the edit
   // tool)
   m_isPicking = true;
-  makeCurrent();
+  QOpenGLWidget::makeCurrent();
   assert(glGetError() == GL_NO_ERROR);
   GLint viewport[4];
   glGetIntegerv(GL_VIEWPORT, viewport);
@@ -3362,6 +3362,7 @@ int SceneViewer::pick(const TPointD &point) {
     }
     p += nameCount;
   }
+  QOpenGLWidget::doneCurrent();
   assert(glGetError() == GL_NO_ERROR);
   m_isPicking = false;
   return ret;


### PR DESCRIPTION
This fixes #1653

This crash can happen with the Skeleton Tool and the Animate Tool (in `All` mode) on vector levels.

Both tools do a passive pick operation which switches the current context with every mouse movement.  I theorize that when it tries to switch context, in this case to itself, some graphics drivers may lose the context and crashes when attempting to do an OpenGL operation.

At the end of this "pick" process I've added a missing statement to release the current context. This seems to have stopped the crash without any apparent impact to the tools.