### PR TITLE
MyPaint Brush Tilt Support

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -96,6 +96,8 @@ public:
   TPointD m_pos;  //!< Mouse position in window coordinates, bottom-left origin.
   double m_pressure;  //!< Pressure of the tablet pen (0.0 - 1.0) , or 1.0 for
                       //! pure mouse events.
+  double m_tiltX, m_tiltY; //! Tablet pen tilt
+  double m_rotation; //! Tablet pen rotation
 
   ModifierMask m_modifiersMask;  //!< Bitmask specifying key modifiers applying
                                  //! on the event.
@@ -114,7 +116,10 @@ public:
       , m_buttons(Qt::NoButton)
       , m_button(Qt::NoButton)
       , m_isTablet(false)
-      , m_isHighFrequent(false) {}
+      , m_isHighFrequent(false)
+      , m_tiltX(0.0)
+      , m_tiltY(0.0)
+      , m_rotation(0.0) {}
 
   bool isShiftPressed() const { return (m_modifiersMask & SHIFT_KEY); }
   bool isAltPressed() const { return (m_modifiersMask & ALT_KEY); }

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -64,6 +64,7 @@ TEnv::IntVar FullcolorModifierLockAlpha("FullcolorModifierLockAlpha", 0);
 TEnv::IntVar FullcolorModifierPaintBehind("FullcolorModifierPaintBehind", 0);
 TEnv::StringVar FullcolorBrushPreset("FullcolorBrushPreset", "<custom>");
 TEnv::IntVar FullcolorBrushSnapGrid("FullcolorBrushSnapGrid", 0);
+TEnv::IntVar FullcolorTiltSensitivity("FullcolorTiltSensitivity", 0);
 
 //----------------------------------------------------------------------------------
 
@@ -142,7 +143,9 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
     , m_notifier(0)
     , m_presetsLoaded(false)
     , m_firstTime(true)
-    , m_snapGrid("Grid", false) {
+    , m_snapGrid("Grid", false)
+    , m_tilt("Tilt", false)
+    , m_enabledTilt(false) {
   bind(TTool::RasterImage | TTool::EmptyTarget);
 
   m_thickness.setNonLinearSlider();
@@ -157,6 +160,7 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_prop.bind(m_modifierPaintBehind);
   m_prop.bind(m_modifierLockAlpha);
   m_prop.bind(m_pressure);
+  m_prop.bind(m_tilt);
   m_prop.bind(m_snapGrid);
   m_prop.bind(m_preset);
 
@@ -166,6 +170,7 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_modifierLockAlpha.setId("LockAlpha");
   m_pressure.setId("PressureSensitivity");
   m_snapGrid.setId("SnapGrid");
+  m_tilt.setId("TiltSensitivity");
 
   m_brushTimer.start();
 }
@@ -207,6 +212,7 @@ void FullColorBrushTool::updateTranslation() {
   m_modifierLockAlpha.setQStringName(tr("Lock Alpha"));
   m_modifierPaintBehind.setQStringName(tr("Paint Behind"));
   m_snapGrid.setQStringName(tr("Grid"));
+  m_tilt.setQStringName(tr("Tilt"));
 }
 
 //---------------------------------------------------------------------------------------------------
@@ -389,6 +395,10 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   }
   m_oldPressure = pressure;
 
+  // Convert QTabletEvent tilt range (-60 to 60) to MyPaint range (-1.0 to 1.0)
+  double tiltX = m_enabledTilt ? (e.m_tiltX / 60.0) : 0.0;
+  double tiltY = m_enabledTilt ? (e.m_tiltY / 60.0) : 0.0;
+
   m_tileSet   = new TTileSetFullColor(ras->getSize());
   m_tileSaver = new TTileSaverFullColor(ras, m_tileSet);
 
@@ -409,7 +419,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   m_strokeRect.empty();
   m_strokeSegmentRect.empty();
   m_toonz_brush->beginStroke();
