### PR TITLE
Fix github cmake version for Linux builds

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -17,6 +17,12 @@ jobs:
             cxx: clang++
     steps:
       - uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
+      - name: Use cmake
+        run: cmake --version
       - name: Install Dependencies
         run: |
           ci-scripts/linux/tahoma-install.sh


### PR DESCRIPTION
Github updated CMake to version 4.0 on their Linux runners.  This is currently causing grief to a lot of projects.  For us it was causing  the opencv build to fail.

Workaround, is to downgrade cmake version back to the last one I saw being used (3.31.6) via `actions-setup-cmake`

Will merge once I see the Linux build was successful.