### PR TITLE
Column Looping

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -147,7 +147,8 @@ enum class PredefinedRect {
   CLIPPING_MASK_AREA,
   FOLDER_INDICATOR_AREA,
   FOLDER_TOGGLE_ICON,
-  BUTTONS_AREA
+  BUTTONS_AREA,
+  LOOP_INDICATOR_AREA
 };
 enum class PredefinedLine {
   LOCKED,              //! dotted vertical line when cell is locked

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -73,6 +73,9 @@ class DVAPI TXshColumn : public TColumnHeader, public TPersist {
   QStack<int> m_folderId;
   int m_folderSelector;
 
+  bool m_loopLimitEnabled;
+  int m_loopToFrame;
+
 public:
 private:
   int m_colorFilterId;
@@ -86,7 +89,8 @@ protected:
     eCamstandTransparent43 = 0x20,  // obsoleto, solo per retrocompatibilita'
     eInvertedMask          = 0x80,
     eRenderMask            = 0x100,
-    eAlphaLocked           = 0x200
+    eAlphaLocked           = 0x200,
+    eLooped                = 0x800
   };
 
   TRaster32P m_icon;
@@ -113,6 +117,8 @@ Constructs a TXshColumn with default value.
       , m_opacity(255)
       , m_colorFilterId(0)  // None
       , m_folderSelector(-1)
+      , m_loopLimitEnabled(false)
+      , m_loopToFrame(-1)
   {}
 
   enum ColumnType {
@@ -216,6 +222,16 @@ Set column status mask to \b on.
   void setCanRenderMask(bool on);
 
   void setAlphaLocked(bool on);
+
+  bool isLooped() const;
+  void setLooped(bool on);
+  int getLoopedFrame(int row, bool forOnionSkin = false);
+  TXshCell getLoopedCell(int row, bool forOnionSkin = false,
+                         bool implicitLookup = true);
+  bool isLoopLimited() const;
+  void setLoopLimitEnabled(bool on);
+  int getLoopToFrame() const;
+  void setLoopToFrame(int frame);
 
   virtual bool isEmpty() const { return true; }
 

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -269,7 +269,8 @@ public:
      zero and sets
           \b \e r0 to 0 and \b \e r1 to -1.
   */
-  int getCellRange(int col, int &r0, int &r1) const;
+  int getCellRange(int col, int &r0, int &r1,
+                   bool ignoreLastStop = false) const;
   /*! Returns the max frame number of xsheet column identified by \b \e col and
      calls \b TXshColumn::getMaxFrame().
           \sa getFrameCount()

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -72,11 +72,15 @@ public:
     int row = TApp::instance()->getCurrentFrame()->getFrame();
     int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
 
+    TXshColumn *column = xsh->getColumn(col);
+
     const TXshCell &cell = xsh->getCell(row, col);
 
     int frameCount = xsh->getFrameCount();
     while (row < frameCount) {
       row++;
+      if (row >= frameCount && column && column->isLooped()) row = 0;
+
       if (xsh->getCell(row, col).isEmpty() ||
           xsh->getCell(row, col).getFrameId().isStopFrame())
         continue;
@@ -104,11 +108,16 @@ public:
     int row = TApp::instance()->getCurrentFrame()->getFrame();
     int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
 
+    TXshColumn *column = xsh->getColumn(col);
+
     TXshCell cell = xsh->getCell(row, col);
 
     // Get *last* cell in previous uniform cell block
+    int frameCount = xsh->getFrameCount();
     while (row >= 0) {
       row--;
+      if (row < 0 && column && column->isLooped()) row = frameCount - 1;
+
       if (xsh->getCell(row, col).isEmpty() ||
           xsh->getCell(row, col).getFrameId().isStopFrame())
         continue;

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -138,7 +138,7 @@ class CellArea final : public QWidget {
                        bool isKeyFrame = false, bool isCamera = false,
                        bool keyHighlight = false);
   void drawEndOfLevelMarker(QPainter &p, QRect rect, bool isNextEmpty,
-                            bool isStopFrame = false);
+                            bool isStopFrame = false, bool isLooped = false);
   void drawCellMarker(QPainter &p, int markId, QRect rect,
                       bool hasFrame = false, bool isNextEmpty = true);
 

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -11,6 +11,8 @@
 #include "toonz/tcolumnhandle.h"
 #include "toonz/txsheet.h"
 
+#include "toonzqt/intfield.h"
+
 #include "../include/tundo.h"
 #include "../include/historytypes.h"
 
@@ -236,6 +238,10 @@ class ColumnTransparencyPopup final : public QWidget {
   QTimer *m_keepClosedTimer;
   bool m_keepClosed;
 
+  QGroupBox *m_loopGroupBox;
+  QCheckBox *m_loopLimit;
+  DVGui::IntLineEdit *m_loopToFrame;
+
 public:
   ColumnTransparencyPopup(XsheetViewer *viewer, QWidget *parent);
   void setColumn(TXshColumn *column);
@@ -263,6 +269,10 @@ protected slots:
   void onRenderMaskCBChanged(int checkedState);
 
   void onAlphaLockCBChanged(int checkedState);
+
+  void onLoopGroupBoxChanged(bool clicked);
+  void onLoopLimitCBChanged(int checkedState);
+  void onLoopToFrameChanged(const QString &);
 
   void resetKeepClosed();
 };
@@ -378,6 +388,7 @@ class ColumnArea final : public QWidget {
     void drawParentHandleName() const;
     void drawFilterColor() const;
     void drawClippingMask() const;
+    void drawLoopIndicator() const;
 
     void drawSoundIcon(bool isPlaying) const;
     void drawVolumeControl(double volume) const;

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -554,6 +554,8 @@ TopToBottomOrientation::TopToBottomOrientation() {
 
     addRect(PredefinedRect::CLIPPING_MASK_AREA, QRect(0, 0, -1, -1));
 
+    addRect(PredefinedRect::LOOP_INDICATOR_AREA, QRect(0, 0, -1, -1));
+
     addRect(PredefinedRect::SOUND_ICON, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::VOLUME_AREA, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));
@@ -667,6 +669,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::CLIPPING_MASK_AREA,
             QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2, ICON_WIDTH,
                   ICON_HEIGHT));
+
+    addRect(PredefinedRect::LOOP_INDICATOR_AREA,
+            QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2,
+                  ICON_WIDTH, ICON_HEIGHT));
 
     addRect(PredefinedRect::SOUND_ICON,
             QRect(thumbnailArea.topLeft(), QSize(40, 30))
@@ -803,6 +809,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
             QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2,
                   ICON_WIDTH, ICON_HEIGHT));
 
+    addRect(PredefinedRect::LOOP_INDICATOR_AREA,
+            QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2,
+                  ICON_WIDTH, ICON_HEIGHT));
+
     addRect(PredefinedRect::SOUND_ICON,
             QRect(thumbnailArea.topLeft(), QSize(40, 30))
                 .adjusted((thumbnailArea.width() / 2) - (40 / 2),
@@ -931,6 +941,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
             QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
 
     addRect(PredefinedRect::CLIPPING_MASK_AREA,
+            QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2,
+                  ICON_WIDTH, ICON_HEIGHT));
+
+    addRect(PredefinedRect::LOOP_INDICATOR_AREA,
             QRect(thumbnail.right() - ICON_WIDTH, thumbnail.top() + 2,
                   ICON_WIDTH, ICON_HEIGHT));
 
@@ -1472,6 +1486,9 @@ LeftToRightOrientation::LeftToRightOrientation(QString layout) {
           QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
 
   addRect(PredefinedRect::CLIPPING_MASK_AREA,
+          QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
+
+  addRect(PredefinedRect::LOOP_INDICATOR_AREA,
           QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
 
   addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));         // hide

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -116,7 +116,10 @@ public:
 
   int getLevelFrame(int frame) const {
     if (!m_cellColumn) return m_frame;
-    TXshCell cell = m_cellColumn->getCell(tfloor(frame));
+    TXshCell cell = m_cellColumn->isLooped()
+                        ? m_cellColumn->getLoopedCell(tfloor(frame))
+                        : m_cellColumn->getCell(tfloor(frame));
+
     assert(!cell.isEmpty());
     return cell.m_frameId.getNumber() - 1;
   }
@@ -882,7 +885,10 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
 
   // Retrieve the corresponding xsheet cell to build up
   /*-- 現在のフレームのセルを取得 --*/
-  TXshCell cell  = lcfx->getColumn()->getCell(tfloor(m_frame));
+  TXshCell cell = lcfx->getColumn()->isLooped()
+                      ? lcfx->getColumn()
+                             ->getLoopedCell(tfloor(m_frame)) : lcfx->getColumn()
+                             ->getCell(tfloor(m_frame));
   int levelFrame = cell.m_frameId.getNumber() - 1;
 
   /*--  ParticlesFxに繋がっておらず、空セルの場合は 中身無しを返す --*/

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -367,7 +367,12 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
   double columnZ        = pegbar->getZ(row);
   double columnNoScaleZ = pegbar->getGlobalNoScaleZ();
 
-  TXshCell cell       = xsh->getCell(row, col);
+  bool isLooped      = column->isLooped();
+  bool loopOnionSkin = isLooped && m_onionSkinDistance != 0 &&
+                       m_onionSkinDistance != c_noOnionSkin;
+
+  TXshCell cell = isLooped ? column->getLoopedCell(row, loopOnionSkin)
+                           : xsh->getCell(row, col);
   TXshLevel *xl       = cell.m_level.getPointer();
   TXshSimpleLevel *sl = xl ? xl->getSimpleLevel() : 0;
   // check the previous row for a stop motion layer

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -900,7 +900,9 @@ TAffine TLevelColumnFx::handledAffine(const TRenderSettings &info,
 TFilePath TLevelColumnFx::getPalettePath(int frame) const {
   if (!m_levelColumn) return TFilePath();
 
-  TXshCell cell = m_levelColumn->getCell(frame);
+  TXshCell cell = m_levelColumn->isLooped()
+                      ? m_levelColumn->getLoopedCell(frame)
+                      : m_levelColumn->getCell(frame);
   if (cell.isEmpty()) return TFilePath();
 
   TXshSimpleLevel *sl = cell.m_level->getSimpleLevel();
@@ -921,7 +923,9 @@ TFilePath TLevelColumnFx::getPalettePath(int frame) const {
 TPalette *TLevelColumnFx::getPalette(int frame) const {
   if (!m_levelColumn) return 0;
 
-  TXshCell cell = m_levelColumn->getCell(frame);
+  TXshCell cell = m_levelColumn->isLooped()
+                      ? m_levelColumn->getLoopedCell(frame)
+                      : m_levelColumn->getCell(frame);
   if (cell.isEmpty()) return 0;
 
   TXshSimpleLevel *sl = cell.m_level->getSimpleLevel();
@@ -948,7 +952,9 @@ void TLevelColumnFx::doDryCompute(TRectD &rect, double frame,
   if (!m_levelColumn) return;
 
   int row       = (int)frame;
-  TXshCell cell = m_levelColumn->getCell(row);
+  TXshCell cell = m_levelColumn->isLooped()
+                      ? m_levelColumn->getLoopedCell(row)
+                      : m_levelColumn->getCell(row);
   if (cell.isEmpty()) return;
 
   TXshSimpleLevel *sl = cell.m_level->getSimpleLevel();
@@ -1002,7 +1008,8 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
 
   // Ensure that a corresponding cell and level exists
   int row       = (int)frame;
-  TXshCell cell = m_levelColumn->getCell(row);
+  TXshCell cell = m_levelColumn->isLooped() ? m_levelColumn->getLoopedCell(row)
+                                            : m_levelColumn->getCell(row);
   if (cell.isEmpty()) return;
 
   TXshSimpleLevel *sl = cell.m_level->getSimpleLevel();
@@ -1462,7 +1469,9 @@ bool TLevelColumnFx::doGetBBox(double frame, TRectD &bBox,
   if (!m_levelColumn) return false;
 
   int row       = (int)frame;
-  TXshCell cell = m_levelColumn->getCell(row);
+  TXshCell cell = m_levelColumn->isLooped()
+                      ? m_levelColumn->getLoopedCell(row)
+                      : m_levelColumn->getCell(row);
   if (cell.isEmpty()) return false;
 
   TXshLevelP xshl = cell.m_level;
@@ -1494,7 +1503,9 @@ bool TLevelColumnFx::doGetBBox(double frame, TRectD &bBox,
     }
     dpi = imageInfo.m_dpix / Stage::inch;
   } else {
-    TXshCell cell = m_levelColumn->getCell(row);
+    TXshCell cell = m_levelColumn->isLooped()
+                        ? m_levelColumn->getLoopedCell(row)
+                        : m_levelColumn->getCell(row);
     TImageP img = cell.getImage(false);
     if (!img) return false;
     bBox = img->getBBox();
@@ -1580,7 +1591,9 @@ std::string TLevelColumnFx::getAlias(double frame,
                                      const TRenderSettings &info) const {
   if (!m_levelColumn) return std::string();
 
-  TXshCell cell = m_levelColumn->getCell((int)frame);
+  TXshCell cell = m_levelColumn->isLooped()
+                      ? m_levelColumn->getLoopedCell((int)frame)
+                      : m_levelColumn->getCell((int)frame);
   if (cell.isEmpty()) return std::string();
 
   TFilePath fp;
@@ -1655,7 +1668,9 @@ TXshColumn *TLevelColumnFx::getXshColumn() const { return m_levelColumn; }
 TAffine TLevelColumnFx::getDpiAff(int frame) {
   if (!m_levelColumn) return TAffine();
 
-  TXshCell cell = m_levelColumn->getCell(frame);
+  TXshCell cell = m_levelColumn->isLooped()
+                      ? m_levelColumn->getLoopedCell(frame)
+                      : m_levelColumn->getCell(frame);
   if (cell.isEmpty()) return TAffine();
 
   TXshSimpleLevel *sl = cell.m_level->getSimpleLevel();

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -525,14 +525,15 @@ void TXsheet::clearAll() {
 
 //-----------------------------------------------------------------------------
 
-int TXsheet::getCellRange(int col, int &r0, int &r1) const {
+int TXsheet::getCellRange(int col, int &r0, int &r1,
+                          bool ignoreLastStop) const {
   r0                 = 0;
   r1                 = -1;
   TXshColumnP column = m_imp->m_columnSet.getColumn(col);
   if (!column) return 0;
   TXshCellColumn *cellColumn = column->getCellColumn();
   if (!cellColumn) return 0;
-  return cellColumn->getRange(r0, r1);
+  return cellColumn->getRange(r0, r1, ignoreLastStop);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -117,6 +117,13 @@ void TXshLevelColumn::loadData(TIStream &is) {
       is >> id;
       setColorFilterId(id);
     } else if (tagName == "cells") {
+      int loopToFrame = 0;
+      is.getTagParam("loopToFrame", loopToFrame);
+      if (loopToFrame > 0) {
+        setLoopLimitEnabled(true);
+        setLoopToFrame(loopToFrame);
+      }
+
       while (is.openChild(tagName)) {
         if (tagName == "cell") {
           TPersist *p = 0;
@@ -174,7 +181,10 @@ void TXshLevelColumn::saveData(TOStream &os) {
     os.child("filter_color_id") << (int)getColorFilterId();
   int r0, r1;
   if (getRange(r0, r1)) {
-    os.openChild("cells");
+    std::map<std::string, std::string> attr;
+    if (isLoopLimited()) attr["loopToFrame"] = std::to_string(getLoopToFrame());
+     
+    os.openChild("cells", attr);
     for (int r = r0; r <= r1; r++) {
       TXshCell cell = getCell(r, false);
       if (cell.isEmpty()) continue;


### PR DESCRIPTION
This adds a new column property `Loop Frames` to Raster, Smart Raster, Vector and, Sub-Scene columns.

![image](https://github.com/user-attachments/assets/0efe831e-75cd-43e6-a70e-5f08eecd1735)

When enabled, all the frames between the 1st exposed frame and the last exposed frame will be repeated automatically.

![image](https://github.com/user-attachments/assets/a1997ca8-fd54-4cf0-8a1e-4569fe0d917d)

By default, it will loop the frame sequence infinitely.  You can select to stop the loop at any time by enabling `Loop To Frame` and specifying the last frame to stop the loop.

Additional Notes:
- Looping begins wherever the 1st frame in the sequence is positioned.
- If the last frame in the sequence is a `Stop Frame`, it is ignored. The looping will actually begin on the last stop frame.
- When enabled, looped cells are uncolored (vs tinted for implicit holds) and will show frame numbers/stop frames.
- A looping icon will appear in the thumbnail and will take on the filter color if there is one.
- `Next Drawing` and `Previous Drawing` commands will loop around the original sequence only.
- Looped cells can be onion skinned, though currently no actions can be done with them.