### PR TITLE
High DPI Scaling preference

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -252,6 +252,10 @@ public:
     return getBoolValue(viewerIndicatorEnabled);
   }
 
+  bool isHighDpiScalingEnabled() const {
+    return getBoolValue(highDpiScalingEnabled);
+  }
+
   // Visualization  tab
   bool getShow0ThickLines() const { return getBoolValue(show0ThickLines); }
   bool getRegionAntialias() const { return getBoolValue(regionAntialias); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -50,6 +50,7 @@ enum PreferencesItemId {
   showIconsInMenu,
   displayIn30bit,
   viewerIndicatorEnabled,
+  highDpiScalingEnabled,
 
   //----------
   // Visualization

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -333,7 +333,8 @@ int main(int argc, char *argv[]) {
 
   // Enables high-DPI scaling. This attribute must be set before QApplication is
   // constructed. Available from Qt 5.6.
-  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  if (Preferences::instance()->isHighDpiScalingEnabled())
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
   QApplication a(argc, argv);
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1329,6 +1329,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {displayIn30bit, tr("30bit Display*")},
       {showIconsInMenu, tr("Show Icons In Menu*")},
       {viewerIndicatorEnabled, tr("Show Viewer Indicators")},
+      {highDpiScalingEnabled, tr("Enable High DPI Scaling*")},
 
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
@@ -1884,6 +1885,8 @@ QWidget* PreferencesPopup::createInterfacePage() {
   lay->addWidget(check30bitBtn, row - 1, 2, Qt::AlignRight);
   if (Preferences::instance()->isShowAdvancedOptionsEnabled())
     insertUI(showIconsInMenu, lay);
+
+  insertUI(highDpiScalingEnabled, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -469,6 +469,8 @@ void Preferences::definePreferenceItems() {
   define(viewerIndicatorEnabled, "viewerIndicatorEnabled", QMetaType::Bool,
          true);
 
+  define(highDpiScalingEnabled, "highDpiScalingEnabled", QMetaType::Bool, true);
+
   // Visualization
   define(show0ThickLines, "show0ThickLines", QMetaType::Bool, true);
   define(regionAntialias, "regionAntialias", QMetaType::Bool, false);


### PR DESCRIPTION
This adds a new `Interface` preference setting `Enable High DPI Scaling`.  This setting is enabled by default.

T2D has always forced High DPI Scaling, however, on lower resolutions (i.e. 1920x1080 at 150%), this causes the UI to be extremely huge.

I've exposed this setting as a preference item for those who have the huge UI issue.  This way they can disable the DPI scaling and bring the UI down to a size appropriate for their lower resolution.