### PR TITLE
Fix misplaced brush preset setting endtag

### DIFF
--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2875,6 +2875,7 @@ void BrushData::saveData(TOStream &os) {
   os.closeChild();
   os.openChild("Modifier_LockAlpha");
   os << (int)m_modifierLockAlpha;
+  os.closeChild();
   os.openChild("Modifier_PaintBehind");
   os << (int)m_modifierPaintBehind;
   os.closeChild();


### PR DESCRIPTION
Related to changes made for #1793 (Raster Paint Behind), this corrects a minor issue when saving brush presets. The `Modifier_LockAlpha` endtag is in the wrong place due to how saving for the new `Paint Behind` setting was added.

