### PR TITLE
Build concurrently to reduce overall build time

### DIFF
--- a/ci-scripts/linux/tahoma-build.sh
+++ b/ci-scripts/linux/tahoma-build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1))
 pushd thirdparty/tiff-4.2.0
-CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig --disable-webp && make
+CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig --disable-webp && make -j "$parallel"
 popd
 
 cd toonz
@@ -24,4 +26,4 @@ cmake ../sources  $CANON_FLAG \
     -DWITH_GPHOTO2:BOOL=ON \
     -DWITH_SYSTEM_SUPERLU=ON
 
-make -j7
+make -j "$parallel"

--- a/ci-scripts/linux/tahoma-buildffmpeg.sh
+++ b/ci-scripts/linux/tahoma-buildffmpeg.sh
@@ -7,11 +7,13 @@ git clone https://github.com/cisco/openh264.git openh264
 cd openh264
 echo "*" >| .gitignore
 
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1))
 echo ">>> Making openh264"
-make
+make -j "$parallel"
 
 echo ">>> Installing openh264"
-sudo make install
+sudo make -j "$parallel" install
 
 cd ..
 
@@ -59,9 +61,9 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
       --disable-indev=jack
 
 echo ">>> Building ffmpeg (shared)"
-make
+make -j "$parallel"
 
 echo ">>> Installing ffmpeg (shared)"
-sudo make install
+sudo make -j "$parallel" install
 
 sudo ldconfig

--- a/ci-scripts/linux/tahoma-buildlibgphoto2.sh
+++ b/ci-scripts/linux/tahoma-buildlibgphoto2.sh
@@ -13,10 +13,12 @@ autoreconf --install --symlink
 
 ./configure --prefix=/usr/local
 
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1))
 echo ">>> Making libgphoto2"
-make
+make -j "$parallel"
 
 echo ">>> Installing libgphoto2"
-sudo make install
+sudo make -j "$parallel" install
 
 cd ..

--- a/ci-scripts/linux/tahoma-buildlibmypaint.sh
+++ b/ci-scripts/linux/tahoma-buildlibmypaint.sh
@@ -15,10 +15,12 @@ echo ">>> Generating libmypaint environment"
 echo ">>> Configuring libmypaint build"
 sudo ./configure
 
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1))
 echo ">>> Building libmypaint"
-sudo make
+sudo make -j "$parallel"
 
 echo ">>> Installing libmypaint"
-sudo make install
+sudo make -j "$parallel" install
 
 sudo ldconfig

--- a/ci-scripts/linux/tahoma-buildopencv.sh
+++ b/ci-scripts/linux/tahoma-buildopencv.sh
@@ -48,9 +48,11 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_NAME_DIR=/usr/local/lib \
       ..
 
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1))
 echo ">>> Building opencv"
-make
+make -j "$parallel"
 
 echo ">>> Installing opencv"
-sudo make install
+sudo make -j "$parallel" install
 

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -5,7 +5,9 @@ echo ">>> Temporary install of Tahoma2D"
 SCRIPTPATH=`dirname "$0"`
 export BUILDDIR=$SCRIPTPATH/../../toonz/build
 cd $BUILDDIR
-sudo make install
+# Leave one processor available for other processing if possible
+parallel=$(($(nproc) < 2 ? 1 : $(nproc) - 1))
+sudo make -j "$parallel" install
 
 sudo ldconfig
 


### PR DESCRIPTION
For parallelism, it's best to query the platform for its parallel capacity. Rather than using all available cores, this commit uses one less so that the computer is still mostly responsive. Of course, if there is only one core available, we should avoid -j0, so we check for that situation first.