-  m_toonz_brush->strokeTo(point, pressure, restartBrushTimer());
+  m_toonz_brush->strokeTo(point, pressure, tiltX, tiltY, restartBrushTimer());
   TRect updateRect = m_strokeSegmentRect * ras->getBounds();
   if (!updateRect.isEmpty()) {
     TRaster32P sourceRas = m_modifierPaintBehind.getValue()
@@ -630,6 +640,10 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
   else
     pressure = m_enabledPressure ? e.m_pressure : 1.0;
 
+  // Convert QTabletEvent tilt range (-60 to 60) to MyPaint range (-1.0 to 1.0)
+  double tiltX = m_enabledTilt ? (e.m_tiltX / 60.0) : 0.0;
+  double tiltY = m_enabledTilt ? (e.m_tiltY / 60.0) : 0.0;
+
   TThickPoint thickPoint(point, pressure);
   std::vector<TThickPoint> pts;
   if (m_smooth.getValue() == 0) {
@@ -643,7 +657,8 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
   for (size_t i = 0; i < pts.size(); ++i) {
     const TThickPoint &thickPoint2 = pts[i];
     m_strokeSegmentRect.empty();
-    m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, brushTimer);
+    m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, tiltX, tiltY,
+                            brushTimer);
     TRect updateRect = m_strokeSegmentRect * ras->getBounds();
     if (!updateRect.isEmpty()) {
       TRaster32P sourceRas = m_modifierPaintBehind.getValue()
@@ -698,6 +713,9 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   if (m_isStraight) {
     pressure = m_oldPressure;
   }
+  // Convert QTabletEvent tilt range (-60 to 60) to MyPaint range (-1.0 to 1.0)
+  double tiltX = m_enabledTilt ? (e.m_tiltX / 60.0) : 0.0;
+  double tiltY = m_enabledTilt ? (e.m_tiltY / 60.0) : 0.0;
 
   TThickPoint thickPoint(point, pressure);
   std::vector<TThickPoint> pts;
@@ -713,7 +731,8 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   for (size_t i = 0; i < pts.size(); ++i) {
     const TThickPoint &thickPoint2 = pts[i];
     m_strokeSegmentRect.empty();
-    m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, brushTimer);
+    m_toonz_brush->strokeTo(thickPoint2, thickPoint2.thick, tiltX, tiltY,
+                            brushTimer);
     if (i == pts.size() - 1) m_toonz_brush->endStroke();
     TRect updateRect = m_strokeSegmentRect * ras->getBounds();
     if (!updateRect.isEmpty()) {
@@ -985,6 +1004,7 @@ bool FullColorBrushTool::onPropertyChanged(std::string propertyName) {
   FullcolorModifierLockAlpha   = m_modifierLockAlpha.getValue() ? 1 : 0;
   FullcolorModifierPaintBehind = m_modifierPaintBehind.getValue() ? 1 : 0;
   FullcolorBrushSnapGrid       = m_snapGrid.getValue() ? 1 : 0;
+  FullcolorTiltSensitivity     = m_tilt.getValue();
 
   if (m_preset.getValue() != CUSTOM_WSTR) {
     m_preset.setValue(CUSTOM_WSTR);
@@ -1042,6 +1062,7 @@ void FullColorBrushTool::loadPreset() {
     m_modifierEraser.setValue(preset.m_modifierEraser);
     m_modifierLockAlpha.setValue(preset.m_modifierLockAlpha);
     m_modifierPaintBehind.setValue(preset.m_modifierPaintBehind);
+    m_tilt.setValue(preset.m_tilt);
   } catch (...) {
   }
 }
@@ -1064,6 +1085,7 @@ void FullColorBrushTool::addPreset(QString name) {
   preset.m_modifierEraser      = m_modifierEraser.getValue();
   preset.m_modifierLockAlpha   = m_modifierLockAlpha.getValue();
   preset.m_modifierPaintBehind = m_modifierPaintBehind.getValue();
+  preset.m_tilt                = m_tilt.getValue();
 
   // Pass the preset to the manager
   m_presetsManager.addPreset(preset);
@@ -1106,6 +1128,7 @@ void FullColorBrushTool::loadLastBrush() {
   m_modifierLockAlpha.setValue(FullcolorModifierLockAlpha ? true : false);
   m_modifierPaintBehind.setValue(FullcolorModifierPaintBehind ? true : false);
   m_snapGrid.setValue(FullcolorBrushSnapGrid ? true : false);
+  m_tilt.setValue(FullcolorTiltSensitivity ? 1 : 0);
 }
 
 //------------------------------------------------------------------
@@ -1138,6 +1161,7 @@ void FullColorBrushTool::updateCurrentStyle() {
         std::max(m_thickness.getValue().second, m_minCursorThick);
     if (!m_enabledPressure) m_minCursorThick = m_maxCursorThick;
   }
+  m_enabledTilt = m_tilt.getValue();
 
   // if this function is called from onEnter(), the clipping rect will not be
   // set in order to update whole viewer.

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -98,9 +98,11 @@ protected:
   TBoolProperty m_modifierPaintBehind;
   TEnumProperty m_preset;
   TBoolProperty m_snapGrid;
+  TBoolProperty m_tilt;
 
   TPixel32 m_currentColor;
   bool m_enabledPressure;
+  bool m_enabledTilt;
   int m_minCursorThick, m_maxCursorThick;
 
   TPointD m_mousePos,    //!< Current mouse position, in world coordinates.

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2126,7 +2126,7 @@ public:
       t   = s->getParameterAtControlPoint(i);
       pos = s->getPoint(t);
       m_strokeSegmentRect.empty();
-      toonz_brush->strokeTo(pos, pressure, 10.0);
+      toonz_brush->strokeTo(pos, pressure, 0, 0, 10.0);
       updateRect = m_strokeSegmentRect * ras->getBounds();
       if (!updateRect.isEmpty())
         toonz_brush->updateDrawing(ras, backupRas, m_strokeSegmentRect, styleId,
@@ -2141,7 +2141,7 @@ public:
           toonz_brush->updateDrawing(ras, backupRas, m_strokeSegmentRect,
                                      styleId, false);
         toonz_brush->beginStroke();
-        toonz_brush->strokeTo(pos, pressure, 10.0);
+        toonz_brush->strokeTo(pos, pressure, 0, 0, 10.0);
       }
     }
     if (shiftStartPoint) {
@@ -2149,7 +2149,7 @@ public:
       t   = s->getParameterAtControlPoint(i);
       pos = s->getPoint(t);
       m_strokeSegmentRect.empty();
-      toonz_brush->strokeTo(pos, pressure, 10.0);
+      toonz_brush->strokeTo(pos, pressure, 0, 0, 10.0);
       updateRect = m_strokeSegmentRect * ras->getBounds();
       if (!updateRect.isEmpty())
         toonz_brush->updateDrawing(ras, backupRas, m_strokeSegmentRect, styleId,
@@ -2269,7 +2269,7 @@ public:
       t   = s->getParameterAtControlPoint(i);
       pos = s->getPoint(t);
       m_strokeSegmentRect.empty();
-      toonz_brush->strokeTo(pos, pressure, 10.0);
+      toonz_brush->strokeTo(pos, pressure, 0, 0, 10.0);
       updateRect = m_strokeSegmentRect * ras->getBounds();
       if (!updateRect.isEmpty())
         ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
@@ -2280,7 +2280,7 @@ public:
         if (!updateRect.isEmpty())
           ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
         toonz_brush->beginStroke();
-        toonz_brush->strokeTo(pos, pressure, 10.0);
+        toonz_brush->strokeTo(pos, pressure, 0, 0, 10.0);
       }
     }
     if (shiftStartPoint) {
@@ -2288,7 +2288,7 @@ public:
       t   = s->getParameterAtControlPoint(i);
       pos = s->getPoint(t);
       m_strokeSegmentRect.empty();
-      toonz_brush->strokeTo(pos, pressure, 10.0);
+      toonz_brush->strokeTo(pos, pressure, 0, 0, 10.0);
       updateRect = m_strokeSegmentRect * ras->getBounds();
       if (!updateRect.isEmpty())
         ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));

--- a/toonz/sources/tnztools/mypainttoonzbrush.cpp
+++ b/toonz/sources/tnztools/mypainttoonzbrush.cpp
@@ -190,14 +190,16 @@ void MyPaintToonzBrush::beginStroke() {
 
 void MyPaintToonzBrush::endStroke() {
   if (!reset) {
-    strokeTo(TPointD(current.x, current.y), current.pressure, 0.f);
+    strokeTo(TPointD(current.x, current.y), current.pressure, current.tiltX,
+             current.tiltY, 0.f);
     beginStroke();
   }
 }
-
+#include <QDebug>
 void MyPaintToonzBrush::strokeTo(const TPointD &point, double pressure,
-                                 double dtime) {
-  Params next(point.x, point.y, pressure, 0.0);
+                                 double tiltX, double tiltY, double dtime) {
+  qDebug() << "point("<<point.x<<","<<point.y<<") pressure="<<pressure<<" tiltX="<<tiltX<<" tiltY=" << tiltY;
+  Params next(point.x, point.y, pressure, tiltX, tiltY, 0.0);
 
   std::vector<TPointD> prevPoints, currPoints, nextPoints;
 
@@ -253,10 +255,11 @@ void MyPaintToonzBrush::strokeTo(const TPointD &point, double pressure,
 
   for (int i = 0; i < nextPoints.size(); i++) {
     Params prevPt(prevPoints[i].x, prevPoints[i].y, previous.pressure,
-                  previous.time);
+                  previous.tiltX, previous.tiltY, previous.time);
     Params currPt(currPoints[i].x, currPoints[i].y, current.pressure,
-                  current.time);
-    Params nextPt(nextPoints[i].x, nextPoints[i].y, next.pressure, next.time);
+                  current.tiltX, current.tiltY, current.time);
+    Params nextPt(nextPoints[i].x, nextPoints[i].y, next.pressure, next.tiltX,
+                  next.tiltY, next.time);
 
     // set initial segment
     Segment stack[maxLevel + 1];
@@ -279,8 +282,8 @@ void MyPaintToonzBrush::strokeTo(const TPointD &point, double pressure,
         segment = sub;
       } else {
         brushes[i].strokeTo(m_mypaintSurface, segment->p2.x, segment->p2.y,
-                            segment->p2.pressure, 0.f, 0.f,
-                            segment->p2.time - p0.time);
+                            segment->p2.pressure, segment->p2.tiltX,
+                            segment->p2.tiltY, segment->p2.time - p0.time);
         if (segment == stack) break;
         p0 = segment->p2;
         --segment;

--- a/toonz/sources/tnztools/mypainttoonzbrush.h
+++ b/toonz/sources/tnztools/mypainttoonzbrush.h
@@ -94,16 +94,22 @@ private:
   struct Params {
     union {
       struct {
-        double x, y, pressure, time;
+        double x, y, pressure, tiltX, tiltY, time;
       };
       struct {
-        double values[4];
+        double values[6];
       };
     };
 
     inline explicit Params(double x = 0.0, double y = 0.0,
-                           double pressure = 0.0, double time = 0.0)
-        : x(x), y(y), pressure(pressure), time(time) {}
+                           double pressure = 0.0, double tiltX = 0.0,
+                           double tiltY = 0.0, double time = 0.0)
+        : x(x)
+        , y(y)
+        , pressure(pressure)
+        , tiltX(tiltX)
+        , tiltY(tiltY)
+        , time(time) {}
 
     inline void setMedian(Params &a, Params &b) {
       for (int i  = 0; i < (int)sizeof(values) / sizeof(values[0]); ++i)
@@ -135,7 +141,8 @@ public:
                     const mypaint::Brush &brush);
   void beginStroke();
   void endStroke();
-  void strokeTo(const TPointD &p, double pressure, double dtime);
+  void strokeTo(const TPointD &p, double pressure, double tiltX, double tiltY,
+                double dtime);
 
   // colormapped
   void updateDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2181,6 +2181,8 @@ void BrushToolOptionsBox::filterControls() {
                      it.key() == "Preset:" || it.key() == "Grid" ||
                      it.key() == "Smooth:" || it.key() == "Paint Behind");
     bool visible = isCommon || (isModifier == showModifiers);
+    // Temporary since Tilt is only available for MyPaint styles
+    if (it.key() == "Tilt") visible = showModifiers;
     it.value()->setVisible(visible);
   }
 
@@ -2192,6 +2194,8 @@ void BrushToolOptionsBox::filterControls() {
                      it.key() == "Preset:" || it.key() == "Grid" ||
                      it.key() == "Smooth:" || it.key() == "Paint Behind");
     bool visible = isCommon || (isModifier == showModifiers);
+    // Temporary since Tilt is only available for MyPaint styles
+    if (it.key() == "Tilt") visible = showModifiers;
     if (QWidget *widget = dynamic_cast<QWidget *>(it.value()))
       widget->setVisible(visible);
   }

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -43,7 +43,7 @@ struct BrushData final : public TPersist {
 
   std::wstring m_name;
   double m_min, m_max, m_smooth, m_hardness, m_opacityMin, m_opacityMax;
-  bool m_pencil, m_pressure;
+  bool m_pencil, m_pressure, m_tilt;
   int m_drawOrder;
   double m_modifierSize, m_modifierOpacity;
   bool m_modifierEraser, m_modifierLockAlpha, m_modifierPaintBehind;
@@ -162,7 +162,8 @@ public:
 
   void loadLastBrush();
 
-  void finishRasterBrush(const TPointD &pos, double pressureVal);
+  void finishRasterBrush(const TPointD &pos, double pressureVal, double tiltX,
+                         double tiltY);
   // return true if the pencil mode is active in the Brush / PaintBrush / Eraser
   // Tools.
   bool isPencilModeActive() override;
@@ -186,6 +187,7 @@ protected:
   TDoubleProperty m_modifierSize;
   TBoolProperty m_modifierLockAlpha;
   TBoolProperty m_snapGrid;
+  TBoolProperty m_tilt;
 
   CMRasterBrush *m_cmRasterBrush;
   TTileSetCM32 *m_tileSet;

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -75,6 +75,8 @@ class SceneViewer final : public TTool::Viewer,
   QColor m_previewBgColor;
 
   double m_pressure;
+  double m_tiltX, m_tiltY;
+  double m_rotation;
   QPointF m_lastMousePos;
   QPointF m_pos;
   Qt::MouseButton m_mouseButton;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -75,11 +75,15 @@ namespace {
 //-----------------------------------------------------------------------------
 
 void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
-                    int widgetHeight, double pressure, int devPixRatio) {
+                    int widgetHeight, double pressure, double tiltX,
+                    double tiltY, double rotation, int devPixRatio) {
   toonzEvent.m_pos = TPointD(event->pos().x() * devPixRatio,
                                   widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
   toonzEvent.m_pressure = 1.0;
+  toonzEvent.m_tiltX    = 0.0;
+  toonzEvent.m_tiltY    = 0.0;
+  toonzEvent.m_rotation = 0.0;
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
@@ -93,13 +97,17 @@ void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
 //-----------------------------------------------------------------------------
 
 void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
-                    int widgetHeight, double pressure, int devPixRatio,
+                    int widgetHeight, double pressure, double tiltX,
+                    double tiltY, double rotation, int devPixRatio,
                     bool isHighFrequent = false) {
   toonzEvent.m_pos = TPointD(
       event->posF().x() * (float)devPixRatio,
       (float)widgetHeight - 1.0f - event->posF().y() * (float)devPixRatio);
   toonzEvent.m_mousePos = event->posF();
   toonzEvent.m_pressure = pressure;
+  toonzEvent.m_tiltX    = tiltX;
+  toonzEvent.m_tiltY    = tiltY;
+  toonzEvent.m_rotation = rotation;
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
@@ -118,7 +126,10 @@ void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
 void initToonzEvent(TMouseEvent &toonzEvent, QKeyEvent *event) {
   toonzEvent.m_pos      = TPointD();
   toonzEvent.m_mousePos = QPointF();
-  toonzEvent.m_pressure = 0;
+  toonzEvent.m_pressure = 0.0;
+  toonzEvent.m_tiltX    = 0.0;
+  toonzEvent.m_tiltY    = 0.0;
+  toonzEvent.m_rotation = 0.0;
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
@@ -256,7 +267,12 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
   // Means we are hovering
   if (m_tabletState != None)
 #endif
+  {
     m_pressure = e->pressure();
+    m_tiltX    = e->xTilt();
+    m_tiltY    = e->yTilt();
+    m_rotation = e->rotation();
+  }
   m_tabletMove = false;
   // Management of the Eraser pointer
   ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
@@ -285,7 +301,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     // So call onPress here in order to enable processing.
     if (e->button() == Qt::LeftButton) m_tabletState = Touched;
     TMouseEvent mouseEvent;
-    initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+    initToonzEvent(mouseEvent, e, height(), m_pressure, m_tiltX, m_tiltY,
+                   m_rotation, getDevPixRatio());
     onPress(mouseEvent);
 
     // create context menu on right click here
@@ -306,7 +323,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       // mousePressEvent gets ignored
       if (m_tabletState == Released || m_tabletState == None) {
         TMouseEvent mouseEvent;
-        initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+        initToonzEvent(mouseEvent, e, height(), m_pressure, m_tiltX, m_tiltY,
+                       m_rotation, getDevPixRatio());
         m_tabletState = Touched;
         onPress(mouseEvent);
       } else if (m_tabletState == Touched) {
@@ -332,7 +350,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       m_tabletState = Released;
 
     TMouseEvent mouseEvent;
-    initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+    initToonzEvent(mouseEvent, e, height(), m_pressure, m_tiltX, m_tiltY,
+                   m_rotation, getDevPixRatio());
     onRelease(mouseEvent);
 
     if (TApp::instance()->getCurrentTool()->isToolBusy())
@@ -343,7 +362,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     if (m_tabletState == StartStroke || m_tabletState == OnStroke) {
       m_tabletState = Released;
       TMouseEvent mouseEvent;
-      initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+      initToonzEvent(mouseEvent, e, height(), m_pressure, m_tiltX, m_tiltY,
+                     m_rotation, getDevPixRatio());
       onRelease(mouseEvent);
     } else
       m_tabletEvent = false;
@@ -375,7 +395,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     // 20msec. (See RasterSelectionTool::leftButtonDrag())
     if (curPos != m_lastMousePos) {
       TMouseEvent mouseEvent;
-      initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio(),
+      initToonzEvent(mouseEvent, e, height(), m_pressure, m_tiltX, m_tiltY,
+                     m_rotation, getDevPixRatio(),
                      m_isBusyOnTabletMove);
       if (!m_isBusyOnTabletMove) {
         m_isBusyOnTabletMove = true;
@@ -502,7 +523,8 @@ void SceneViewer::mouseMoveEvent(QMouseEvent *event) {
   // setTabletTracking(true).
 
   TMouseEvent mouseEvent;
-  initToonzEvent(mouseEvent, event, height(), 1.0, getDevPixRatio());
+  initToonzEvent(mouseEvent, event, height(), 1.0, 0.0, 0.0, 0.0,
+                 getDevPixRatio());
   onMove(mouseEvent);
 }
 
@@ -783,7 +805,8 @@ void SceneViewer::mousePressEvent(QMouseEvent *event) {
 
   TMouseEvent mouseEvent;
   m_mouseState = Touched;
-  initToonzEvent(mouseEvent, event, height(), 1.0, getDevPixRatio());
+  initToonzEvent(mouseEvent, event, height(), 1.0, 0.0, 0.0, 0.0,
+                 getDevPixRatio());
   onPress(mouseEvent);
 }
 
@@ -955,7 +978,8 @@ void SceneViewer::mouseReleaseEvent(QMouseEvent *event) {
 
   TMouseEvent mouseEvent;
   if (m_mouseState != None) m_mouseState = Released;
-  initToonzEvent(mouseEvent, event, height(), 1.0, getDevPixRatio());
+  initToonzEvent(mouseEvent, event, height(), 1.0, 0.0, 0.0, 0.0,
+                 getDevPixRatio());
   onRelease(mouseEvent);
 }
 //-----------------------------------------------------------------------------
@@ -1047,7 +1071,10 @@ void SceneViewer::onRelease(const TMouseEvent &event) {
   if (m_current3DDevice != NONE) {
     m_mouseButton = Qt::NoButton;
     m_tabletEvent = false;
-    m_pressure    = 0;
+    m_pressure    = 0.0;
+    m_tiltX       = 0.0;
+    m_tiltY       = 0.0;
+    m_rotation    = 0.0;
     if (m_current3DDevice == SIDE_LEFT_3D)
       set3DLeftSideView();
     else if (m_current3DDevice == SIDE_RIGHT_3D)
@@ -1126,7 +1153,10 @@ void SceneViewer::doQuit() {
 
   m_mouseState                                = None;
   m_tabletMove                                = false;
-  m_pressure                                  = 0;
+  m_pressure                                  = 0.0;
+  m_tiltX                                     = 0.0;
+  m_tiltY                                     = 0.0;
+  m_rotation                                  = 0.0;
 }
 
 //-----------------------------------------------------------------------------
@@ -1143,7 +1173,10 @@ void SceneViewer::resetTabletStatus() {
   m_tabletEvent   = false;
   m_tabletState   = None;
   m_tabletMove    = false;
-  m_pressure      = 0;
+  m_pressure      = 0.0;
+  m_tiltX         = 0.0;
+  m_tiltY         = 0.0;
+  m_rotation      = 0.0;
   m_buttonClicked = false;
   if (TApp::instance()->getCurrentTool()->isToolBusy())
     TApp::instance()->getCurrentTool()->setToolBusy(false);
@@ -1896,7 +1929,8 @@ void SceneViewer::mouseDoubleClickEvent(QMouseEvent *event) {
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   if (!tool || !tool->isEnabled()) return;
   TMouseEvent toonzEvent;
-  initToonzEvent(toonzEvent, event, height(), 1.0, getDevPixRatio());
+  initToonzEvent(toonzEvent, event, height(), 1.0, 0.0, 0.0, 0.0,
+                 getDevPixRatio());
   TPointD pos =
       tool->getMatrix().inv() * winToWorld(event->pos() * getDevPixRatio());
   TObjectHandle *objHandle = TApp::instance()->getCurrentObject();

--- a/toonz/sources/toonz/viewereventlogpopup.cpp
+++ b/toonz/sources/toonz/viewereventlogpopup.cpp
@@ -205,10 +205,14 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
 
     QTabletEvent *te = dynamic_cast<QTabletEvent *>(e);
     float pressure   = (int)(te->pressure() * 1000 + 0.5);
-    eventMsg         = tr("Stylus pressed at X=%1 Y=%2 Pressure=%3%")
+    eventMsg = tr("Stylus pressed at X=%1 Y=%2 Pressure=%3% TiltX=%4 TiltY=%5 "
+                  "Rotation=%6")
                    .arg(te->pos().x())
                    .arg(te->pos().y())
-                   .arg(pressure / 10.0);
+                   .arg(pressure / 10.0)
+                   .arg(te->xTilt())
+                   .arg(te->yTilt())
+                   .arg(te->rotation());
   } break;
 
   case QEvent::TabletMove: {
@@ -221,11 +225,15 @@ void ViewerEventLogPopup::addEventMessage(QEvent *e) {
             ? tr("dragged")
             : tr("moved");
     float pressure = (int)(te->pressure() * 1000 + 0.5);
-    eventMsg       = tr("Stylus %1 to X=%2 Y=%3 Pressure=%4%")
-                   .arg(operation)
-                   .arg(te->pos().x())
-                   .arg(te->pos().y())
-                   .arg(pressure / 10.0);
+    eventMsg =
+        tr("Stylus %1 to X=%2 Y=%3 Pressure=%4% TiltX=%5 TiltY=%6 Rotation=%7")
+            .arg(operation)
+            .arg(te->pos().x())
+            .arg(te->pos().y())
+            .arg(pressure / 10.0)
+            .arg(te->xTilt())
+            .arg(te->yTilt())
+            .arg(te->rotation());
   } break;
 
   case QEvent::TabletRelease: {


### PR DESCRIPTION
This adds the new toolbar option, `Tilt` which is only available for MyPaint styles...for now.  It is available on both Raster and Smart Raster brush toolbars when a MyPaint style is selected.

Similar to `Pressure`, enabling `Tilt` will capture tilt information from pens that support it.  The tilt information is passed to the MyPaint brush engine so it can be applied to styles that are configured for Tilt sensitivity.

Example of a MyPaint style that uses Tilt:  `Classic` -> `Marker-Fat`


 