### PR TITLE
Adjust parallelism and exit codes for build scripts

### DIFF
--- a/ci-scripts/linux/tahoma-build.sh
+++ b/ci-scripts/linux/tahoma-build.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
-pushd thirdparty/tiff-4.2.0
-CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig --disable-webp && make
-popd
 
-cd toonz
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1)) || exit;
+
+pushd thirdparty/tiff-4.2.0 || exit;
+CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig --disable-webp && make -j "$parallel" || exit;
+popd || exit;
+
+cd toonz || exit;
 
 if [ ! -d build ]
 then
    mkdir build
 fi
-cd build
+cd build || exit;
 
-source /opt/qt515/bin/qt515-env.sh
+source /opt/qt515/bin/qt515-env.sh || exit;
 
 if [ -d ../../thirdparty/canon/Header ]
 then
@@ -22,6 +26,6 @@ export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 cmake ../sources  $CANON_FLAG \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DWITH_GPHOTO2:BOOL=ON \
-    -DWITH_SYSTEM_SUPERLU=ON
+    -DWITH_SYSTEM_SUPERLU=ON || exit;
 
-make -j7
+make -j "$parallel" || exit;

--- a/ci-scripts/linux/tahoma-buildffmpeg.sh
+++ b/ci-scripts/linux/tahoma-buildffmpeg.sh
@@ -1,24 +1,26 @@
 #!/bin/bash
-cd thirdparty
+cd thirdparty || exit;
 
 echo ">>> Cloning openH264"
 git clone https://github.com/cisco/openh264.git openh264
 
-cd openh264
+cd openh264 || exit;
 echo "*" >| .gitignore
 
 echo ">>> Making openh264"
-make
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1)) || exit;
+make -j "$parallel" || exit;
 
 echo ">>> Installing openh264"
-sudo make install
+sudo make install -j "$parallel" || exit;
 
-cd ..
+cd .. || exit;
 
 echo ">>> Cloning ffmpeg"
 git clone -b v4.3.1 https://github.com/tahoma2d/FFmpeg ffmpeg
 
-cd ffmpeg
+cd ffmpeg || exit;
 echo "*" >| .gitignore
 
 echo ">>> Configuring to build ffmpeg (shared)"
@@ -56,12 +58,12 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
       --enable-shared \
       --disable-static \
       --disable-libjack \
-      --disable-indev=jack
+      --disable-indev=jack || exit;
 
 echo ">>> Building ffmpeg (shared)"
-make
+make -j "$parallel" || exit;
 
 echo ">>> Installing ffmpeg (shared)"
-sudo make install
+sudo make install -j "$parallel" || exit;
 
-sudo ldconfig
+sudo ldconfig || exit;

--- a/ci-scripts/linux/tahoma-buildlibgphoto2.sh
+++ b/ci-scripts/linux/tahoma-buildlibgphoto2.sh
@@ -1,22 +1,23 @@
 #!/bin/bash
-cd thirdparty
+cd thirdparty || exit;
 
 echo ">>> Cloning libgphoto2"
-git clone https://github.com/tahoma2d/libgphoto2.git libgphoto2_src
+git clone https://github.com/tahoma2d/libgphoto2.git libgphoto2_src || exit;
 
-cd libgphoto2_src
+cd libgphoto2_src || exit;
 
-git checkout tahoma2d-version
+git checkout tahoma2d-version || exit;
 
 echo ">>> Configuring libgphoto2"
-autoreconf --install --symlink
+autoreconf --install --symlink || exit;
 
-./configure --prefix=/usr/local
+./configure --prefix=/usr/local || exit;
 
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1)) || exit;
 echo ">>> Making libgphoto2"
-make
+make -j "$parallel" || exit;
 
 echo ">>> Installing libgphoto2"
-sudo make install
+sudo make -j "$parallel" install || exit;
 
-cd ..

--- a/ci-scripts/linux/tahoma-buildlibmypaint.sh
+++ b/ci-scripts/linux/tahoma-buildlibmypaint.sh
@@ -1,24 +1,26 @@
 #!/bin/bash
-cd thirdparty/libmypaint
+cd thirdparty/libmypaint || exit;
 
 echo ">>> Cloning libmypaint"
-git clone https://github.com/tahoma2d/libmypaint src
+git clone https://github.com/tahoma2d/libmypaint src || exit;
 
-cd src
+cd src || exit;
 echo "*" >| .gitignore
 
 export CFLAGS='-Ofast -ftree-vectorize -fopt-info-vec-optimized -march=native -mtune=native -funsafe-math-optimizations -funsafe-loop-optimizations'
 
 echo ">>> Generating libmypaint environment"
-./autogen.sh
+./autogen.sh || exit;
 
 echo ">>> Configuring libmypaint build"
