### PR TITLE
Fix blocked shortcuts after pen use

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -118,7 +118,16 @@ void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
   toonzEvent.m_isHighFrequent = isHighFrequent;
   // this delays autosave during stylus button press until after the next
   // brush stroke - this minimizes problems from interruptions to tablet input
-  TApp::instance()->getCurrentTool()->setToolBusy(true);
+  bool isBusy = ((event->buttons() & Qt::LeftButton) ||
+                 (event->buttons() & Qt::RightButton) ||
+                 (event->buttons() & Qt::MiddleButton))
+#if defined(LINUX) || defined(FREEBSD)
+                // Since Linux doesn't always register leave events, include
+                // pressure in check
+                && pressure != 0.0
+#endif
+      ;
+  TApp::instance()->getCurrentTool()->setToolBusy(isBusy);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes #1850 that revealed an issue after changes were made to block shortcuts when tool is busy (#1844). 

The problem was caused by pre-existing logic in which the stylus was incorrectly flagging the current tool as being busy when just hovering over the canvas.  This issue does not affect Windows builds, but did impact Linux builds. I think it might also impact macOS builds.  Likely prevented autosave from really working in Linux/macOS builds.

Affecting all builds, I've modified the logic so it only flags the tool as busy if any button is pressed while moving the stylus.  For Linux systems, at least, there is an added pressure check because a Leave event isn't always registered when the stylus is lifted straight up.  Remains to be seen if this is also needed by macOS.

Once this is merged, I will rebuild 1.5.3 fix release and republish it.

