### PR TITLE
Fix missing Linux Action ccache directory

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           ci-scripts/linux/tahoma-install.sh
           sudo apt-get install ccache
+          mkdir -p /home/runner/.ccache
       - name: Restore cache
         id: restore-cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
Fixes a minor issue with Linux builds missing a ccache directory, preventing caching.

At the moment it isn't an issue since there is an existing cache to restore. Will be an issue if the cache is somehow lost.

Will merge once all checks are successful.