### PR TITLE
Fix canceling selection when modifiers used

### DIFF
--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -475,7 +475,8 @@ LevelMoverTool::LevelMoverTool(XsheetViewer *viewer)
     , m_undo(0)
     , m_moved(false)
     , m_columnsMoved(false)
-    , m_dragged(false) {}
+    , m_dragged(false)
+    , m_modifierPressed(false) {}
 
 LevelMoverTool::~LevelMoverTool() {}
 
@@ -552,6 +553,8 @@ void LevelMoverTool::onClick(const QMouseEvent *e) {
   CellPosition cellPosition = getViewer()->xyToPosition(e->pos());
   int row                   = cellPosition.frame();
   int col                   = cellPosition.layer();
+
+  m_modifierPressed = e->modifiers() != Qt::NoModifier;
 
   m_qualifiers = 0;
   if (Preferences::instance()->getDragCellsBehaviour() == 1)
@@ -763,6 +766,7 @@ void LevelMoverTool::onRelease(const CellPosition &pos) {
   // Reset current selection if we didn't move
   TCellSelection *selection = getViewer()->getCellSelection();
   if (!Preferences::instance()->isShowDragBarsEnabled() && !m_dragged &&
+      !m_modifierPressed &&
       (cellMover->getRowCount() > 1 || cellMover->getColumnCount() > 1)) {
     selection->selectNone();
     selection->selectCell(pos.frame(), pos.layer());

--- a/toonz/sources/toonz/xshcellmover.h
+++ b/toonz/sources/toonz/xshcellmover.h
@@ -111,6 +111,7 @@ protected:
   bool m_moved;
   bool m_columnsMoved;
   bool m_dragged;
+  bool m_modifierPressed;
 
   bool isTotallyEmptyColumn(int col) const;
   virtual bool canMove(const TPoint &pos);

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1803,7 +1803,7 @@ public:
 class ColumnMoveDragTool final : public XsheetGUI::DragTool {
   QPoint m_firstPos, m_curPos;
   int m_firstCol, m_targetCol;
-  bool m_dropOnColumnFolder, m_folderChanged, m_dragged;
+  bool m_dropOnColumnFolder, m_folderChanged, m_dragged, m_modifierPressed;
   QStack<int> m_addToFolder;
 
 public:
@@ -1813,7 +1813,8 @@ public:
       , m_targetCol(-1)
       , m_dropOnColumnFolder(false)
       , m_folderChanged(false)
-      , m_dragged(false) {}
+      , m_dragged(false)
+      , m_modifierPressed(false) {}
 
   bool canDrop(const CellPosition &pos) {
     int col = pos.layer();
@@ -1834,6 +1835,7 @@ public:
     m_dropOnColumnFolder = false;
     m_folderChanged      = false;
     m_dragged            = false;
+    m_modifierPressed    = event->modifiers() != Qt::NoModifier;
     m_addToFolder.clear();
 
     m_firstPos                  = event->pos();
@@ -2065,7 +2067,7 @@ public:
 
     // Reset current selection if we didn't move
     if (!Preferences::instance()->isShowDragBarsEnabled() && !m_dragged &&
-        !oldIndices.empty() && oldIndices.size() > 1) {
+        !m_modifierPressed && !oldIndices.empty() && oldIndices.size() > 1) {
       selection->selectNone();
       selection->selectColumn(pos.layer());
       getViewer()->setCurrentColumn(pos.layer());


### PR DESCRIPTION
This is related to #1721, changing when a multi-cell/column is cleared when tapped.  Now when you are holding a modifier key (`Ctrl`, `Shift`, `Alt`, `Meta`) and tap inside the selection area, it will no longer cancel the selection.