### PR TITLE
Increase Size of Step Lines in Motion Path

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -3691,8 +3691,10 @@ void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
           glTranslated(point.x, point.y, 0);
           glRotated(degree, 0, 0, 1);
           glBegin(GL_LINES);
-          glVertex2d(0, 3 + width);
-          glVertex2d(0, -3 - width);
+          // glVertex2d(0, 3 + width); 
+          // glVertex2d(0, -3 - width); 
+          glVertex2d(0, 20 + width); //   Increase Size of Step Lines in Motion Path,
+          glVertex2d(0, -20 - width); //  Improve Visibility
           glEnd();
           if (playing && currentStep == i) {
             tglDrawDisk(TPointD(0, 0), 4 + width * 3);


### PR DESCRIPTION
The lines representing the steps in the motion path were quite small, making it difficult to see them clearly on small screens or from a certain distance. This often required excessive zooming in on the preview, causing a loss of reference to the overall composition of the photograph. The size has been increased to improve visibility and usability.

![imagen](https://github.com/user-attachments/assets/5cc2f628-fec5-4021-af54-e7ff12b1e4aa)
