### PR TITLE
Fix incorrect type cast for with/without canon support

### DIFF
--- a/toonz/sources/stopmotion/jpgconverter.h
+++ b/toonz/sources/stopmotion/jpgconverter.h
@@ -33,8 +33,14 @@ class JpgConverter : public QThread {
   EdsStreamRef m_stream;
 #endif
 
-#if defined(MACOSX) || defined(LINUX)
+#if defined(MACOSX)
+#ifdef WITH_CANON
   EdsUInt64 m_dataSize = 0;
+#else
+  unsigned long long m_dataSize = 0;
+#endif
+#elif defined(LINUX)
+  unsigned long long m_dataSize = 0;
 #else
   unsigned __int64 m_dataSize = 0;
 #endif


### PR DESCRIPTION
Fixed the canon SDK change impacting Linux (I think it felt left out) as well as for macOS PRs where Canon SDK isn't present.