### PR TITLE
Fix on-canvas widget/indicator visibility

### DIFF
--- a/toonz/sources/common/tvrender/tglregions.cpp
+++ b/toonz/sources/common/tvrender/tglregions.cpp
@@ -191,7 +191,7 @@ static void drawFirstControlPoint(const TVectorRenderData &rd,
 
   glPushMatrix();
   tglMultMatrix(rd.m_aff);
-  if (!rd.m_animatedGuidedDrawing) glLineWidth(2.0f);
+  if (!rd.m_animatedGuidedDrawing) glLineWidth(2.0f * rd.m_devPixRatio);
   glColor3d(0.0, 1.0, 0.0);
   if (!rd.m_animatedGuidedDrawing) {
     drawArrows(stroke, false);
@@ -235,7 +235,7 @@ static void drawFirstControlPoint(const TVectorRenderData &rd,
     glEnd();
   }
 
-  glLineWidth(1.0f);
+  glLineWidth(1.0f * rd.m_devPixRatio);
   glPopMatrix();
 }
 

--- a/toonz/sources/include/ext/Designer.h
+++ b/toonz/sources/include/ext/Designer.h
@@ -30,8 +30,10 @@ class Selector;
    * @brief This class is a visitor to manage properly Draw method.
    */
 class DVAPI Designer {
+  int m_devPixRatio;
+
 public:
-  Designer();
+  Designer(int devPixRatio = 1.0);
   virtual ~Designer();
   /**
 */
@@ -48,6 +50,8 @@ public:
   virtual void draw(Selector *);
 
   double getPixelSize2() const;
+
+  int getDevPixRatio() const { return m_devPixRatio; }
 };
 }
 #endif  // !defined(DESIGNER_H)

--- a/toonz/sources/include/ext/OverallDesigner.h
+++ b/toonz/sources/include/ext/OverallDesigner.h
@@ -30,7 +30,7 @@ class DVAPI OverallDesigner final : public Designer {
   void setPosition();
 
 public:
-  OverallDesigner(int x, int y);
+  OverallDesigner(int x, int y, int devPixRaio);
   virtual ~OverallDesigner();
   void draw(SmoothDeformation *) override;
   void draw(CornerDeformation *) override;

--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -11,10 +11,15 @@
 #include "tools/cursors.h"
 #include "tpalette.h"
 
+#include "toonzqt/imageutils.h"
+#include "toonzqt/glwidget_for_highdpi.h"
+
 // TnzCore includes
 #include "tcommon.h"
 #include "tgeometry.h"
 #include "tfilepath.h"
+
+#include "toonzqt/gutil.h"
 
 // Qt includes
 #include <QString>
@@ -612,7 +617,7 @@ protected:
   OpenGL).
 */
 
-class TTool::Viewer {
+class TTool::Viewer : public GLWidgetForHighDpi {
 protected:
   ImagePainter::VisualSettings
       m_visualSettings;  //!< Settings used by the Viewer to draw scene contents
@@ -623,7 +628,8 @@ protected:
   QWidget *m_viewerWidget  = nullptr;
 
 public:
-  Viewer(QWidget *widget) : m_viewerWidget(widget) {}
+  Viewer(QWidget *widget, ImageUtils::FullScreenWidget *parent)
+      : GLWidgetForHighDpi(parent), m_viewerWidget(widget) {}
   virtual ~Viewer() {}
 
   const ImagePainter::VisualSettings &visualSettings() const {
@@ -737,6 +743,8 @@ public:
   void doPickGuideStroke(const TPointD &pos);
 
   QWidget *viewerWidget() { return m_viewerWidget; }
+
+  int getDevPixRatio() const { return getDevicePixelRatio(m_viewerWidget); }
 };
 
 #endif

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -268,10 +268,12 @@ private:
 
   std::vector<TStroke *> m_guidedStrokes;
 
+  int m_devPixRatio;
+
 public:
   RasterPainter(const TDimension &dim, const TAffine &viewAff,
                 const TRect &rect, const ImagePainter::VisualSettings &vs,
-                bool checkFlags);
+                bool checkFlags, int devPixRatio = 1);
 
   void onImage(const Stage::Player &data) override;
   void onVectorImage(TVectorImage *vi, const Stage::Player &data);
@@ -349,10 +351,12 @@ class DVAPI OpenGlPainter final : public Visitor  // Yep, the name sucks...
 
   bool m_singleColumnEnabled;
 
+  int m_devPixRatio;
+
 public:
   OpenGlPainter(const TAffine &viewAff, const TRect &rect,
                 const ImagePainter::VisualSettings &vs, bool isViewer,
-                bool isAlphaEnabled);
+                bool isAlphaEnabled, int devPixRatio = 1);
 
   bool isViewer() const { return m_isViewer; }
   void enableCamera3D(bool on) { m_camera3d = on; }

--- a/toonz/sources/include/tvectorrenderdata.h
+++ b/toonz/sources/include/tvectorrenderdata.h
@@ -90,6 +90,9 @@ public:
   bool m_animatedGuidedDrawing = false;
   //!  \deprecated  Use the above individual options instead.
   //!  \todo  Remove it ASAP.
