### PR TITLE
Fix uploading Debian packages to Nightly

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           allowUpdates: true
           artifactErrorsFailBuild: false
-          artifacts: toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz
+          artifacts: toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz,toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.deb
           artifactContentType: "raw"
           body: ${{ github.event.head_commit.message }}
           name: Latest Nightly ${{ env.NIGHTLYDATE }}
@@ -117,7 +117,7 @@ jobs:
         with:
           allowUpdates: true
           artifactErrorsFailBuild: false
-          artifacts: toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz
+          artifacts: toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.tar.gz,toonz/build/Tahoma2D-linux-${{ matrix.compiler }}.deb
           artifactContentType: "raw"
           body: ${{ github.event.head_commit.message }}
           name: ${{ env.NIGHTLYDATETIME }}


### PR DESCRIPTION
Fixes newly created Debian package not uploading to the Nightly.

As soon as this PR completes it's checks, I will merge it in order to verify the Nightly is updated correctly.