### PR TITLE
Fix Implicit Clear Frames

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -3011,7 +3011,7 @@ void TCellSelection::clearFrames() {
       continue;
 
     for (r = r1; r >= r0; r--) {
-      TXshCell cell = xsh->getCell(r, c, false, false);
+      TXshCell cell = xsh->getCell(r, c);
 
       if (cell.isEmpty() || cell.getFrameId().isStopFrame() ||
           cell.m_level->getChildLevel() || !cell.getImage(false))


### PR DESCRIPTION
This fixes `Clear Frames` so they also work on implicit and looped (v1.6) frames.