### PR TITLE
Fix startup console warnings and errors

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -397,7 +397,8 @@ int main(int argc, char *argv[]) {
 
   a.installNativeEventFilter(new OSXMouseDragFilter);
 #endif
-
+/* In wrong spot but don't want to move it in case it causes problems when
+  forced on all the time
 #ifdef Q_OS_WIN
   //	Since currently Tahoma does not work with OpenGL of software or
   // angle,	force Qt to use desktop OpenGL
@@ -405,7 +406,7 @@ int main(int argc, char *argv[]) {
   // Thus, ANGLE seems to be enabled as of now.
   a.setAttribute(Qt::AA_UseDesktopOpenGL, true);
 #endif
-
+*/
   // Some Qt objects are destroyed badly without a living qApp. So, we must
   // enforce a way to either
   // postpone the application destruction until the very end, OR ensure that

--- a/toonz/sources/toonz/motionpathpanel.cpp
+++ b/toonz/sources/toonz/motionpathpanel.cpp
@@ -442,16 +442,15 @@ void MotionPathPanel::highlightActiveSpline() {
         m_graphFrame->show();
         m_playToolbar->show();
       } else {
-        QString qss = "background: rgba(" +
+        QString qss = "QLabel { background: rgba(" +
                       QString::number(m_selectedColor.red()) + ", " +
                       QString::number(m_selectedColor.green()) + ", " +
                       QString::number(m_selectedColor.blue()) +
                       ", 0);"
                       " border-radius: 2;"
                       " padding-left: 2px;"
-                      " padding-right: 2px;"
-                      " :hover{"
-                      " background: rgb(" +
+                      " padding-right: 2px; }"
+                      " QLabel:hover{ background: rgb(" +
                       QString::number(m_hoverColor.red()) + ", " +
                       QString::number(m_hoverColor.green()) + ", " +
                       QString::number(m_hoverColor.blue()) +

--- a/toonz/sources/toonz/toolbar.cpp
+++ b/toonz/sources/toonz/toolbar.cpp
@@ -300,6 +300,7 @@ void Toolbar::updateOrientation(bool isVertical) {
     m_panel->setOrientation(m_isVertical);
     m_panel->setFixedWidth(m_isVertical ? 44 : QWIDGETSIZE_MAX);
     m_panel->setFixedHeight(m_isVertical ? QWIDGETSIZE_MAX : 44);
+    m_panel->setMinimumHeight(44);
     if (m_isVertical)
       m_panel->resize(44, x);
     else
@@ -308,6 +309,7 @@ void Toolbar::updateOrientation(bool isVertical) {
 
   setFixedWidth(m_isVertical ? 34 : QWIDGETSIZE_MAX);
   setFixedHeight(m_isVertical ? QWIDGETSIZE_MAX : 34);
+  setMinimumHeight(34);
   setOrientation(m_isVertical ? Qt::Vertical : Qt::Horizontal);
   setSizePolicy(QSizePolicy::Policy::Expanding,
                   QSizePolicy::Policy::Expanding);

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -769,5 +769,6 @@
 		<file>Resources/scripticon.png</file>
 		<file>Resources/savescreen.png</file>
 		<file>Resources/scrub.png</file>
-	</qresource>
+		<file>Resources/vcroot.svg</file>
+  </qresource>
 </RCC>

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -1089,7 +1089,7 @@ ParamViewer::ParamViewer(QWidget *parent, Qt::WindowFlags flags)
   {
     mainLayout->addWidget(m_tablePageSet, 1);
 
-    QHBoxLayout *showPreviewButtonLayout = new QHBoxLayout(this);
+    QHBoxLayout *showPreviewButtonLayout = new QHBoxLayout();
     showPreviewButtonLayout->setContentsMargins(3, 3, 3, 3);
     showPreviewButtonLayout->setSpacing(3);
     {
@@ -1248,7 +1248,7 @@ FxSettings::FxSettings(QWidget *parent, const TPixel32 &checkCol1,
   {
     swatchLayout->addWidget(m_viewer, 0, Qt::AlignHCenter);
 
-    QHBoxLayout *toolBarLayout = new QHBoxLayout(swatchContainer);
+    QHBoxLayout *toolBarLayout = new QHBoxLayout();
     {
       toolBarLayout->addWidget(m_toolBar, 0,
                                Qt::AlignHCenter | Qt::AlignBottom);


### PR DESCRIPTION
This fixes the following console warnings and errors that are thrown when starting.

`Could not parse stylesheet of object ClickablePathLabel(0x2711e3d6230, name = "MotionPathLabel")`
`qt.svg: Cannot open file ':Resources/vcroot.svg', because: No such file or directory`
`QLayout: Attempting to add QLayout "" to ParamViewer "", which already has a layout`
`QLayout: Attempting to add QLayout "" to QWidget "", which already has a layout`
`QWidget::setMinimumSize: (ToolBar/TPanel) Negative sizes (34,-10) are not possible`
`Attribute Qt::AA_UseDesktopOpenGL must be set before QCoreApplication is created.`