### PR TITLE
Smart Raster Selection - Selective mode

### DIFF
--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -38,6 +38,10 @@ class RasterImageData;
 //! Selection of TToonzImage and TRasterImage.
 //-----------------------------------------------------------------------------
 
+#define LINES L"Lines"
+#define AREAS L"Areas"
+#define ALL L"Lines & Areas"
+
 class DVAPI RasterSelection final : public TSelection {
   TImageP m_currentImage;
   TXshCell m_currentImageCell;
@@ -58,6 +62,9 @@ class DVAPI RasterSelection final : public TSelection {
   bool m_createdFrame;
   bool m_createdLevel;
   bool m_renumberedLevel;
+
+  TPixelCM32 m_selectivePixelCM32;
+  std::wstring m_selectiveMode;
 
 private:
   bool pasteSelection(const RasterImageData *data);
@@ -152,6 +159,13 @@ Can be different from getSelectionBound() after a free deform transformation. */
   bool isTransformed();
 
   bool isEditable();
+
+  void setSelectivePixelCM32(TPixelCM32 pix, std::wstring mode) {
+    m_selectivePixelCM32 = pix;
+    m_selectiveMode      = mode; 
+  }
+  TPixelCM32 getSelectivePixelCM32() { return m_selectivePixelCM32; }
+  std::wstring getSelectiveMode() { return m_selectiveMode; }
 };
 
 #endif  // RASTER_SELECTION_H

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -374,6 +374,9 @@ class SelectionToolOptionsBox final : public ToolOptionsBox,
   TTool *m_tool;
 
   ToolOptionCheckbox *m_setSaveboxCheckbox;
+  ToolOptionCheckbox *m_selective;
+  ToolOptionCombo *m_selectiveMode;
+  QLabel *m_selectiveModeLabel;
   bool m_isVectorSelction;
   QLabel *m_scaleXLabel;
   SelectionScaleField *m_scaleXField;

--- a/toonz/sources/tnztools/rasterselectiontool.cpp
+++ b/toonz/sources/tnztools/rasterselectiontool.cpp
@@ -465,6 +465,9 @@ TEnv::StringVar RasterSelectionType("SelectionToolInknpaintType",
                                     "Rectangular");
 TEnv::StringVar FullColorSelectionType("SelectionToolFullcolorType",
                                        "Rectangular");
+TEnv::IntVar RasterSelectionSelective("SelectionToolInknpaintTypeSelective", 0);
+TEnv::StringVar RasterSelectionSelectiveMode(
+    "SelectionToolInknpaintTypeSelectiveMode", "Lines");
 
 //=============================================================================
 // RasterSelectionTool
@@ -476,7 +479,19 @@ RasterSelectionTool::RasterSelectionTool(int targetType)
     , m_selectionFreeDeformer(0)
     , m_noAntialiasing("No Antialiasing", false)
     , m_modifySavebox("Modify Savebox", false)
+    , m_selective("Selective", false)
+    , m_selectiveMode("Mode:")
     , m_setSaveboxTool(0) {
+  if (m_targetType & ToonzImage) {
+    m_prop.bind(m_selective);
+    m_selective.setId("Selective");
+
+    m_selectiveMode.addValue(LINES);
+    m_selectiveMode.addValue(AREAS);
+    m_selectiveMode.addValue(ALL);
+    m_prop.bind(m_selectiveMode);
+    m_selective.setId("Mode");
+  }
   m_prop.bind(m_noAntialiasing);
   m_rasterSelection.setView(this);
   if (m_targetType & ToonzImage) {
@@ -604,6 +619,16 @@ void RasterSelectionTool::leftButtonDown(const TPointD &pos,
     m_setSaveboxTool->leftButtonDown(pos);
     return;
   }
+
+  TPixelCM32 selectivePix;
+  std::wstring selectiveMode = ALL;
+  if (m_selective.getValue()) {
+    int styleId   = TTool::getApplication()->getCurrentLevelStyleIndex();
+    selectivePix  = TPixelCM32(styleId, styleId, 0);
+    selectiveMode = m_selectiveMode.getValue();
+  }
+  m_rasterSelection.setSelectivePixelCM32(selectivePix, selectiveMode);
+
   SelectionTool::leftButtonDown(pos, e);
 }
 
@@ -1066,6 +1091,9 @@ void RasterSelectionTool::onActivate() {
       m_strokeSelectionType.setValue(
           ::to_wstring(RasterSelectionType.getValue()));
       m_modifySavebox.setValue(ModifySavebox ? 1 : 0);
+      m_selective.setValue(RasterSelectionSelective ? 1 : 0);
+      m_selectiveMode.setValue(
+          ::to_wstring(RasterSelectionSelectiveMode.getValue()));
     } else
       m_strokeSelectionType.setValue(
           ::to_wstring(FullColorSelectionType.getValue()));
@@ -1089,7 +1117,9 @@ bool RasterSelectionTool::onPropertyChanged(std::string propertyName) {
   if (SelectionTool::onPropertyChanged(propertyName)) return true;
 
   if (m_targetType & ToonzImage) {
-    ModifySavebox = (int)(m_modifySavebox.getValue());
+    ModifySavebox                = (int)(m_modifySavebox.getValue());
+    RasterSelectionSelective     = (int)(m_selective.getValue());
+    RasterSelectionSelectiveMode = ::to_string(m_selectiveMode.getValue());
     invalidate();
   }
   if (propertyName == m_noAntialiasing.getName()) {
@@ -1103,8 +1133,14 @@ bool RasterSelectionTool::onPropertyChanged(std::string propertyName) {
 //-----------------------------------------------------------------------------
 
 void RasterSelectionTool::updateTranslation() {
-  if (m_targetType & ToonzImage)
+  if (m_targetType & ToonzImage) {
     m_modifySavebox.setQStringName(tr("Modify Savebox"));
+    m_selective.setQStringName(tr("Selective"));
+    m_selectiveMode.setQStringName(tr("Mode:"));
+    m_selectiveMode.setItemUIName(LINES, tr("Lines"));
+    m_selectiveMode.setItemUIName(AREAS, tr("Areas"));
+    m_selectiveMode.setItemUIName(ALL, tr("Lines & Areas"));
+  }
 
   m_noAntialiasing.setQStringName(tr("No Antialiasing"));
   SelectionTool::updateTranslation();

--- a/toonz/sources/tnztools/rasterselectiontool.cpp
+++ b/toonz/sources/tnztools/rasterselectiontool.cpp
@@ -467,7 +467,7 @@ TEnv::StringVar FullColorSelectionType("SelectionToolFullcolorType",
                                        "Rectangular");
 TEnv::IntVar RasterSelectionSelective("SelectionToolInknpaintTypeSelective", 0);
 TEnv::StringVar RasterSelectionSelectiveMode(
-    "SelectionToolInknpaintTypeSelectiveMode", "Lines");
+    "SelectionToolInknpaintTypeSelectiveMode", "Lines & Areas");
 
 //=============================================================================
 // RasterSelectionTool
@@ -483,14 +483,14 @@ RasterSelectionTool::RasterSelectionTool(int targetType)
     , m_selectiveMode("Mode:")
     , m_setSaveboxTool(0) {
   if (m_targetType & ToonzImage) {
-    m_prop.bind(m_selective);
-    m_selective.setId("Selective");
-
     m_selectiveMode.addValue(LINES);
     m_selectiveMode.addValue(AREAS);
     m_selectiveMode.addValue(ALL);
     m_prop.bind(m_selectiveMode);
     m_selective.setId("Mode");
+ 
+    m_prop.bind(m_selective);
+    m_selective.setId("Selective");
   }
   m_prop.bind(m_noAntialiasing);
   m_rasterSelection.setView(this);
@@ -621,13 +621,12 @@ void RasterSelectionTool::leftButtonDown(const TPointD &pos,
   }
 
   TPixelCM32 selectivePix;
-  std::wstring selectiveMode = ALL;
   if (m_selective.getValue()) {
     int styleId   = TTool::getApplication()->getCurrentLevelStyleIndex();
     selectivePix  = TPixelCM32(styleId, styleId, 0);
-    selectiveMode = m_selectiveMode.getValue();
   }
-  m_rasterSelection.setSelectivePixelCM32(selectivePix, selectiveMode);
+  m_rasterSelection.setSelectivePixelCM32(selectivePix,
+                                          m_selectiveMode.getValue());
 
   SelectionTool::leftButtonDown(pos, e);
 }

--- a/toonz/sources/tnztools/rasterselectiontool.h
+++ b/toonz/sources/tnztools/rasterselectiontool.h
@@ -192,6 +192,8 @@ class RasterSelectionTool final : public SelectionTool {
   //! Used in ToonzRasterImage to switch from selection tool to modify savebox
   //! tool.
   TBoolProperty m_modifySavebox;
+  TBoolProperty m_selective;
+  TEnumProperty m_selectiveMode;
   SetSaveboxTool *m_setSaveboxTool;
   TBoolProperty m_noAntialiasing;
 

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1129,7 +1129,10 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
     : ToolOptionsBox(parent)
     , m_tool(tool)
     , m_isVectorSelction(false)
-    , m_setSaveboxCheckbox(0) {
+    , m_setSaveboxCheckbox(0)
+    , m_selective(0)
+    , m_selectiveMode(0)
+    , m_selectiveModeLabel(0) {
   TPropertyGroup *props = tool->getProperties(0);
   assert(props->getPropertyCount() > 0);
 
@@ -1157,6 +1160,13 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   m_moveYField = new SelectionMoveField(selectionTool, 1, "Move Y");
 
   if (rasterSelectionTool) {
+    m_selective =
+        dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Selective"));
+    m_selectiveMode =
+        dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
+    if (m_selectiveMode)
+      m_selectiveModeLabel = m_labels.value(m_selectiveMode->propertyName());
+
     TBoolProperty *modifySetSaveboxProp =
         rasterSelectionTool->getModifySaveboxProperty();
     if (modifySetSaveboxProp)
@@ -1344,6 +1354,11 @@ void SelectionToolOptionsBox::updateStatus() {
       if (w && w != m_setSaveboxCheckbox) w->setEnabled(!disable);
     }
     if (disable) return;
+  }
+
+  if (m_selective) {
+    m_selectiveModeLabel->setEnabled(m_selective->isChecked());
+    m_selectiveMode->setEnabled(m_selective->isChecked());
   }
 
   m_scaleXField->updateStatus();

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1129,10 +1129,7 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
     : ToolOptionsBox(parent)
     , m_tool(tool)
     , m_isVectorSelction(false)
-    , m_setSaveboxCheckbox(0)
-    , m_selective(0)
-    , m_selectiveMode(0)
-    , m_selectiveModeLabel(0) {
+    , m_setSaveboxCheckbox(0) {
   TPropertyGroup *props = tool->getProperties(0);
   assert(props->getPropertyCount() > 0);
 
@@ -1160,13 +1157,6 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   m_moveYField = new SelectionMoveField(selectionTool, 1, "Move Y");
 
   if (rasterSelectionTool) {
-    m_selective =
-        dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Selective"));
-    m_selectiveMode =
-        dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
-    if (m_selectiveMode)
-      m_selectiveModeLabel = m_labels.value(m_selectiveMode->propertyName());
-
     TBoolProperty *modifySetSaveboxProp =
         rasterSelectionTool->getModifySaveboxProperty();
     if (modifySetSaveboxProp)
@@ -1354,11 +1344,6 @@ void SelectionToolOptionsBox::updateStatus() {
       if (w && w != m_setSaveboxCheckbox) w->setEnabled(!disable);
     }
     if (disable) return;
-  }
-
-  if (m_selective) {
-    m_selectiveModeLabel->setEnabled(m_selective->isChecked());
-    m_selectiveMode->setEnabled(m_selective->isChecked());
   }
 
   m_scaleXField->updateStatus();


### PR DESCRIPTION
This adds 2 new Smart Raster Selection Tool options, `Mode` and `Selective`:

![image](https://github.com/user-attachments/assets/377bbdcc-c816-48fa-842a-e9dc739536a1)

`Mode` allows you to target pixels that were colored by the Brush tool (Lines), by the Paint Brush/Fill Tool (Areas) or both (standard selection behavior)
`Selective` allows you to only select pixels with the currently selected style.

Limitation:  When selecting `Areas`, the style will be pulled from blended pixels (has Ink and Paint) like in aliased lines and even unaliased lines where the fill tool added paint beneath it.  When this happens, the extracted style will become fully opaque as close to the center of the aliased line (or edge of solid line) creating an aliased edge of the area and will not blended back.

https://github.com/user-attachments/assets/e46ee9fa-94e8-4ea3-b8b8-4a81baafb46f
