### PR TITLE
Cleanup post Debian package creation

### DIFF
--- a/toonz/installer/linux/deb-creator/debcreator.sh
+++ b/toonz/installer/linux/deb-creator/debcreator.sh
@@ -236,6 +236,13 @@ function _updateInstalledSize() {
     echo "[INFO] Installed size updated to $installed_size KB"
 }
 
+function _postBuildCleanup() {
+    echo "[INFO] Post-build cleanup: Removing $temp_extract/squashfs-root"
+    rm -rf "$temp_extract/squashfs-root"
+    echo "[INFO] Post-build cleanup: Removing $final_folder"
+    rm -rf "$final_folder"
+}
+
 # ======================================================================
 # Main 
 # ======================================================================
@@ -270,6 +277,7 @@ function _main() {
     _updateInstalledSize
     _setPermissions
     _createDeb
+    _postBuildCleanup
 }
 
 _main "$@"


### PR DESCRIPTION
This will add a step after creating the Debian package that will clean up any temporary directories it has created/used.

I believe this will help an issue with the ccache failing to save due to running out of space on the runner.  Hopefully this will reclaim enough space to allow the save ccache to complete successfully.

Will merge as soon as I can verify that it helps.