### PR TITLE
WinKey as Modifier Key

### DIFF
--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -119,7 +119,8 @@ TApp::TApp()
     , m_isStarting(false)
     , m_isPenCloseToTablet(false)
     , m_canHideTitleBars(CanHideTitleBarsWhenLocked == 1 ? true : false)
-    , m_showTitleBars(ShowTitleBarsWhenLocked == 1 ? true : false) {
+    , m_showTitleBars(ShowTitleBarsWhenLocked == 1 ? true : false)
+    , m_metaPressed(false) {
   m_currentScene         = new TSceneHandle();
   m_currentXsheet        = new TXsheetHandle();
   m_currentFrame         = new TFrameHandle();
@@ -800,6 +801,30 @@ void TApp::onStopAutoSave() {
 //-----------------------------------------------------------------------------
 
 bool TApp::eventFilter(QObject *watched, QEvent *e) {
+  switch (e->type()) {
+  case QEvent::KeyPress:
+  case QEvent::KeyRelease: {
+    QKeyEvent *ke = dynamic_cast<QKeyEvent *>(e);
+    if (isMetaPressed()) ke->setModifiers(ke->modifiers() | Qt::MetaModifier);
+    break;
+  }
+  case QEvent::MouseButtonPress:
+  case QEvent::MouseButtonRelease:
+  case QEvent::MouseButtonDblClick:
+  case QEvent::MouseMove: {
+    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    if (isMetaPressed()) me->setModifiers(me->modifiers() | Qt::MetaModifier);
+    break;
+  }
+  case QEvent::TabletPress:
+  case QEvent::TabletRelease:
+  case QEvent::TabletMove: {
+    QTabletEvent *te = dynamic_cast<QTabletEvent *>(e);
+    if (isMetaPressed()) te->setModifiers(te->modifiers() | Qt::MetaModifier);
+    break;
+  }
+  }
+
   if (e->type() == QEvent::TabletEnterProximity) {
     m_isPenCloseToTablet = true;
   } else if (e->type() == QEvent::TabletLeaveProximity) {

--- a/toonz/sources/toonz/tapp.h
+++ b/toonz/sources/toonz/tapp.h
@@ -97,6 +97,8 @@ class TApp final : public QObject,
   bool m_isStarting;
   bool m_isPenCloseToTablet;
 
+  bool m_metaPressed;
+
 public:
   /*!
           A static pointer to the main application.
@@ -231,6 +233,9 @@ public:
   }
 
   LocatorPopup *getActiveLocator() const { return m_activeLocator; }
+
+  bool isMetaPressed() { return m_metaPressed; }
+  void setMetaPressed(bool pressed) { m_metaPressed = pressed; }
 
 protected:
   bool eventFilter(QObject *obj, QEvent *event) override;


### PR DESCRIPTION
The Windows Key which normally opens the Windows menu, can also be used as a modifier key (`Meta`).

This change does the following:
- Disables the `WinKey` from opening the Windows menu only when T2D is in focus
- Allows the `WinKey` to be used as a modifier key in shortcuts.  It shows as `Meta+`
- Allows for future features to use `WinKey` as a modifier much like `Ctrl`, `Shift`, `Alt`

This change only affects Windows builds.
The `Meta` key for macOS users is the `Command` key and this change should have no impact to those builds.
Exploring an option for Linux.