### PR TITLE
Fix missing Theme selector (macos/linux)

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -228,14 +228,14 @@ public:
   void setWorkingDirectory() {
     QString workingDirectoryTmp = QDir::currentPath();
 
-#if defined(LINUX) || defined(FREEBSD)
-    QString appPath =
-        workingDirectoryTmp + "/" + QCoreApplication::applicationName();
-    QDir appDir(appPath);
-    appPath = appDir.canonicalPath();
-    if (!appPath.isEmpty())
-      workingDirectoryTmp = TFilePath(appPath).getParentDir().getQString();
-#endif
+//#if defined(LINUX) || defined(FREEBSD)
+//    QString appPath =
+//        workingDirectoryTmp + "/" + QCoreApplication::applicationName();
+//    QDir appDir(appPath);
+//    appPath = appDir.canonicalPath();
+//    if (!appPath.isEmpty())
+//      workingDirectoryTmp = TFilePath(appPath).getParentDir().getQString();
+//#endif
 
     QByteArray ba                = workingDirectoryTmp.toLatin1();
     const char *workingDirectory = ba.data();


### PR DESCRIPTION
This fixes #1690, the missing `Theme` selector on macOS and Linux builds.

This was due to adding a preference setting check for High DPI Scaling (#1660) before everything was fully initialized at startup.

Changed the location of where everything was initialized which primarily impacts how macOS and Linux builds determines the current working directory.