### PR TITLE
Fix double-clicking 1st folder item not working

### DIFF
--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -2073,9 +2073,9 @@ void FileBrowser::onSelectedItems(const std::set<int> &indexes) {
 
 void FileBrowser::onClickedItem(int index) {
   if (0 <= index && index < (int)m_items.size()) {
-    // if the parent folder is clicked, then move the current folder
+    // if the folder is clicked, then move the current folder
     TFilePath fp = m_items[index].m_path;
-    //if (index == 0 && m_items[index].m_isFolder) {
+    // if (m_items[index].m_isFolder) {
     //  setFolder(fp, true);
     //  QModelIndex index = m_folderTreeView->currentIndex();
     //  if (index.isValid()) m_folderTreeView->scrollTo(index);
@@ -2088,8 +2088,8 @@ void FileBrowser::onClickedItem(int index) {
 
 void FileBrowser::onDoubleClickedItem(int index) {
   // TODO: Avoid duplicate code with onClickedItem().
-  if (0 < index && index < (int)m_items.size()) {
-    // if the folder is doubleClicked, then move the current folder
+  if (0 <= index && index < (int)m_items.size()) {
+    // if the folder is clicked, then move the current folder
     TFilePath fp = m_items[index].m_path;
     if (m_items[index].m_isFolder) {
       setFolder(fp, true);


### PR DESCRIPTION
This reverts the commit "Make single click to not change current folder except clicked.." that was recently ported from OT.

The intent of the fix was to prevent moving into folders when performing a single click on a folder in the item list.  I have reverted it for the following reasons:

1. It prevents normal double-click operations from occurring on the 1st (top) item in the item list, whether it be a file or a directory.
2. The issue the commit was trying to address was not an issue in T2D.  We resolved this issue a long time ago. 