### PR TITLE
Fix Task Render/Cleanup failure (Linux)

### DIFF
--- a/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
@@ -30,6 +30,7 @@ using namespace TVER;
 // 2017-04-15.
 #include <netdb.h>      // gethostbyname
 #include <arpa/inet.h>  // inet_ntoa
+#include <filesystem>
 #endif
 
 //*************************************************************************
@@ -379,7 +380,10 @@ static QString getExeName(bool isComposer) {
   TVER::ToonzVersion tver;
   return "Contents/MacOS/" + name;
 #else
-  return name;
+  QString appPath =
+      QString::fromStdString(std::filesystem::canonical("/proc/self/exe"));
+  TFilePath path(appPath);
+  return path.getParentDir().getQString() + "/" + name;
 #endif
 }
 

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -29,6 +29,9 @@ using namespace TVER;
 #else
 #include <sys/param.h>
 #include <unistd.h>
+#ifndef MACOSX
+#include <filesystem>
+#endif
 #endif
 
 // #define REDIRECT_OUTPUT
@@ -381,7 +384,10 @@ static QString getExeName(bool isComposer) {
   TVER::ToonzVersion tver;
   return "\"./Contents/MacOS/" + name + "\" ";
 #else
-  return name;
+  QString appPath =
+      QString::fromStdString(std::filesystem::canonical("/proc/self/exe"));
+  TFilePath path(appPath);
+  return path.getParentDir().getQString() + "/" + name;
 #endif
 }
 


### PR DESCRIPTION
This fixes an issue with Task rendering/cleanup failing in Linux builds, especially when run through an AppImage.

T2D's executables are in a temporary location when run through an AppImage so when it tries to call the `tcomposer` or `tcleanup` executable, it fails when it isn't in the current working directory.

Added logic to find the current path of the running `Tahoma2D` executable and building a full path to `tcomposer`/`tcleanup`.  This expects that they are in the same directory as the main executable.