### PR TITLE
Fix macOS working directory path

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -78,8 +78,7 @@ public:
     QString settingsPath;
 
 #ifdef MACOSX
-    settingsPath = QString::fromStdString(getApplicationFileName()) +
-                   QString(".app") +
+    settingsPath = QString::fromStdString(getWorkingDirectory()) +
                    QString("/Contents/Resources/SystemVar.ini");
 #else
 #ifdef HAIKU
@@ -254,8 +253,7 @@ public:
     // everything together when it translocates.
     if (!m_isPortable) {
       portableCheck =
-          TFilePath(m_workingDirectory + "\\" + getApplicationFileName() +
-                    ".app\\tahomastuff\\");
+          TFilePath(m_workingDirectory + "\\tahomastuff\\");
       portableStatus = TFileStatus(portableCheck);
       m_isPortable   = portableStatus.doesExist();
       if (m_isPortable)

--- a/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
@@ -377,8 +377,7 @@ static QString getExeName(bool isComposer) {
   return name + ".exe ";
 #elif defined(MACOSX)
   TVER::ToonzVersion tver;
-  return QString::fromStdString(tver.getAppName()) + ".app/Contents/MacOS/" +
-         name;
+  return "Contents/MacOS/" + name;
 #else
   return name;
 #endif

--- a/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
+++ b/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
@@ -70,7 +70,7 @@ TFilePath getGlobalRoot() {
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
   std::string unixpath =
-      "./" + tver.getAppName() + ".app/Contents/Resources/configfarmroot.txt";
+      "./Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
   std::string unixpath = "/etc/" + tver.getAppName() + "/tahoma.conf";
@@ -115,7 +115,7 @@ TFilePath getLocalRoot() {
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
   std::string unixpath =
-      "./" + tver.getAppName() + ".app/Contents/Resources/configfarmroot.txt";
+      "./Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
 #ifdef FREEBSD

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -68,7 +68,7 @@ TFilePath getGlobalRoot() {
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
   std::string unixpath =
-      "./" + tver.getAppName() + ".app/Contents/Resources/configfarmroot.txt";
+      "./Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
   std::string unixpath = "/etc/" + tver.getAppName() + "/tahoma.conf";
@@ -112,7 +112,7 @@ TFilePath getLocalRoot() {
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
   std::string unixpath =
-      "./" + tver.getAppName() + ".app/Contents/Resources/configfarmroot.txt";
+      "./Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
 #ifdef FREEBSD
@@ -379,8 +379,7 @@ static QString getExeName(bool isComposer) {
   return name + ".exe ";
 #elif defined(MACOSX)
   TVER::ToonzVersion tver;
-  return "\"./" + QString::fromStdString(tver.getAppName()) +
-         ".app/Contents/MacOS/" + name + "\" ";
+  return "\"./Contents/MacOS/" + name + "\" ";
 #else
   return name;
 #endif

--- a/toonz/sources/toonzlib/thirdparty.cpp
+++ b/toonz/sources/toonzlib/thirdparty.cpp
@@ -98,16 +98,8 @@ QString autodetectFFmpeg() {
   folderList.append(".");
   folderList.append("./ffmpeg");  // ffmpeg folder
 
-#ifdef MACOSX
-  // Look inside app
-  folderList.append("./" +
-                    QString::fromStdString(TEnv::getApplicationFileName()) +
-                    ".app/ffmpeg");  // ffmpeg folder
-#elif defined(LINUX) || defined(FREEBSD)
-  // Need to account for symbolic links
   folderList.append(TEnv::getWorkingDirectory().getQString() +
                     "/ffmpeg");  // ffmpeg folder
-#endif
 
 #ifndef _WIN32
   folderList.append("/app/bin");
@@ -271,16 +263,8 @@ QString autodetectRhubarb() {
   folderList.append(".");
   folderList.append("./rhubarb");  // rhubarb folder
 
-#ifdef MACOSX
-  // Look inside app
-  folderList.append("./" +
-                    QString::fromStdString(TEnv::getApplicationFileName()) +
-                    ".app/rhubarb");  // rhubarb folder
-#elif defined(LINUX) || defined(FREEBSD)
-  // Need to account for symbolic links
   folderList.append(TEnv::getWorkingDirectory().getQString() +
                     "/rhubarb");  // rhubarb folder
-#endif
 
 #ifndef _WIN32
   folderList.append("/app/bin");


### PR DESCRIPTION
Fix fixes the reported problems introduced by changes made in #1694 (a fix for #1660):
- Task rendering would start but never complete.
- The installed version would not start

This was due to how the working directory path was being determined but not used correctly in other areas of T2D after the prior fix.  The working directory path is now the application's root folder (Tahoma2D.app) instead of the directory it is run from.

