### PR TITLE
Fix windows scripting build path

### DIFF
--- a/ci-scripts/windows/tahoma-build.bat
+++ b/ci-scripts/windows/tahoma-build.bat
@@ -13,20 +13,14 @@ REM Setup for local builds
 set MSVCVERSION="Visual Studio 16 2019"
 set BOOST_ROOT=C:\boost\boost_1_74_0
 set OPENCV_DIR=C:\opencv\451\build
-REM set QT_PATH=C:\Qt\5.9.7\msvc2019_64
 set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
 
 REM These are effective when running from Actions
 IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
 IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
-REM IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 (
-REM 	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
-REM )
 
 set WITH_WINTAB=Y
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64 (
-	set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64
-)
+IF EXIST ..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64 set QT_PATH=..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64
 
 set WITH_CANON=N
 IF EXIST ..\..\thirdparty\canon\Header set WITH_CANON=Y

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -38,12 +38,10 @@ del Tahoma2D\*.ilk
 echo ">>> Configuring Tahoma2D.exe for deployment"
 
 REM Setup for local builds
-REM set QT_PATH=C:\Qt\5.9.7\msvc2019_64
 set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
 
 REM These are effective when running from Actions/Appveyor
-REM IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.9\msvc2019_64
-IF EXIST D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64 set QT_PATH=D:\a\tahoma2d\tahoma2d\thirdparty\qt\5.15.2_wintab\msvc2019_64
+IF EXIST ..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64 set QT_PATH=..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64
 
 set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
 IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC" set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"


### PR DESCRIPTION
This fixes a minor issue with the Windows build scripts when run in Github runners.

It appears that Windows Github runners could download the repo to the `C:` drive instead of the `D:` drive like it has been. The build script expected had some absolute paths referencing the `D:` drive and would not build if it could not find everything it needed.

Corrected it to use a relative path rather than an absolute path.

Will merge once I confirm the Windows artifact has been successfully built.