-sudo ./configure
+sudo ./configure || exit;
 
 echo ">>> Building libmypaint"
-sudo make
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1)) || exit;
+sudo make -j "$parallel" || exit;
 
 echo ">>> Installing libmypaint"
-sudo make install
+sudo make -j "$parallel" install || exit;
 
-sudo ldconfig
+sudo ldconfig || exit;

--- a/ci-scripts/linux/tahoma-buildopencv.sh
+++ b/ci-scripts/linux/tahoma-buildopencv.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-cd thirdparty
+cd thirdparty || exit;
 
 echo ">>> Cloning opencv"
-git clone https://github.com/tahoma2d/opencv
+git clone https://github.com/tahoma2d/opencv || exit;
 
-cd opencv
+cd opencv || exit;
 echo "*" >| .gitignore
 
 if [ ! -d build ]
 then
-   mkdir build
+   mkdir build || exit;
 fi
-cd build
+cd build || exit;
 
 echo ">>> Cmaking openv"
 cmake -DCMAKE_BUILD_TYPE=Release \
@@ -46,11 +46,13 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_opencv_python2=OFF \
       -DBUILD_opencv_python3=ON \
       -DCMAKE_INSTALL_NAME_DIR=/usr/local/lib \
-      ..
+      .. || exit;
 
 echo ">>> Building opencv"
-make
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1)) || exit;
+make -j "$parallel" || exit;
 
 echo ">>> Installing opencv"
-sudo make install
+sudo make -j "$parallel" install || exit;
 

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -1,42 +1,42 @@
 #!/bin/bash
-source /opt/qt515/bin/qt515-env.sh
+source /opt/qt515/bin/qt515-env.sh || exit;
 
 echo ">>> Temporary install of Tahoma2D"
 SCRIPTPATH=`dirname "$0"`
 export BUILDDIR=$SCRIPTPATH/../../toonz/build
-cd $BUILDDIR
-sudo make install
+cd $BUILDDIR || exit;
+sudo make install || exit;
 
-sudo ldconfig
+sudo ldconfig || exit;
 
 echo ">>> Creating appDir"
 if [ -d appdir ]
 then
    rm -rf appdir
 fi
-mkdir -p appdir/usr
+mkdir -p appdir/usr || exit;
 
 echo ">>> Copy and configure Tahoma2D installation in appDir"
