### PR TITLE
Fix alpha lock

### DIFF
--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -274,10 +274,17 @@ public:
 
     // rasIn e' un raster dello stesso tipo di tile.getRaster()
 
+    if (infoIn.m_isAlphaLockMask) {
+      infoIn.m_applyMask = false;
+      infoIn.m_isAlphaLockMask = false;
+    }
     TTile inTile;
     m_fx->allocateAndCompute(inTile, rectIn.getP00(),
                              TDimension(rectInI.getLx(), rectInI.getLy()),
                              tile.getRaster(), frame, infoIn);
+
+    infoIn.m_applyMask       = info.m_applyMask;
+    infoIn.m_isAlphaLockMask = info.m_isAlphaLockMask;
 
     infoIn.m_affine = appliedAff;
     TRasterFx::applyAffine(tile, inTile, infoIn);

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -498,7 +498,12 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
       PlayerSet::iterator it;
       for (it = players.begin(); it != players.end(); it++) {
         Player alphaRefPlayer = *it;
-        if (alphaRefPlayer.m_ancestorColumnIndex != alphaRefColIdx) continue;
+        if ((subSheetColIndex != -1 &&
+             (alphaRefPlayer.m_ancestorColumnIndex != subSheetColIndex ||
+              alphaRefPlayer.m_column != alphaRefColIdx)) ||
+            (subSheetColIndex == -1 &&
+             alphaRefPlayer.m_ancestorColumnIndex != alphaRefColIdx))
+          continue;
 
         Player alphaPlayer = player;
 
@@ -968,6 +973,14 @@ void StageBuilder::visit(PlayerSet &players, Visitor &visitor, bool isPlaying) {
         }
         visitor.enableMask(maskType);
         i++;
+
+        // For alpha locked columns, draw alpha locked image on top
+        // of each mask except last one which we'll do later.
+        if (player.m_isAlphaLocked && i < player.m_masks.size()) {
+          visitor.onImage(player);
+          masks.pop_back();
+          visitor.disableMask();
+        }
       }
     }
     player.m_isPlaying = isPlaying;


### PR DESCRIPTION
This fixes the following issues with Alpha Lock (#1666)

- Alpha Lock not applying to Sub-Scenes
- Alpha Locked column is missing when the base of the Alpha Locked column is animated (Raster/Smart Raster only)