### PR TITLE
Fix startup crash due to incompatible DLLs

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -1070,6 +1070,19 @@ QString TSystem::findFileLocation(QStringList folderList, QString fileName) {
   return "";
 }
 
+bool TSystem::isDLLBlackListed(QString dllFile) {
+  QStringList dllBlackList = {"lvcod64.dll", "ff_vfw.dll", "tsccvid64.dll",
+                              "hapcodec.dll"};
+
+  for (int x = 0; x < dllBlackList.count(); x++) {
+    if (dllFile.contains(dllBlackList.at(x), Qt::CaseInsensitive)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 #else
 
 #include <windows.h>

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -272,6 +272,9 @@ DVAPI QString getUserName();
 DVAPI QString getSystemValue(const TFilePath &name);
 DVAPI TFilePath getUniqueFile(QString field = "");
 #endif
+
+DVAPI bool isDLLBlackListed(QString dllFile);
+
 }
 
 //


### PR DESCRIPTION
This is an attempt to fix the crash startup due to DLLs like
- `lvcod64.dll`
- `ff_vfw.dll`
- `tsccvid64.dll`
- `hapcodec.dll`

I've added a DDL Black list so that when searching for a Video codec that handles AVIs, it will skip the DLLs mentioned above.

I think in prior attempts at fixing this, I had the checks in the wrong place so it was attempting to filter out the DLLs too late.  I've moved it to the proper location so skips it before it tries to access it.

fixes #1390, fixes #1505, fixes #1593, fixes #1680, fixes #1710
