### PR TITLE
Fix Delete Style Color

### DIFF
--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -212,7 +212,7 @@ void TPalette::Page::removeStyle(int indexInPage, bool flagOnly) {
   m_palette->m_styleAnimationTable.erase(styleId);
   if (!flagOnly)
     m_palette->m_styles[styleId].second =
-        TColorStyleP(new TSolidColorStyle(TPixel32::Black));
+        TColorStyleP(new TSolidColorStyle(TPixel32::Red));
   m_styleIds.erase(m_styleIds.begin() + indexInPage);
 }
 


### PR DESCRIPTION
An issue with deleted styles was fixed in 1.3.  With that the change anything drawn with that style that was not deleted would to turn black.  Prior to that fix, it used to turn red.

At a suggestion, this PR changes the color of strokes drawn in a delete style to turn red instead of black.