### PR TITLE
Fix relative drawing onion skin guided drawing

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -731,7 +731,8 @@ public:
     invalidateAll();
   }
 
-  void getGuidedFrameIdx(int *backIdx, int *frontIdx);
+  void getGuidedFrameIdx(TXsheet *xsh, int row, int col, int *backIdx,
+                         int *frontIdx);
   void doPickGuideStroke(const TPointD &pos);
 
   QWidget *viewerWidget() { return m_viewerWidget; }

--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -199,6 +199,8 @@ since underlying onion-skinned drawings must be visible.
   bool isRelativeFrameMode() const { return m_isRelativeFrameMode; }
   void setRelativeFrameMode(bool on);
 
+  int getFrameIdxFromRos(int ros, TXsheet *xsh, int row, int col);
+
 private:
   std::vector<std::pair<int, double>> m_fos,
       m_mos, m_dos;               //!< Fixed, Mobile (relative frames mode), Drawing Onion Skin

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1633,9 +1633,13 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
   int osBack  = -1;
   int osFront = -1;
 
-  getViewer()->getGuidedFrameIdx(&osBack, &osFront);
-
   TFrameHandle *currentFrame = getApplication()->getCurrentFrame();
+  TXsheet *xsh               = app->getCurrentXsheet()->getXsheet();
+  int row                    = currentFrame->getFrameIndex();
+  int col                    = app->getCurrentColumn()->getColumnIndex();
+
+  getViewer()->getGuidedFrameIdx(xsh, row, col, &osBack, &osFront);
+
   bool resultBack            = false;
   bool resultFront           = false;
   TFrameId oFid;
@@ -1645,8 +1649,6 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
   TUndoManager::manager()->beginBlock();
   if (osBack != -1) {
     if (currentFrame->isEditingScene()) {
-      TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-      int col      = app->getCurrentColumn()->getColumnIndex();
       if (xsh && col >= 0) {
         TXshCell cell             = xsh->getCell(osBack, col);
         if (!cell.isEmpty()) oFid = cell.getFrameId();

--- a/toonz/sources/toonzlib/onionskinmask.cpp
+++ b/toonz/sources/toonzlib/onionskinmask.cpp
@@ -400,6 +400,44 @@ void OnionSkinMask::setRelativeFrameMode(bool on) {
   RelativeFrameMode     = m_isRelativeFrameMode;
 }
 
+int OnionSkinMask::getFrameIdxFromRos(int ros, TXsheet *xsh, int row, int col) {
+  if (isRelativeFrameMode()) return row + ros;
+
+  if (!ros || !xsh || col < 0) return -1;
+  int r0, r1;
+  xsh->getCellRange(col, r0, r1);
+  
+  if (r1 <= r0) return -1;
+
+  if (ros < 0) {
+    std::vector<TXshCell> prevCells(row - r0 + 1);
+    xsh->getCells(r0, col, prevCells.size(), &(prevCells[0]));
+    TXshCell lastCell;
+    for (int x = prevCells.size() - 2; x >= 0; x--) {
+      if (prevCells[x].isEmpty() || prevCells[x].getFrameId().isStopFrame() ||
+          prevCells[x] == lastCell)
+        continue;
+      lastCell = prevCells[x];
+      ros++;
+      if (!ros) return x;
+    }
+  } else if (ros > 0) {
+    std::vector<TXshCell> nextCells(r1 - row + 1);
+    xsh->getCells(row, col, nextCells.size(), &(nextCells[0]));
+    TXshCell lastCell = nextCells[0];
+    for (int x = 1; x < nextCells.size(); x++) {
+      if (nextCells[x].isEmpty() || nextCells[x].getFrameId().isStopFrame() ||
+          nextCells[x] == lastCell)
+        continue;
+      lastCell = nextCells[x];
+      ros--;
+      if (!ros) return row + x;
+    }
+  }
+
+  return -1;
+}
+
 //***************************************************************************
 //    OnionSkinMaskModifier  implementation
 //***************************************************************************


### PR DESCRIPTION
This fixes an issue with Vector Guided Drawing while using Relative Drawing onion skin.

When using this new onion skin mode, guided drawing worked fine when all the frames were on 1s.  Fixed the logic to account for held cells, implicit or explicit.