### PR TITLE
New and updated shortcuts

### DIFF
--- a/toonz/sources/tnztools/plastictool.h
+++ b/toonz/sources/tnztools/plastictool.h
@@ -31,6 +31,8 @@
 #include "tcg/tcg_base.h"
 #include "tcg/tcg_controlled_access.h"
 
+#include "../toonz/menubarcommandids.h"
+
 // Qt includes
 #include <QObject>
 

--- a/toonz/sources/tnztools/plastictool_animate.cpp
+++ b/toonz/sources/tnztools/plastictool_animate.cpp
@@ -190,23 +190,20 @@ void PlasticTool::addContextMenuActions_animate(QMenu *menu) {
 
   if (m_sd.getPointer() == nullptr) return;
 
+  QAction *action;
   if (!m_svSel.isEmpty()) {
-    QAction *setKey = menu->addAction(tr("Set Key"));
-    ret = ret && connect(setKey, SIGNAL(triggered()), &l_plasticTool,
-                         SLOT(setKey_undo()));
+    action = CommandManager::instance()->getAction(MI_SetKeyframes);
+    menu->addAction(action);
 
-    QAction *setRestKey = menu->addAction(tr("Set Rest Key"));
-    ret = ret && connect(setRestKey, SIGNAL(triggered()), &l_plasticTool,
-                         SLOT(setRestKey_undo()));
+  action = CommandManager::instance()->getAction(MI_SetRestKeyframes);
+    menu->addAction(action);
   }
 
-  QAction *setGlobalKey = menu->addAction(tr("Set Global Key"));
-  ret = ret && connect(setGlobalKey, SIGNAL(triggered()), &l_plasticTool,
-                       SLOT(setGlobalKey_undo()));
+  action = CommandManager::instance()->getAction(MI_SetGlobalKeyframes);
+  menu->addAction(action);
 
-  QAction *setGlobalRestKey = menu->addAction(tr("Set Global Rest Key"));
-  ret = ret && connect(setGlobalRestKey, SIGNAL(triggered()), &l_plasticTool,
-                       SLOT(setGlobalRestKey_undo()));
+  action = CommandManager::instance()->getAction(MI_SetGlobalRestKeyframes);
+  menu->addAction(action);
 
   menu->addSeparator();
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2597,6 +2597,13 @@ void MainWindow::defineActions() {
                              QT_TR_NOOP("Open/Close Folder"), "");
   createRightClickMenuAction(MI_SetKeyframes, QT_TR_NOOP("&Set Key"), "Z",
                              "set_key");
+  createRightClickMenuAction(MI_SetRestKeyframes, QT_TR_NOOP("&Set Rest Key"),
+                             "", "");
+  createRightClickMenuAction(MI_SetGlobalKeyframes,
+                             QT_TR_NOOP("&Set Global Key"), "", "");
+  createRightClickMenuAction(MI_SetGlobalRestKeyframes,
+                             QT_TR_NOOP("&Set Global Rest Key"), "", "");
+
   createRightClickMenuAction(MI_ShiftKeyframesDown,
                              QT_TR_NOOP("&Shift Keys Down"), "",
                              "shift_keys_down");
@@ -2744,6 +2751,10 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_SetNonLinearControlPoint,
                              QT_TR_NOOP("&Set Nonlinear Control Point"), "",
                              "set_nonlinear_cp");
+  createRightClickMenuAction(MI_PlasticCopySkeleton,
+                             QT_TR_NOOP("&Copy Skeleton"), "", "");
+  createRightClickMenuAction(MI_PlasticPasteSkeleton,
+                             QT_TR_NOOP("&Paste Skeleton"), "", "");
 
   // createRightClickMenuAction(MI_LoadSubSceneFile, QT_TR_NOOP("Load As
   // Sub-xsheet"),   ""); createRightClickMenuAction(MI_LoadResourceFile,
