### PR TITLE
Show image in cell tooltip

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -465,6 +465,9 @@ public:
   QString getTimelineLayoutPreference() const {
     return getStringValue(timelineLayoutPreference);
   }
+  bool isShowImagesInCellTooltipEnabled() {
+    return getBoolValue(showImagesInCellTooltip);
+  }
 
   // Animation  tab
   int getKeyframeType() const { return getIntValue(keyframeType); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -154,6 +154,7 @@ enum PreferencesItemId {
   showFrameNumberWithLetters,
   showDragBars,
   timelineLayoutPreference,
+  showImagesInCellTooltip,
 
   //----------
   // Animation

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1452,6 +1452,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {levelNameDisplayType, tr("Level Name Display:")},
       {showFrameNumberWithLetters,
        tr("Show \"ABC\" Appendix to the Frame Number in Scene Cell")},
+      {showImagesInCellTooltip, tr("Show Images in Cell Tooltips")},
 
       // Animation
       {keyframeType, tr("Default Interpolation:")},
@@ -2203,6 +2204,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   insertDualUIs(showDragBars, timelineLayoutPreference, lay,
                 QList<ComboBoxItem>(),
                 getComboItemList(timelineLayoutPreference));
+  insertUI(showImagesInCellTooltip, lay);
   insertUI(DragCellsBehaviour, lay, getComboItemList(DragCellsBehaviour));
   insertUI(pasteCellsBehavior, lay, getComboItemList(pasteCellsBehavior));
   insertUI(ignoreAlphaonColumn1Enabled, lay);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -4092,22 +4092,26 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
     if (isSoundTextColumn)
       m_tooltip = cell.getSoundTextLevel()->getFrameText(
           cell.m_frameId.getNumber() - 1);
-    else if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
-      m_tooltip =
-          (fid.isEmptyFrame() || fid.isNoFrame())
-              ? QString::fromStdWString(levelName)
-              : QString::fromStdWString(levelName) + QString(" ") +
-                    m_viewer->getFrameNumberWithLetters(fid.getNumber());
-      if (cell.getSimpleLevel() && !fid.isStopFrame()) m_tooltipCell = cell;
-    } else {
-      QString frameNumber("");
-      if (fid.getNumber() >= 0) frameNumber = QString::number(fid.getNumber());
-      if (!fid.getLetter().isEmpty()) frameNumber += fid.getLetter();
-      m_tooltip =
-          QString((frameNumber.isEmpty()) ? QString::fromStdWString(levelName)
-                                          : QString::fromStdWString(levelName) +
-                                                QString(" ") + frameNumber);
-      if (cell.getSimpleLevel() && !fid.isStopFrame()) m_tooltipCell = cell;
+    else {
+      if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
+        m_tooltip =
+            (fid.isEmptyFrame() || fid.isNoFrame())
+                ? QString::fromStdWString(levelName)
+                : QString::fromStdWString(levelName) + QString(" ") +
+                      m_viewer->getFrameNumberWithLetters(fid.getNumber());
+      } else {
+        QString frameNumber("");
+        if (fid.getNumber() >= 0)
+          frameNumber = QString::number(fid.getNumber());
+        if (!fid.getLetter().isEmpty()) frameNumber += fid.getLetter();
+        m_tooltip = QString((frameNumber.isEmpty())
+                                ? QString::fromStdWString(levelName)
+                                : QString::fromStdWString(levelName) +
+                                      QString(" ") + frameNumber);
+      }
+      if (Preferences::instance()->isShowImagesInCellTooltipEnabled() &&
+          cell.getSimpleLevel() && !fid.isStopFrame())
+        m_tooltipCell = cell;
     }
   } else if (isSoundColumn &&
              o->rect(PredefinedRect::PREVIEW_TRACK)

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3977,10 +3977,18 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
   } else
     m_viewer->stopAutoPan();
 
-  m_pos = pos;
-  CellPosition cellPosition = m_viewer->xyToPosition(pos);
-  int row                   = cellPosition.frame();
-  int col                   = cellPosition.layer();
+  CellPosition cellPosition = m_viewer->xyToPosition(m_pos);
+  int oldRow                = cellPosition.frame();
+  int oldCol                = cellPosition.layer();
+
+  m_pos        = pos;
+  cellPosition = m_viewer->xyToPosition(pos);
+  int row      = cellPosition.frame();
+  int col      = cellPosition.layer();
+
+  if (QToolTip::isVisible() && (oldRow != row || oldCol != col))
+    QToolTip::hideText();
+
   if (getDragTool()) {
     getDragTool()->onDrag(event);
     if (m_keyHighlight != QPoint(-1, -1))

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -5,6 +5,8 @@
 
 #include <QWidget>
 #include <QLineEdit>
+#include <QTimer>
+
 #include "orientation.h"
 
 #include "toonz/txshcell.h"
@@ -93,6 +95,9 @@ class CellArea final : public QWidget {
 
   QPoint m_pos;
   QString m_tooltip;
+  TXshCell m_tooltipCell;
+  
+  QTimer *m_timer;
 
   RenameCellField *m_renameCell;
 
@@ -208,6 +213,7 @@ protected slots:
   // replace level with another level in the cast
   void onReplaceByCastedLevel(QAction *action);
   void onSetCellMark();
+  void onDelayToolTip();
 };
 
 }  // namespace XsheetGUI

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2299,8 +2299,8 @@ QPixmap ColumnArea::getColumnIcon(int columnIndex) {
     QPixmap icon =
         zColumn ? FxIconPixmapManager::instance()->getFxIconPm(
                       zColumn->getZeraryColumnFx()->getZeraryFx()->getFxType())
-                : IconGenerator::instance()->getIcon(xl, cell.m_frameId, false,
-                                                     onDemand);
+            : IconGenerator::instance()->getIcon(xl, cell.m_frameId, false,
+                                                 onDemand);
     QRect thumbnailImageRect = o->rect(PredefinedRect::THUMBNAIL);
     if (thumbnailImageRect.isEmpty()) return QPixmap();
     // Adjust for folder indicator

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -627,6 +627,8 @@ void Preferences::definePreferenceItems() {
   define(showDragBars, "showDragBars", QMetaType::Bool, false);
   define(timelineLayoutPreference, "timelineLayoutPreference", QMetaType::QString,
          "NoDragCompact");
+  define(showImagesInCellTooltip, "showImagesInCellTooltip",
+         QMetaType::Bool, true);
 
   // Animation
   define(keyframeType, "keyframeType", QMetaType::Int, 2);  // Linear


### PR DESCRIPTION
With this PR a cell's image will display in the tooltip when hovering over Raster, Smart Raster or Vector cell.

![image](https://github.com/user-attachments/assets/153bf6f1-3f0e-4898-849e-f4f36ea8c916)

The image shown is the same image as shown in the Level Strip.

This feature can be enabled (default)/disabled via a preference setting in  the ` Scene` tab

![image](https://github.com/user-attachments/assets/2e38509d-9043-40e1-b4a4-94a09c7c15ce)