-cp -r /opt/tahoma2d/* appdir/usr
-cp appdir/usr/share/applications/*.desktop appdir
-cp appdir/usr/share/icons/hicolor/*/apps/*.png appdir
-mv appdir/usr/lib/tahoma2d/* appdir/usr/lib
-rmdir appdir/usr/lib/tahoma2d
+cp -r /opt/tahoma2d/* appdir/usr || exit;
+cp appdir/usr/share/applications/*.desktop appdir || exit;
+cp appdir/usr/share/icons/hicolor/*/apps/*.png appdir || exit;
+mv appdir/usr/lib/tahoma2d/* appdir/usr/lib || exit;
+rmdir appdir/usr/lib/tahoma2d || exit;
 
 echo ">>> Creating Tahoma2D directory"
 if [ -d Tahoma2D ]
 then
    rm -rf Tahoma2D
 fi
-mkdir Tahoma2D
+mkdir Tahoma2D || exit;
 
 echo ">>> Copying stuff to Tahoma2D/tahomastuff"
 
-mv appdir/usr/share/tahoma2d/stuff Tahoma2D/tahomastuff
-chmod -R 777 Tahoma2D/tahomastuff
-rmdir appdir/usr/share/tahoma2d
+mv appdir/usr/share/tahoma2d/stuff Tahoma2D/tahomastuff || exit;
+chmod -R 777 Tahoma2D/tahomastuff || exit;
+rmdir appdir/usr/share/tahoma2d || exit;
 
-find Tahoma2D/tahomastuff -name .gitkeep -exec rm -f {} \;
+find Tahoma2D/tahomastuff -name .gitkeep -exec rm -f {} \; || exit;
 
 if [ -d ../../thirdparty/apps/ffmpeg/bin ]
 then
@@ -45,9 +45,9 @@ then
    then
       rm -rf Tahoma2D/ffmpeg
    fi
-   mkdir -p Tahoma2D/ffmpeg
-   cp -R ../../thirdparty/apps/ffmpeg/bin/ffmpeg ../../thirdparty/apps/ffmpeg/bin/ffprobe Tahoma2D/ffmpeg
-   chmod -R 755 Tahoma2D/ffmpeg
+   mkdir -p Tahoma2D/ffmpeg || exit;
+   cp -R ../../thirdparty/apps/ffmpeg/bin/ffmpeg ../../thirdparty/apps/ffmpeg/bin/ffprobe Tahoma2D/ffmpeg || exit;
+   chmod -R 755 Tahoma2D/ffmpeg || exit;
 fi
 
 if [ -d ../../thirdparty/apps/rhubarb ]
@@ -57,31 +57,31 @@ then
    then
       rm -rf Tahoma2D/rhubarb
    fi
-   mkdir -p Tahoma2D/rhubarb
-   cp -R ../../thirdparty/apps/rhubarb/rhubarb ../../thirdparty/apps/rhubarb/res Tahoma2D/rhubarb
-   chmod 755 -R Tahoma2D/rhubarb
+   mkdir -p Tahoma2D/rhubarb || exit;
+   cp -R ../../thirdparty/apps/rhubarb/rhubarb ../../thirdparty/apps/rhubarb/res Tahoma2D/rhubarb || exit;
+   chmod 755 -R Tahoma2D/rhubarb || exit;
 fi
 
 if [ -d ../../thirdparty/canon/Library ]
 then
    echo ">>> Copying canon libraries"
-   cp -R ../../thirdparty/canon/Library/x86_64/* appdir/usr/lib
+   cp -R ../../thirdparty/canon/Library/x86_64/* appdir/usr/lib || exit;
 fi
 
 echo ">>> Copying libghoto2 supporting directories"
-cp -r /usr/local/lib/libgphoto2 appdir/usr/lib
-cp -r /usr/local/lib/libgphoto2_port appdir/usr/lib
+cp -r /usr/local/lib/libgphoto2 appdir/usr/lib || exit;
+cp -r /usr/local/lib/libgphoto2_port appdir/usr/lib || exit;
 
-rm appdir/usr/lib/libgphoto2/print-camera-list
-find appdir/usr/lib/libgphoto2* -name *.la -exec rm -f {} \;
-find appdir/usr/lib/libgphoto2* -name *.so -exec patchelf --set-rpath '$ORIGIN/../..' {} \;
+rm appdir/usr/lib/libgphoto2/print-camera-list || exit;
+find appdir/usr/lib/libgphoto2* -name *.la -exec rm -f {} \; || exit;
+find appdir/usr/lib/libgphoto2* -name *.so -exec patchelf --set-rpath '$ORIGIN/../..' {} \; || exit;
 
 echo ">>> Creating Tahoma2D/Tahoma2D.AppImage"
 
 if [ ! -f linuxdeployqt*.AppImage ]
 then
-   wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-   chmod a+x linuxdeployqt*.AppImage
+   wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" || exit;
+   chmod a+x linuxdeployqt*.AppImage || exit;
 fi
 
 export LD_LIBRARY_PATH=appdir/usr/lib/tahoma2d
@@ -92,17 +92,17 @@ export LD_LIBRARY_PATH=appdir/usr/lib/tahoma2d
    -executable=appdir/usr/bin/tcomposer \
    -executable=appdir/usr/bin/tconverter \
    -executable=appdir/usr/bin/tfarmcontroller \
-   -executable=appdir/usr/bin/tfarmserver 
+   -executable=appdir/usr/bin/tfarmserver  || exit;
 
-rm appdir/AppRun
-cp ../sources/scripts/AppRun appdir
-chmod 775 appdir/AppRun
+rm appdir/AppRun || exit;
+cp ../sources/scripts/AppRun appdir || exit;
+chmod 775 appdir/AppRun || exit;
 
-./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma2D -appimage -no-strip 
+./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma2D -appimage -no-strip  || exit;
 
-mv Tahoma2D*.AppImage Tahoma2D/Tahoma2D.AppImage
+mv Tahoma2D*.AppImage Tahoma2D/Tahoma2D.AppImage || exit;
 
 echo ">>> Creating Tahoma2D Linux package"
 
-tar zcf Tahoma2D-linux.tar.gz Tahoma2D
+tar zcf Tahoma2D-linux.tar.gz Tahoma2D || exit;
 

--- a/ci-scripts/linux/tahoma-get3rdpartyapps.sh
+++ b/ci-scripts/linux/tahoma-get3rdpartyapps.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-cd thirdparty
+cd thirdparty || exit;
 
 if [ ! -d apps ]
 then
    mkdir apps
 fi
-cd apps
+cd apps || exit;
 echo "*" >| .gitignore
 
 echo ">>> Getting FFmpeg"
@@ -13,9 +13,9 @@ if [ -d ffmpeg ]
 then
    rm -rf ffmpeg
 fi
-wget https://github.com/tahoma2d/FFmpeg/releases/download/v5.0.0/ffmpeg-5.0.0-linux64-static-lgpl.zip
-unzip ffmpeg-5.0.0-linux64-static-lgpl.zip 
-mv ffmpeg-5.0.0-linux64-static-lgpl ffmpeg
+wget https://github.com/tahoma2d/FFmpeg/releases/download/v5.0.0/ffmpeg-5.0.0-linux64-static-lgpl.zip || exit;
+unzip ffmpeg-5.0.0-linux64-static-lgpl.zip || exit;
+mv ffmpeg-5.0.0-linux64-static-lgpl ffmpeg || exit;
 
 
 echo ">>> Getting Rhubarb Lip Sync"
@@ -23,6 +23,6 @@ if [ -d rhubarb ]
 then
    rm -rf rhubarb ]
 fi
-wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.13.0/rhubarb-lip-sync-tahoma2d-linux.zip
-unzip rhubarb-lip-sync-tahoma2d-linux.zip -d rhubarb
+wget https://github.com/tahoma2d/rhubarb-lip-sync/releases/download/v1.13.0/rhubarb-lip-sync-tahoma2d-linux.zip || exit;
+unzip rhubarb-lip-sync-tahoma2d-linux.zip -d rhubarb || exit;
 

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
-sudo add-apt-repository --yes ppa:beineri/opt-qt-5.15.2-focal
-sudo apt-get update
-sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt515script libsuperlu-dev qt515svg qt515tools qt515multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg-turbo8-dev libturbojpeg0-dev libglib2.0-dev qt515serialport
-# Removed: libopenjpeg-dev 
-sudo apt-get install -y nasm yasm libgnutls28-dev libunistring-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libfreetype6-dev libopencore-amrnb-dev libopencore-amrwb-dev libspeex-dev libsoxr-dev libopenjp2-7-dev
-sudo apt-get install -y python3-pip
-sudo apt-get install -y build-essential libgirepository1.0-dev autotools-dev intltool gettext libtool patchelf autopoint libusb-1.0-0 libusb-1.0-0-dev
-sudo apt-get install -y libdeflate-dev
 
-pip3 install --upgrade pip
-pip3 install numpy
+sudo add-apt-repository --yes ppa:beineri/opt-qt-5.15.2-focal || exit;
+sudo apt-get update || exit;
+sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt515script libsuperlu-dev qt515svg qt515tools qt515multimedia wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg-turbo8-dev libturbojpeg0-dev libglib2.0-dev qt515serialport || exit;
+# Removed: libopenjpeg-dev 
+sudo apt-get install -y nasm yasm libgnutls28-dev libunistring-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libfreetype6-dev libopencore-amrnb-dev libopencore-amrwb-dev libspeex-dev libsoxr-dev libopenjp2-7-dev || exit;
+sudo apt-get install -y python3-pip || exit;
+sudo apt-get install -y build-essential libgirepository1.0-dev autotools-dev intltool gettext libtool patchelf autopoint libusb-1.0-0 libusb-1.0-0-dev || exit;
+sudo apt-get install -y libdeflate-dev || exit;
+
+pip3 install --upgrade pip || exit;
+pip3 install numpy || exit;
 
 # Leave repo directory for this step
-cd ..
+cd .. || exit;
 
 # someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
 #if [ ! -f liblz4.deb ]
@@ -28,21 +29,21 @@ cd ..
 #sudo dpkg -i liblz4.deb liblz4-dev.deb
 
 # Remove this as the version that is there is old and causes issues compiling opencv
-sudo apt-get remove libprotobuf-dev
+sudo apt-get remove libprotobuf-dev || exit;
 
 # Need protoc3 for some compiles.  don't use the apt-get version as it's too old.
 
 if [ ! -d protoc3 ]
 then
-   wget https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
+   wget https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip || exit;
    # Unzip
-   unzip protoc-3.6.1-linux-x86_64.zip -d protoc3
+   unzip protoc-3.6.1-linux-x86_64.zip -d protoc3 || exit;
 fi
 
 # Move protoc to /usr/local/bin/
-sudo cp -pr protoc3/bin/* /usr/local/bin/
+sudo cp -pr protoc3/bin/* /usr/local/bin/ || exit;
 
 # Move protoc3/include to /usr/local/include/
-sudo cp -pr protoc3/include/* /usr/local/include/
+sudo cp -pr protoc3/include/* /usr/local/include/ || exit;
 
-sudo ldconfig
+sudo ldconfig || exit;


### PR DESCRIPTION
It's difficult to detect failures if they're ignored and the build keeps going. Adding "|| exit" after a command will

1. Check the return code of the pipeline
1. If the return code is non-zero, "||" runs the second command, "exit"
1. "exit" will exit the script returning the exit status of the last command executed (see man bash; "exit [n]")

Also, for parallelism, it's best to query the platform for its parallel capacity. Rather than using all available cores, this commit uses one less so that the computer is still mostly responsive. Of course, if there is only one core available, we should avoid -j0, so we check for that situation first.