### PR TITLE
Loop Frames

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -147,7 +147,9 @@ enum class PredefinedRect {
   CLIPPING_MASK_AREA,
   FOLDER_INDICATOR_AREA,
   FOLDER_TOGGLE_ICON,
-  BUTTONS_AREA
+  BUTTONS_AREA,
+  LOOP_START_MARKER_AREA,
+  LOOP_END_MARKER_AREA
 };
 enum class PredefinedLine {
   LOCKED,              //! dotted vertical line when cell is locked
@@ -184,7 +186,9 @@ enum class PredefinedPath {
   FRAME_MARKER_DIAMOND_SMALL,
   FRAME_MARKER_DIAMOND,
   FRAME_MARKER_DIAMOND_LARGE,
-  NAVIGATION_TAG
+  NAVIGATION_TAG,
+  LOOP_START_MARKER,
+  LOOP_END_MARKER
 };
 enum class PredefinedPoint {
   KEY_HIDDEN,  //! move extender handle that much if key icons are disabled

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -196,14 +196,19 @@ public:
      an empty cell.
           \sa setCell(), getCells(), setCells()
   */
-  const TXshCell &getCell(int row, int col, bool implicitLookup = true) const;
+  const TXshCell &getCell(int row, int col, bool implicitLookup = true,
+                          bool loopedLookup = true) const;
 
-  const TXshCell &getCell(const CellPosition &pos,
-                          bool implicitLookup = true) const;
+  const TXshCell &getCell(const CellPosition &pos, bool implicitLookup = true,
+                          bool loopedLookup = true) const;
 
   bool isImplicitCell(int row, int col) const;
 
   bool isImplicitCell(const CellPosition &pos) const;
+
+  bool isLoopedCell(int row, int col) const;
+
+  bool isLoopedCell(const CellPosition &pos) const;
 
   bool setCell(int row, int col, const TXshCell &cell);
   /*! Set \b \e cells[] to \b \e rowCount cells of column identified by index \b
@@ -213,7 +218,7 @@ public:
           \sa getCells(), setCells(), getCell()
 */
   void getCells(int row, int col, int rowCount, TXshCell cells[],
-                bool implicitLookup = false) const;
+                bool implicitLookup = false, bool loopedLookup = false) const;
   /*! If column identified by index \b \e col is a \b TXshCellColumn or is empty
     and is not
     locked, this method sets to \b \e cells[] the given \b \e rowCount cells of

--- a/toonz/sources/include/toonz/txshsoundcolumn.h
+++ b/toonz/sources/include/toonz/txshsoundcolumn.h
@@ -137,10 +137,12 @@ public:
   /*! Return min row not empty.*/
   int getFirstRow() const override;
 
-  const TXshCell &getCell(int row, bool implicitLookup = false) const override;
+  const TXshCell &getCell(int row, bool implicitLookup = false,
+                          bool loopedLookup = false) const override;
   TXshCell getSoundCell(int row);
   void getCells(int row, int rowCount, TXshCell cells[],
-                bool implicitLookup = false) override;
+                bool implicitLookup = false,
+                bool loopedLookup = false) override;
 
   bool setCell(int row, const TXshCell &cell) override;
   /*! Return false if cannot set cells.*/

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -366,6 +366,7 @@ TImage *TTool::touchImage(bool forDuplicate) {
 
   TXshCell cell       = xsh->getCell(row, col);
   bool isImplicitCell = xsh->isImplicitCell(row, col);
+  bool isLoopedCell   = xsh->isLoopedCell(row, col);
 
   // Stop frames cannot be modified
   if (cell.getFrameId().isStopFrame()) return 0;
@@ -393,14 +394,15 @@ TImage *TTool::touchImage(bool forDuplicate) {
 
     // current cell is not empty
     if (isCreateInHoldCellsEnabled && row > 0 &&
-        xsh->getCell(row - 1, col) == xsh->getCell(row, col)) {
+        (isLoopedCell ||
+         (xsh->getCell(row - 1, col) == xsh->getCell(row, col)))) {
       // CreateInHoldCells is enabled and the current cell is a "hold".
       // We must create a new drawing.
       // measure the hold length (starting from the current row) : r0-r1
       int r0 = row, r1 = row;
       if (isAutoStretchEnabled)
         while (!cell.getFrameId().isStopFrame() &&
-               xsh->getCell(r1 + 1, col, false) == cell)
+               xsh->getCell(r1 + 1, col, false, false) == cell)
           r1++;
       // find the proper frameid (possibly addisng suffix, in order to avoid a
       // fid already used)

--- a/toonz/sources/toonz/autoinputcellnumberpopup.cpp
+++ b/toonz/sources/toonz/autoinputcellnumberpopup.cpp
@@ -153,7 +153,8 @@ AutoInputCellNumberUndo::AutoInputCellNumberUndo(int increment, int interval,
     TXsheetP xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     for (int c = 0; c < m_columnIndices.size(); ++c) {
       for (int r = m_r0; r <= rowUpTo; ++r) {
-        const TXshCell &cell = xsh->getCell(r, m_columnIndices.at(c), false);
+        const TXshCell &cell =
+            xsh->getCell(r, m_columnIndices.at(c), false, false);
         m_beforeCells[k++] = cell;
       }
     }
@@ -164,7 +165,8 @@ AutoInputCellNumberUndo::AutoInputCellNumberUndo(int increment, int interval,
     int k        = 0;
     TXsheetP xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     for (int c = 0; c < m_columnIndices.size(); ++c) {
-      const TXshCell &cell = xsh->getCell(m_r0, m_columnIndices.at(c), false);
+      const TXshCell &cell =
+          xsh->getCell(m_r0, m_columnIndices.at(c), false, false);
       m_beforeCells[k++] = cell;
     }
   }
@@ -431,7 +433,7 @@ bool AutoInputCellNumberPopup::getTarget(std::vector<int> &columnIndices,
       if (column->getColumnType() != TXshColumn::eLevelType) continue;
       // try to find the topmost available level in the column
       for (int row = r0; row <= r1; row++) {
-        TXshCell cell = xsh->getCell(row, col);
+        TXshCell cell = xsh->getCell(row, col, true, false);
         if (cell.isEmpty()) continue;
         TXshSimpleLevel *simpleLevel = cell.getSimpleLevel();
         TXshChildLevel *childLevel   = cell.getChildLevel();
@@ -469,7 +471,7 @@ bool AutoInputCellNumberPopup::getTarget(std::vector<int> &columnIndices,
       int tmpR0, tmpR1;
       column->getRange(tmpR0, tmpR1);
       for (int row = tmpR0; row <= tmpR1; row++) {
-        TXshCell cell = xshColumn->getCell(row);
+        TXshCell cell = xshColumn->getCell(row, true, false);
         if (cell.isEmpty()) continue;
         TXshSimpleLevel *simpleLevel = cell.getSimpleLevel();
         TXshChildLevel *childLevel   = cell.getChildLevel();

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -140,6 +140,11 @@ public:
   void inbetweenEaseIn() { inbetween(TInbetween::EaseInInterpolation); }
   void inbetweenEaseOut() { inbetween(TInbetween::EaseOutInterpolation); }
   void inbetweenEaseInOut() { inbetween(TInbetween::EaseInOutInterpolation); }
+
+  void loopFrames();
+  void loopFrameRange(int col, int r0, int r1);
+  void removeFrameLoop();
+  void removeFrameLoopRange(int col, int r0, int r1);
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -664,11 +664,14 @@ ReframeUndo::ReframeUndo(int r0, int r1, std::vector<int> columnIndeces,
     int colLen0, colLen1;
     column->getRange(colLen0, colLen1);
     TXshCell tmpCell = column->getCell(m_r1, true, false);
+    bool isLastLooped = column->isLoopedFrame(m_r1);
     // For the purposes counting cells at the end, treat stop frames as empty
     // cells
     if (tmpCell.getFrameId().isStopFrame())
       tmpCell = TXshCell(0, TFrameId::EMPTY_FRAME);
     while (rTo < colLen1) {
+      if (!isLastLooped && column->isLoopedFrame(rTo + 1))
+        break;  // Stop if it's the start of looped frames
       TXshCell nextCell = column->getCell(rTo + 1, true, false);
       if (nextCell.getFrameId().isStopFrame())
         nextCell = TXshCell(0, TFrameId::EMPTY_FRAME);

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1823,7 +1823,7 @@ void CloneLevelUndo::insertCells() const {
   for (int c = m_range.m_c0; c <= m_range.m_c1; ++c) {
     TXshLevelP lastLevel = 0;
     for (int r = m_range.m_r0; r <= m_range.m_r1; ++r) {
-      TXshCell srcCell = xsh->getCell(r, c, false, false);
+      TXshCell srcCell = xsh->getCell(r, c, false, true);
       if (srcCell.isEmpty() && useImplicitHold &&
           xsh->isColumnEmpty(c + m_range.getColCount()))
         srcCell = xsh->getCell(r, c, true);

--- a/toonz/sources/toonz/columncommand.h
+++ b/toonz/sources/toonz/columncommand.h
@@ -60,6 +60,9 @@ void unifyColumnVisibilityToggles();
 
 void groupColumns(const std::set<int> &indices);
 void ungroupColumns(const std::set<int> &indices);
+
+void loopColumns(std::set<int> &indices);
+void removeColumnLoops(std::set<int> &indices);
 }  // namespace ColumnCmd
 
 #endif

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -100,6 +100,8 @@ void TColumnSelection::enableCommands() {
   enableCommand(this, MI_Autorenumber, &TColumnSelection::renumberColumns);
   enableCommand(this, MI_Group, &TColumnSelection::groupColumns);
   enableCommand(this, MI_Ungroup, &TColumnSelection::ungroupColumns);
+  enableCommand(this, MI_LoopFrames, &TColumnSelection::loopColumns);
+  enableCommand(this, MI_RemoveFrameLoop, &TColumnSelection::removeColumnLoops);
 }
 //-----------------------------------------------------------------------------
 
@@ -370,4 +372,20 @@ void TColumnSelection::hideColumns() {
   // colonne)
   //  TApp::instance()->->notify(TColumnHeadChange());
   app->getCurrentScene()->setDirtyFlag(true);
+}
+
+//-----------------------------------------------------------------------------
+
+void TColumnSelection::loopColumns() {
+  m_indices.erase(-1);  // Ignore camera column
+  if (m_indices.empty()) return;
+  ColumnCmd::loopColumns(m_indices);
+}
+
+//-----------------------------------------------------------------------------
+
+void TColumnSelection::removeColumnLoops() {
+  m_indices.erase(-1);  // Ignore camera column
+  if (m_indices.empty()) return;
+  ColumnCmd::removeColumnLoops(m_indices);
 }

--- a/toonz/sources/toonz/columnselection.h
+++ b/toonz/sources/toonz/columnselection.h
@@ -58,6 +58,9 @@ public:
   void reframeWithEmptyInbetweens();
 
   void renumberColumns();
+
+  void loopColumns();
+  void removeColumnLoops();
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -1832,7 +1832,7 @@ bool ReplaceLevelPopup::execute() {
     int r, c;
     for (c = m_range.m_c0; c <= m_range.m_c1; c++)
       for (r = m_range.m_r0; r <= m_range.m_r1; r++) {
-        TXshCell cell = xsh->getCell(r, c, false);
+        TXshCell cell = xsh->getCell(r, c, false, false);
         if (!cell.m_level.getPointer()) continue;
         cell.m_level = xl;
         xsh->setCell(r, c, cell);
@@ -1844,7 +1844,7 @@ bool ReplaceLevelPopup::execute() {
     std::set<int>::iterator i = m_columnRange.begin();
     while (i != m_columnRange.end()) {
       for (int r = 0; r < frameLength; r++) {
-        TXshCell cell = xsh->getCell(r, *i, false);
+        TXshCell cell = xsh->getCell(r, *i, false, false);
         if (!cell.m_level.getPointer()) continue;
         cell.m_level = xl;
         xsh->setCell(r, *i, cell);

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -332,7 +332,7 @@ bool beforeCellsInsert(TXsheet *xsh, int row, int &col, int rowCount,
   int i              = 0;
   TXshColumn *column = xsh->getColumn(col);
 
-  for (i = 0; i < rowCount && (xsh->getCell(row + i, col, false).isEmpty());
+  for (i = 0; i < rowCount && (xsh->getCell(row + i, col, false, false).isEmpty());
        i++) {
   }
   int type = (column && !column->isEmpty()) ? column->getColumnType()
@@ -519,7 +519,7 @@ public:
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     for (c = m_col0; c <= m_col1; c++)
       for (r = m_row0; r <= m_row1; r++) {
-        TXshCell cell             = xsh->getCell(r, c, false);
+        TXshCell cell             = xsh->getCell(r, c, false, false);
         TXshSimpleLevel *oldLevel = cell.getSimpleLevel();
         TFrameId fid              = cell.getFrameId();
         QPair<int, int> cellId(r, c);

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -902,12 +902,12 @@ void LipSyncPopup::onApplyButton() {
   std::vector<TXshLevelP> previousLevels;
   for (int previousFrame = startFrame; previousFrame < lastFrame;
        previousFrame++) {
-    TXshCell cell = xsh->getCell(previousFrame, m_col, false);
+    TXshCell cell = xsh->getCell(previousFrame, m_col, false, false);
     previousFrameIds.push_back(cell.m_frameId);
     previousLevels.push_back(cell.m_level);
   }
   if (Preferences::instance()->isImplicitHoldEnabled()) {
-    TXshCell cell = xsh->getCell(lastFrame, m_col, false);
+    TXshCell cell = xsh->getCell(lastFrame, m_col, false, false);
     previousFrameIds.push_back(cell.m_frameId);
     previousLevels.push_back(cell.m_level);
   }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2287,6 +2287,8 @@ void MainWindow::defineActions() {
                         "inbetween_easeout");
   createMenuCellsAction(MI_InbetweenEaseInOut, QT_TR_NOOP("&Ease In/Out"), "",
                         "inbetween_easeinout");
+  createMenuCellsAction(MI_LoopFrames, QT_TR_NOOP("Loop Frames"), "", "");
+  createMenuCellsAction(MI_RemoveFrameLoop, QT_TR_NOOP("Remove Frame Loop"), "", "");
 
   // Menu - Play
 

--- a/toonz/sources/toonz/matchlinecommand.cpp
+++ b/toonz/sources/toonz/matchlinecommand.cpp
@@ -328,7 +328,7 @@ void doCloneLevelNoSave(const TCellSelection::Range &range,
 
     // OverwriteDialog* dialog = new OverwriteDialog();
     for (int r = range.m_r0; r <= range.m_r1; ++r) {
-      TXshCell cell = xsh->getCell(r, c, false);
+      TXshCell cell = xsh->getCell(r, c, false, false);
 
       fid = cell.getFrameId();
 
@@ -377,13 +377,13 @@ void doCloneLevelNoSave(const TCellSelection::Range &range,
       if (!fid.isStopFrame()) {
         int k;
         for (k = range.m_r0; k < r; k++) {
-          if (xsh->getCell(k, c, false).getImage(true).getPointer() ==
+          if (xsh->getCell(k, c, false, false).getImage(true).getPointer() ==
               img.getPointer()) {
-            TFrameId oldFid = xsh->getCell(k, c, false).getFrameId();
+            TFrameId oldFid = xsh->getCell(k, c, false, false).getFrameId();
             assert(fid == oldFid);
             sl->setFrame(
                 fid,
-                xsh->getCell(k, c + range.getColCount(), false).getImage(true));
+                xsh->getCell(k, c + range.getColCount(), false, false).getImage(true));
             break;
           }
         }

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -539,6 +539,8 @@ void TopBar::loadMenubar() {
   addMenuItem(cellsMenu, MI_Rolldown);
   addMenuItem(cellsMenu, MI_TimeStretch);
   addMenuItem(cellsMenu, MI_AutoInputCellNumber);
+  addMenuItem(cellsMenu, MI_LoopFrames);
+  addMenuItem(cellsMenu, MI_RemoveFrameLoop);
   cellsMenu->addSeparator();
   QMenu *drawingSubMenu = cellsMenu->addMenu(tr("Drawing Substitution"));
   {

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -547,4 +547,7 @@
 #define MI_InbetweenEaseIn "MI_InbetweenEaseIn"
 #define MI_InbetweenEaseOut "MI_InbetweenEaseOut"
 #define MI_InbetweenEaseInOut "MI_InbetweenEaseInOut"
+
+#define MI_LoopFrames "MI_LoopFrames"
+#define MI_RemoveFrameLoop "MI_RemoveFrameLoop"
 #endif

--- a/toonz/sources/toonz/timestretchpopup.cpp
+++ b/toonz/sources/toonz/timestretchpopup.cpp
@@ -68,7 +68,7 @@ public:
     TXsheetP xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     for (int c = c0; c <= c1; c++)
       for (int r = r0; r <= r1; r++) {
-        const TXshCell &cell = xsh->getCell(r, c, false);
+        const TXshCell &cell = xsh->getCell(r, c, false, false);
         m_cells[k++] = cell;
       }
   }

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -75,6 +75,16 @@ public:
     const TXshCell &cell = xsh->getCell(row, col);
 
     int frameCount = xsh->getFrameCount();
+    if (row >= frameCount - 1) {
+      if (xsh->getColumn(col)->isLoopedFrame(row)) {
+        std::pair<int, int> loop = xsh->getColumn(col)->getLoopForRow(row);
+        frameCount = row + (loop.second - loop.first + 1);
+      } else if (xsh->getColumn(col)->isInLoopRange(row)) {
+        std::pair<int, int> loop = xsh->getColumn(col)->getLoopWithRow(row);
+        frameCount = row + (loop.second - loop.first + 1);
+      }
+    }
+
     while (row < frameCount) {
       row++;
       if (xsh->getCell(row, col).isEmpty() ||

--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -107,7 +107,7 @@ void CellsMover::getImplicitCellInfo() {
       column->getRange(r0, r1);
       TXshCell currentCell;
       for (int r = r0; r <= r1 + 1; r++) {
-        TXshCell tmpCell = cellCol->getCell(r, false);
+        TXshCell tmpCell = cellCol->getCell(r, false, false);
         if (tmpCell != currentCell) {
           if (m_qualifiers & eCopyCells)
             cellInfo.insert(r, tmpCell);
@@ -208,7 +208,7 @@ void CellsMover::moveCells(const TPoint &pos) const {
           continue;
         }
         // a cell at the bottom of the inserted cells
-        TXshCell bottomCell = xsh->getCell(r + m_rowCount - 1, c + i, false);
+        TXshCell bottomCell = xsh->getCell(r + m_rowCount - 1, c + i, false, false);
         for (int tmp_r = r + m_rowCount; tmp_r <= itr.key() - 1 + m_rowCount;
              tmp_r++)
           if (Preferences::instance()->isImplicitHoldEnabled())
@@ -307,7 +307,7 @@ bool CellsMover::canMoveCells(const TPoint &pos) {
   int count = 0;
   for (int i = 0; i < m_colCount; i++) {
     for (int j = 0; j < m_rowCount; j++) {
-      if (!xsh->getCell(r + j, c + i, false).isEmpty()) return false;
+      if (!xsh->getCell(r + j, c + i, false, false).isEmpty()) return false;
       count++;
     }
   }

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -103,6 +103,7 @@ class CellArea final : public QWidget {
 
   bool m_dragBeginEase, m_dragEndEase, m_dragKeyframe;
   QPoint m_keyHighlight;
+  QPoint m_loopFrameMarkerHighlight;
 
   void drawCells(QPainter &p, const QRect toBeUpdated);
   void drawNonEmptyBackground(QPainter &p) const;
@@ -143,9 +144,10 @@ class CellArea final : public QWidget {
                        bool isKeyFrame = false, bool isCamera = false,
                        bool keyHighlight = false);
   void drawEndOfLevelMarker(QPainter &p, QRect rect, bool isNextEmpty,
-                            bool isStopFrame = false);
+                            bool isStopFrame = false, bool isLooped = false);
   void drawCellMarker(QPainter &p, int markId, QRect rect,
                       bool hasFrame = false, bool isNextEmpty = true);
+  void drawLoopFrameMarker(QPainter &p, int row, int col);
 
   // Restistusce true
   bool getEaseHandles(int r0, int r1, double e0, double e1, int &rh0, int &rh1);
@@ -156,6 +158,9 @@ class CellArea final : public QWidget {
   void setDragTool(DragTool *dragTool);
 
   void updateKeyHighlight(int row, int col);
+
+  bool isOverLoopFrameMarker(int row, int col, QPoint mouseInCell,
+                             QPoint frameAdj);
 
 public:
   CellArea(XsheetViewer *parent, Qt::WindowFlags flags = Qt::WindowFlags());

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -4021,6 +4021,8 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       menu.addMenu(reframeSubMenu);
       menu.addAction(cmdManager->getAction(MI_AutoInputCellNumber));
       menu.addAction(cmdManager->getAction(MI_Autorenumber));
+      menu.addAction(cmdManager->getAction(MI_LoopFrames));
+      menu.addAction(cmdManager->getAction(MI_RemoveFrameLoop));
     }
 
     if (containsRasterLevel(m_viewer->getColumnSelection())) {

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -360,7 +360,7 @@ public:
 
     for (int c = 0; c != colsCount; ++c) {
       // Store cell
-      const TXshCell &cell = xsh->getCell(m_frame, c, false);
+      const TXshCell &cell = xsh->getCell(m_frame, c, false, false);
       m_cells[c] = cell;
 
       // Store stage object keyframes
@@ -736,7 +736,7 @@ SetGlobalStopframeUndo::SetGlobalStopframeUndo(int frame,
     TXshCellColumn *cellColumn = xshColumn->getCellColumn();
     if (!cellColumn || cellColumn->isEmpty()) continue;
 
-    TXshCell cell = cellColumn->getCell(m_frame, false);
+    TXshCell cell = cellColumn->getCell(m_frame, false, false);
     if (!cell.isEmpty()) continue;
 
     m_oldCells.push_back(std::make_pair(c, cell));
@@ -765,7 +765,7 @@ void SetGlobalStopframeUndo::redo() const {
 
     if (cell.isEmpty()) {  // Might have hit a stop frame
       for (int r = m_frame - 1; r >= 0; r--) {
-        cell = cellColumn->getCell(r, false);
+        cell = cellColumn->getCell(r, false, false);
         if (cell.isEmpty()) continue;
         break;
       }
@@ -870,7 +870,7 @@ RemoveGlobalStopframeUndo::RemoveGlobalStopframeUndo(
     TXshCellColumn *cellColumn = xshColumn->getCellColumn();
     if (!cellColumn || cellColumn->isEmpty()) continue;
 
-    TXshCell cell = cellColumn->getCell(m_frame, false);
+    TXshCell cell = cellColumn->getCell(m_frame, false, false);
     if (!cell.getFrameId().isStopFrame()) continue;
 
     m_oldCells.push_back(std::make_pair(c, cell));
@@ -894,7 +894,7 @@ void RemoveGlobalStopframeUndo::redo() const {
     TXshCellColumn *cellColumn = xshColumn->getCellColumn();
     if (!cellColumn || cellColumn->isEmpty()) continue;
 
-    TXshCell cell = cellColumn->getCell(m_frame, false);
+    TXshCell cell = cellColumn->getCell(m_frame, false, false);
     if (!cell.getFrameId().isStopFrame()) continue;
 
     cellColumn->clearCells(m_frame, 1);
@@ -955,7 +955,7 @@ public:
       tempCol = c;
       while (r <= m_range.m_r1 + 1) {
         tempRow = r;
-        if (xsh->getCell(tempRow, tempCol, false).isEmpty())
+        if (xsh->getCell(tempRow, tempCol, false, false).isEmpty())
           emptyCells.push_back(std::make_pair(tempRow, tempCol));
         r++;
       }

--- a/toonz/sources/toonz/xsheetdragtool.h
+++ b/toonz/sources/toonz/xsheetdragtool.h
@@ -72,6 +72,9 @@ public:
   static DragTool *makeVolumeDragTool(XsheetViewer *viewer);
 
   static DragTool *makeNavigationTagDragTool(XsheetViewer *viewer);
+
+  static DragTool *makeLoopFrameMarkerMoverTool(XsheetViewer *viewer,
+                                                bool isStart);
 };
 
 void setPlayRange(int r0, int r1, int step, bool withUndo = true);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1009,13 +1009,19 @@ QRect XsheetViewer::rangeToXYRect(const CellRange &range) const {
 void XsheetViewer::drawPredefinedPath(QPainter &p, PredefinedPath which,
                                       const CellPosition &pos,
                                       optional<QColor> fill,
-                                      optional<QColor> outline) const {
+                                      optional<QColor> outline,
+                                      int lineWidth) const {
   QPoint xy         = positionToXY(pos);
   QPainterPath path = orientation()->path(which).translated(xy);
   if (fill) p.fillPath(path, QBrush(*fill));
   if (outline) {
-    p.setPen(*outline);
+    QPen oldPen = p.pen();
+    QPen newPen = oldPen;
+    newPen.setColor(*outline);
+    newPen.setWidth(lineWidth);
+    p.setPen(newPen);
     p.drawPath(path);
+    p.setPen(oldPen);
   }
 }
 
@@ -1023,12 +1029,18 @@ void XsheetViewer::drawPredefinedPath(QPainter &p, PredefinedPath which,
 
 void XsheetViewer::drawPredefinedPath(QPainter &p, PredefinedPath which,
                                       QPoint xy, optional<QColor> fill,
-                                      optional<QColor> outline) const {
+                                      optional<QColor> outline,
+                                      int lineWidth) const {
   QPainterPath path = orientation()->path(which).translated(xy);
   if (fill) p.fillPath(path, QBrush(*fill));
   if (outline) {
-    p.setPen(*outline);
+    QPen oldPen = p.pen();
+    QPen newPen = oldPen;
+    newPen.setColor(*outline);
+    newPen.setWidth(lineWidth);
+    p.setPen(newPen);
     p.drawPath(path);
+    p.setPen(oldPen);
   }
 }
 

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -763,11 +763,11 @@ public:
 
   void drawPredefinedPath(QPainter &p, PredefinedPath which,
                           const CellPosition &pos, optional<QColor> fill,
-                          optional<QColor> outline) const;
+                          optional<QColor> outline, int lineWidth = 1) const;
 
   void drawPredefinedPath(QPainter &p, PredefinedPath which, QPoint xy,
-                          optional<QColor> fill,
-                          optional<QColor> outline) const;
+                          optional<QColor> fill, optional<QColor> outline,
+                          int lineWidth = 1) const;
 
   //---------
 

--- a/toonz/sources/toonzlib/multimediarenderer.cpp
+++ b/toonz/sources/toonzlib/multimediarenderer.cpp
@@ -191,8 +191,8 @@ bool MultimediaRenderer::Imp::hasKeyDrawing(TFx *fx, int row) {
     TXshCellColumn *celCol = col->getCellColumn();
     if (!celCol) return false;
 
-    TXshCell cell     = celCol->getCell(row, false);
-    TXshCell prevCell = row > 0 ? celCol->getCell(row - 1, false) : TXshCell();
+    TXshCell cell     = celCol->getCell(row, false, false);
+    TXshCell prevCell = row > 0 ? celCol->getCell(row - 1, false, false) : TXshCell();
 
     if (cell.isEmpty() || cell.getFrameId().isStopFrame() || cell == prevCell)
       return false;

--- a/toonz/sources/toonzlib/onionskinmask.cpp
+++ b/toonz/sources/toonzlib/onionskinmask.cpp
@@ -102,9 +102,10 @@ void OnionSkinMask::getAll(int currentRow,
     // Translate relative drawing position to frame drawing position
     int r0, r1;
     int n = xsh->getCellRange(col, r0, r1);
+    if (currentRow > n) n = currentRow + 1;
     std::vector<TXshCell> cells(n);
     bool useImplicit = Preferences::instance()->isImplicitHoldEnabled();
-    xsh->getCells(r0, col, n, &cells[0]);
+    xsh->getCells(r0, col, n, &cells[0], false, true);
     TXshCell startCell = xsh->getCell(currentRow, col);
     for (; dosIt != dosEnd;) {
       int r             = currentRow - r0;
@@ -411,7 +412,7 @@ int OnionSkinMask::getFrameIdxFromRos(int ros, TXsheet *xsh, int row, int col) {
 
   if (ros < 0) {
     std::vector<TXshCell> prevCells(row - r0 + 1);
-    xsh->getCells(r0, col, prevCells.size(), &(prevCells[0]));
+    xsh->getCells(r0, col, prevCells.size(), &(prevCells[0]), false, true);
     TXshCell lastCell;
     for (int x = prevCells.size() - 2; x >= 0; x--) {
       if (prevCells[x].isEmpty() || prevCells[x].getFrameId().isStopFrame() ||
@@ -423,7 +424,7 @@ int OnionSkinMask::getFrameIdxFromRos(int ros, TXsheet *xsh, int row, int col) {
     }
   } else if (ros > 0) {
     std::vector<TXshCell> nextCells(r1 - row + 1);
-    xsh->getCells(row, col, nextCells.size(), &(nextCells[0]));
+    xsh->getCells(row, col, nextCells.size(), &(nextCells[0]), false, true);
     TXshCell lastCell = nextCells[0];
     for (int x = 1; x < nextCells.size(); x++) {
       if (nextCells[x].isEmpty() || nextCells[x].getFrameId().isStopFrame() ||

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -463,6 +463,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
       QRect((FRAME_HEADER_WIDTH - NAV_TAG_HEIGHT) / 2,
             (CELL_HEIGHT - NAV_TAG_WIDTH) / 2, NAV_TAG_HEIGHT, NAV_TAG_WIDTH));
 
+  addRect(PredefinedRect::LOOP_START_MARKER_AREA,
+          QRect(1, 1, CELL_WIDTH - 2, 5));
+  addRect(PredefinedRect::LOOP_END_MARKER_AREA,
+          QRect(1, -1, CELL_WIDTH - 2, 5)
+              .adjusted(0, CELL_HEIGHT - 5, 0, CELL_HEIGHT - 5));
+
   // Column viewer
   addRect(PredefinedRect::LAYER_HEADER,
           QRect(0, 1, CELL_WIDTH, use_header_height - 3));
@@ -1177,6 +1183,18 @@ TopToBottomOrientation::TopToBottomOrientation() {
   tag.lineTo(QPointF(0, -3));
   addPath(PredefinedPath::NAVIGATION_TAG, tag);
 
+  QPainterPath loopStart(QPointF(0, 5));
+  loopStart.lineTo(QPointF(0, 0));
+  loopStart.lineTo(QPointF(CELL_WIDTH - 2, 0));
+  loopStart.lineTo(QPointF(CELL_WIDTH - 2, 5));
+  addPath(PredefinedPath::LOOP_START_MARKER, loopStart);
+
+  QPainterPath loopEnd(QPointF(0, 0));
+  loopEnd.lineTo(QPointF(0, 5));
+  loopEnd.lineTo(QPointF(CELL_WIDTH - 2, 5));
+  loopEnd.lineTo(QPointF(CELL_WIDTH - 2, 0));
+  addPath(PredefinedPath::LOOP_END_MARKER, loopEnd);
+
   //
   // Points
   //
@@ -1410,6 +1428,12 @@ LeftToRightOrientation::LeftToRightOrientation(QString layout) {
           QRect((CELL_WIDTH - NAV_TAG_WIDTH) / 2,
                 (FRAME_HEADER_HEIGHT - NAV_TAG_HEIGHT) / 2, NAV_TAG_WIDTH,
                 NAV_TAG_HEIGHT));
+
+  addRect(PredefinedRect::LOOP_START_MARKER_AREA,
+          QRect(1, 1, 5, CELL_HEIGHT - 2));
+  addRect(PredefinedRect::LOOP_END_MARKER_AREA,
+          QRect(-1, 1, 5, CELL_HEIGHT - 2)
+              .adjusted(CELL_WIDTH - 5, 0, CELL_WIDTH - 5, 0));
 
   // Column viewer
   addRect(PredefinedRect::LAYER_HEADER,
@@ -1688,6 +1712,18 @@ LeftToRightOrientation::LeftToRightOrientation(QString layout) {
   tag.lineTo(QPointF(-3, 9));
   tag.lineTo(QPointF(-3, 0));
   addPath(PredefinedPath::NAVIGATION_TAG, tag);
+
+  QPainterPath loopStart(QPointF(5, CELL_HEIGHT - 2));
+  loopStart.lineTo(QPointF(0, CELL_HEIGHT - 2));
+  loopStart.lineTo(QPointF(0, 1));
+  loopStart.lineTo(QPointF(5, 1));
+  addPath(PredefinedPath::LOOP_START_MARKER, loopStart);
+
+  QPainterPath loopEnd(QPointF(0, CELL_HEIGHT - 2));
+  loopEnd.lineTo(QPointF(5, CELL_HEIGHT - 2));
+  loopEnd.lineTo(QPointF(5, 1));
+  loopEnd.lineTo(QPointF(0, 1));
+  addPath(PredefinedPath::LOOP_END_MARKER, loopEnd);
 
   //
   // Points

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -137,6 +137,7 @@ const TXshCell &TXshCellColumn::getCell(int row, bool implicitLookup,
           if (adjustedRow < 0) adjustedRow += totalFrames;
           r = (adjustedRow % totalFrames) + r0 - m_first;
           if (r < 0) return emptyCell;
+          if (r >= m_cells.size()) r = m_cells.size() - 1;
           if (!m_cells[r].isEmpty()) return m_cells[r];
         }
       }

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -255,7 +255,7 @@ void TXshCellColumn::getCells(int row, int rowCount, TXshCell cells[],
   }
   endDstCell = cells + rowCount;
   while (dstCell < endDstCell) {
-    if(loopsAvailable && isLoopedFrame(src)) {
+    if (loopsAvailable && isLoopedFrame(src + m_first)) {
       int i = getLoopedFrame(src + m_first) - m_first;
       TXshCell cell = i >= m_cells.size() ? emptyCell: m_cells[i];
       *dstCell++    = cell;

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -53,8 +53,8 @@ int TXshCellColumn::getRange(int &r0, int &r1, bool ignoreLastStop) const {
   for (i = cellCount - 1; i >= 0 && m_cells[i].isEmpty(); i--) {
   }
   r1 = m_first + i;
-  if (r1 < m_cells.size() && r1 > r0 && ignoreLastStop &&
-      m_cells[r1].getFrameId().isStopFrame())
+  if (r1 > r0 && ignoreLastStop &&
+      m_cells[cellCount - 1].getFrameId().isStopFrame())
     r1--;
   return r1 - r0 + 1;
 }
@@ -84,8 +84,8 @@ int TXshCellColumn::getMaxFrame(bool ignoreLastStop) const {
 int TXshCellColumn::getFirstRow() const { return m_first; }
 
 //-----------------------------------------------------------------------------
-
-const TXshCell &TXshCellColumn::getCell(int row, bool implicitLookup) const {
+const TXshCell &TXshCellColumn::getCell(int row, bool implicitLookup,
+                                        bool loopedLookup) const {
   static TXshCell emptyCell;
 
   if (row < 0 || row < m_first || !m_cells.size()) return emptyCell;
@@ -95,21 +95,61 @@ const TXshCell &TXshCellColumn::getCell(int row, bool implicitLookup) const {
                          getColumnType() != ColumnType::eSoundTextType &&
                          getColumnType() != ColumnType::eSoundType;
 
-  int r = row - m_first;
+  bool loopsAvailable = loopedLookup && hasLoops();
 
-  if (r >= m_cells.size()) {
-    if (!implicitEnabled) return emptyCell;
+  int r        = row - m_first;
+  bool pastEnd = r >= m_cells.size();
+  if (pastEnd) {
+    if (!implicitEnabled && !loopsAvailable) return emptyCell;
     r = m_cells.size() - 1;
-    if (m_cells[r].getFrameId().isStopFrame()) return emptyCell;
+    if (implicitEnabled && m_cells[r].getFrameId().isStopFrame())
+      return emptyCell;
   }
 
-  if (m_cells[r].isEmpty() && implicitEnabled) {
-    for (; r >= 0; r--) {
-      if (m_cells[r].isEmpty()) continue;
-      if (m_cells[r].getFrameId().isStopFrame()) return emptyCell;
-      break;
+  if (m_cells[r].isEmpty() || pastEnd) {
+    if (loopsAvailable) {
+      int loopIndex = -1;
+      QList<std::pair<int, int>> loops = getLoops();
+      for (int i = 0; i < loops.size(); i++) {
+        // Not a loop frame if within a loop range
+        if (row >= loops.at(i).first && row <= loops.at(i).second) break;
+        // Find the preceeding loop closest to the row
+        if (row > loops.at(i).second &&
+            (loopIndex < 0 || loops.at(i).second > loops.at(loopIndex).second))
+          loopIndex = i;
+      }
+
+      if (loopIndex != -1) {
+        int r0 = getLoops().at(loopIndex).first;
+        int r1 = getLoops().at(loopIndex).second;
+
+        // Check between end of loop range and current row to see if it truely
+        // is a looped frame.
+        for (int r2 = row - 1; r2 > r1; r2--) {
+          int adjR = r2 - m_first;
+          if (adjR >= m_cells.size()) continue;
+          if (!m_cells[adjR].isEmpty()) r0 = r1 = -1;
+        }
+
+        if (r1 >= 0 && row >= r0) {
+          int totalFrames = r1 - r0 + 1;
+          int adjustedRow = row - r0;
+          if (adjustedRow < 0) adjustedRow += totalFrames;
+          r = (adjustedRow % totalFrames) + r0 - m_first;
+          if (r < 0) return emptyCell;
+          if (!m_cells[r].isEmpty()) return m_cells[r];
+        }
+      }
     }
-    if (r < 0) return emptyCell;
+
+    if (implicitEnabled) {
+      for (; r >= 0; r--) {
+        if (m_cells[r].isEmpty()) continue;
+        if (m_cells[r].getFrameId().isStopFrame()) return emptyCell;
+        break;
+      }
+      if (r < 0) return emptyCell;
+    } 
   }
 
   return m_cells[r];
@@ -127,8 +167,13 @@ bool TXshCellColumn::isCellImplicit(int row) const {
   if (!Preferences::instance()->isImplicitHoldEnabled() ||
       getColumnType() == ColumnType::eSoundType ||
       getColumnType() == ColumnType::eSoundTextType || row < 0 ||
-      row < m_first || getCell(row).isEmpty())
+      row < m_first || getCell(row).isEmpty() ||
+      getCell(row).getFrameId().isStopFrame())
     return false;
+
+  if (row > 0 && hasLoops() &&
+      getCell(row - 1, false, true) == getCell(row, false, true))
+    return true;
 
   // If we got here, the cell is technically not empty
   // If it is truely empty in the array, then it is implicit
@@ -164,7 +209,7 @@ void TXshCellColumn::checkColumn() const {
 //-----------------------------------------------------------------------------
 
 void TXshCellColumn::getCells(int row, int rowCount, TXshCell cells[],
-                              bool implicitLookup) {
+                              bool implicitLookup, bool loopedLookup) {
   const TXshCell emptyCell;
   int first = m_first;
   int i;
@@ -173,6 +218,8 @@ void TXshCellColumn::getCells(int row, int rowCount, TXshCell cells[],
     for (i = 0; i < rowCount; i++) cells[i] = emptyCell;
     return;
   }
+
+  bool loopsAvailable = loopedLookup && hasLoops();
 
   int dst, src, n, delta;
   n     = rowCount;
@@ -193,10 +240,11 @@ void TXshCellColumn::getCells(int row, int rowCount, TXshCell cells[],
   endDstCell += n;
   TXshCell tmpCell;
   while (dstCell < endDstCell) {
-    TXshCell cell = m_cells[src];
+    int i = !loopsAvailable ? src : (getLoopedFrame(src + m_first) - m_first);
+
+    TXshCell cell = m_cells[i];
     if (implicitLookup) {
-      if (cell.isEmpty() && src > 0 &&
-          !tmpCell.isEmpty()) {
+      if (cell.isEmpty() && i > 0 && !tmpCell.isEmpty()) {
         cell = tmpCell;
       } else if (!cell.getFrameId().isStopFrame())
         tmpCell = cell;
@@ -206,11 +254,20 @@ void TXshCellColumn::getCells(int row, int rowCount, TXshCell cells[],
   }
   endDstCell = cells + rowCount;
   while (dstCell < endDstCell) {
+    if(loopsAvailable && isLoopedFrame(src)) {
+      int i = getLoopedFrame(src + m_first) - m_first;
+      TXshCell cell = i >= m_cells.size() ? emptyCell: m_cells[i];
+      *dstCell++    = cell;
+      src++;
+      continue;
+    }
+
     TXshCell cell = m_cells[cellCount - 1];
     if (implicitLookup && !cell.getFrameId().isStopFrame())
       *dstCell++ = cell;
     else
       *dstCell++ = emptyCell;
+    src++;
   }
 }
 
@@ -265,6 +322,7 @@ bool TXshCellColumn::setCell(int row, const TXshCell &cell) {
   //"[r0,r1]"
   int index = row - m_first;
   assert(0 <= index && index < (int)m_cells.size());
+
   m_cells[index] = cell;
   // if(index == 0) updateIcon();
   if (cell.isEmpty()) {
@@ -1041,4 +1099,170 @@ void TXshColumn::saveFolderInfo(TOStream &os) {
   os.openChild("folderIds");
   for (int i = 0; i < m_folderId.size(); i++) os << m_folderId[i];
   os.closeChild();  // folderIds
+}
+
+//-----------------------------------------------------------------------------
+
+std::pair<int, int> TXshColumn::getLoopForRow(int row) {
+  if (!hasLoops()) return std::pair<int, int>(-1, -1);
+
+  int loopIndex = -1;
+  for (int i = 0; i < m_loops.size(); i++) {
+    if (row >= m_loops.at(i).first && row <= m_loops.at(i).second) continue;
+    // Find the preceeding loop closest to the row
+    if (row > m_loops.at(i).second &&
+        (loopIndex < 0 || m_loops.at(i).second > m_loops.at(loopIndex).second))
+      loopIndex = i;
+  }
+
+  // Not a loop frame if it's before all loops
+  if (loopIndex != -1) return m_loops.at(loopIndex);
+
+  return std::pair<int, int>(-1, -1);
+}
+
+//-----------------------------------------------------------------------------
+
+std::pair<int, int> TXshColumn::getLoopWithRow(int row) {
+  if (!hasLoops()) return std::pair<int, int>(-1, -1);
+
+  for (int i = 0; i < m_loops.size(); i++) {
+    if (row >= m_loops.at(i).first && row <= m_loops.at(i).second)
+      return m_loops.at(i);
+  }
+
+  return std::pair<int, int>(-1, -1);
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::isInLoopRange(int row) {
+  if (!hasLoops()) return false;
+
+  for (int i = 0; i < m_loops.size(); i++) {
+    if (row >= m_loops.at(i).first && row <= m_loops.at(i).second) return true;
+  }
+
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::isLoopedFrame(int row) {
+  if (!hasLoops()) return false;
+
+  TXshCellColumn *cellColumn = getCellColumn();
+  if (cellColumn) {
+    // Not a loop frame if it is real
+    TXshCell cell = cellColumn->getCell(row, false, false);
+    if (!cell.isEmpty()) return false;
+  }
+  int loopIndex = -1;
+  for (int i = 0; i < m_loops.size(); i++) {
+    // Not a loop frame if within a loop range
+    if (row >= m_loops.at(i).first && row <= m_loops.at(i).second) return false;
+    // Find the preceeding loop closest to the row
+    if (row > m_loops.at(i).second &&
+        (loopIndex < 0 || m_loops.at(i).second > m_loops.at(loopIndex).second))
+      loopIndex = i;
+  }
+
+  // Not a loop frame if it's before all loops
+  if (loopIndex == -1) return false;
+
+  // Check between end of loop range and current row to see if it truely is a
+  // looped frame.
+  if (cellColumn) {
+    for (int r = row - 1; r > m_loops.at(loopIndex).second; r--) {
+      TXshCell cell = cellColumn->getCell(r, false, false);
+      if (!cell.isEmpty()) return false;
+    }
+  }
+
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+int TXshColumn::getLoopedFrame(int row, bool forOnionSkin) {
+  if (!hasLoops()) return row;
+
+  TXshCellColumn *cellColumn = getCellColumn();
+  if (cellColumn) {
+    // Not a loop frame if it is real
+    TXshCell cell = cellColumn->getCell(row, false, false);
+    if (!cell.isEmpty()) return row;
+  }
+
+  int loopIndex = -1;
+  for (int i = 0; i < m_loops.size(); i++) {
+    // Not a loop frame if withing a loop range
+    if (row >= m_loops.at(i).first && row <= m_loops.at(i).second) return row;
+    // Find the preceeding loop closest to the row
+    if (row > m_loops.at(i).second &&
+        (loopIndex < 0 || m_loops.at(i).second > m_loops.at(loopIndex).second))
+      loopIndex = i;
+  }
+
+  // Not a loop frame if it's before all loops
+  if (loopIndex == -1) return row;
+
+  int r0 = m_loops.at(loopIndex).first;
+  int r1 = m_loops.at(loopIndex).second;
+
+  if (cellColumn) {
+    // Check between end of loop range and current row to see if it truely is a
+    // looped frame.  A stop frame between it prevents that from happening
+    for (int r = row - 1; r > r1; r--) {
+      TXshCell cell = cellColumn->getCell(r, false, false);
+      if (!cell.isEmpty()) return row;
+    }
+  }
+
+  if (r1 < 0 || (!forOnionSkin && row < r0)) return row;
+
+  int totalFrames = r1 - r0 + 1;
+  int adjustedRow = row - r0;
+  if (adjustedRow < 0) adjustedRow += totalFrames;
+
+  int loopedRow = (adjustedRow % totalFrames) + r0;
+  return loopedRow;
+}
+
+//-----------------------------------------------------------------------------
+
+TXshCell TXshColumn::getLoopedCell(int row, bool forOnionSkin,
+                                   bool implicitLookup) {
+  TXshCellColumn *cellColumn = getCellColumn();
+  if (!cellColumn) return TXshCell();
+
+  int loopedRow = getLoopedFrame(row, forOnionSkin);
+
+  if (loopedRow < 0) return TXshCell();
+
+  return cellColumn->getCell(loopedRow, implicitLookup);
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshColumn::loadLoopInfo(std::string tagName, TIStream &is) {
+  if (tagName != "loops") return false;
+  m_loops.clear();
+  while (!is.eos()) {
+    int startFrame, endFrame;
+    is >> startFrame >> endFrame;
+    m_loops.push_back(std::pair<int, int>(startFrame, endFrame));
+  }
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshColumn::saveLoopInfo(TOStream &os) {
+  if (m_loops.isEmpty()) return;
+
+  os.openChild("loops");
+  for (int i = 0; i < m_loops.size(); i++)
+    os << m_loops[i].first << m_loops[i].second;
+  os.closeChild();  // loops
 }

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -90,6 +90,7 @@ TXshColumn *TXshLevelColumn::clone() const {
   column->setColorTag(getColorTag());
   column->setColorFilterId(getColorFilterId());
   column->setFolderIdStack(getFolderIdStack());
+  column->setLoops(getLoops());
 
   // column->updateIcon();
   return column;

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -159,6 +159,8 @@ void TXshLevelColumn::loadData(TIStream &is) {
       // do nothing
     } else if (loadFolderInfo(tagName, is)) {
       // do nothing
+    } else if (loadLoopInfo(tagName, is)) {
+      // do nothing
     } else
       throw TException("TXshLevelColumn, unknown tag: " + tagName);
     is.closeChild();
@@ -176,14 +178,14 @@ void TXshLevelColumn::saveData(TOStream &os) {
   if (getRange(r0, r1)) {
     os.openChild("cells");
     for (int r = r0; r <= r1; r++) {
-      TXshCell cell = getCell(r, false);
+      TXshCell cell = getCell(r, false, false);
       if (cell.isEmpty()) continue;
       TFrameId fid = cell.m_frameId;
       int n = 1, inc = 0, dr = fid.getNumber();
       // If fid has not letter save more than one cell and its incrementation;
       // otherwise save one cell.
       if (r < r1 && fid.getLetter().isEmpty()) {
-        TXshCell cell2 = getCell(r + 1, false);
+        TXshCell cell2 = getCell(r + 1, false, false);
         TFrameId fid2  = cell2.m_frameId;
         if (cell2.m_level.getPointer() == cell.m_level.getPointer() &&
             fid2.getLetter().isEmpty()) {
@@ -191,7 +193,7 @@ void TXshLevelColumn::saveData(TOStream &os) {
           n++;
           for (;;) {
             if (r + n > r1) break;
-            cell2         = getCell(r + n, false);
+            cell2         = getCell(r + n, false, false);
             TFrameId fid2 = cell2.m_frameId;
             if (cell2.m_level.getPointer() != cell.m_level.getPointer() ||
                 !fid2.getLetter().isEmpty())
@@ -213,6 +215,8 @@ void TXshLevelColumn::saveData(TOStream &os) {
   saveCellMarks(os);
   // folder info
   saveFolderInfo(os);
+  // Loop info
+  saveLoopInfo(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -77,7 +77,7 @@ void TXshMeshColumn::saveData(TOStream &os) {
     os.openChild("cells");
     {
       for (int r = r0; r <= r1; ++r) {
-        TXshCell cell = getCell(r, false);
+        TXshCell cell = getCell(r, false, false);
         if (cell.isEmpty()) continue;
 
         TFrameId fid = cell.m_frameId;
@@ -86,7 +86,7 @@ void TXshMeshColumn::saveData(TOStream &os) {
         // If fid has no letter save more than one cell and its increment -
         // otherwise save just one cell
         if (r < r1 && fid.getLetter().isEmpty()) {
-          TXshCell cell2 = getCell(r + 1, false);
+          TXshCell cell2 = getCell(r + 1, false, false);
           TFrameId fid2  = cell2.m_frameId;
 
           if (cell2.m_level.getPointer() == cell.m_level.getPointer() &&
@@ -95,7 +95,7 @@ void TXshMeshColumn::saveData(TOStream &os) {
             for (++n;; ++n) {
               if (r + n > r1) break;
 
-              cell2         = getCell(r + n, false);
+              cell2         = getCell(r + n, false, false);
               TFrameId fid2 = cell2.m_frameId;
 
               if (cell2.m_level.getPointer() != cell.m_level.getPointer() ||
@@ -118,6 +118,8 @@ void TXshMeshColumn::saveData(TOStream &os) {
   saveCellMarks(os);
   // folder info
   saveFolderInfo(os);
+  // Loop info
+  saveLoopInfo(os);
 }
 
 //------------------------------------------------------------------
@@ -178,6 +180,8 @@ void TXshMeshColumn::loadData(TIStream &is) {
     } else if (loadCellMarks(tagName, is)) {
       is.closeChild();
     } else if (loadFolderInfo(tagName, is)) {
+      is.closeChild();
+    } else if (loadLoopInfo(tagName, is)) {
       is.closeChild();
     } else
       is.skipCurrentTag();

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -55,6 +55,7 @@ TXshColumn *TXshMeshColumn::clone() const {
   column->setColorTag(getColorTag());
   column->setColorFilterId(getColorFilterId());
   column->setFolderIdStack(getFolderIdStack());
+  column->setLoops(getLoops());
 
   return column;
 }

--- a/toonz/sources/toonzlib/txshpalettecolumn.cpp
+++ b/toonz/sources/toonzlib/txshpalettecolumn.cpp
@@ -78,6 +78,8 @@ void TXshPaletteColumn::loadData(TIStream &is) {
       // do nothing
     } else if (loadFolderInfo(tagName, is)) {
       // do nothing
+    } else if (loadLoopInfo(tagName, is)) {
+      // do nothing
     } else {
       throw TException("TXshPaletteColumn, unknown tag: " + tagName);
     }
@@ -89,17 +91,17 @@ void TXshPaletteColumn::saveData(TOStream &os) {
   if (getRange(r0, r1)) {
     os.openChild("cells");
     for (int r = r0; r <= r1; r++) {
-      TXshCell cell = getCell(r, false);
+      TXshCell cell = getCell(r, false, false);
       if (cell.isEmpty()) continue;
       int n = 1, inc = 0, dr = cell.m_frameId.getNumber();
       if (r < r1) {
-        TXshCell cell2 = getCell(r + 1, false);
+        TXshCell cell2 = getCell(r + 1, false, false);
         if (cell2.m_level.getPointer() == cell.m_level.getPointer()) {
           inc = cell2.m_frameId.getNumber() - dr;
           n++;
           for (;;) {
             if (r + n > r1) break;
-            cell2 = getCell(r + n, false);
+            cell2 = getCell(r + n, false, false);
             if (cell2.m_level.getPointer() != cell.m_level.getPointer()) break;
             if (cell2.m_frameId.getNumber() != dr + n * inc) break;
             n++;
@@ -117,6 +119,8 @@ void TXshPaletteColumn::saveData(TOStream &os) {
   saveCellMarks(os);
   // folder info
   saveFolderInfo(os);
+  // Loop info
+  saveLoopInfo(os);
 }
 
 PERSIST_IDENTIFIER(TXshPaletteColumn, "paletteColumn")

--- a/toonz/sources/toonzlib/txshpalettecolumn.cpp
+++ b/toonz/sources/toonzlib/txshpalettecolumn.cpp
@@ -27,6 +27,7 @@ TXshColumn *TXshPaletteColumn::clone() const {
   column->m_cells = m_cells;
   column->m_first = m_first;
   column->setFolderIdStack(getFolderIdStack());
+  column->setLoops(getLoops());
 
   // column->updateIcon();
   return column;

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -323,7 +323,8 @@ int TXshSoundColumn::getFirstRow() const {
 
 //-----------------------------------------------------------------------------
 
-const TXshCell &TXshSoundColumn::getCell(int row, bool implicitLookup) const {
+const TXshCell &TXshSoundColumn::getCell(int row, bool implicitLookup,
+                                         bool loopedLookup) const {
   static TXshCell emptyCell;
 
   ColumnLevel *l = getColumnLevelByFrame(row);
@@ -399,7 +400,7 @@ void TXshSoundColumn::checkColumn() const {
 //-----------------------------------------------------------------------------
 
 void TXshSoundColumn::getCells(int row, int rowCount, TXshCell cells[],
-                               bool implicitLookup) {
+                               bool implicitLookup, bool loopedLookup) {
   // le celle da settare sono [ra, rb]
   int ra = row;
   int rb = row + rowCount - 1;

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -183,6 +183,8 @@ void TXshZeraryFxColumn::loadData(TIStream &is) {
       // do nothing
     } else if (loadFolderInfo(tagName, is)) {
       // do nothing
+    } else if (loadLoopInfo(tagName, is)) {
+      // do nothing
     } else
       throw TException("expected <status> or <cells>");
     is.closeChild();
@@ -198,14 +200,14 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
   if (getRange(r0, r1)) {
     os.openChild("cells");
     for (int r = r0; r <= r1; r++) {
-      TXshCell cell = getCell(r, false);
+      TXshCell cell = getCell(r, false, false);
       if (cell.isEmpty()) continue;
       int fnum           = cell.m_frameId.getNumber();
       if (fnum > 1) fnum = 1;  // Should always be 1 unless it's stopframe
       int n              = 1;
 
       if (r < r1) {
-        TXshCell cell2 = getCell(r + 1, false);
+        TXshCell cell2 = getCell(r + 1, false, false);
         if (!cell2.isEmpty()) {
           int fnum2            = cell2.m_frameId.getNumber();
           if (fnum2 > 1) fnum2 = 1;  // Should always be 1 unless it's stopframe
@@ -213,7 +215,7 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
             n++;
             for (;;) {
               if (r + n > r1) break;
-              cell2 = getCell(r + n, false);
+              cell2 = getCell(r + n, false, false);
               if (cell2.isEmpty()) break;
               fnum2 = cell2.m_frameId.getNumber();
               if (fnum2 > 1)
@@ -237,6 +239,8 @@ void TXshZeraryFxColumn::saveData(TOStream &os) {
   saveCellMarks(os);
   // folder info
   saveFolderInfo(os);
+  // Loop info
+  saveLoopInfo(os);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -81,6 +81,7 @@ bool TXshZeraryFxColumn::canSetCell(const TXshCell &cell) const {
 TXshColumn *TXshZeraryFxColumn::clone() const {
   TXshZeraryFxColumn *column = new TXshZeraryFxColumn(*this);
   column->setFolderIdStack(getFolderIdStack());
+  column->setLoops(getLoops());
   return column;
 }
 


### PR DESCRIPTION
This new feature allows you to select 2 or more frames to implicitly and repeatedly loop the sequence on the timeline/xsheet.

The new actions, `Loop Frames` and `Remove Frame Loop`, can be found in the main `Cell` dropdown menu as well as the cell context menu. They can be assigned shortcuts.

![image](https://github.com/user-attachments/assets/da7810ae-bc38-4e48-8f68-03a112ab0f99)

Behavior
- Looping frames works whether you are using Implicit Holds or not.
- Looped frames will be implicitly looped until either a stop frame or an exposed frame is encountered.
- A looped selection is based on the scene frames they are initially set at and do not move with frame selections or frame movements.
- You can have multiple looped selections in the same column/layer but they cannot be overlapped or nested.
- Looped frames cannot be set on Sound, Note Text or Folder columns.
- Your selection can include multiple columns as targets for these actions.
- Most Cell commands will treat looped frames as empty frames.  Some Cell/Level commands may treat looped frames as real frames.

Display
- A looped selection is denoted by loop frame markers (brackets) on the start and end frames on the timeline/xsheet.
- Implicitly looped frames are uncolored (vs tinted for implicit holds) but will show frame numbers and stop frames that are looped.

Changing loop frames
- You can click and drag either end of the loop frame markers to expand/shrink the looped sequence.
- `Shift` + drag of either loop frame marker will shift both frame markers at the same time in the same direction
- `Alt` + drag of either loop frame marker will  shift both frame markers at the same time in opposite directions

Removing loops
- Select any frame within a looped selection and choose `Remove Frame Loop` to delete that loop.
- Can delete multiple loop selections, even across multiple columns, by ensuring your selection includes at least 1 frame in that loop.

Column looping
- In addition to the locations mention above, the `Loop Frames` and `Remove Frame Loop` actions can be found in the column context menu.
- You can select 1 or more columns as targets for these actions.
- Looping columns in this manner will define the sequence at the 1st expose frame and end at the last exposed frame.
