### PR TITLE
Add Raster Tool Option - Paint Behind

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -95,6 +95,7 @@ protected:
   TDoubleProperty m_modifierOpacity;
   TBoolProperty m_modifierEraser;
   TBoolProperty m_modifierLockAlpha;
+  TBoolProperty m_modifierPaintBehind;
   TEnumProperty m_preset;
   TBoolProperty m_snapGrid;
 

--- a/toonz/sources/tnztools/mypainttoonzbrush.h
+++ b/toonz/sources/tnztools/mypainttoonzbrush.h
@@ -141,6 +141,9 @@ public:
   void updateDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
                      const TRect &bbox, int styleId, bool lockAlpha) const;
 
+  void updateDrawing(const TRaster32P ras, const TRaster32P rasBackup,
+                     const TRect &bbox, bool paintBehind) const;
+
   void addSymmetryBrushes(double lines, double rotation, TPointD centerPoint,
                           bool useLineSymmetry, TPointD dpiScale);
   bool hasSymmetryBrushes() { return m_brushCount > 1; }

--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -367,7 +367,7 @@ PaintBrushTool::PaintBrushTool()
     // sostituire i nomi con quelli del current, tipo W_ToolOptions...
     , m_rasThickness("Size:", 1, 1000, 10, 5)
     , m_colorType("Mode:")                     // W_ToolOptions_InkOrPaint
-    , m_onlyEmptyAreas("Selective", false)     // W_ToolOptions_Selective
+    , m_onlyEmptyAreas("Paint Behind", false)     // W_ToolOptions_Selective
     , m_firstTime(true)
     , m_pressure("Pressure", true)
     , m_task(PAINTBRUSH)
@@ -387,7 +387,7 @@ PaintBrushTool::PaintBrushTool()
   m_prop.bind(m_pressure);
   m_prop.bind(m_modifierLockAlpha);
 
-  m_onlyEmptyAreas.setId("Selective");
+  m_onlyEmptyAreas.setId("PaintBehind");
   m_colorType.setId("Mode");
   m_pressure.setId("PressureSensitivity");
   m_modifierLockAlpha.setId("LockAlpha");
@@ -403,7 +403,7 @@ void PaintBrushTool::updateTranslation() {
   m_colorType.setItemUIName(AREAS, tr("Areas"));
   m_colorType.setItemUIName(ALL, tr("Lines & Areas"));
 
-  m_onlyEmptyAreas.setQStringName(tr("Selective", NULL));
+  m_onlyEmptyAreas.setQStringName(tr("Paint Behind", NULL));
 
   m_pressure.setQStringName(tr("Pressure"));
 

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2178,7 +2178,8 @@ void BrushToolOptionsBox::filterControls() {
     bool isModifier = (it.key().substr(0, 8) == "Modifier");
     bool isCommon =
         (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
-         it.key() == "Preset:" || it.key() == "Grid" || it.key() == "Smooth:");
+                     it.key() == "Preset:" || it.key() == "Grid" ||
+                     it.key() == "Smooth:" || it.key() == "Paint Behind");
     bool visible = isCommon || (isModifier == showModifiers);
     it.value()->setVisible(visible);
   }
@@ -2188,7 +2189,8 @@ void BrushToolOptionsBox::filterControls() {
     bool isModifier = (it.key().substr(0, 8) == "Modifier");
     bool isCommon =
         (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
-         it.key() == "Preset:" || it.key() == "Grid" || it.key() == "Smooth:");
+                     it.key() == "Preset:" || it.key() == "Grid" ||
+                     it.key() == "Smooth:" || it.key() == "Paint Behind");
     bool visible = isCommon || (isModifier == showModifiers);
     if (QWidget *widget = dynamic_cast<QWidget *>(it.value()))
       widget->setVisible(visible);

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1701,7 +1701,7 @@ PaintbrushToolOptionsBox::PaintbrushToolOptionsBox(QWidget *parent, TTool *tool,
 
   m_colorMode = dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
   m_selectiveMode =
-      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Selective"));
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Paint Behind"));
   m_lockAlphaMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Lock Alpha"));
 

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2849,6 +2849,8 @@ void BrushData::saveData(TOStream &os) {
   os.closeChild();
   os.openChild("Modifier_LockAlpha");
   os << (int)m_modifierLockAlpha;
+  os.openChild("Modifier_PaintBehind");
+  os << (int)m_modifierPaintBehind;
   os.closeChild();
 }
 
@@ -2885,6 +2887,8 @@ void BrushData::loadData(TIStream &is) {
       is >> val, m_modifierEraser = val, is.matchEndTag();
     else if (tagName == "Modifier_LockAlpha")
       is >> val, m_modifierLockAlpha = val, is.matchEndTag();
+    else if (tagName == "Modifier_PaintBehind")
+      is >> val, m_modifierPaintBehind = val, is.matchEndTag();
     else
       is.skipCurrentTag();
   }

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -46,7 +46,7 @@ struct BrushData final : public TPersist {
   bool m_pencil, m_pressure;
   int m_drawOrder;
   double m_modifierSize, m_modifierOpacity;
-  bool m_modifierEraser, m_modifierLockAlpha;
+  bool m_modifierEraser, m_modifierLockAlpha, m_modifierPaintBehind;
 
   BrushData();
   BrushData(const std::wstring &name);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3264,6 +3264,8 @@ void MainWindow::defineActions() {
                           QT_TR_NOOP("Rotate Selection/Object Left"), "");
   createToolOptionsAction("A_ToolOption_RotateRight",
                           QT_TR_NOOP("Rotate Selection/Object Right"), "");
+  createToolOptionsAction("A_ToolOption_PaintBehind", QT_TR_NOOP("Paint Behind"),
+                          "");
   // Visualization
 
   createViewerAction(V_ZoomIn, QT_TR_NOOP("Zoom In"), "+");


### PR DESCRIPTION
A new `Paint Behind` tool option has been added to the raster `Brush Tool`.  Works with both standard and MyPaint brushes styles.

![image](https://github.com/user-attachments/assets/dab6c632-f81a-4802-a2db-15be4e4127f8)

A shortcut can be assigned to it:

![image](https://github.com/user-attachments/assets/7e4bd63f-6c98-407f-a0fd-4e124316406a)

Additional change:

The `Paint Brush Tool`'s `Selective` option has been renamed to `Paint Behind`. It now uses the new shortcut entry as well.