+ 
+  int m_devPixRatio;
+
 public:
   TVectorRenderData(ViewerSettings, const TAffine &aff,
                     const TRect &clippingRect, const TPalette *palette,
@@ -123,7 +126,8 @@ public:
       , m_indexToHighlight(-1)
       , m_highLightNow(false)
       , m_guidedCf(0)
-      , m_showGuidedDrawing(false) {}
+      , m_showGuidedDrawing(false)
+      , m_devPixRatio(1) {}
 
   TVectorRenderData(ProductionSettings, const TAffine &aff,
                     const TRect &clippingRect, const TPalette *palette,
@@ -154,7 +158,8 @@ public:
       , m_indexToHighlight(-1)
       , m_highLightNow(false)
       , m_guidedCf(0)
-      , m_showGuidedDrawing(false) {}
+      , m_showGuidedDrawing(false)
+      , m_devPixRatio(1) {}
 
   TVectorRenderData(const TVectorRenderData &other, const TAffine &aff,
                     const TRect &clippingRect, const TPalette *palette,
@@ -183,7 +188,8 @@ public:
       , m_indexToHighlight(other.m_indexToHighlight)
       , m_highLightNow(other.m_highLightNow)
       , m_guidedCf(other.m_guidedCf)
-      , m_showGuidedDrawing(other.m_showGuidedDrawing) {
+      , m_showGuidedDrawing(other.m_showGuidedDrawing)
+      , m_devPixRatio(other.m_devPixRatio) {
   }  //!< Constructs from explicit primary context settings while
      //!  copying the rest from another instance.
 
@@ -215,7 +221,8 @@ public:
       , m_indexToHighlight(-1)
       , m_highLightNow(false)
       , m_guidedCf(0)
-      , m_showGuidedDrawing(false) {
+      , m_showGuidedDrawing(false)
+      , m_devPixRatio(1) {
   }  //!< Constructs settings with default ViewerSettings.
      //!  \deprecated   Use constructors with explicit settings type tag.
 };

--- a/toonz/sources/tnzext/Designer.cpp
+++ b/toonz/sources/tnzext/Designer.cpp
@@ -6,7 +6,7 @@
 
 //-----------------------------------------------------------------------------
 
-ToonzExt::Designer::Designer() {}
+ToonzExt::Designer::Designer(int devPixRatio) : m_devPixRatio(devPixRatio) {}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/tnzext/OverallDesigner.cpp
+++ b/toonz/sources/tnzext/OverallDesigner.cpp
@@ -192,7 +192,8 @@ void showCorners(const TStroke *s, int cornerSize, double pixelSize) {
 
 //-----------------------------------------------------------------------------
 
-ToonzExt::OverallDesigner::OverallDesigner(int x, int y) : x_(x), y_(y) {
+ToonzExt::OverallDesigner::OverallDesigner(int x, int y, int devPixRatio)
+    : Designer(devPixRatio), x_(x), y_(y) {
   pixelSize_ = sqrt(this->getPixelSize2());
   scale_     = pixelSize_ != 0.0 ? pixelSize_ : 1.0;
 }
@@ -391,11 +392,11 @@ void ToonzExt::OverallDesigner::draw(ToonzExt::Selector *selector) {
         std::min(stroke_length, length_at_w + emi_selector_length));
   }
 
-  float prev_line_width = 1.0;
+  float prev_line_width = 1.0 * getDevPixRatio();
 
   glGetFloatv(GL_LINE_WIDTH, &prev_line_width);
 
-  glLineWidth(2.0);
+  glLineWidth(2.0 * getDevPixRatio());
   drawStrokeCenterLine(ref, pixelSize_, interval);
   glLineWidth(prev_line_width);
 }

--- a/toonz/sources/tnzext/Selector.cpp
+++ b/toonz/sources/tnzext/Selector.cpp
@@ -13,9 +13,9 @@ const GLfloat s_highlightedColor[] = {150.0 / 255.0, 255.0 / 255.0,
                                       140.0 / 255.0};
 const double s_sqrt_2      = sqrt(2.0);
 const double s_radius      = 5.0;
-const double s_over_size   = 10;
-const double s_length      = 15;
-const double s_square_size = 5;
+const double s_over_size   = 10.0;
+const double s_length      = 15.0;
+const double s_square_size = 8.0;
 const double s_arrow_ratio = 2.5;
 
 void drawArrow(const TPointD &from, const TPointD &direction, double length,
@@ -110,7 +110,10 @@ TPointD Selector::getUp() const {
 void Selector::draw(Designer *designer) {
   if (!strokeRef_ || !isVisible_) return;
 
-  pixel_size_ = designer ? sqrt(designer->getPixelSize2()) : 1.0;
+  int devPixRatio = designer->getDevPixRatio();
+
+  pixel_size_ =
+      (designer ? sqrt(designer->getPixelSize2()) : 1.0) * devPixRatio;
 
   TPointD v = this->getUp(), n = normalize(rotate90(v));
 
@@ -144,7 +147,7 @@ void Selector::draw(Designer *designer) {
 
   {
     // the circle center is in
-    TPointD down = -this->getUp(), center = pnt + down * (height_);
+    TPointD down = -this->getUp(), center = pnt + down * (height_ * 1.25);
     const double length = s_square_size * 0.5 * pixel_size_;
 
     TPointD
@@ -311,7 +314,7 @@ Selector::Selection Selector::getSelection(const TPointD &pos) {
   // one pixel of tolerance
   if (tdistance2(center, pos) <= sq(radius + pixel_size_)) return POSITION;
 
-  center = pnt + down * (height_);
+  center = pnt + down * (height_ * 1.25);
 
   // const double  length = s_length * pixel_size_;
   const double length = s_square_size * 0.5 * pixel_size_;

--- a/toonz/sources/tnzext/meshutils.cpp
+++ b/toonz/sources/tnzext/meshutils.cpp
@@ -328,7 +328,6 @@ void tglDraw(const TMeshImage &meshImage, const DrawableTextureData &texData,
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glEnable(GL_LINE_SMOOTH);
-  glLineWidth(1.0f);
 
   glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
 

--- a/toonz/sources/tnztools/bendertool.cpp
+++ b/toonz/sources/tnztools/bendertool.cpp
@@ -677,11 +677,15 @@ void BenderTool::increaseCP(TStroke *tmpStroke, int beginEndOrAll) {
 //-----------------------------------------------------------------------------
 
 void BenderTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   // TAffine viewMatrix = getViewer()->getViewMatrix();
   // glPushMatrix();
   // tglMultMatrix(viewMatrix);
 
   double pixelSize = getPixelSize();
+
+  glLineWidth((1.0 * devPixRatio));
 
   typedef std::map<TStroke *, ArrayOfStroke>::const_iterator mapTACit;
   for (mapTACit cit1 = m_metaStroke.begin(); cit1 != m_metaStroke.end();

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -368,6 +368,10 @@ void ControlPointEditorTool::draw() {
     return;
   }
 
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
+
   TPixel color1, color2;
   if (m_action == RECT_SELECTION)  // Disegna il rettangolo per la selezione
   {

--- a/toonz/sources/tnztools/cuttertool.cpp
+++ b/toonz/sources/tnztools/cuttertool.cpp
@@ -186,6 +186,8 @@ public:
     // glPushMatrix();
     // tglMultMatrix(viewMatrix);
 
+    int devPixRatio = m_viewer->getDevPixRatio();
+
     const double pixelSize = getPixelSize();
 
     double len = m_cursor.thick + 15 * pixelSize;
@@ -198,6 +200,8 @@ public:
       v = normalize(v);
 
       v = v * (len);
+
+      glLineWidth(1.0 * devPixRatio);
 
       tglColor(TPixelD(0.1, 0.9, 0.1));
       tglDrawSegment(p - v, p + v);

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -1145,7 +1145,7 @@ void EditTool::drawMainHandle() {
   TAffine parentAff    = xsh->getParentPlacement(objId, frame);
   TAffine aff          = xsh->getPlacement(objId, frame);
   TPointD center       = Stage::inch * xsh->getCenter(objId, frame);
-  int devPixRatio      = getDevicePixelRatio(m_viewer->viewerWidget());
+  int devPixRatio      = m_viewer->getDevPixRatio();
   // the gadget appears on the center of the level. orientation and dimension
   // are independent of the movement of the level
   glPushMatrix();
@@ -1301,6 +1301,10 @@ void EditTool::draw() {
 
   /*-- Show nothing on Level Editing mode --*/
   if (TTool::getApplication()->getCurrentFrame()->isEditingLevel()) return;
+
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
 
   // if the column and its children are all hidden, only draw fx gadgets
   if (!transformEnabled()) {

--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -2966,7 +2966,7 @@ void FxGadgetController::invalidateViewer() { m_tool->invalidate(); }
 //---------------------------------------------------------------------------
 
 int FxGadgetController::getDevPixRatio() {
-  return getDevicePixelRatio(m_tool->getViewer()->viewerWidget());
+  return m_tool->getViewer()->getDevPixRatio();
 }
 
 //---------------------------------------------------------------------------

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2949,6 +2949,10 @@ void FillTool::onFrameSwitched() {
 //-----------------------------------------------------------------------------
 
 void FillTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth((1.0 * devPixRatio));
+
   if (m_fillOnlySavebox.getValue()) {
     TToonzImageP ti = (TToonzImageP)getImage(false);
     if (ti) {

--- a/toonz/sources/tnztools/fingertool.cpp
+++ b/toonz/sources/tnztools/fingertool.cpp
@@ -356,6 +356,8 @@ void FingerTool::updateTranslation() {
 //-----------------------------------------------------------------------------
 
 void FingerTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   if (m_pointSize == -1) {
     return;
   }
@@ -374,6 +376,8 @@ void FingerTool::draw() {
     glColor3d(0.5, 0.8, 0.8);
   else
     glColor3d(1.0, 0.0, 0.0);
+
+  glLineWidth(1.0 * devPixRatio);
 
   drawEmptyCircle(m_toolSize.getValue(), m_mousePos, true, lx % 2 == 0,
                   ly % 2 == 0);

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -824,7 +824,11 @@ void FullColorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 //-------------------------------------------------------------------------------------------------------------
 
 void FullColorBrushTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   if (TRasterImageP ri = TRasterImageP(getImage(false))) {
+    glLineWidth(1.0 * devPixRatio);
+
     if (m_isStraight) {
       tglColor(TPixel32::Red);
       tglDrawSegment(m_firstPoint, m_lastPoint);

--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -1159,10 +1159,15 @@ void FullColorEraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 //----------------------------------------------------------------------------------------------------------
 
 void FullColorEraserTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   double pixelSize2 = getPixelSize() * getPixelSize();
   m_thick           = sqrt(pixelSize2) / 2.0;
   TRasterImageP img = (TRasterImageP)getImage(false);
   if (!img) return;
+
+  glLineWidth(1.0 * devPixRatio);
+  
 //  TPixel color = ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg
 //                     ? TPixel32::White
 //                     : TPixel32::Black;

--- a/toonz/sources/tnztools/fullcolorfilltool.cpp
+++ b/toonz/sources/tnztools/fullcolorfilltool.cpp
@@ -423,8 +423,13 @@ int FullColorFillTool::getCursorId() const {
 }
 
 void FullColorFillTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   if (m_frameRange.getIndex() && m_firstClick) {
     tglColor(TPixel::Red);
+
+    glLineWidth((1.0 * devPixRatio));
+
     drawCross(m_firstPoint, 6);
 
     SymmetryTool *symmetryTool = dynamic_cast<SymmetryTool *>(

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -1530,8 +1530,11 @@ public:
   }
 
   void onDeactivate() override {
+    int devPixRatio = m_viewer->getDevPixRatio();
+
     if (m_isRotatingOrMoving) {
       tglColor(m_color);
+      glLineWidth(1.0 * devPixRatio);
       for (int i = 0; i < m_rotatedStroke.size(); i++)
         drawStrokeCenterline(*m_rotatedStroke[i], sqrt(tglGetPixelSize2()));
       return;
@@ -1545,6 +1548,10 @@ public:
   }
 
   void draw() override {
+    int devPixRatio = m_viewer->getDevPixRatio();
+
+    glLineWidth(1.0 * devPixRatio);
+
     if (m_param.m_frameRange.getIndex() && m_firstStrokes.size()) {
       tglColor(m_color);
       for (int i = 0; i < m_firstStrokes.size(); i++)

--- a/toonz/sources/tnztools/hooktool.cpp
+++ b/toonz/sources/tnztools/hooktool.cpp
@@ -308,10 +308,14 @@ void HookTool::drawHooks(HookSet *hookSet, const TFrameId &fid, bool isOnion) {
 void HookTool::draw() {
   // ToolUtils::drawRect(TRectD(10,10,110,110), TPixel32(255,200,200), 0xFFF0);
 
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   // draw the current image bounding box
   const double v200 = 200.0 / 255.0;
   TImageP image     = getImage(false);
   if (!image) return;
+
+  glLineWidth(1.0 * devPixRatio);
 
   if (m_frameRange.getIndex() && m_firstClick) {
     tglColor(TPixel::Red);

--- a/toonz/sources/tnztools/irontool.cpp
+++ b/toonz/sources/tnztools/irontool.cpp
@@ -79,8 +79,11 @@ public:
   ToolType getToolType() const override { return TTool::LevelWriteTool; }
 
   void draw() override {
+    int devPixRatio = m_viewer->getDevPixRatio();
+
     if (m_draw && (TVectorImageP)getImage(false)) {
       glColor3d(1, 0, 1);
+      glLineWidth(1.0 * devPixRatio);
       if (m_cursor.thick > 0) tglDrawCircle(m_cursor, m_cursor.thick);
       tglDrawCircle(m_cursor, m_cursor.thick + 4 * getPixelSize());
     }

--- a/toonz/sources/tnztools/magnettool.cpp
+++ b/toonz/sources/tnztools/magnettool.cpp
@@ -400,6 +400,8 @@ lefrightButtonDown(p);
   };
 
   void draw() override {
+    int devPixRatio  = m_viewer->getDevPixRatio();
+
     TVectorImageP vi = TImageP(getImage(true));
     if (!vi) return;
 
@@ -408,6 +410,8 @@ lefrightButtonDown(p);
     // tglMultMatrix(viewMatrix);
 
     double pointSize = m_toolSize.getValue();
+
+    glLineWidth(1.0 * devPixRatio);
 
     tglColor(TPixel32::Red);
     tglDrawCircle(m_pointAtMove, pointSize);

--- a/toonz/sources/tnztools/morphtool.cpp
+++ b/toonz/sources/tnztools/morphtool.cpp
@@ -13,6 +13,8 @@
 #include "toonz/tframehandle.h"
 #include "toonz/txshsimplelevel.h"
 
+#include "toonzqt/gutil.h"
+
 #include <QKeyEvent>
 
 class Deformation {
@@ -174,6 +176,10 @@ void MorphTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 }
 
 void MorphTool::draw() {
+  int devPixRatio = getDevicePixelRatio();
+
+  glLineWidth(1.0 * devPixRatio);
+
   m_pixelSize = sqrt(tglGetPixelSize2());
   if (m_vi2) {
     TVectorRenderData rd(TTranslation(10, 10), TRect(), 0, 0);

--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -442,6 +442,8 @@ void PaintBrushTool::fixMousePos(TPointD pos, bool precise) {
 //-----------------------------------------------------------------------------
 
 void PaintBrushTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   // If toggled off, don't draw brush outline
   if (!Preferences::instance()->isCursorOutlineEnabled()) return;
 
@@ -458,6 +460,7 @@ void PaintBrushTool::draw() {
   else
     glColor3d(1.0, 0.0, 0.0);
 
+  glLineWidth(1.0 * devPixRatio);
   drawEmptyCircle(tround(m_rasThickness.getValue().second), m_mousePos, true,
                   lx % 2 == 0, ly % 2 == 0);
   drawEmptyCircle(tround(m_rasThickness.getValue().first), m_mousePos, true,

--- a/toonz/sources/tnztools/perspectivetool.cpp
+++ b/toonz/sources/tnztools/perspectivetool.cpp
@@ -341,8 +341,6 @@ void PerspectiveControls::drawControls(SceneViewer *viewer) {
   double circleRadius = m_handleRadius * m_unit;
   double diskRadius   = (m_handleRadius - 2) * m_unit;
 
-  glLineWidth(1.5);
-
   glLineStipple(1, 0xFFFF);
   glEnable(GL_LINE_STIPPLE);
 
@@ -699,6 +697,10 @@ void PerspectiveTool::draw(SceneViewer *viewer) {
                           ->getScene()
                           ->getCurrentCamera()
                           ->getStageRect();
+
+  int devPixRatio = viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
 
   for (int i = 0; i < m_perspectiveObjs.size(); i++) {
     if (!m_perspectiveObjs[i]) continue;
@@ -1998,7 +2000,6 @@ void VanishingPointPerspective::draw(SceneViewer *viewer, TRectD cameraRect) {
   glEnable(GL_BLEND);
   glEnable(GL_LINE_SMOOTH);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glLineWidth(1.0f);
 
   TPointD p = getCenterPoint();
 
@@ -2164,7 +2165,6 @@ void LinePerspective::draw(SceneViewer *viewer, TRectD cameraRect) {
   glEnable(GL_BLEND);  // Enable blending.
   glEnable(GL_LINE_SMOOTH);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glLineWidth(1.0f);
 
   TPointD p = getCenterPoint();
 
@@ -2231,7 +2231,6 @@ void LinePerspective::draw(SceneViewer *viewer, TRectD cameraRect) {
     }
   }
 
-  glLineWidth(1.0f);
   glDisable(GL_LINE_SMOOTH);
   glDisable(GL_BLEND);
 }

--- a/toonz/sources/tnztools/pinchtool.cpp
+++ b/toonz/sources/tnztools/pinchtool.cpp
@@ -421,6 +421,8 @@ void PinchTool::onImageChanged() {
 //-----------------------------------------------------------------------------
 
 void PinchTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   GLMatrixGuard guard;
 
   TVectorImageP img(getImage(true));
@@ -435,7 +437,9 @@ void PinchTool::draw() {
 
   StrokeDeformation *deformation = m_deformation;
 
-  OverallDesigner designer((int)m_curr.x, (int)m_curr.y);
+  OverallDesigner designer((int)m_curr.x, (int)m_curr.y, devPixRatio);
+
+  glLineWidth(1.0 * devPixRatio);
 
   // m_active == true means that a button down is done (drag)
   if (!m_active) {

--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -1740,14 +1740,16 @@ static void drawFilledSquare(const TPointD &pos, double radius) {
 //------------------------------------------------------------------------
 
 static void drawHandle(const TPointD &pos, double radius,
-                       const TPixel32 &color) {
+                       const TPixel32 &color, int devPixRatio) {
   glColor4ub(0, 0, 0, color.m);  // Black border
-  glLineWidth(4.0f);
+  glLineWidth(4.0f * devPixRatio);
   drawSquare(pos, radius);
 
   glColor4ub(color.r, color.g, color.b, color.m);
-  glLineWidth(2.0f);
+  glLineWidth(2.0f * devPixRatio);
   drawSquare(pos, radius);
+
+  glLineWidth(1.0f * devPixRatio);
 }
 
 //------------------------------------------------------------------------
@@ -1796,7 +1798,6 @@ void PlasticTool::drawHighlights(const SkDP &sd,
                                  const PlasticSkeleton *skeleton,
                                  double pixelSize) {
   glColor3f(1.0f, 0.0f, 0.0f);  // Red
-  glLineWidth(1.0f);
 
   // Vertex highlights
   if (m_svHigh >= 0) {
@@ -1834,7 +1835,6 @@ void PlasticTool::drawSelections(const SkDP &sd,
                                  const PlasticSkeleton &skeleton,
                                  double pixelSize) {
   glColor3f(1.0f, 0.0f, 0.0f);  // Red
-  glLineWidth(1.0f);
 
   double handleRadius = SELECTED_HANDLE_SIZE * pixelSize;
 
@@ -1865,6 +1865,8 @@ void PlasticTool::drawSelections(const SkDP &sd,
 
 void PlasticTool::drawSkeleton(const PlasticSkeleton &skel, double pixelSize,
                                UCHAR alpha) {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   struct locals {
     inline static void drawLine(const TPointD &p0, const TPointD &p1) {
       glVertex2d(p0.x, p0.y);
@@ -1882,7 +1884,7 @@ void PlasticTool::drawSkeleton(const PlasticSkeleton &skel, double pixelSize,
           eEnd(edges.end());
 
       glColor4ub(0, 0, 0, alpha);
-      glLineWidth(4.0f);  // Black border
+      glLineWidth(4.0f * devPixRatio);  // Black border
 
       glBegin(GL_LINES);
       {
@@ -1893,7 +1895,7 @@ void PlasticTool::drawSkeleton(const PlasticSkeleton &skel, double pixelSize,
       glEnd();
 
       glColor4ub(250, 184, 70, alpha);
-      glLineWidth(2.0f);  // Yellow/Orange-ish line center
+      glLineWidth(2.0f * devPixRatio);  // Yellow/Orange-ish line center
 
       glBegin(GL_LINES);
       {
@@ -1902,6 +1904,7 @@ void PlasticTool::drawSkeleton(const PlasticSkeleton &skel, double pixelSize,
                            skel.vertex(et->vertex(1)).P());
       }
       glEnd();
+      glLineWidth(1.0f * devPixRatio);
     }
 
     // Draw vertices
@@ -1922,7 +1925,7 @@ void PlasticTool::drawSkeleton(const PlasticSkeleton &skel, double pixelSize,
       if (vt != vEnd) {
         for (vt = ++vertices.begin(); vt != vEnd; ++vt)
           drawHandle(vt->P(), handleRadius,
-                     vt->m_interpolate ? magenta : yellow);
+                     vt->m_interpolate ? magenta : yellow, devPixRatio);
       }
     }
   }
@@ -2131,6 +2134,10 @@ void PlasticTool::drawAngleLimits(const SkDP &sd, int skelId, int v,
 //------------------------------------------------------------------------
 
 void PlasticTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
+
   glPushAttrib(GL_LINE_BIT | GL_COLOR_BUFFER_BIT | GL_ENABLE_BIT);
 
   glEnable(GL_BLEND);

--- a/toonz/sources/tnztools/plastictool_meshedit.cpp
+++ b/toonz/sources/tnztools/plastictool_meshedit.cpp
@@ -1232,6 +1232,8 @@ void PlasticTool::cutEdges_mesh_undo() {
 //------------------------------------------------------------------------
 
 void PlasticTool::draw_mesh() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   struct Locals {
     PlasticTool *m_this;
     double m_pixelSize;
@@ -1246,7 +1248,6 @@ void PlasticTool::draw_mesh() {
       const objects_container &objects = m_this->m_mvSel.objects();
 
       glColor3ub(255, 0, 0);  // Red
-      glLineWidth(1.0f);
 
       const double hSize = MESH_SELECTED_HANDLE_SIZE * m_pixelSize;
 
@@ -1259,12 +1260,12 @@ void PlasticTool::draw_mesh() {
       }
     }
 
-    void drawEdgeSelections() {
+    void drawEdgeSelections(int devPixRatio) {
       typedef MeshSelection::objects_container objects_container;
       const objects_container &objects = m_this->m_meSel.objects();
 
       glColor3ub(0, 0, 255);  // Blue
-      glLineWidth(2.0f);
+      glLineWidth(2.0f * devPixRatio);
 
       glBegin(GL_LINES);
 
@@ -1280,6 +1281,7 @@ void PlasticTool::draw_mesh() {
       }
 
       glEnd();
+      glLineWidth(1.0f * devPixRatio); // reset back to baseline
     }
 
     void drawVertexHighlights() {
@@ -1290,7 +1292,6 @@ void PlasticTool::draw_mesh() {
             m_this->m_mi->meshes()[vHigh.m_meshIdx]->vertex(vHigh.m_idx);
 
         glColor3ub(255, 0, 0);  // Red
-        glLineWidth(1.0f);
 
         const double hSize = MESH_HIGHLIGHTED_HANDLE_SIZE * m_pixelSize;
 
@@ -1315,7 +1316,6 @@ void PlasticTool::draw_mesh() {
           glLineStipple(1, 0xCCCC);
 
           glColor3ub(0, 0, 255);  // Blue
-          glLineWidth(1.0f);
 
           glBegin(GL_LINES);
           drawLine(vx0.P(), vx1.P());
@@ -1333,7 +1333,7 @@ void PlasticTool::draw_mesh() {
   // Draw additional overlays
   if (m_mi) {
     locals.drawVertexSelections();
-    locals.drawEdgeSelections();
+    locals.drawEdgeSelections(devPixRatio);
 
     locals.drawVertexHighlights();
     locals.drawEdgeHighlights();

--- a/toonz/sources/tnztools/pumptool.cpp
+++ b/toonz/sources/tnztools/pumptool.cpp
@@ -165,6 +165,8 @@ void PumpTool::onEnter() {
 //----------------------------------------------------------------------
 
 void PumpTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   if (!m_draw || !m_enabled) return;
 
   TVectorImageP vi = TImageP(getImage(false));
@@ -174,6 +176,9 @@ void PumpTool::draw() {
 
   TPalette *palette = vi->getPalette();
   assert(palette);
+
+  glLineWidth(1.0 * devPixRatio);
+
   if (m_active) {
     // Editing with the tool
     assert(m_outStroke);

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -954,6 +954,10 @@ TPointD EraserTool::fixMousePos(TPointD pos, bool precise) {
 //------------------------------------------------------------------------
 
 void EraserTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
+
   if (m_eraseType.getValue() == SEGMENTERASE && m_eraseOnlySavebox.getValue()) {
     TToonzImageP ti = (TToonzImageP)getImage(false);
     if (ti) {

--- a/toonz/sources/tnztools/rasterselectiontool.cpp
+++ b/toonz/sources/tnztools/rasterselectiontool.cpp
@@ -876,6 +876,10 @@ void RasterSelectionTool::draw() {
   TRasterImageP ri = (TRasterImageP)image;
   if (!ti && !ri) return;
 
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
+
   if (m_setSaveboxTool && m_modifySavebox.getValue()) {
     m_setSaveboxTool->draw();
     return;

--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -663,12 +663,17 @@ public:
   //------------------------------------------------------------
 
   void draw() override {
+    int devPixRatio   = m_viewer->getDevPixRatio();
+
     double pixelSize2 = getPixelSize() * getPixelSize();
     m_thick           = sqrt(pixelSize2) / 2.0;
 //    TPixel color = ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg
 //                       ? TPixel32::White
 //                       : TPixel32::Black;
     TPixel color = TPixel32::Red;
+
+    glLineWidth((1.0 * devPixRatio));
+
     if (m_closeType.getValue() == RECT_CLOSE) {
       if (m_multi.getIndex() && m_firstFrameSelected) {
         if (m_firstStrokes.size()) {

--- a/toonz/sources/tnztools/rgbpickertool.cpp
+++ b/toonz/sources/tnztools/rgbpickertool.cpp
@@ -267,6 +267,8 @@ void RGBPickerTool::onImageChanged() {
 }
 
 void RGBPickerTool::draw() {
+  int devPixRatio   = m_viewer->getDevPixRatio();
+
   double pixelSize2 = getPixelSize() * getPixelSize();
   m_thick           = sqrt(pixelSize2) / 2.0;
   if (m_makePick) {
@@ -291,6 +293,7 @@ void RGBPickerTool::draw() {
   if (m_passivePick.getValue() == true) {
     passivePick();
   }
+  glLineWidth(1.0 * devPixRatio);
   if (m_pickType.getValue() == RECT_PICK && !m_makePick) {
     TPixel color = ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg
                        ? TPixel32::White

--- a/toonz/sources/tnztools/rulertool.cpp
+++ b/toonz/sources/tnztools/rulertool.cpp
@@ -51,7 +51,10 @@ void RulerTool::onImageChanged() {
 //----------------------------------------------------------------------------------------------
 
 void RulerTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   /*--- 始点が設定されていたら、描画 ---*/
+  glLineWidth(1.0 * devPixRatio);
   if (m_firstPos != TConst::nowhere) {
     tglColor((m_dragMode == MoveFirstPos) ? TPixel32(51, 204, 26)
                                           : TPixel32::Red);

--- a/toonz/sources/tnztools/shifttracetool.cpp
+++ b/toonz/sources/tnztools/shifttracetool.cpp
@@ -22,7 +22,6 @@
 #include "toonzqt/menubarcommand.h"
 
 #include "toonz/preferences.h"
-#include "toonzqt/gutil.h"
 
 #include "tgl.h"
 #include <math.h>
@@ -245,7 +244,7 @@ void ShiftTraceTool::drawControlRect() {  // TODO
                                           inksOnly);
     color       = (m_ghostIndex == 0) ? backOniColor : frontOniColor;
     double unit = sqrt(tglGetPixelSize2());
-    unit *= getDevicePixelRatio(m_viewer->viewerWidget());
+    unit *= m_viewer->getDevPixRatio();
     TRectD coloredBox = box.enlarge(3.0 * unit);
     tglColor(color);
     glBegin(GL_LINE_STRIP);
@@ -581,6 +580,10 @@ void ShiftTraceTool::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
 }
 
 void ShiftTraceTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
+
   updateData();
   drawControlRect();
   drawCurve();

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -1373,6 +1373,8 @@ void SkeletonTool::drawDrawingBrowser(const TXshCell &cell,
 void SkeletonTool::drawMainGadget(const TPointD &center) {
   assert(glGetError() == GL_NO_ERROR);
 
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   double r  = 10 * getPixelSize();
   double cx = center.x + r * 1.1;
   double cy = center.y - r * 1.1;
@@ -1386,7 +1388,7 @@ void SkeletonTool::drawMainGadget(const TPointD &center) {
     return;
   }
 
-  QImage img(19, 19, QImage::Format_ARGB32);
+  QImage img(19 * devPixRatio, 19 * devPixRatio, QImage::Format_ARGB32);
   img.fill(Qt::transparent);
   QPainter p(&img);
   // p.setRenderHints(QPainter::Antialiasing|QPainter::TextAntialiasing);
@@ -1394,9 +1396,9 @@ void SkeletonTool::drawMainGadget(const TPointD &center) {
   QPainterPath pp;
   int dx = 1, dy = 0;
   for (int i = 0; i < 4; i++) {
-    int x = 9 + dx * 8;
-    int y = 9 + dy * 8;
-    pp.moveTo(9, 9);
+    int x = 9 * devPixRatio + dx * 8 * devPixRatio;
+    int y = 9 * devPixRatio + dy * 8 * devPixRatio;
+    pp.moveTo(9 * devPixRatio, 9 * devPixRatio);
     pp.lineTo(x, y);
     pp.lineTo(x - 2 * dx - 2 * dy, y - 2 * dy + 2 * dx);
     pp.moveTo(x, y);
@@ -1406,18 +1408,19 @@ void SkeletonTool::drawMainGadget(const TPointD &center) {
     dy    = d;
   }
 
-  p.setPen(QPen(Qt::white, 3));
+  p.setPen(QPen(Qt::white, 3 * devPixRatio));
   p.drawPath(pp);
-  p.setPen(Qt::black);
+  p.setPen(QPen(Qt::black, 1 * devPixRatio));
   p.drawPath(pp);
 
   p.setBrush(QColor(54, 213, 54));
-  p.drawRect(6, 6, 6, 6);
+  p.drawRect(6 * devPixRatio, 6 * devPixRatio, 6 * devPixRatio,
+             6 * devPixRatio);
   QImage texture = img.mirrored().convertToFormat(QImage::Format_RGBA8888);
   // texture.save("c:\\urka.png");
 
   glRasterPos2f(center.x + r * 1.1, center.y - r * 1.1);
-  glBitmap(0, 0, 0, 0, -9, -9, NULL);
+  glBitmap(0, 0, 0, 0, -9 * devPixRatio, -9 * devPixRatio, NULL);
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glDrawPixels(texture.width(), texture.height(), GL_RGBA, GL_UNSIGNED_BYTE,

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -30,7 +30,6 @@
 // TnzQt includes
 #include "toonzqt/selection.h"
 #include "toonzqt/selectioncommandids.h"
-#include "toonzqt/gutil.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -1265,7 +1264,7 @@ void SkeletonTool::drawDrawingBrowser(const TXshCell &cell,
                      std::to_string(cell.m_frameId.getNumber());
 
   QString qText = QString::fromStdString(name);
-  int devPixRatio = getDevicePixelRatio(getViewer()->viewerWidget());
+  int devPixRatio = getViewer()->getDevPixRatio();
   QFont font("Arial", 10 * devPixRatio);  // ,QFont::Bold);
   QFontMetrics fm(font);
   QSize textSize   = fm.boundingRect(qText).size();
@@ -1432,9 +1431,13 @@ void SkeletonTool::drawMainGadget(const TPointD &center) {
 //-------------------------------------------------------------------
 
 void SkeletonTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   // parent object reference system
   // glColor3d(1,0,0);
   // tglDrawRect(0,0,100,100);
+
+  glLineWidth(1.0 * devPixRatio);
 
   if (m_label != "")
     ToolUtils::drawBalloon(m_labelPos, m_label, TPixel32::Red, TPoint(20, -20),

--- a/toonz/sources/tnztools/symmetrytool.cpp
+++ b/toonz/sources/tnztools/symmetrytool.cpp
@@ -479,6 +479,10 @@ void SymmetryTool::draw(SceneViewer *viewer) {
                           ->getCurrentCamera()
                           ->getStageRect();
 
+  int devPixRatio = viewer->getDevPixRatio();
+
+  glLineWidth(1.0f * devPixRatio);
+
   m_symmetryObj.draw(viewer, cameraRect);
 
   bool drawControls = getApplication()->getCurrentTool()->getTool() == this;
@@ -895,7 +899,6 @@ void SymmetryObject::draw(SceneViewer *viewer, TRectD cameraRect) {
   glEnable(GL_BLEND);
   glEnable(GL_LINE_SMOOTH);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glLineWidth(1.0f);
 
   TPointD p = getCenterPoint();
 
@@ -988,8 +991,6 @@ void SymmetryObject::drawControls(SceneViewer *viewer) {
 
   double circleRadius = m_handleRadius * m_unit;
   double diskRadius   = (m_handleRadius - 2) * m_unit;
-
-  glLineWidth(1.5);
 
   glLineStipple(1, 0xFFFF);
   glEnable(GL_LINE_STIPPLE);

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -1514,7 +1514,7 @@ void ToolUtils::drawBalloon(const TPointD &pos, std::string text,
                             std::vector<TRectD> *otherBalloons) {
   TTool::Viewer *viewer =
       TTool::getApplication()->getCurrentTool()->getTool()->getViewer();
-  int devPixRatio = getDevicePixelRatio(viewer->viewerWidget());
+  int devPixRatio = viewer->getDevPixRatio();
   QString qText   = QString::fromStdString(text);
   QFont font("Arial");  // ,QFont::Bold);
   font.setPixelSize(13 * devPixRatio);
@@ -1658,7 +1658,7 @@ void ToolUtils::drawHook(const TPointD &pos, ToolUtils::HookType type,
                          bool highlighted, bool onionSkin) {
   TTool::Viewer *viewer =
       TTool::getApplication()->getCurrentTool()->getTool()->getViewer();
-  int devPixRatio = getDevicePixelRatio(viewer->viewerWidget());
+  int devPixRatio = viewer->getDevPixRatio();
   int r = 10, d = r + r;
   QImage image(d * devPixRatio, d * devPixRatio, QImage::Format_ARGB32);
   image.fill(Qt::transparent);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2376,6 +2376,10 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 //-------------------------------------------------------------------------------------------------------------
 
 void ToonzRasterBrushTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+ 
+  glLineWidth(1.0 * devPixRatio);
+
   if (m_isStraight) {
     tglColor(TPixel32::Red);
     tglDrawSegment(m_firstPoint, m_lastPoint);

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1982,6 +1982,10 @@ void ToonzVectorBrushTool::checkGuideSnapping(bool beforeMousePress,
 //-------------------------------------------------------------------------------------------------------------
 
 void ToonzVectorBrushTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
+
   /*--ショートカットでのツール切り替え時に赤点が描かれるのを防止する--*/
   if (m_minThick == 0 && m_maxThick == 0 &&
       !Preferences::instance()->getShow0ThickLines())

--- a/toonz/sources/tnztools/trackertool.cpp
+++ b/toonz/sources/tnztools/trackertool.cpp
@@ -8,7 +8,6 @@
 #include "toonz/txshlevelhandle.h"
 #include "toonz/tscenehandle.h"
 #include "toonzqt/selectioncommandids.h"
-#include "toonzqt/gutil.h"
 
 #include "toonzqt/selection.h"
 #include "tproperty.h"
@@ -288,7 +287,9 @@ void TrackerTool::draw() {
     selectedObjectId = -1;
   int i              = 0;
   double pixelSize   = getPixelSize();
-  int devPixRatio    = getDevicePixelRatio(m_viewer->viewerWidget());
+  int devPixRatio    = m_viewer->getDevPixRatio();
+
+  glLineWidth(1.0 * devPixRatio);
 
   std::vector<TRectD> balloons;  // this is used to avoid balloons overlapping
   // draw hooks

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -976,6 +976,8 @@ void TypeTool::updateMouseCursor(const TPointD &pos) {
 void TypeTool::draw() {
   if (!m_active || !getImage(false)) return;
 
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   TFontManager *instance = TFontManager::instance();
 
   /*TAffine viewMatrix = getViewer()->getViewMatrix();
@@ -991,6 +993,8 @@ glPushMatrix();
   UINT size = m_string.size();
 
   TPoint descenderP(0, TFontManager::instance()->getLineDescender());
+
+  glLineWidth(1.0 * devPixRatio);
 
   for (int j = 0; j < (int)size; j++) {
     if (m_string[j].isReturn()) continue;

--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -475,6 +475,8 @@ void EraserTool::updateTranslation() {
 //-----------------------------------------------------------------------------
 
 void EraserTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   if (!m_multi.getIndex() && m_pointSize <= 0) return;
 
   double pixelSize2 = getPixelSize() * getPixelSize();
@@ -482,6 +484,9 @@ void EraserTool::draw() {
 
   TImageP image(getImage(false));
   TVectorImageP vi = image;
+
+  glLineWidth(1.0 * devPixRatio);
+
   if (vi) {
 //    bool blackBg = ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg;
 //    TPixel color = blackBg ? TPixel32::White : TPixel32::Red;

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -1785,8 +1785,11 @@ void VectorSelectionTool::drawGroup(const TVectorImage &vi) {
 //-----------------------------------------------------------------------------
 
 void VectorSelectionTool::draw() {
+  int devPixRatio  = m_viewer->getDevPixRatio();
   TVectorImageP vi = TImageP(getImage(false));
   if (!vi) return;
+
+  glLineWidth(1.0 * devPixRatio);
 
   if (isLevelType() || isSelectedFramesType()) {
     drawInLevelType(*vi);

--- a/toonz/sources/tnztools/vectortapetool.cpp
+++ b/toonz/sources/tnztools/vectortapetool.cpp
@@ -331,8 +331,12 @@ public:
   }
 
   void draw() override {
+    int devPixRatio = m_viewer->getDevPixRatio();
+
     TVectorImageP vi(getImage(false));
     if (!vi) return;
+
+    glLineWidth(1.0 * devPixRatio);
 
     // TAffine viewMatrix = getViewer()->getViewMatrix();
     // glPushMatrix();

--- a/toonz/sources/tnztools/viewtools.cpp
+++ b/toonz/sources/tnztools/viewtools.cpp
@@ -59,7 +59,7 @@ public:
 
   void draw() override {
     if (!m_dragging) return;
-
+    int devPixRatio  = m_viewer->getDevPixRatio();
     TPointD center   = m_viewer->winToWorld(m_center);
     double pixelSize = getPixelSize();
     double unit      = pixelSize;
@@ -69,6 +69,7 @@ public:
     glColor3f(1, 0, 0);
 
     double u = 4;
+    glLineWidth((1.0 * devPixRatio));
     glBegin(GL_LINES);
     glVertex2d(0, -10);
     glVertex2d(0, 10);
@@ -185,6 +186,8 @@ void RotateTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 }
 
 void RotateTool::draw() {
+  int devPixRatio = m_viewer->getDevPixRatio();
+
   glColor3f(1, 0, 0);
   double u = 50;
   if (m_cameraCentered.getValue())
@@ -196,6 +199,7 @@ void RotateTool::draw() {
     u                                  = u * sqrt(aff.det());
     m_center                           = aff * TPointD(0, 0);
   }
+  glLineWidth(1.0 * devPixRatio);
   tglDrawSegment(TPointD(-u + m_center.x, m_center.y),
                  TPointD(u + m_center.x, m_center.y));
   tglDrawSegment(TPointD(m_center.x, -u + m_center.y),

--- a/toonz/sources/toonz/cleanuppreview.cpp
+++ b/toonz/sources/toonz/cleanuppreview.cpp
@@ -24,6 +24,7 @@
 
 // TnzQt includes
 #include "toonzqt/icongenerator.h"
+#include "toonzqt/gutil.h"
 #include "historytypes.h"
 
 // Toonz includes
@@ -616,8 +617,11 @@ void CameraTestTool::drawClosestFieldCamera(double pixelSize) {
 //--------------------------------------------------------------------------
 
 void CameraTestTool::draw() {
+  int devPixRatio  = getDevicePixelRatio();
   double pixelSize = getPixelSize();
   glPushMatrix();
+
+  glLineWidth(1.0 * devPixRatio);
 
   CleanupParameters *cp =
       CleanupSettingsModel::instance()->getCurrentParameters();

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -541,6 +541,9 @@ void ImageViewer::paintGL() {
       TApp::instance()->getCurrentScene()->getScene()->getProperties();
   // enable checks only in the color model
   m_visualSettings.m_useChecks = m_isColorModel;
+
+  glLineWidth((1.0 * getDevPixRatio()));
+
   ImagePainter::paintImage(m_image, imageSize, viewerSize, aff,
                            m_visualSettings, m_compareSettings, loadbox);
 

--- a/toonz/sources/toonz/ruler.cpp
+++ b/toonz/sources/toonz/ruler.cpp
@@ -4,7 +4,6 @@
 #include "sceneviewer.h"
 #include "tapp.h"
 #include "toonz/tscenehandle.h"
-#include "toonzqt/gutil.h"
 
 #include "toonz/toonzscene.h"
 #include "toonz/stage.h"

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -816,8 +816,7 @@ public:
 //-----------------------------------------------------------------------------
 
 SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
-    : GLWidgetForHighDpi(parent)
-    , TTool::Viewer(this)
+    : TTool::Viewer(this, parent)
     , m_pressure(0)
     , m_lastMousePos(0, 0)
     , m_mouseButton(Qt::NoButton)
@@ -2107,6 +2106,8 @@ void SceneViewer::paintGL() {
     }
   }
 
+  glLineWidth(1.0 * getDevPixRatio());
+
   // Il freezed e' attivo ed e' in stato "normale": mostro l'immagine grabbata.
   if (m_freezedStatus == NORMAL_FREEZED) {
     assert(!!m_viewGrabImage);
@@ -2199,7 +2200,7 @@ void SceneViewer::drawScene() {
   m_minZ = 0;
   if (is3DView()) {
     Stage::OpenGlPainter painter(getViewMatrix(), clipRect, m_visualSettings,
-                                 true, false);
+                                 true, false, getDevPixRatio());
     painter.enableCamera3D(true);
     painter.setPhi(m_phi3D);
     int xsheetLevel = 0;
@@ -2304,7 +2305,7 @@ void SceneViewer::drawScene() {
     m_visualSettings.m_showBBox = viewBBoxToggle.getStatus();
 
     Stage::RasterPainter painter(viewerSize, viewAff, clipRect,
-                                 m_visualSettings, true);
+                                 m_visualSettings, true, getDevPixRatio());
 
     // darken blended view mode for viewing the non-cleanuped and stacked
     // drawings
@@ -2481,7 +2482,7 @@ void SceneViewer::drawSceneOverlay() {
 
   if (is3DView()) {
     Stage::OpenGlPainter painter(viewAff, clipRect, m_visualSettings, true,
-                                 false);
+                                 false, getDevPixRatio());
     painter.enableCamera3D(true);
     painter.setPhi(m_phi3D);
 
@@ -2496,7 +2497,7 @@ void SceneViewer::drawSceneOverlay() {
     TDimension viewerSize(width(), height());
 
     Stage::RasterPainter painter(viewerSize, viewAff, clipRect,
-                                 m_visualSettings, true);
+                                 m_visualSettings, true, getDevPixRatio());
 
     if (ri)
       painter.onRasterImage(ri.getPointer(), player);
@@ -3703,7 +3704,6 @@ void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
         }
       }
     }
-    glLineWidth(1.0);
     glDisable(GL_LINE_SMOOTH);
     glDisable(GL_BLEND);
     glPopMatrix();

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -13,7 +13,6 @@
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
 #include "toonzqt/flipconsole.h"
-#include "toonzqt/glwidget_for_highdpi.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -64,8 +63,7 @@ public:
 // SceneViewer
 //-----------------------------------------------------------------------------
 
-class SceneViewer final : public GLWidgetForHighDpi,
-                          public TTool::Viewer,
+class SceneViewer final : public TTool::Viewer,
                           public Previewer::Listener {
   Q_OBJECT
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -2109,6 +2109,7 @@ void SceneViewer::mouseRotate(const TMouseEvent &e) {
   }
   m_oldPos = p;
 
+  glLineWidth(1.0 * getDevPixRatio());
   tglDrawSegment(TPointD(-u + m_center.x, m_center.y),
                  TPointD(u + m_center.x, m_center.y));
   tglDrawSegment(TPointD(m_center.x, -u + m_center.y),

--- a/toonz/sources/toonz/vectorizerswatch.cpp
+++ b/toonz/sources/toonz/vectorizerswatch.cpp
@@ -338,7 +338,11 @@ bool VectorizerSwatchArea::Swatch::event(QEvent *e) {
 //-----------------------------------------------------------------------------
 
 void VectorizerSwatchArea::Swatch::paintGL() {
+  int devPixRatio = getDevicePixelRatio();
+
   if (isEnabled()) {
+    glLineWidth(1.0 * devPixRatio);
+
     drawBackground();
 
     if (m_img) {
@@ -378,7 +382,7 @@ void VectorizerSwatchArea::Swatch::drawVectors() {
 
 void VectorizerSwatchArea::Swatch::drawInProgress() {
   glColor3d(1.0, 0.0, 0.0);
-  glLineWidth(3.0);
+  glLineWidth(3.0 * getDevPixRatio());
 
   pushGLWinCoordinates();
 
@@ -394,7 +398,7 @@ void VectorizerSwatchArea::Swatch::drawInProgress() {
 
   popGLCoordinates();
 
-  glLineWidth(1.0);
+  glLineWidth(1.0 * getDevPixRatio());
 }
 
 //*****************************************************************************

--- a/toonz/sources/toonz/viewerdraw.cpp
+++ b/toonz/sources/toonz/viewerdraw.cpp
@@ -626,7 +626,6 @@ void ViewerDraw::drawGridsAndOverlays(SceneViewer *viewer, double pixelSize) {
   glEnable(GL_LINE_SMOOTH);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glColor4d(1.0, 0.3, 1.0, (double)GuideOpacity / 100.0);
-  glLineWidth(1.0f);
 
   double lengthX = rect.x1 - rect.x0;
   double lengthY = rect.y1 - rect.y0;
@@ -638,7 +637,7 @@ void ViewerDraw::drawGridsAndOverlays(SceneViewer *viewer, double pixelSize) {
 
   double phiX = (rect.x1 - rect.x0) / 1.618;
   double phiY = (rect.y1 - rect.y0) / 1.618;
-  glLineWidth(1.0f);
+
   glDisable(GL_LINE_SMOOTH);
   glDisable(GL_BLEND);
 }
@@ -646,13 +645,15 @@ void ViewerDraw::drawGridsAndOverlays(SceneViewer *viewer, double pixelSize) {
 //-----------------------------------------------------------------------------
 
 void ViewerDraw::drawCameraOverlays(SceneViewer *viewer, double pixelSize) {
+  int devPixRatio = viewer->getDevPixRatio();
+
   TRectD rect = getCameraRect();
 
   glEnable(GL_BLEND);  // Enable blending.
   glEnable(GL_LINE_SMOOTH);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glColor4d(1.0, 0.3, 1.0, (double)GuideOpacity / 100.0);
-  glLineWidth(0.5f);
+  glLineWidth(0.5f * devPixRatio);
 
   double lengthX = rect.x1 - rect.x0;
   double lengthY = rect.y1 - rect.y0;
@@ -696,7 +697,7 @@ void ViewerDraw::drawCameraOverlays(SceneViewer *viewer, double pixelSize) {
     glEnd();
   }
 
-  glLineWidth(1.0f);
+  glLineWidth(1.0f * devPixRatio);
   glDisable(GL_LINE_SMOOTH);
   glDisable(GL_BLEND);
 }

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -363,7 +363,7 @@ int Picker::getRow() const {
 RasterPainter::RasterPainter(const TDimension &dim, const TAffine &viewAff,
                              const TRect &rect,
                              const ImagePainter::VisualSettings &vs,
-                             bool checkFlags)
+                             bool checkFlags, int devPixRatio)
     : Visitor(vs)
     , m_dim(dim)
     , m_viewAff(viewAff)
@@ -371,7 +371,8 @@ RasterPainter::RasterPainter(const TDimension &dim, const TAffine &viewAff,
     , m_maskLevel(0)
     , m_singleColumnEnabled(false)
     , m_checkFlags(checkFlags)
-    , m_doRasterDarkenBlendedView(false) {}
+    , m_doRasterDarkenBlendedView(false)
+    , m_devPixRatio(devPixRatio) {}
 
 //-----------------------------------------------------------------------------
 
@@ -921,6 +922,7 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
   rd.m_show0ThickStrokes     = prefs.getShow0ThickLines();
   rd.m_regionAntialias       = prefs.getRegionAntialias();
   rd.m_animatedGuidedDrawing = prefs.getAnimatedGuidedDrawing();
+  rd.m_devPixRatio           = m_devPixRatio;
   if (player.m_onionSkinDistance != 0 &&
       (player.m_isCurrentColumn || player.m_isCurrentXsheetLevel)) {
     if (player.m_isGuidedDrawingEnabled == 3         // show guides on all
@@ -1156,7 +1158,7 @@ void RasterPainter::onToonzImage(TToonzImage *ti, const Stage::Player &player) {
 
 OpenGlPainter::OpenGlPainter(const TAffine &viewAff, const TRect &rect,
                              const ImagePainter::VisualSettings &vs,
-                             bool isViewer, bool alphaEnabled)
+                             bool isViewer, bool alphaEnabled, int devPixRatio)
     : Visitor(vs)
     , m_viewAff(viewAff)
     , m_clipRect(rect)
@@ -1167,7 +1169,8 @@ OpenGlPainter::OpenGlPainter(const TAffine &viewAff, const TRect &rect,
     , m_alphaEnabled(alphaEnabled)
     , m_paletteHasChanged(false)
     , m_minZ(0)
-    , m_singleColumnEnabled(false) {}
+    , m_singleColumnEnabled(false)
+    , m_devPixRatio(devPixRatio) {}
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
This change attempts to improve the visibility of on-canvas widgets, guides and visual indicators for High DPI monitors.

With Full HD monitors on-canvas widgets, guides, and indicators were drawn knowing the device pixel ratio (DPR) was 1:1.  With high DPI monitors (i.e. 4K), the device pixel ratio is 1:2.  As such, a normal 1 pixel line appears thinner/fainter on a 4K monitor.

Added logic to get the DPR of the monitor where the canvas is at and adjust the thickness of lines accordingly.