### PR TITLE
Implementing ability to install (and delete should you desire that) shaders from a valid zip file.

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -14,6 +14,9 @@ project(Tahoma2D)
 # list of var-names
 set(_init_vars)
 
+
+
+
 #-----------------------------------------------------------------------------
 # Select build target
 set(BUILD_TARGET_WIN       OFF)
@@ -228,6 +231,7 @@ elseif(BUILD_ENV_UNIXLIKE)
     set(CMAKE_CXX_STANDARD 17)
 
     find_package(Qt5Widgets)
+    find_package(KF5Archive ${KF_VERSION} REQUIRED)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
     if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -564,7 +564,7 @@ elseif(BUILD_ENV_UNIXLIKE AND WITH_CANON)
         Tahoma2D Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
         Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort Qt5::UiTools
         ${GL_LIB} ${GLUT_LIB} ${GLU_LIB} ${CANON_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS}
-        ${EXTRA_LIBS} dl
+        ${EXTRA_LIBS} KF5::Archive dl
     )
 
 elseif(BUILD_ENV_UNIXLIKE)
@@ -587,7 +587,7 @@ elseif(BUILD_ENV_UNIXLIKE)
         Tahoma2D Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
         Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::SerialPort Qt5::UiTools
         ${GL_LIB} ${GLUT_LIB} ${GLU_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS}
-        ${EXTRA_LIBS} dl
+        ${EXTRA_LIBS} KF5::Archive dl
     )
 endif()
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -70,6 +70,9 @@
 #include <QCoreApplication>
 #include <QMainWindow>
 #include <QApplication>
+#include <QStandardPaths>
+#include <QDir>
+#include <QTextStream>
 
 //***********************************************************************************
 //    FileBrowserPopup  implementation
@@ -1977,6 +1980,14 @@ LoadColorModelPopup::LoadColorModelPopup()
 }
 
 //--------------------------------------------------------------
+InstallShaderPopup::InstallShaderPopup()
+  : FileBrowserPopup(tr("Import A Shader"), Options(), "", new QFrame(0)) {
+    setOkText(tr("Load"));
+
+    addFilterType("tdgl");
+  }
+
+//--------------------------------------------------------------
 
 void LoadColorModelPopup::onFilePathsSelected(
     const std::set<TFilePath> &paths) {
@@ -2017,6 +2028,8 @@ bool LoadColorModelPopup::execute() {
     DVGui::error(QObject::tr("Cannot load Color Model in current palette."));
     return false;
   }
+
+
 
   PaletteCmd::ColorModelLoadingConfiguration config;
 
@@ -2070,6 +2083,20 @@ bool LoadColorModelPopup::execute() {
   return true;
 }
 
+//--------------------------------------------------------------
+
+bool InstallShaderPopup::execute() {
+  auto tpath = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+
+  QDir pathDir(tpath);
+
+  
+  
+  
+
+  return true;
+    
+  }
 //--------------------------------------------------------------
 
 void LoadColorModelPopup::showEvent(QShowEvent *e) {
@@ -2350,6 +2377,9 @@ OpenPopupCommandHandler<SavePaletteAsPopup> savePalettePopupCommand(
     MI_SavePaletteAs);
 OpenPopupCommandHandler<LoadColorModelPopup> loadColorModelPopupCommand(
     MI_LoadColorModel);
+OpenPopupCommandHandler<InstallShaderPopup> importShaderFilePopupCommand(
+    MI_ImportShaderFile);
+//Add DeleteShaderPopup
 OpenPopupCommandHandler<ImportMagpieFilePopup> importMagpieFilePopupCommand(
     MI_ImportMagpieFile);
 

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -400,6 +400,16 @@ protected slots:
   void onFilePathsSelected(const std::set<TFilePath> &paths);
 };
 
+//----------------------------------------------------------------------------
+class InstallShaderPopup final : public FileBrowserPopup {
+  Q_OBJECT
+
+  public:
+    InstallShaderPopup();
+
+    bool execute() override;
+};
+
 //-----------------------------------------------------------------------------
 
 class ImportMagpieFilePopup final : public FileBrowserPopup {

--- a/toonz/sources/toonz/fileviewerpopup.h
+++ b/toonz/sources/toonz/fileviewerpopup.h
@@ -5,6 +5,7 @@
 
 #include <QWidget>
 
+
 #include "tfilepath.h"
 #include "tlevel_io.h"
 #include "tpalette.h"

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1882,6 +1882,10 @@ void MainWindow::defineActions() {
   createMenuFileAction(MI_LoadColorModel, QT_TR_NOOP("&Load Color Model..."),
                        "", "load_colormodel",
                        tr("Load an image as a color guide."));
+  createMenuFileAction(MI_ImportShaderFile, QT_TR_NOOP("&Import Shader File"),
+                      "","", tr("Import A Shader To Use For Visual Effects Via OpenGL"));
+  createMenuFileAction(MI_DeleteShader, QT_TR_NOOP("&Delete Installed Shader"),
+                      "","",tr("Remove And Delete An Already Installed Shader."));
   createMenuFileAction(MI_ImportMagpieFile,
                        QT_TR_NOOP("&Import Toonz Lip Sync File..."), "",
                        "dialogue_import",

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -326,6 +326,10 @@ void TopBar::loadMenubar() {
   fileMenu->addSeparator();
   addMenuItem(fileMenu, MI_LoadColorModel);
   fileMenu->addSeparator();
+  QMenu *shadersInstallMenu = fileMenu->addMenu(tr("Install Or Delete Shader")); {
+    addMenuItem(shadersInstallMenu, MI_ImportShaderFile);
+    addMenuItem(shadersInstallMenu, MI_DeleteShader);
+  }
   QMenu *projectManagementMenu = fileMenu->addMenu(tr("Project Management"));
   {
     addMenuItem(projectManagementMenu, MI_NewProject);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -42,6 +42,8 @@
 #define MI_OverwritePalette "MI_OverwritePalette"
 #define MI_SaveAsDefaultPalette "MI_SaveAsDefaultPalette"
 #define MI_LoadColorModel "MI_LoadColorModel"
+#define MI_ImportShaderFile "MI_ImportShaderFile"
+#define MI_DeleteShader "MI_DeleteShader"
 #define MI_ImportMagpieFile "MI_ImportMagpieFile"
 #define MI_NewNoteLevel "MI_NewNoteLevel"
 #define MI_RemoveEmptyColumns "MI_RemoveEmptyColumns"


### PR DESCRIPTION
Like I mentioned previously, it's very tedious and verbose to install manually, so I'm attempting to implement myself some basic form of shader (GLSL) installation.

The library I decided upon was karchive. It is maintained by the KDE Project, so zero chance of it dying because the devs vanished or something like that. It's under the LGPL, so fine to use with this project.

So far I've managed to implement a class of a menu entry and it launches the file selector. It can do something upon loading the file. I need to implement:  
1. Extract the tdgl (Just a valid zip file renamed. Nothing more nothing less) and place it under tmp. Qt5 will be able to locate per operating system the tmp location.
2. Read the SHADER_<name>.xml file to know the parameters necessary, this will be required for current.txt.
3. Add in each entry with parameters being its own entry line for the current.txt file.
4. Add in the shader name in fxs.lst.
5. Lastly, move the shader.xml file and the shader files themselves to the shaders dir.

So far so good, I request a bit of assistance in getting around the Tahoma2D source code. Such as how can I store the output of execute into a variable or something like that so it can later send to karchive the zip file to use?

As for delete (aka uninstall), that's a PR for a different day. Right now, I want installation to work.