### PR TITLE
Remove unncessary folders from ccache

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -33,9 +33,6 @@ jobs:
         with:
           path: |
             /home/runner/.ccache
-            /home/runner/work/tahoma2d/taoma2d/thirdparty/openh264
-            /home/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg
-            /home/runner/work/tahoma2d/taoma2d/thirdparty/opencv
           key: ${{ runner.os }}-${{ matrix.compiler }}-refs/heads/master
           restore-keys: |
             ${{ runner.os }}-${{ matrix.compiler }}-
@@ -146,7 +143,4 @@ jobs:
         with:
           path: |
             /home/runner/.ccache
-            /home/runner/work/tahoma2d/taoma2d/thirdparty/openh264
-            /home/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg
-            /home/runner/work/tahoma2d/taoma2d/thirdparty/opencv
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.ref }}

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           path: |
             /Users/runner/.ccache
-            /Users/runner/work/tahoma2d/taoma2d/thirdparty/aom
-            /Users/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg
-            /Users/runner/work/tahoma2d/taoma2d/thirdparty/opencv
           key: ${{ runner.os }}-refs/heads/master
           restore-keys: |
             ${{ runner.os }}-
@@ -130,7 +127,4 @@ jobs:
         with:
           path: |
             /Users/runner/.ccache
-            /Users/runner/work/tahoma2d/taoma2d/thirdparty/aom
-            /Users/runner/work/tahoma2d/taoma2d/thirdparty/ffmpeg
-            /Users/runner/work/tahoma2d/taoma2d/thirdparty/opencv
           key: ${{ runner.os }}-${{ github.ref }}


### PR DESCRIPTION
Removing some folders  from macOS/Linux biulds that don't need to be part of ccache which is making the cache larger than it really needs to be.
