### PR TITLE
Fix canceling cell/column selection

### DIFF
--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -474,7 +474,8 @@ LevelMoverTool::LevelMoverTool(XsheetViewer *viewer)
     , m_validPos(false)
     , m_undo(0)
     , m_moved(false)
-    , m_columnsMoved(false) {}
+    , m_columnsMoved(false)
+    , m_dragged(false) {}
 
 LevelMoverTool::~LevelMoverTool() {}
 
@@ -644,6 +645,8 @@ void LevelMoverTool::onCellChange(int row, int col) {
 
   if (pos == m_aimedPos) return;
 
+  m_dragged = true;
+
   m_aimedPos = pos;
 
   m_validPos = canMoveColumns(pos);
@@ -756,6 +759,16 @@ void LevelMoverTool::onRelease(const CellPosition &pos) {
 
   if (!getViewer()->orientation()->isVerticalTimeline())
     TUndoManager::manager()->endBlock();
+
+  // Reset current selection if we didn't move
+  TCellSelection *selection = getViewer()->getCellSelection();
+  if (!Preferences::instance()->isShowDragBarsEnabled() && !m_dragged &&
+      (cellMover->getRowCount() > 1 || cellMover->getColumnCount() > 1)) {
+    selection->selectNone();
+    selection->selectCell(pos.frame(), pos.layer());
+    getViewer()->setCurrentRow(pos.frame());
+    getViewer()->setCurrentColumn(pos.layer());
+  }
 }
 
 void LevelMoverTool::drawCellsArea(QPainter &p) {

--- a/toonz/sources/toonz/xshcellmover.h
+++ b/toonz/sources/toonz/xshcellmover.h
@@ -110,6 +110,7 @@ protected:
   LevelMoverUndo *m_undo;
   bool m_moved;
   bool m_columnsMoved;
+  bool m_dragged;
 
   bool isTotallyEmptyColumn(int col) const;
   virtual bool canMove(const TPoint &pos);


### PR DESCRIPTION
When drag bars are not enabled, to clear an active multi-cell/column selection, you currently need to tap an unselected cell/column. 

This fix allows the canceling a cell or column selection by effectively tapping any part of the active selection without moving the selection.  Similar behavior can be found in Krita/CSP.

"Effectively tapping" means either quick tap or a click, pause or movement within the selected cell/column, and release. 
Clicking, moving the selection away and back to the original position, and then releasing will not reset the selection.


