### PR TITLE
Fix Control Point Editor Pen Lag

### DIFF
--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -724,6 +724,7 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
   TPointD delta = pos - m_pos;
 
   if (m_action == CP_MOVEMENT) {
+    if (e.isHighFrequent()) return;
     if (!m_selection.isSelected(m_lastPointSelected) && e.isShiftPressed())
       m_selection.select(m_lastPointSelected);  // Controllo che non venga
                                                 // deselezionata l'ultima
@@ -745,11 +746,13 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
     m_isImageChanged = true;
   }
   if (m_action == SEGMENT_MOVEMENT) {
+    if (e.isHighFrequent()) return;
     m_moveControlPointEditorStroke = *m_controlPointEditorStroke.clone();
     moveSegment(delta, true, e.isShiftPressed());
     m_isImageChanged = true;
   }
   if (m_action == OUT_SPEED_MOVEMENT || m_action == IN_SPEED_MOVEMENT) {
+    if (e.isHighFrequent()) return;
     m_pos = pos;
     moveSpeed(delta, m_action == IN_SPEED_MOVEMENT);
     m_isImageChanged = true;


### PR DESCRIPTION
This fixes pen lag in the Control Point Editor tool when there is a large number of strokes in the frame.