### PR TITLE
Fix Plastic Tool crash and history messages

### DIFF
--- a/toonz/sources/tnztools/plastictool_animate.cpp
+++ b/toonz/sources/tnztools/plastictool_animate.cpp
@@ -60,6 +60,8 @@ public:
     l_suspendParamsObservation = false;
     l_plasticTool.onChange();
   }
+
+  QString getHistoryString() override { return "Plastic (animate): Animate Vertex"; }
 };
 
 }  // namespace

--- a/toonz/sources/tnztools/plastictool_build.cpp
+++ b/toonz/sources/tnztools/plastictool_build.cpp
@@ -200,6 +200,7 @@ public:
   void undo() const override {
     const_cast<AddVertexUndo &>(*this).VertexUndo::removeVertex();
   }
+  QString getHistoryString() override { return "Plastic (build): Add Vertex"; }
 };
 
 //------------------------------------------------------------------------
@@ -216,6 +217,10 @@ public:
   }
   void undo() const override {
     const_cast<RemoveVertexUndo &>(*this).VertexUndo::insertVertex();
+  }
+
+  QString getHistoryString() override {
+    return "Plastic (build): Remove Vertex";
   }
 };
 
@@ -239,6 +244,10 @@ public:
     TCG_ASSERT(!m_children.empty(), return );
 
     const_cast<InsertVertexUndo &>(*this).VertexUndo::removeVertex();
+  }
+
+  QString getHistoryString() override {
+    return "Plastic (build): Insert Vertex";
   }
 };
 
@@ -267,7 +276,7 @@ public:
 
   void redo() const override {
     PlasticTool::TemporaryActivation tempActivate(m_row, m_col);
-
+    if (!m_skeleton) return;
     l_plasticTool.addSkeleton(m_skelId, new PlasticSkeleton(*m_skeleton));
     ::invalidateXsheet();
   }
@@ -288,6 +297,10 @@ public:
 
   void redo() const override { AddSkeletonUndo::undo(); }
   void undo() const override { AddSkeletonUndo::redo(); }
+
+  QString getHistoryString() override {
+    return QString("Plastic (build): Remove Skeleton Id %1").arg(skeletonId());
+  }
 };
 
 //------------------------------------------------------------------------
@@ -340,6 +353,11 @@ public:
     m_skelIdsKeyframes.clear();
 
     RemoveSkeletonUndo::undo();  // Invalidates the xsheet
+  }
+
+  QString getHistoryString() override {
+    return QString("Plastic (build): Remove Skeleton Id %1 w/ Keyframes")
+        .arg(skeletonId());
   }
 };
 
@@ -413,6 +431,10 @@ public:
         skelIdsParam->deleteKeyframe(kf.m_frame);
     }
   }
+
+  QString getHistoryString() override {
+    return QString("Plastic (build): Set Skeleton Id %1").arg(skeletonId());
+  }
 };
 
 //========================================================================
@@ -462,6 +484,8 @@ public:
         ->invalidate();  // Should be a TStageObject's implementation detail ...
     l_plasticTool.invalidate();
   }
+
+  QString getHistoryString() override { return "Plastic (build): Move Vertex"; }
 };
 
 }  // namespace
@@ -866,8 +890,7 @@ int PlasticTool::addSkeleton_undo(const PlasticSkeletonP &skeleton) {
 
 //------------------------------------------------------------------------
 
-void PlasticTool::addSkeleton_undo(int skelId,
-                                   const PlasticSkeletonP &skeleton) {
+void PlasticTool::addSkeleton_undo(int skelId, const PlasticSkeletonP &skeleton) {
   TUndoManager *manager = TUndoManager::manager();
   manager->beginBlock();
   {

--- a/toonz/sources/tnztools/plastictool_meshedit.cpp
+++ b/toonz/sources/tnztools/plastictool_meshedit.cpp
@@ -683,6 +683,8 @@ public:
     l_plasticTool.invalidate();
     l_plasticTool.notifyImageChanged();
   }
+
+  QString getHistoryString() override { return "Plastic (edit): Move Vertex"; }
 };
 
 //==============================================================================
@@ -721,6 +723,8 @@ public:
 
   void undo() const override { redo(); }  // Operation is idempotent (indices
                                           // are perfectly restored, too)
+
+  QString getHistoryString() override { return "Plastic (edit): Swap Edge"; }
 };
 
 //==============================================================================
@@ -796,6 +800,8 @@ public:
     l_plasticTool.invalidate();
     l_plasticTool.notifyImageChanged();
   }
+
+  QString getHistoryString() override { return "Plastic (edit): Collapse Edge"; }
 };
 
 //==============================================================================
@@ -850,6 +856,8 @@ public:
     l_plasticTool.invalidate();
     l_plasticTool.notifyImageChanged();
   }
+
+  QString getHistoryString() override { return "Plastic (edit): Split Edge"; }
 };
 
 //==============================================================================
@@ -910,6 +918,8 @@ public:
     l_plasticTool.invalidate();
     l_plasticTool.notifyImageChanged();
   }
+
+  QString getHistoryString() override { return "Plastic (edit): Cut Edge"; }
 };
 
 }  // namespace

--- a/toonz/sources/tnztools/plastictool_rigidity.cpp
+++ b/toonz/sources/tnztools/plastictool_rigidity.cpp
@@ -93,6 +93,8 @@ public:
     PlasticDeformerStorage::instance()->invalidateMeshImage(
         mi.getPointer(), PlasticDeformerStorage::MESH);
   }
+
+  QString getHistoryString() override { return "Plastic (rigid): Paint Rigid"; }
 };
 
 }  // namespace


### PR DESCRIPTION
This PR does the following for Plastic Tool

- Fixes a crash that is caused by the following steps:
  - Copy Skeleton
  - Delete copied skeleton
  - Pasted Skeleton
  - Undo

- Replaces `Unidentified Action` with Plastic tool information.