### PR TITLE
Fix Gap Closure results (Tape Tool)

### DIFF
--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -1836,20 +1836,20 @@ void getClosingSegments(TL2LAutocloser &l2lautocloser, double facMin,
 
   double w;
   if (isCloseEnoughP2L(facMin, facMax, s1, 0.0, s2, w, forAutoClose) &&
-      w != 0.0 && w != 1.0)
+      (forAutoClose || (w != 0.0 && w != 1.0)))
     segments.push_back(std::pair<double, double>(0.0, w));
 
   if (isCloseEnoughP2L(facMin, facMax, s2, 1.0, s1, w, forAutoClose) &&
-      w != 0.0 && w != 1.0)
+      (forAutoClose || (w != 0.0 && w != 1.0)))
     segments.push_back(std::pair<double, double>(w, 1.0));
 
   if (s1 != s2) {
     if (isCloseEnoughP2L(facMin, facMax, s2, 0.0, s1, w, forAutoClose) &&
-        w != 0.0 && w != 1.0)
+        (forAutoClose || (w != 0.0 && w != 1.0)))
       segments.push_back(std::pair<double, double>(w, 0.0));
 
     if (isCloseEnoughP2L(facMin, facMax, s1, 1.0, s2, w, forAutoClose) &&
-        w != 0.0 && w != 1.0)
+        (forAutoClose || (w != 0.0 && w != 1.0)))
       segments.push_back(std::pair<double, double>(1.0, w));
   }
 }

