### PR TITLE
Fix camera loading crash + improve Sony configuration

### DIFF
--- a/toonz/sources/stopmotion/gphotocam.cpp
+++ b/toonz/sources/stopmotion/gphotocam.cpp
@@ -140,12 +140,14 @@ void GPhotoCam::resetGphotocam(bool liveViewOpen) {
 //-----------------------------------------------------------------
 
 void GPhotoCam::loadCameraConfigKeys(QString manufacturer) {
-  int i = sizeof(cameraConfigKeys) - 1;
+  int i = 0;
 
-  if (manufacturer.contains("Canon"))
-    i = 0;
-  else if (manufacturer.contains("Nikon"))
-    i = 1;
+  // Look for known T2D configurations
+  for (int x = 1; x < CAMERACONFIGKEYS_COUNT; x++) {
+    if (!manufacturer.contains(cameraConfigKeys[x].manufacturer)) continue;
+    i = x;
+    break;
+  }
 
   m_configKeys.modeKey         = cameraConfigKeys[i].keys.modeKey;
   m_configKeys.batteryLevelKey = cameraConfigKeys[i].keys.batteryLevelKey;

--- a/toonz/sources/stopmotion/gphotocam.h
+++ b/toonz/sources/stopmotion/gphotocam.h
@@ -37,6 +37,10 @@ const struct {
   QString manufacturer;
   GPConfigKeys keys;
 } cameraConfigKeys[] = {
+    {"Default",
+     {"expprogram", "Battery Level", "shutterspeed", "f-number", "iso",
+      "whitebalance", 0, "imagequality", "imagesize", "exposurecompensation",
+      "colortemperature", "manualfocusdrive", 0, "viewfinder", 0}},
     // Canon
     {"Canon",
      {"autoexposuremode", "batterylevel", "shutterspeed", "aperture", "iso",
@@ -48,10 +52,13 @@ const struct {
      {"expprogram", "batterylevel", "shutterspeed", "f-number", "iso",
       "whitebalance", 0, "imagequality", "imagesize", "exposurecompensation", 0,
       "manualfocusdrive", "changeafarea", "viewfinder", 0}},
-    {0,
-     {"expprogram", "Battery Level", "shutterspeed", "f-number", "iso",
+    // Sony
+    {"Sony",
+     {"expprogram", "batterylevel", "shutterspeed", "f-number", "iso",
       "whitebalance", 0, "imagequality", "imagesize", "exposurecompensation",
-      "colortemperature", "manualfocusdrive", 0, "viewfinder", 0}}};
+      "colortemperature", "zoom", 0, "movie", 0}}};
+
+#define CAMERACONFIGKEYS_COUNT 4
 
 //-----------------------------------------------------------------
 


### PR DESCRIPTION
This fixes #1692, I think.

There was a memory leak that occurred whenever T2D was trying to find pre-configured settings for non-Canon/Nikon cameras.  This would result in crashes if there were no configurations for the camera being detected.

Additionally, added specific configurations for Sony cameras.  Most of it was already supported by default but there were a few differences that were noted and configured specifically for Sony support.

NOTE: I don't have a Sony camera, so will need someone with a Sony camera to test this with before I merge it if possible. 
 Specifically need testing with turning Live View off/on and manual focus. cc: @charliemartinez 