### PR TITLE
Fix Linux packaging space usage

### DIFF
--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -118,6 +118,9 @@ chmod +x ../installer/linux/deb-creator/debcreator.sh
  -p $TAHOMA2DVERSION \
  -v $TAHOMA2DVERSION \
  -t ../installer/linux/deb-creator/deb-template \
- -c ./Tahoma2D/Tahoma2D.AppImage
+ -x ./appdir \
+ -f ./Tahoma2D/ffmpeg \
+ -r ./Tahoma2D/rhubarb \
+ -s ../../stuff
 
  mv tahoma2d_*_amd64.deb Tahoma2D-linux.deb


### PR DESCRIPTION
This will fix an issue with Linux builds running out of space.

This appears to be due to Debian packaging process extracting and copying the contents of the Tahoma2D.AppImage.  With the original AppImage source directories, this means there are 3 copies of the AppImage contents using up a lot of space.  This results in failure when either the Debian packaging process or saving of ccache runs out of space.

Modified the Debian packaging script to accept additional arguments so that it will use the existing `appdir` and a few other directories that were used to create the original `Tahoma2D.AppImage` instead of extracting and copying.