### PR TITLE
Fix compiling latest CanonSDK for macOS

### DIFF
--- a/toonz/sources/stopmotion/canon.cpp
+++ b/toonz/sources/stopmotion/canon.cpp
@@ -830,7 +830,7 @@ bool Canon::downloadImage(EdsBaseRef object) {
          m_imageQuality.toLower().contains("jpg")) &&
         m_imageQuality.toLower().contains("raw")) {
 #ifdef MACOSX
-      UInt64 rawStreamSize = 0;
+      EdsUInt64 rawStreamSize = 0;
 #else
       unsigned __int64 rawStreamSize = 0;
 #endif
@@ -873,8 +873,8 @@ bool Canon::downloadImage(EdsBaseRef object) {
   }
 
 #ifdef MACOSX
-  UInt64 jpgStreamSize = 0;
-  UInt64 rawStreamSize = 0;
+  EdsUInt64 jpgStreamSize = 0;
+  EdsUInt64 rawStreamSize = 0;
 #else
   unsigned __int64 jpgStreamSize     = 0;
   unsigned __int64 rawStreamSize     = 0;

--- a/toonz/sources/stopmotion/jpgconverter.h
+++ b/toonz/sources/stopmotion/jpgconverter.h
@@ -34,7 +34,7 @@ class JpgConverter : public QThread {
 #endif
 
 #if defined(MACOSX) || defined(LINUX)
-  unsigned long long m_dataSize = 0;
+  EdsUInt64 m_dataSize = 0;
 #else
   unsigned __int64 m_dataSize = 0;
 #endif


### PR DESCRIPTION
Fixing macOS build error due to type changes in latest Canon SDK....3rd times a charm?

