### PR TITLE
Column Alpha Lock

### DIFF
--- a/toonz/sources/common/tfx/binaryFx.cpp
+++ b/toonz/sources/common/tfx/binaryFx.cpp
@@ -696,11 +696,13 @@ class ColumnMaskFx final : public TBaseRasterFx {
   FX_DECLARATION(ColumnMaskFx)
 
   TRasterFxPort m_source, m_mask;
+  TBoolParamP m_isAlphaLockMask;
 
 public:
-  ColumnMaskFx() {
+  ColumnMaskFx() : m_isAlphaLockMask(false) {
     addInputPort("Source", m_source);
     addInputPort("Mask", m_mask);
+    bindParam(this, "isAlphaLockMask", m_isAlphaLockMask);
     setName(L"ColumnMaskFx");
     enableComputeInFloat(true);
   }
@@ -737,6 +739,7 @@ public:
                                  frame, maskRi);
 
     maskRi.m_applyMask = true;
+    maskRi.m_isAlphaLockMask = m_isAlphaLockMask;
     m_mask->compute(srcTile, frame, maskRi);
 
     // Replace original tile with masked tile

--- a/toonz/sources/include/tfxutil.h
+++ b/toonz/sources/include/tfxutil.h
@@ -40,7 +40,7 @@ DVAPI void deleteKeyframes(const TFxP &fx, int frame);
 DVAPI void setKeyframe(const TFxP &dstFx, int dstFrame, const TFxP &srcFx,
                        int srcFrame, bool changedOnly = false);
 
-DVAPI TFxP makeMask(const TFxP &source, const TFxP &mask);
+DVAPI TFxP makeMask(const TFxP &source, const TFxP &mask, bool isAlphaLockMask);
 
 }  // namespace TFxUtil
 

--- a/toonz/sources/include/toonz/stageplayer.h
+++ b/toonz/sources/include/toonz/stageplayer.h
@@ -123,6 +123,8 @@ public:
   bool m_isInvertedMask;
   bool m_canRenderMask;
 
+  bool m_isAlphaLocked;
+
 public:
   Player();
 

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -85,7 +85,8 @@ protected:
     eMasked                = 0x10,
     eCamstandTransparent43 = 0x20,  // obsoleto, solo per retrocompatibilita'
     eInvertedMask          = 0x80,
-    eRenderMask            = 0x100
+    eRenderMask            = 0x100,
+    eAlphaLocked           = 0x200
   };
 
   TRaster32P m_icon;
@@ -205,6 +206,7 @@ Return true if column is a mask.
   bool isInvertedMask() const;
   bool canRenderMask() const;
 
+  bool isAlphaLocked() const;
   /*!
 Set column status mask to \b on.
 \sa isMask()
@@ -212,6 +214,8 @@ Set column status mask to \b on.
   void setIsMask(bool on);
   void setInvertedMask(bool on);
   void setCanRenderMask(bool on);
+
+  void setAlphaLocked(bool on);
 
   virtual bool isEmpty() const { return true; }
 

--- a/toonz/sources/include/toonz/txshlevelcolumn.h
+++ b/toonz/sources/include/toonz/txshlevelcolumn.h
@@ -88,7 +88,7 @@ Return \b TFx.
   // Used in TCellData::getNumbers
   bool setNumbers(int row, int rowCount, const TXshCell cells[]);
 
-  std::vector<TXshColumn *> getColumnMasks();
+  std::vector<TXshColumn *> getColumnMasks(int frame);
 
 private:
   // not implemented

--- a/toonz/sources/include/toonz/txshzeraryfxcolumn.h
+++ b/toonz/sources/include/toonz/txshzeraryfxcolumn.h
@@ -88,7 +88,7 @@ Return \b TZeraryColumnFx.
    * icon. */
   void updateIcon() {}
 
-  std::vector<TXshColumn *> getColumnMasks();
+  std::vector<TXshColumn *> getColumnMasks(int frame);
 
 private:
   // not implemented

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -172,6 +172,8 @@ public:
   bool m_useMaskBox;
   bool m_plasticMask;
 
+  bool m_isAlphaLockMask;
+
   int m_lastFrame;
 
 public:

