### PR TITLE
Reverse Clipping Mask Stacking Placement

### DIFF
--- a/toonz/sources/include/toonz/stageplayer.h
+++ b/toonz/sources/include/toonz/stageplayer.h
@@ -121,7 +121,6 @@ public:
 
   bool m_isMask;
   bool m_isInvertedMask;
-  bool m_canRenderMask;
 
   bool m_isAlphaLocked;
 

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -85,7 +85,7 @@ protected:
     eMasked                = 0x10,
     eCamstandTransparent43 = 0x20,  // obsoleto, solo per retrocompatibilita'
     eInvertedMask          = 0x80,
-    eRenderMask            = 0x100,
+    eRenderMask            = 0x100, // Obsolete but don't remove or it may impact older scens
     eAlphaLocked           = 0x200
   };
 
@@ -204,7 +204,6 @@ Return true if column is a mask.
 */
   bool isMask() const;
   bool isInvertedMask() const;
-  bool canRenderMask() const;
 
   bool isAlphaLocked() const;
   /*!
@@ -213,7 +212,6 @@ Set column status mask to \b on.
 */
   void setIsMask(bool on);
   void setInvertedMask(bool on);
-  void setCanRenderMask(bool on);
 
   std::vector<TXshColumn *> getColumnMasks(int frame);
 

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -215,6 +215,8 @@ Set column status mask to \b on.
   void setInvertedMask(bool on);
   void setCanRenderMask(bool on);
 
+  std::vector<TXshColumn *> getColumnMasks(int frame);
+
   void setAlphaLocked(bool on);
 
   virtual bool isEmpty() const { return true; }

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -229,7 +229,6 @@ class ColumnTransparencyPopup final : public QWidget {
 
   QGroupBox *m_maskGroupBox;
   QCheckBox *m_invertMask;
-  QCheckBox *m_renderMask;
 
   QCheckBox *m_alphaLock;
 
@@ -260,7 +259,6 @@ protected slots:
 
   void onMaskGroupBoxChanged(bool clicked);
   void onInvertMaskCBChanged(int checkedState);
-  void onRenderMaskCBChanged(int checkedState);
 
   void onAlphaLockCBChanged(int checkedState);
 

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -1025,8 +1025,7 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
     }
 
     // Add check for/create all ClippingMaskFx here
-    if (m_applyMasks && (sl || isSubXsheet) &&
-        (!column->isMask() || column->canRenderMask())) {
+    if (m_applyMasks && (sl || isSubXsheet) && !column->isMask()) {
       m_applyMasks = false;
       std::vector<TXshColumn *> masks = column->getColumnMasks(m_frame);
       bool isAlphaLocked              = column->isAlphaLocked();

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -509,6 +509,7 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         mask->push_back(alphaRefPlayer);
         m_maskPool.push_back(mask);
         std::stable_sort(mask->begin(), mask->end(), PlayerLt());
+        player.m_masks.insert(player.m_masks.end(), alphaRefPlayer.m_masks.begin(), alphaRefPlayer.m_masks.end());
         player.m_masks.push_back(maskIndex);
       }
     }
