### PR TITLE
Fix edit missing controlpoint crash

### DIFF
--- a/toonz/sources/tnztools/controlpointselection.cpp
+++ b/toonz/sources/tnztools/controlpointselection.cpp
@@ -971,7 +971,7 @@ ControlPointEditorStroke::PointType ControlPointEditorStroke::getPointTypeAt(
 
   if (minDistance2 < distance2)
     distance2 = minDistance2;
-  else if (strokeDistance > distance2) {
+  else if (strokeDistance > distance2 || nextIndex(precPointIndex) == -1) {
     distance2 = strokeDistance;
     index     = -1;
     type      = NONE;


### PR DESCRIPTION
Not sure what causes it to happen, but a stroke can be created with a missing end control point as shown here:
![image](https://github.com/user-attachments/assets/2969dfb5-9432-4e04-a5e3-fc7a613a117d)
 (left - incomplete stroke isolated from a user's image, right - corrected stroke)

A crash would occur with the `Control Point Editor Tool` whenever you clicked between the last control point and the rest of the stroke.  This change prevents the crash by not allowing the selection of any part of the stroke beyond the last control point (segment or handle).

Sample image: [badcp.zip](https://github.com/user-attachments/files/17894470/badcp.zip)
