### PR TITLE
Build on MSVC 2022

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies

--- a/ci-scripts/windows/tahoma-build.bat
+++ b/ci-scripts/windows/tahoma-build.bat
@@ -10,13 +10,13 @@ IF NOT EXIST build mkdir build
 cd build
 
 REM Setup for local builds
-set MSVCVERSION="Visual Studio 16 2019"
-set BOOST_ROOT=C:\boost\boost_1_74_0
-set OPENCV_DIR=C:\opencv\451\build
+set MSVCVERSION="Visual Studio 17 2022"
+set BOOST_ROOT=C:\boost\boost_1_87_0
+set OPENCV_DIR=C:\opencv\4110\build
 set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
 
 REM These are effective when running from Actions
-IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
+IF EXIST C:\local\boost_1_87_0 set BOOST_ROOT=C:\local\boost_1_87_0
 IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
 
 set WITH_WINTAB=Y

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -18,9 +18,9 @@ copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll Tahoma2D
 copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll Tahoma2D
 
 IF EXIST C:\tools\opencv (
-   copy /Y "C:\tools\opencv\build\x64\vc14\bin\opencv_world451.dll" Tahoma2D
+   copy /Y "C:\tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" Tahoma2D
 ) ELSE (
-   copy /Y "C:\opencv\451\build\x64\vc14\bin\opencv_world451.dll" Tahoma2D
+   copy /Y "C:\opencv\4110\build\x64\vc16\bin\opencv_world4110.dll" Tahoma2D
 )
 
 IF EXIST ..\..\thirdparty\canon\Header (
@@ -43,13 +43,13 @@ set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
 REM These are effective when running from Actions/Appveyor
 IF EXIST ..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64 set QT_PATH=..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64
 
-set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
-IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC" set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"
+set VCINSTALLDIR="C:\Program Files\Microsoft Visual Studio\2022\Community\VC"
+IF EXIST "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC" set VCINSTALLDIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC"
 
 %QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe --opengl
 
-xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.29.30133\x64\Microsoft.VC142.CRT Tahoma2D
-xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.29.30133\x64\Microsoft.VC142.OpenMP Tahoma2D
+xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.42.34433\x64\Microsoft.VC143.CRT Tahoma2D
+xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.42.34433\x64\Microsoft.VC143.OpenMP Tahoma2D
 
 del /A- /S Tahoma2D\tahomastuff\*.gitkeep
 

--- a/ci-scripts/windows/tahoma-install.bat
+++ b/ci-scripts/windows/tahoma-install.bat
@@ -1,13 +1,7 @@
-choco install opencv --version=4.5.1
-choco install boost-msvc-14.2 --version=1.74.0
+choco install opencv --version=4.11.0
+choco install boost-msvc-14.3 --version=1.87.0
 
 mkdir thirdparty\qt
-
-REM Install Qt 5.9
-REM curl -fsSL -o Qt5.9.7_msvc2019_64.zip https://github.com/tahoma2d/qt5/releases/download/v5.9.7/Qt5.9.7_msvc2019_64.zip
-REM 7z x Qt5.9.7_msvc2019_64.zip
-REM rename Qt5.9.7_msvc2019_64 5.9
-REM move 5.9 thirdparty\qt
 
 REM Install Custom Qt 5.15.2 with WinTab support
 curl -fsSL -o Qt5.15.2_wintab.zip https://github.com/tahoma2d/qt5/releases/download/v5.15.2/Qt5.15.2_wintab.zip

--- a/toonz/sources/.clang-format
+++ b/toonz/sources/.clang-format
@@ -1,5 +1,5 @@
 BasedOnStyle: Google
-Standard: C++11
+Standard: c++17
 UseTab: Never
 AccessModifierOffset: -2
 AlignAfterOpenBracket: true


### PR DESCRIPTION
Github is deprecating the `windows-2019` runner at the end of this month.  This requires moving to another runner.  I have opeted to move to the next available one, `windows-2022`, instead of the latest.

I've made the following changes
- Updated scripts to build on MSVC 2022 (required)
- Updated OpenCV to 4.11.0
- Updated Boost to 1.87.0