### PR TITLE
Update Canon EDSDK to v13.18.40

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get CanonSDK
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' }}
         run: |
-          wget --header="Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" --header="Accept:application/octet-stream" -O EDSDK_Macintosh.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/132789028
+          wget --header="Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" --header="Accept:application/octet-stream" -O EDSDK_Macintosh.zip https://github.com/tahoma2d/CanonSDK/releases/download/v13.18.40/EDSDK_v13.18.40_Macintosh.zip
           unzip EDSDK_Macintosh.zip -d EDSDK_Macintosh
           unzip EDSDK_Macintosh/Macintosh.dmg.zip -d EDSDK_Macintosh
           7z x EDSDK_Macintosh/Macintosh.dmg -oEDSDK_Macintosh

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get CanonSDK
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' }}
         run: |
-          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Windows.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/132789036
+          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Windows.zip https://github.com/tahoma2d/CanonSDK/releases/download/v13.18.40/EDSDK_v13.18.40_Windows.zip
           7z x EDSDK_Windows.zip -oEDSDK_Windows
           move EDSDK_Windows\EDSDK\Header thirdparty\canon
           move EDSDK_Windows\EDSDK_64\Dll thirdparty\canon


### PR DESCRIPTION
Updating the Canon EDSDK library to the latest version for both Windows and macOS builds.

Hoping it will fix an issue some macOS users are experiencing on newer OS versions.

NOTE:  Since PR's cannot be built with Canon support, I will merge this once the builds are successful.  Will need to review the log to see if it downloaded the lastest successfully and test the nightly versions for any issues.