--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -2164,8 +2164,8 @@ void getClosingPoints(const TRectD &rect, double fac, const TVectorImageP &vi,
 
   for (; it != strokeStartSegments.end(); it++) {
     SegmentData segData = it->second;
-    if (segData.distance == 0) continue;
-//    if (segData.distance < autoTol) continue;
+//    if (segData.distance == 0) continue;
+    if (segData.distance < autoTol) continue;
     if (segData.segType == 1 && segData.startIdx > segData.endIdx) continue;
 
     startPoints.push_back(
@@ -2177,8 +2177,8 @@ void getClosingPoints(const TRectD &rect, double fac, const TVectorImageP &vi,
 
   for (; it != strokeEndSegments.end(); it++) {
     SegmentData segData = it->second;
-    if (segData.distance == 0) continue;
-//    if (segData.distance < autoTol) continue;
+//    if (segData.distance == 0) continue;
+    if (segData.distance < autoTol) continue;
     if (segData.segType == 1 && segData.startIdx > segData.endIdx) continue;
 
     startPoints.push_back(

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -667,7 +667,7 @@ class TapeToolOptionsBox final : public ToolOptionsBox {
   ToolOptionCheckbox *m_smoothMode, *m_joinStrokesMode;
   ToolOptionCombo *m_toolMode, *m_typeMode, *m_multiFrameMode;
   QLabel *m_autocloseLabel;
-  ToolOptionSlider *m_autocloseField;
+  ToolOptionPairSlider *m_autocloseField;
 
 public:
   TapeToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,

--- a/toonz/sources/include/tvectorimage.h
+++ b/toonz/sources/include/tvectorimage.h
@@ -422,7 +422,7 @@ private:  // not implemented
 DVAPI VIStroke *cloneVIStroke(VIStroke *vs);
 DVAPI void deleteVIStroke(VIStroke *vs);
 
-DVAPI void getClosingPoints(const TRectD &rect, double fac,
+DVAPI void getClosingPoints(const TRectD &rect, double minfac, double fac,
                             const TVectorImageP &vi,
                             std::vector<std::pair<int, double>> &startPoints,
                             std::vector<std::pair<int, double>> &endPoints);

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2387,7 +2387,7 @@ FillTool::FillTool(int targetType)
     , m_segment("Segment", false)
     , m_onionStyleId(0)
     , m_currCell(-1, -1)
-    , m_maxGapDistance("Maximum Gap", 0.01, 10.0, 1.15)
+    , m_maxGapDistance("Auto Close Gap", 0.01, 10.0, 1.15)
     , m_closeStyleIndex("Style Index:", L"current")  // W_ToolOptions_InkIndex
     , m_rasterGapDistance("Distance:", 1, 100, 10)
     , m_closeRasterGaps("Gaps:")
@@ -2509,7 +2509,7 @@ void FillTool::updateTranslation() {
   m_referenced.setQStringName(tr("Refer Visible"));
   m_fillDepth.setQStringName(tr("Fill Depth"));
   m_segment.setQStringName(tr("Segment"));
-  m_maxGapDistance.setQStringName(tr("Maximum Gap"));
+  m_maxGapDistance.setQStringName(tr("Auto Close Gap"));
   m_autopaintLines.setQStringName(tr("Autopaint Lines"));
   m_fillOnlySavebox.setQStringName(tr("Savebox"));
   m_rasterGapDistance.setQStringName(tr("Distance:"));

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2587,7 +2587,7 @@ TapeToolOptionsBox::TapeToolOptionsBox(QWidget *parent, TTool *tool,
   m_toolMode = dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode"));
   m_typeMode = dynamic_cast<ToolOptionCombo *>(m_controls.value("Type"));
   m_autocloseField =
-      dynamic_cast<ToolOptionSlider *>(m_controls.value("Distance"));
+      dynamic_cast<ToolOptionPairSlider *>(m_controls.value("Distance"));
   if (m_autocloseField)
     m_autocloseLabel = m_labels.value(m_autocloseField->propertyName());
   m_multiFrameMode   = dynamic_cast<ToolOptionCombo *>(m_controls.value("Frame Range:"));

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -61,7 +61,7 @@ ToolOptionControl::ToolOptionControl(TTool *tool, std::string propertyName,
 
 void ToolOptionControl::notifyTool(bool addToUndo) {
   std::string tempPropertyName = m_propertyName;
-  if (addToUndo && m_propertyName == "Maximum Gap")
+  if (addToUndo && m_propertyName == "Auto Close Gap")
     tempPropertyName = tempPropertyName + "withUndo";
   m_tool->onPropertyChanged(tempPropertyName);
 }

--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
@@ -600,7 +600,7 @@ void ToolOptionsShortcutInvoker::initialize() {
 void ToolOptionsShortcutInvoker::notifyTool(TTool* tool, TProperty* p,
                                             bool addToUndo) {
   std::string tempPropertyName = p->getName();
-  if (addToUndo && tempPropertyName == "Maximum Gap")
+  if (addToUndo && tempPropertyName == "Auto Close Gap")
     tempPropertyName = tempPropertyName + "withUndo";
   tool->onPropertyChanged(tempPropertyName);
 }

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -754,7 +754,7 @@ static void buildAutocloseImage(
     points[0]       = p1;
     points[1]       = 0.5 * (p1 + p2);
     points[2]       = p2;
-    points[0].thick = points[1].thick = points[2].thick = 0.0;
+    points[0].thick = points[1].thick = points[2].thick = 0.25;
     TStroke *auxStroke                                  = new TStroke(points);
     auxStroke->setStyle(2);
     vaux->addStroke(auxStroke);

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -761,6 +761,7 @@ static void buildAutocloseImage(
   }
 }
 
+TEnv::DoubleVar AutocloseFactorMin("InknpaintAutocloseFactorMin", 1.15);
 TEnv::DoubleVar AutocloseFactor("InknpaintAutocloseFactor", 4.0);
 
 static void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
@@ -771,7 +772,8 @@ static void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
   }
 
   std::vector<std::pair<int, double>> startPoints, endPoints;
-  getClosingPoints(vi->getBBox(), AutocloseFactor, vi, startPoints, endPoints);
+  getClosingPoints(vi->getBBox(), AutocloseFactorMin, AutocloseFactor, vi,
+                   startPoints, endPoints);
   TVectorImage *vaux = new TVectorImage();
 
   rd.m_palette = plt;


### PR DESCRIPTION
This PR attempts to filter the "noise" of the results using the Tape Tool in `Rectangle` mode and View Gap Check.

The logic for what gap segments has been updated.  The results of the list of possible closing segments are filtered as follows:
- All line-2-line segments are discarded.
- Any endpoint-2-line or line-2-endpoint segments that form an acute angle < 45 degrees are discarded.
- Any gap segments that cross other existing lines are discarded.
- The shortest allowable segment from an endpoint to another endpoint or line is kept.
- endpoint-2-endpoint segments are favored over shorter endpoint-2-line segments if the endpoint-2-line segment is close enough to the end of the stroke.

Additionally:
- The Fill Tool's `Maximum Gap` toolbar option has been renamed to `Auto Close Gap`. It not longer influences the Tape Tool's rectangular mode.
- Added a `Min` distance setting to the Tape Tool's rectangular mode.  Default value is 1.15 (the default for Auto Close Gap).

Tape tool example before and after results using `Distance` = 100
![image](https://github.com/user-attachments/assets/9db2ece1-d24a-4ccb-9696-0d1e1730c355)