@@ -3061,6 +3072,8 @@ void MainWindow::defineActions() {
                           "");
   createToolOptionsAction("A_ToolOption_GlobalKey", QT_TR_NOOP("Global Key"),
                           "", "global_key");
+  createToolOptionsAction("A_ToolOption_KeepDistance", QT_TR_NOOP("Keep Distance"),
+                          "", "");
 
   createToolOptionsAction("A_IncreaseMaxBrushThickness",
                           QT_TR_NOOP("Brush size - Increase max"), "I");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2170,7 +2170,7 @@ void MainWindow::defineActions() {
                          "delete_lines");
   createMenuXsheetAction(MI_MergeColumns, QT_TR_NOOP("&Merge Levels"), "",
                          "merge_levels");
-  createMenuXsheetAction(MI_NewOutputFx, QT_TR_NOOP("&New Output"), "Alt+O",
+  createMenuXsheetAction(MI_NewOutputFx, QT_TR_NOOP("&New Output"), "",
                          "output");
   createMenuXsheetAction(MI_InsertSceneFrame, QT_TR_NOOP("Insert Frame"), "",
                          "insert_frame");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2626,6 +2626,8 @@ void MainWindow::defineActions() {
                RightClickMenuCommandType, "zero_thick_lines");
   createToggle(MI_CursorOutline, QT_TR_NOOP("Toggle Cursor Size Outline"), "",
                false, RightClickMenuCommandType);
+  createRightClickMenuAction(MI_ClearAllOnionSkinMarkers,
+                             QT_TR_NOOP("&Clear All Onion Skin Markers"), "");
   createRightClickMenuAction(MI_ToggleCurrentTimeIndicator,
                              QT_TR_NOOP("Toggle Current Time Indicator"), "");
   createRightClickMenuAction(MI_DuplicateFile, QT_TR_NOOP("Duplicate"), "",

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -185,6 +185,9 @@
 #define MI_Duplicate "MI_Duplicate"
 #define MI_CloneLevel "MI_CloneLevel"
 #define MI_SetKeyframes "MI_SetKeyframes"
+#define MI_SetRestKeyframes "MI_SetRestKeyframes"
+#define MI_SetGlobalKeyframes "MI_SetGlobalKeyframes"
+#define MI_SetGlobalRestKeyframes "MI_SetGlobalRestKeyframes"
 
 #define MI_ViewCamera "MI_ViewCamera"
 #define MI_ViewBBox "MI_ViewBBox"
@@ -438,6 +441,8 @@
 #define MI_PlasticPaintRigid "MI_PlasticPaintRigid"
 #define MI_PlasticBuildSkeleton "MI_PlasticBuildSkeleton"
 #define MI_PlasticAnimate "MI_PlasticAnimate"
+#define MI_PlasticCopySkeleton "MI_PlasticCopySkeleton"
+#define MI_PlasticPasteSkeleton "MI_PlasticPasteSkeleton"
 
 #define MI_BrushAutoFillOn "MI_BrushAutoFillOn"
 #define MI_BrushAutoFillOff "MI_BrushAutoFillOff"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -260,6 +260,7 @@
 #define MI_MaximizePanel "MI_MaximizePanel"
 #define MI_FullScreenWindow "MI_FullScreenWindow"
 #define MI_OnionSkin "MI_OnionSkin"
+#define MI_ClearAllOnionSkinMarkers "MI_ClearAllOnionSkinMarkers"
 #define MI_ZeroThick "MI_ZeroThick"
 #define MI_CursorOutline "MI_CursorOutline"
 #define MI_ViewerIndicator "MI_ViewerIndicator"

--- a/toonz/sources/toonz/onionskinmaskgui.cpp
+++ b/toonz/sources/toonz/onionskinmaskgui.cpp
@@ -11,6 +11,9 @@
 
 #include "toonz/onionskinmask.h"
 
+#include "toonzqt/menubarcommand.h"
+#include "../toonz/menubarcommandids.h"
+
 #include <QMenu>
 
 //=============================================================================
@@ -141,6 +144,7 @@ void OnioniSkinMaskGUI::OnionSkinSwitcher::clearDOS() {
 }
 
 void OnioniSkinMaskGUI::OnionSkinSwitcher::clearOS() {
+  if (!switcher.isActive()) return; 
   clearFOS();
   clearMOS();
   clearDOS();
@@ -161,7 +165,6 @@ void OnioniSkinMaskGUI::OnionSkinSwitcher::enableRelativeDrawingMode() {
 //------------------------------------------------------------------------------
 
 void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
-  static OnioniSkinMaskGUI::OnionSkinSwitcher switcher;
   if (switcher.isActive()) {
     QAction *dectivateOnionSkin =
         menu->addAction(QString(QObject::tr("Deactivate Onion Skin")));
@@ -203,10 +206,9 @@ void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
       }
       OnionSkinMask osm = switcher.getMask();
       if (osm.getFosCount() || osm.getMosCount() || osm.getDosCount()) {
-        QAction *clearAllOnionSkins = menu->addAction(
-            QString(QObject::tr("Clear All Onion Skin Markers")));
-        menu->connect(clearAllOnionSkins, SIGNAL(triggered()), &switcher,
-                      SLOT(clearOS()));
+        QAction *clearAllOnionSkins =
+            CommandManager::instance()->getAction(MI_ClearAllOnionSkinMarkers);
+        menu->addAction(clearAllOnionSkins);
       }
       if (osm.getFosCount() &&
           ((osm.isRelativeFrameMode() && osm.getMosCount()) ||
@@ -304,5 +306,16 @@ void OnioniSkinMaskGUI::resetShiftTraceFrameOffset() {
       secondOffset++;
     }
     setGhostOffset(firstOffset, secondOffset);
+  }
+}
+
+//------------------------------------------------------------------------------
+
+void OnioniSkinMaskGUI::OnionSkinSwitcher::enableCommands() {
+  QAction *action =
+      CommandManager::instance()->getAction(MI_ClearAllOnionSkinMarkers);
+  if (!action->isEnabled()) {
+    action->setEnabled(true);
+    connect(action, SIGNAL(triggered()), this, SLOT(clearOS()));
   }
 }

--- a/toonz/sources/toonz/onionskinmaskgui.h
+++ b/toonz/sources/toonz/onionskinmaskgui.h
@@ -36,6 +36,8 @@ public:
   bool isEveryFrame() const;
   bool isRelativeFrameMode() const;
 
+  void enableCommands();
+
 public slots:
   void activate();
   void deactivate();
@@ -50,6 +52,8 @@ public slots:
   void enableRelativeFrameMode();
   void enableRelativeDrawingMode();
 };
+
+static OnionSkinSwitcher switcher;
 
 //-----------------------------------------------------------------------------
 }  // namespace OnioniSkinMaskGUI

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -272,6 +272,8 @@ RowArea::RowArea(XsheetViewer *parent, Qt::WindowFlags flags)
   // for displaying the pinned center keys when the skeleton tool is selected
   connect(TApp::instance()->getCurrentTool(), SIGNAL(toolSwitched()), this,
           SLOT(update()));
+
+  OnioniSkinMaskGUI::switcher.enableCommands();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
### New
- Plastic Tool
  - Tool Modifiers (Toolbar)
    - `Keep Distance`
  - Right-click Menu Commands
    - `Copy Skeleton`
    - `Paste Skeleton`
    - `Set Rest Key`  (Animate context menu)
    - `Set Global Key`  (Animate context menu)
    - `Set Global Rest Key`  (Animate context menu)

- Timeline/Xsheet
  - Onion Skin - Right-click Menu Commands
    - `Clear All Onion Skin Markers`
 
### Updated
- Plastic Tool
  - Tool Modifiers (Toolbar)
    - `Global Key` -  Now uses existing shortcut
  - Right-click Menu Commands
    - `Set Key`  (Animate context menu) - Now uses existing shortcut

- `New Output` - Removed default setting (`Alt+O`)
