### PR TITLE
Fix temp tool switching

### DIFF
--- a/toonz/sources/tnztools/toolhandle.cpp
+++ b/toonz/sources/tnztools/toolhandle.cpp
@@ -78,6 +78,7 @@ void ToolHandle::restoreTool() {
           Preferences::instance()->getTempToolSwitchtimer()) {
     setTool(m_storedToolName);
   }
+  m_storedToolName = "";
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1507,6 +1507,10 @@ bool SceneViewer::event(QEvent *e) {
                     e->type() == QEvent::KeyPress)) {
     QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
 
+    if (!keyEvent->isAutoRepeat()) {
+      TApp::instance()->getCurrentTool()->storeTool();
+    }
+
     std::string keyStr = QKeySequence(keyEvent->key() + keyEvent->modifiers())
                              .toString()
                              .toStdString();
@@ -1590,6 +1594,13 @@ bool SceneViewer::event(QEvent *e) {
         invalidateToolStatus();
         e->accept();
         return true;
+      }
+    } else {
+      if (!((QKeyEvent *)e)->isAutoRepeat()) {
+        QWidget *focusWidget = QApplication::focusWidget();
+        if (focusWidget == 0 ||
+            QString(focusWidget->metaObject()->className()) == "SceneViewer")
+          TApp::instance()->getCurrentTool()->restoreTool();
       }
     }
   }

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -823,6 +823,9 @@ bool TApp::eventFilter(QObject *watched, QEvent *e) {
                              .toStdString();
     QAction *action = CommandManager::instance()->getActionFromShortcut(keyStr);
     if (action) {
+      if (!keyEvent->isAutoRepeat()) {
+        TApp::instance()->getCurrentTool()->storeTool();
+      }
       e->accept();
       return true;
     }


### PR DESCRIPTION
This restores and fixes temp tool switching to tools other than `Hand`, `Rotate` and `Zoom` tools that was inadvertently removed when blocking tool switches while tool was active (#1844).