@@ -740,11 +741,11 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
       // Find the immediate column that this is using as reference
       for (int a = i - 1; a >= 0; a--) {
         TXshColumnP alphaColumn = xsh->getColumn(a);
-        if (!alphaColumn || alphaColumn->isEmpty())
-          break;
-        // Ignore other alpha locked and mesh type columns
+        if (!alphaColumn || alphaColumn->isEmpty()) break;
+        // Ignore other alpha locked, mesh and mask columns
         if (alphaColumn->isAlphaLocked() ||
-            alphaColumn->getColumnType() == TXshColumn::eMeshType)
+            alphaColumn->getColumnType() == TXshColumn::eMeshType ||
+            alphaColumn->isMask())
           continue;
         if (alphaColumn->getColumnType() == TXshColumn::eLevelType &&
             alphaColumn->isCamstandVisible()) {
@@ -760,7 +761,9 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     }
 
     if (column && !column->isEmpty() && !column->getSoundColumn() &&
-        !column->getFolderColumn()) {
+        !column->getFolderColumn() &&
+        (!column->isMask() || column->canRenderMask())) {
+
       if (!column->isPreviewVisible() && checkPreviewVisibility) {
         if (!isMask && column->getColumnType() != TXshColumn::eMeshType) {
           while (m_masks.size() > maskCount) m_masks.pop_back();
@@ -770,27 +773,34 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
       if (column->isCamstandVisible() ||
           includeUnvisible)  // se l'"occhietto" non e' chiuso
       {
-        if (column->isMask() && !column->isCellEmpty(row) &&
-            !xsh->getCell(row, c).getFrameId().isStopFrame())
-        {
-          if (column->canRenderMask())
-            addCellWithOnionSkin(players, scene, xsh, row, c, level, false,
-                                 isAlphaLocked, lockedAlphaColIndex,
-                                 subSheetColIndex);
+        // scan ahead for masks
+        for (int x = c + 1; x < columnCount; x++) {
+          TXshColumn *maskCol = xsh->getColumn(x);
+          if (!maskCol || maskCol->isCellEmpty(row) ||
+              xsh->getCell(row, x).getFrameId().isStopFrame() ||
+              !maskCol->isCamstandVisible())
+            break;
+
+          // Skip mesh files
+          if (maskCol->getColumnType() == TXshColumn::eMeshType) continue;
+
+          if (!maskCol->isMask()) break;
+
           isMask = true;
           std::vector<int> saveMasks;
           saveMasks.swap(m_masks);
           int maskIndex   = m_maskPool.size();
           PlayerSet *mask = new PlayerSet();
           m_maskPool.push_back(mask);
-          addCellWithOnionSkin(*mask, scene, xsh, row, c, level, true, false, -1);
+          addCellWithOnionSkin(*mask, scene, xsh, row, x, level, true, false, -1);
           std::stable_sort(mask->begin(), mask->end(), PlayerLt());
           saveMasks.swap(m_masks);
-          m_masks.push_back(maskIndex);
-        } else
-          addCellWithOnionSkin(players, scene, xsh, row, c, level, false,
-                               isAlphaLocked, lockedAlphaColIndex,
-                               subSheetColIndex);
+          m_masks.insert(m_masks.begin(), maskIndex);
+        }
+
+        addCellWithOnionSkin(players, scene, xsh, row, c, level, false,
+                             isAlphaLocked, lockedAlphaColIndex,
+                             subSheetColIndex);
       }
     }
     if (!isMask && column->getColumnType() != TXshColumn::eMeshType) {
@@ -929,7 +939,6 @@ void StageBuilder::addSimpleLevelFrame(PlayerSet &players,
 }
 
 //-----------------------------------------------------------------------------
-
 void StageBuilder::visit(PlayerSet &players, Visitor &visitor, bool isPlaying) {
   std::vector<int> masks;
   int m                = players.size();
@@ -961,14 +970,6 @@ void StageBuilder::visit(PlayerSet &players, Visitor &visitor, bool isPlaying) {
         }
         visitor.enableMask(maskType);
         i++;
-
-        // For alpha locked columns, draw alpha locked image on top
-        // of each mask except last one which we'll do later.
-        if (player.m_isAlphaLocked && i < player.m_masks.size()) {
-          visitor.onImage(player);
-          masks.pop_back();
-          visitor.disableMask();
-        }
       }
     }
     player.m_isPlaying = isPlaying;

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -431,7 +431,6 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         scene->getProperties()->getColorFilterColor(column->getColorFilterId());
     player.m_isMask              = isMask;
     player.m_isInvertedMask      = isMask ? column->isInvertedMask() : false;
-    player.m_canRenderMask       = isMask ? column->canRenderMask() : false;
     player.m_isAlphaLocked       = isAlphaLocked;
 
     if (m_subXSheetStack.empty()) {
@@ -761,8 +760,7 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     }
 
     if (column && !column->isEmpty() && !column->getSoundColumn() &&
-        !column->getFolderColumn() &&
-        (!column->isMask() || column->canRenderMask())) {
+        !column->getFolderColumn() && !column->isMask()) {
 
       if (!column->isPreviewVisible() && checkPreviewVisibility) {
         if (!isMask && column->getColumnType() != TXshColumn::eMeshType) {

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -52,7 +52,6 @@ Stage::Player::Player()
     , m_currentDrawingOnTop(false)
     , m_isMask(false)
     , m_isInvertedMask(false)
-    , m_canRenderMask(false)
     , m_isAlphaLocked(false) {}
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -996,8 +996,7 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
                                const TRenderSettings &info) {
   if (!m_levelColumn) return;
 
-  if (m_levelColumn->isMask() && !info.m_applyMask &&
-      !m_levelColumn->canRenderMask() && !info.m_plasticMask)
+  if (m_levelColumn->isMask() && !info.m_applyMask && !info.m_plasticMask)
     return;
 
   // Ensure that a corresponding cell and level exists
@@ -1630,7 +1629,6 @@ std::string TLevelColumnFx::getAlias(double frame,
       if (!mask) break;
 
       if (mask->isInvertedMask()) maskAlias += "inv";
-      if (mask->canRenderMask()) maskAlias += "render";
       break;
     }
     rdata += maskAlias;
@@ -1913,7 +1911,6 @@ std::string TZeraryColumnFx::getAlias(double frame,
         if (!mask) break;
 
         if (mask->isInvertedMask()) maskAlias += "inv";
-        if (mask->canRenderMask()) maskAlias += "render";
         break;
       }
       rdata += "," + maskAlias;

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -776,12 +776,6 @@ bool TXshColumn::isInvertedMask() const {
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::canRenderMask() const {
-  return (m_status & eRenderMask) != 0;
-}
-
-//-----------------------------------------------------------------------------
-
 bool TXshColumn::isAlphaLocked() const {
   return (m_status & eAlphaLocked) != 0;
 }
@@ -800,16 +794,6 @@ void TXshColumn::setIsMask(bool on) {
 
 void TXshColumn::setInvertedMask(bool on) {
   const int mask = eInvertedMask;
-  if (on)
-    m_status |= mask;
-  else
-    m_status &= ~mask;
-}
-
-//-----------------------------------------------------------------------------
-
-void TXshColumn::setCanRenderMask(bool on) {
-  const int mask = eRenderMask;
   if (on)
     m_status |= mask;
   else

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -318,49 +318,14 @@ bool TXshLevelColumn::setNumbers(int row, int rowCount,
 std::vector<TXshColumn *> TXshLevelColumn::getColumnMasks(int frame) {
   std::vector<TXshColumn *> masks;
 
-  if (m_index <= 0) return masks;
-
-  int startIndex = m_index - 1;
+  if (m_index < 0) return masks;
 
   TXsheet *xsh    = getXsheet();
   TXshColumn *col = xsh->getColumn(m_index);
 
-  // Find the reference column (essentially the mask)
-  if (col->isAlphaLocked()) {
-    for (int i = startIndex; i >= 0; i--) {
-      TXshColumn *rcol = xsh->getColumn(i);
+  if (!col) return masks;
 
-      if (!rcol || rcol->isEmpty()) break;
-      // ignore mesh levels and other alpha locked columns
-      if (rcol->getColumnType() == TXshColumn::eMeshType ||
-          rcol->isAlphaLocked())
-        continue;
-      if (rcol->getColumnType() == TXshColumn::eLevelType &&
-          rcol->isPreviewVisible()) {
-        TXshCell cell = xsh->getCell(frame, i);
-        if (cell.isEmpty() || cell.getFrameId().isStopFrame()) break;
-        masks.push_back(rcol);
-        startIndex--;
-      }
-      break;
-    }
-
-    if (!masks.size()) return masks;
-  }
-
-  for (int i = startIndex; i >= 0; i--) {
-    TXshColumn *mcol = xsh->getColumn(i);
-
-    if (!mcol || mcol->isEmpty()) break;
-    if (mcol->getColumnType() == TXshColumn::eMeshType)
-      continue;  // ignore mesh levels
-    if (!mcol->isMask() || !mcol->isPreviewVisible()) break;
-    TXshCell cell = xsh->getCell(frame, i);
-    if (cell.isEmpty() || cell.getFrameId().isStopFrame()) break;
-    masks.push_back(mcol);
-  }
-
-  return masks;
+  return col->getColumnMasks(frame);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
To follow more in line with the logical stacking order (and other software), this PR changes the placement and stacking order of Clipping Masks.

Clipping Masks now need to be placed **above** (timeline)/**right** (xsheet) of the clipped column.
Clipping is done in order from bottom->top/left->right.

![image](https://github.com/user-attachments/assets/c43e47b8-08af-4cef-929d-82df5182ed43)

Note: Due to change in stacking order, `Render Mask` has been removed.