### PR TITLE
Rhubarb Recognizer option

### DIFF
--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -241,6 +241,14 @@ LipSyncPopup::LipSyncPopup()
   m_startAt     = new DVGui::IntLineEdit(this, 0);
   m_restToEnd   = new QCheckBox(tr("Extend Rest Drawing to End Marker"), this);
 
+  m_recognizerLabel = new QLabel(tr("Recognizer"));
+  m_recognizer      = new QComboBox(this);
+  m_recognizer->addItem("PocketSphinx (English)");
+  m_recognizer->addItem("Phonetic");
+
+  m_recognizerLabel->hide();
+  m_recognizer->hide();
+
   QImage placeHolder(160, 90, QImage::Format_ARGB32);
   placeHolder.fill(Qt::white);
 
@@ -449,10 +457,14 @@ LipSyncPopup::LipSyncPopup()
   QHBoxLayout *insertAtLay = new QHBoxLayout();
   insertAtLay->setContentsMargins(0, 0, 0, 0);
   insertAtLay->setSpacing(4);
+  // Only 1 of these should be active at any time
   m_insertAtLabel = new QLabel(tr("Insert at Frame: "));
   insertAtLay->addWidget(m_insertAtLabel);
   insertAtLay->addWidget(m_startAt);
+  insertAtLay->addWidget(m_recognizerLabel);
+  insertAtLay->addWidget(m_recognizer);
   insertAtLay->addStretch();
+
   optionsLay->addLayout(insertAtLay);
   optionsLay->addWidget(m_restToEnd);
   m_topLayout->addLayout(optionsLay);
@@ -501,15 +513,21 @@ void LipSyncPopup::setPage(int index) {
   if (index == 1) {
     m_insertAtLabel->show();
     m_startAt->show();
+    m_recognizerLabel->hide();
+    m_recognizer->hide();
   }
   else {
     if (m_soundLevels->currentIndex() < m_soundLevels->count() - 1) {
       m_insertAtLabel->hide();
       m_startAt->hide();
+      m_recognizerLabel->show();
+      m_recognizer->show();
     }
     else {
       m_insertAtLabel->show();
       m_startAt->show();
+      m_recognizerLabel->hide();
+      m_recognizer->hide();
     }
   }
 }
@@ -590,10 +608,14 @@ void LipSyncPopup::refreshSoundLevels() {
   if (m_soundLevels->currentIndex() < m_soundLevels->count() - 1) {
     m_insertAtLabel->hide();
     m_startAt->hide();
+    m_recognizerLabel->show();
+    m_recognizer->show();
   }
   else {
     m_insertAtLabel->show();
     m_startAt->show();
+    m_recognizerLabel->hide();
+    m_recognizer->hide();
   }
 }
 
@@ -739,6 +761,10 @@ void LipSyncPopup::runRhubarb() {
                                 ->getFrameRate());
   args << "--datFrameRate" << QString::number(frameRate) << "--machineReadable";
 
+  if (m_recognizer->currentText() == "Phonetic")
+    args << "-r"
+         << "phonetic";
+
   args << m_audioPath;
   m_progressDialog->show();
   connect(m_rhubarb, &QProcess::readyReadStandardError, this,
@@ -787,10 +813,14 @@ void LipSyncPopup::onLevelChanged(int index) {
   if (m_soundLevels->currentIndex() < m_soundLevels->count() - 1) {
     m_insertAtLabel->hide();
     m_startAt->hide();
+    m_recognizerLabel->show();
+    m_recognizer->show();
   }
   else {
     m_insertAtLabel->show();
     m_startAt->show();
+    m_recognizerLabel->hide();
+    m_recognizer->hide();
   }
 }
 

--- a/toonz/sources/toonz/lipsyncpopup.h
+++ b/toonz/sources/toonz/lipsyncpopup.h
@@ -84,6 +84,8 @@ class LipSyncPopup final : public DVGui::Dialog {
   QStackedWidget *m_stackedChooser;
   TabBarContainter *m_tabBarContainer;  //!< Tabs container for pages
   DVGui::TabBar *m_tabBar;
+  QLabel *m_recognizerLabel;
+  QComboBox *m_recognizer;
 
 public:
   LipSyncPopup();


### PR DESCRIPTION
This exposes a Rhubarb Lip Sync option, `Recognizer`, which allowing users to select the appropriate speech recognition to use.

![image](https://github.com/user-attachments/assets/3725c59a-068c-4a39-bec4-bf6a6c99b219)

Rhubarb uses the following Recognizers,
- `PocketSphinx` - An open-source speech recognition library that recognizes English dialog. This is the default.
- `Phonetic` - Used for recognizing individual sounds and syllables. Best for non-English dialog.