--- a/toonz/sources/tnzbase/tfxutil.cpp
+++ b/toonz/sources/tnzbase/tfxutil.cpp
@@ -173,7 +173,8 @@ void TFxUtil::setKeyframe(const TFxP &dstFx, int dstFrame, const TFxP &srcFx,
 
 //-------------------------------------------------------------------
 
-TFxP TFxUtil::makeMask(const TFxP &source, const TFxP &mask) {
+TFxP TFxUtil::makeMask(const TFxP &source, const TFxP &mask,
+                       bool isAlphaLockMask) {
   if (!source)
     return 0;
   else if (!mask)
@@ -190,6 +191,10 @@ TFxP TFxUtil::makeMask(const TFxP &source, const TFxP &mask) {
   if (!columnMaskFx->connect("Source", source.getPointer()) ||
       !columnMaskFx->connect("Mask", mask.getPointer()))
     assert(!"Could not connect ports!");
+
+  dynamic_cast<TBoolParam *>(
+      columnMaskFx->getParams()->getParam("isAlphaLockMask"))
+      ->setDefaultValue(isAlphaLockMask);
 
   return columnMaskFx;
 }

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -896,7 +896,10 @@ void TRasterFx::compute(TTile &tile, double frame,
   enlargeToI(bbox);
 
   TRectD interestingRect(tilePlacement * bbox);
-  if (myIsEmpty(interestingRect)) return;
+  if (myIsEmpty(interestingRect)) {
+    if (info.m_isAlphaLockMask) tile.getRaster()->clear();
+    return;
+  }
 
   TDimension tileSize = tile.getRaster()->getSize();
   // The format of the incoming raster depends on whether the previous node
@@ -1224,7 +1227,8 @@ TRenderSettings::TRenderSettings()
     , m_invertedMask(false)
     , m_useMaskBox(false)
     , m_plasticMask(false)
-    , m_lastFrame(0) {}
+    , m_lastFrame(0)
+    , m_isAlphaLockMask(false) {}
 
 //------------------------------------------------------------------------------
 

--- a/toonz/sources/toonz/icons/dark/actions/16/alpha_locked.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/alpha_locked.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg892"
+   sodipodi:docname="alpha_locked.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview894"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:snap-global="false"
+     inkscape:zoom="57.359601"
+     inkscape:cx="6.9473984"
+     inkscape:cy="9.065614"
+     inkscape:window-width="1920"
+     inkscape:window-height="1141"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g26504"
+     units="px"
+     showguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid965" />
+  </sodipodi:namedview>
+  <defs
+     id="defs889">
+    <pattern
+       id="EMFhbasepattern"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+    <pattern
+       id="EMFhbasepattern-9"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+  </defs>
+  <g
+     id="g26504"
+     transform="matrix(1.6720609,0,0,0.91886337,0.91229516,-1.4452179)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88607px;line-height:125%;font-family:Calibri;-inkscape-font-specification:'Calibri Bold';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="-0.42898867"
+       y="3.5730193"
+       id="text13803"><tspan
+         sodipodi:role="line"
+         x="-0.42898867"
+         y="3.5730193"
+         id="tspan13801"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Calibri;-inkscape-font-specification:'Calibri Bold';stroke-width:0.264583"><tspan
+           dx="0"
+           dy="0"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88607px;font-family:Calibri;-inkscape-font-specification:'Calibri Bold';fill:#000000;stroke-width:0.264583"
+           id="tspan13797">α</tspan><tspan
+           dx="0"
+           dy="0"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88607px;font-family:Calibri;-inkscape-font-specification:'Calibri Bold';fill:#000000;stroke-width:0.264583"
+           id="tspan13799"> </tspan></tspan></text>
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.323439"
+       d="M -0.42898866,2.5224623 H 1.7710814 v 0.3793548 h -2.20007006 z"
+       id="path13805" />
+  </g>
+</svg>

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -621,6 +621,7 @@
     <file>icons/dark/actions/16/motion_path.svg</file>
 
     <file>icons/dark/actions/16/clipping_mask.svg</file>
+    <file>icons/dark/actions/16/alpha_locked.svg</file>
 
     <file>icons/dark/actions/16/export_oca.svg</file>
     <file>icons/dark/actions/16/export_xdts.svg</file>

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -231,6 +231,8 @@ class ColumnTransparencyPopup final : public QWidget {
   QCheckBox *m_invertMask;
   QCheckBox *m_renderMask;
 
+  QCheckBox *m_alphaLock;
+
   QTimer *m_keepClosedTimer;
   bool m_keepClosed;
 
@@ -259,6 +261,8 @@ protected slots:
   void onMaskGroupBoxChanged(bool clicked);
   void onInvertMaskCBChanged(int checkedState);
   void onRenderMaskCBChanged(int checkedState);
+
+  void onAlphaLockCBChanged(int checkedState);
 
   void resetKeepClosed();
 };

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -52,7 +52,8 @@ Stage::Player::Player()
     , m_currentDrawingOnTop(false)
     , m_isMask(false)
     , m_isInvertedMask(false)
-    , m_canRenderMask(false) {}
+    , m_canRenderMask(false)
+    , m_isAlphaLocked(false) {}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1622,7 +1622,7 @@ std::string TLevelColumnFx::getAlias(double frame,
       rdata += "column_0";
   }
 
-  std::vector<TXshColumn *> masks = m_levelColumn->getColumnMasks();
+  std::vector<TXshColumn *> masks = m_levelColumn->getColumnMasks(frame);
   if (masks.size()) {
     std::string maskAlias = "masked";
     for (int i = 0; i < masks.size(); i++) {
@@ -1905,7 +1905,7 @@ std::string TZeraryColumnFx::getAlias(double frame,
   std::string rdata = "";
 
   if (m_zeraryFxColumn) {
-    std::vector<TXshColumn *> masks = m_zeraryFxColumn->getColumnMasks();
+    std::vector<TXshColumn *> masks = m_zeraryFxColumn->getColumnMasks(frame);
     if (masks.size()) {
       std::string maskAlias = "masked";
       for (int i = 0; i < masks.size(); i++) {

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -782,6 +782,12 @@ bool TXshColumn::canRenderMask() const {
 
 //-----------------------------------------------------------------------------
 
+bool TXshColumn::isAlphaLocked() const {
+  return (m_status & eAlphaLocked) != 0;
+}
+
+//-----------------------------------------------------------------------------
+
 void TXshColumn::setIsMask(bool on) {
   const int mask = eMasked;
   if (on)
@@ -804,6 +810,16 @@ void TXshColumn::setInvertedMask(bool on) {
 
 void TXshColumn::setCanRenderMask(bool on) {
   const int mask = eRenderMask;
+  if (on)
+    m_status |= mask;
+  else
+    m_status &= ~mask;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshColumn::setAlphaLocked(bool on) {
+  const int mask = eAlphaLocked;
   if (on)
     m_status |= mask;
   else

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -333,7 +333,7 @@ std::vector<TXshColumn *> TXshLevelColumn::getColumnMasks(int frame) {
       if (!rcol || rcol->isEmpty()) break;
       // ignore mesh levels and other alpha locked columns
       if (rcol->getColumnType() == TXshColumn::eMeshType ||
-          rcol->getColumnType() == TXshColumn::eAlphaLocked)
+          rcol->isAlphaLocked())
         continue;
       if (rcol->getColumnType() == TXshColumn::eLevelType &&
           rcol->isPreviewVisible()) {

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -241,7 +241,7 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
 
 //-----------------------------------------------------------------------------
 
-std::vector<TXshColumn *> TXshZeraryFxColumn::getColumnMasks() {
+std::vector<TXshColumn *> TXshZeraryFxColumn::getColumnMasks(int frame) {
   std::vector<TXshColumn *> masks;
 
   if (m_index <= 0) return masks;
@@ -254,6 +254,8 @@ std::vector<TXshColumn *> TXshZeraryFxColumn::getColumnMasks() {
     if (mcol->getColumnType() == TXshColumn::eMeshType)
       continue;  // ignore mesh levels
     if (!mcol->isMask() || !mcol->isPreviewVisible()) break;
+    TXshCell cell = xsh->getCell(frame, i);
+    if (cell.isEmpty() || cell.getFrameId().isStopFrame()) break;
     masks.push_back(mcol);
   }
 


### PR DESCRIPTION
This adds a new column setting `Alpha Lock` to any Raster, Smart Raster and Vector column.

![image](https://github.com/user-attachments/assets/4af3f6b2-1bd4-4e27-91a0-3b32ec5029f0)

This is similar to Clipping Masks, where the alpha locked column will only show where parts of the referenced drawing is visible.

![image](https://github.com/user-attachments/assets/4e266981-2ac5-4dcd-8e1a-c5f648a0f17a)

How to use:
- The reference column is below (timeline)/before (xsheet) the Alpha Locked column.
- Other Alpha Locked columns and Mesh Columns between the Alpha Locked column and the reference column are ignored.
- Multiple Alpha Locked columns can be applied to 1 reference column.
- If there are any other column types below/before the Alpha Locked column, the reference column is hiddne or, there is no exposed cell in the reference column, the alpha locked cell will not be displayed.
- Alpha Lock can be applied to Raster, Smart raster, Vector and, Sub-Scene columns.
- A column can only have `Alpha Lock` or `Clipping Mask` enabled, not both.
