### PR TITLE
Remove rasterized vector pink box

### DIFF
--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -409,6 +409,9 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
 
             return ri;
           }
+      } else {
+        TRaster32P ras(1, 1);
+        return TRasterImageP(ras);
       }
     }
   }


### PR DESCRIPTION
This fixes #1781 which was caused by the visualize as raster vector changes ported from OT.

Technically the pink box is valid which means there was nothing rasterized, but prior to the patch this would have only be displayed if a non-vector image was sent to be rasterized.

This change will now return a 1x1 empty raster image for empty rasterized vectors as it did before the patch.