### PR TITLE
Stylus Settings Popup (Raster Brush & MyPaint styles)

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1690,20 +1690,24 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
+#StylusConfigPopup QListWidget,
 #PreferencesPopup QListWidget {
   background-color: #262626;
   alternate-background-color: #262626;
   border: 1 solid #111111;
   font-size: 13px;
 }
+#StylusConfigPopup QListWidget::item,
 #PreferencesPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
+#StylusConfigPopup QListWidget::item:hover,
 #PreferencesPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.1);
   color: #e6e6e6;
 }
+#StylusConfigPopup QListWidget::item:selected,
 #PreferencesPopup QListWidget::item:selected {
   background-color: #a35293;
   color: #ffffff;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -1690,20 +1690,24 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
+#StylusConfigPopup QListWidget,
 #PreferencesPopup QListWidget {
   background-color: #0c0c0c;
   alternate-background-color: #0c0c0c;
   border: 1 solid #060606;
   font-size: 13px;
 }
+#StylusConfigPopup QListWidget::item,
 #PreferencesPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
+#StylusConfigPopup QListWidget::item:hover,
 #PreferencesPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.1);
   color: #e6e6e6;
 }
+#StylusConfigPopup QListWidget::item:selected,
 #PreferencesPopup QListWidget::item:selected {
   background-color: #a35293;
   color: #ffffff;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1690,20 +1690,24 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
+#StylusConfigPopup QListWidget,
 #PreferencesPopup QListWidget {
   background-color: #cecece;
   alternate-background-color: #cecece;
   border: 1 solid #a8a8a8;
   font-size: 13px;
 }
+#StylusConfigPopup QListWidget::item,
 #PreferencesPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
+#StylusConfigPopup QListWidget::item:hover,
 #PreferencesPopup QListWidget::item:hover {
   background-color: #b5b5b5;
   color: #000;
 }
+#StylusConfigPopup QListWidget::item:selected,
 #PreferencesPopup QListWidget::item:selected {
   background-color: #d97fbe;
   color: #000;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -1690,20 +1690,24 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
+#StylusConfigPopup QListWidget,
 #PreferencesPopup QListWidget {
   background-color: #343434;
   alternate-background-color: #343434;
   border: 1 solid #2c2c2c;
   font-size: 13px;
 }
+#StylusConfigPopup QListWidget::item,
 #PreferencesPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
+#StylusConfigPopup QListWidget::item:hover,
 #PreferencesPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.1);
   color: #e6e6e6;
 }
+#StylusConfigPopup QListWidget::item:selected,
 #PreferencesPopup QListWidget::item:selected {
   background-color: #a35293;
   color: #ffffff;

--- a/stuff/config/qss/Medium/less/layouts/popups.less
+++ b/stuff/config/qss/Medium/less/layouts/popups.less
@@ -41,6 +41,7 @@ QDialog {
    Preferences
 ----------------------------------------------------------------------------- */
 
+#StylusConfigPopup,
 #PreferencesPopup {
   & QListWidget {
     background-color: @prefs-tree-bg-color;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1690,20 +1690,24 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
+#StylusConfigPopup QListWidget,
 #PreferencesPopup QListWidget {
   background-color: #767676;
   alternate-background-color: #767676;
   border: 1 solid #5a5a5a;
   font-size: 13px;
 }
+#StylusConfigPopup QListWidget::item,
 #PreferencesPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
+#StylusConfigPopup QListWidget::item:hover,
 #PreferencesPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.15);
   color: #000;
 }
+#StylusConfigPopup QListWidget::item:selected,
 #PreferencesPopup QListWidget::item:selected {
   background-color: #c16099;
   color: #000;

--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -703,6 +703,14 @@ std::istream &operator>>(std::istream &is, TRect &rect) {
   return is >> rect.x0 >> rect.y0 >> rect.x1 >> rect.y1;
 }
 
+std::istream &operator>>(std::istream &is, QList<TPointD> &pts) {
+  double x, y;
+  while (is >> x >> y) {
+    pts.push_back(TPointD(x, y));
+  }
+  return is;
+}
+
 template <class T>
 std::string toString2(T value) {
   std::ostringstream ss;
@@ -715,6 +723,19 @@ std::string toString2(TRect value) {
   std::ostringstream ss;
   ss << value.x0 << " " << value.y0 << " " << value.x1 << " " << value.y1
      << '\0';
+  return ss.str();
+}
+
+template <>
+std::string toString2(QList<TPointD> value) {
+  std::ostringstream ss;
+  bool first = true;
+  for (auto pt : value) {
+    if (!first) ss << " ";
+    first = false;
+    ss << pt.x << " " << pt.y;
+  }
+  ss << '\0';
   return ss.str();
 }
 
@@ -788,5 +809,20 @@ RectVar::operator TRect() const {
   return v;
 }
 void RectVar::operator=(const TRect &v) { assignValue(toString2(v)); }
+
+
+//-------------------------------------------------------------------
+
+PointListVar::PointListVar(std::string name, const QList<TPointD> &defValue)
+    : Variable(name, toString2(defValue)) {}
+PointListVar::PointListVar(std::string name) : Variable(name) {}
+PointListVar::operator QList<TPointD>() const {
+  QList<TPointD> v;
+  fromString(getValue(), v);
+  return v;
+}
+void PointListVar::operator=(const QList<TPointD> &v) {
+  assignValue(toString2(v));
+}
 
 //=========================================================

--- a/toonz/sources/include/tenv.h
+++ b/toonz/sources/include/tenv.h
@@ -80,6 +80,14 @@ public:
   void operator=(const TRect &v);
 };
 
+class DVAPI PointListVar final : public Variable {
+public:
+  PointListVar(std::string name, const QList<TPointD> &defValue);
+  PointListVar(std::string name);
+  operator QList<TPointD>() const;
+  void operator=(const QList<TPointD> &v);
+};
+
 //-------------------------------------------------------
 
 // NOTA BENE: bisogna chiamare setApplication() il prima possibile

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -167,6 +167,7 @@ private:
   void visit(TStyleIndexProperty *p) override;
   void visit(TPointerProperty *p) override;
   void visit(TColorChipProperty *p) override;
+  void visit(TStylusProperty *p) override;
 };
 
 //***********************************************************************************************
@@ -922,4 +923,4 @@ signals:
   //  void toolOptionChange();
 };
 
-#endif  // PANE_H
+#endif  // TOOLOPTIONS_H

--- a/toonz/sources/include/toonzqt/graphwidget.h
+++ b/toonz/sources/include/toonzqt/graphwidget.h
@@ -4,12 +4,24 @@
 #define GRAPHWIDGET_H
 
 #include "toonz/tstageobjectspline.h"
-#include "toonzqt/intfield.h"
+#include "toonzqt/doublefield.h"
 
 #include <QObject>
 #include <QWidget>
 #include <QMouseEvent>
 #include <QImage>
+#include <QLabel>
+#include <QPushButton>
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZQT_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
 
 class QFrame;
 class TThickPoint;
@@ -18,7 +30,7 @@ class TThickPoint;
 // GraphArea
 //-----------------------------------------------------------------------------
 
-class GraphWidget : public QWidget {
+class DVAPI GraphWidget : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(QColor SplineColor READ getSplineColor WRITE setSplineColor
@@ -62,23 +74,45 @@ class GraphWidget : public QWidget {
   int m_BottomMargin;
 
   bool m_isLinear;
-  bool m_lockExtremePoints = true;
-  bool m_constrainToBounds = true;
+  bool m_lockExtremePoints;
+  bool m_lockExtremeXPoints;
+  bool m_constrainToBounds;
 
   QPointF m_preMousePos;
 
   bool m_isEnlarged;
 
-  double m_maxXValue = 255.0;
-  double m_maxYValue = 255.0;
-  double m_cpMargin  = 20.0;
+  double m_minXValue;
+  double m_maxXValue;
+  double m_minYValue;
+  double m_maxYValue;
+  double m_cpMargin;
+  int m_gridSpacing;
+  QPointF m_xyOffset;
+  QPointF m_cursorPos;
+
+  bool m_isDragging;
 
 public:
   explicit GraphWidget(QWidget* parent = nullptr);
   QSize minimumSizeHint() const override;
   QSize sizeHint() const override;
-  void setMaxXValue(int x) { m_maxXValue = x; }
-  void setMaxYValue(int y) { m_maxYValue = y; }
+  void setMinXValue(double x) {
+    m_minXValue = x;
+    m_xyOffset.setX(-x);
+  }
+  void setMaxXValue(double x) { m_maxXValue = x; }
+  void setMinYValue(double y) {
+    m_minYValue = y;
+    m_xyOffset.setY(-y);
+  }
+  void setMaxYValue(double y) { m_maxYValue = y; }
+  void setCpMargin(double m) { m_cpMargin = m; }
+  void setGridSpacing(int spacing) { m_gridSpacing = spacing; }
+  void setLockExtremePoints(bool locked) { m_lockExtremePoints = locked; }
+  void setLockExtremeXPoints(bool xlocked) { m_lockExtremeXPoints = xlocked; }
+
+  void initializeSpline();
 
   void setPoints(QList<TPointD> points);
   void clearPoints() { m_points.clear(); }
@@ -88,6 +122,12 @@ public:
   void setCurrentControlPointIndex(int index) {
     m_currentControlPointIndex = index;
   };
+
+  TPointD getControlPoint(int index) {
+    if (m_points.isEmpty() || index >= m_points.count()) return TPointD(0, 0);
+    return TPointD(m_points.at(index).x() - m_xyOffset.x(),
+                   m_points.at(index).y() - m_xyOffset.y());
+  }
 
   bool eventFilter(QObject* object, QEvent* event) override;
 
@@ -127,6 +167,7 @@ protected:
   void selectPreviousControlPoint();
 
   QPainterPath getPainterPath();
+  QPoint clipToBorder(const QPoint p);
 
   void paintEvent(QPaintEvent*) override;
   void mouseMoveEvent(QMouseEvent*) override;
@@ -145,6 +186,70 @@ signals:
 
   void firstLastXPostionChanged(double, double);
   void updateCurrentPosition(int, QPointF);
+};
+
+//=============================================================================
+// Graph GUI
+//-----------------------------------------------------------------------------
+
+class DVAPI GraphGUIWidget : public QWidget {
+  Q_OBJECT
+
+  GraphWidget *m_graph;
+  QLabel *m_minXLabel, *m_midXLabel, *m_maxXLabel, *m_minYLabel, *m_midYLabel,
+      *m_maxYLabel;
+  QPushButton* m_resetBtn;
+
+  DVGui::DoubleLineEdit *m_outValue, *m_inValue;
+  QList<TPointD> m_defaultCurve;
+
+  bool m_updating;
+
+public:
+  GraphGUIWidget(QWidget* parent = nullptr);
+
+  void setMinXLabel(QString label) { m_minXLabel->setText(label); }
+  void setMidXLabel(QString label) { m_midXLabel->setText(label); }
+  void setMaxXLabel(QString label) { m_maxXLabel->setText(label); }
+  void setMinYLabel(QString label) { m_minYLabel->setText(label); }
+  void setMidYLabel(QString label) { m_midYLabel->setText(label); }
+  void setMaxYLabel(QString label) { m_maxYLabel->setText(label); }
+
+  // For passing onto graph
+  void setMaximumGraphSize(int w, int h) { m_graph->setMaximumSize(w, h); }
+  void setMinXValue(double value) { m_graph->setMinXValue(value); }
+  void setMaxXValue(double value) { m_graph->setMaxXValue(value); }
+  void setMinYValue(double value) { m_graph->setMinYValue(value); }
+  void setMaxYValue(double value) { m_graph->setMaxYValue(value); }
+  void setCpMargin(double margin) { m_graph->setCpMargin(margin); }
+  void setGridSpacing(int spacing) { m_graph->setGridSpacing(spacing); }
+  void setLockExtremePoints(bool isLocked) {
+    m_graph->setLockExtremePoints(isLocked);
+  }
+  void setLockExtremeXPoints(bool xlocked) {
+    m_graph->setLockExtremeXPoints(xlocked);
+  }
+  void setLinear(bool isLinear) { m_graph->setLinear(isLinear); }
+  void setCurve(QList<TPointD> points) { m_graph->setPoints(points); }
+  void clearPoints() { m_graph->clearPoints(); }
+  QList<TPointD> getCurve() { return m_graph->getPoints(); }
+  void initializeSpline() { m_graph->initializeSpline(); }
+
+  void setDefaultCurve(QList<TPointD> curve) { m_defaultCurve = curve; }
+  QList<TPointD> getDefaultCurve() { return m_defaultCurve; }
+
+protected slots:
+  void onCurvePointAdded(int);
+  void onCurveChanged(bool isDragging);
+  void onCurvePointRemoved(int);
+  void onUpdateCurrentPosition(int, QPointF);
+  void onCurveReset();
+
+  void onOutValueChanged();
+  void onInValueChanged();
+
+signals:
+  void curveChanged(bool isDragging);
 };
 
 #endif  // GRAPHWIDGET_H

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -25,6 +25,7 @@
 #include "toonzqt/glwidget_for_highdpi.h"
 #include "toonzqt/dvdialog.h"
 #include "toonzqt/hexcolornames.h"
+#include "toonzqt/stylusconfigpopup.h"
 
 // Qt includes
 #include <QWidget>
@@ -711,6 +712,9 @@ class SettingsPage final : public QScrollArea {
   TColorStyleP m_editedStyle;  //!< A copy of the current style being edited by
                                //! the Style Editor.
 
+  StylusConfigPopup *m_stylusConfig;
+  int m_parameterId;
+
   bool
       m_updating;  //!< Whether the page is copying style content to its widget,
                    //!  to be displayed.
@@ -735,6 +739,10 @@ private slots:
   void onAutofillChanged();
   void onValueChanged(bool isDragging = false);
   void onValueReset();
+  void onResetStyle();
+  void onOpenStylusConfig();
+  void onConfigStateChanged(int);
+  void onConfigCurveChanged(int, bool);
 };
 
 //=============================================================================

--- a/toonz/sources/include/toonzqt/stylusconfigpopup.h
+++ b/toonz/sources/include/toonzqt/stylusconfigpopup.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#ifndef STYLUSCONFIGPOPUP_H
+#define STYLUSCONFIGPOPUP_H
+
+#include "graphwidget.h"
+
+#include <QWidget>
+#include <QGroupBox>
+
+#include <QListWidget>
+
+class GraphGUIWidget;
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZQT_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+
+//=============================================================================
+//
+// StylusConfigTarget
+//
+//=============================================================================
+
+class DVAPI StylusConfigPopup final : public QWidget {
+  Q_OBJECT
+
+  struct GraphProperties {
+    bool enabled;
+    double minX, maxX, minY, maxY;
+    QList<TPointD> defaultCurve, curve;
+    QString minXLabel, midXLabel, maxXLabel, minYLabel, midYLabel, maxYLabel;
+  };
+
+  QLabel *m_graphTitleLabel;
+  GraphGUIWidget *m_graph;
+  QListWidget *m_configList;
+  std::vector<GraphProperties> m_configProperties;
+  int m_currentIndex;
+
+  QTimer *m_keepClosedTimer;
+  bool m_keepClosed;
+
+public:
+  StylusConfigPopup(QString title, QWidget *parent);
+
+  GraphGUIWidget *getGraphGUI() { return m_graph; }
+
+  void setGraphTitle(QString title) { m_graphTitleLabel->setText(title); }
+
+  int addConfiguration(QString name);
+
+  void setConfiguration(int configId, double minX, double maxX, double minY,
+                        double maxY, QList<TPointD> defaultCurve,
+                        QString minXLabel = "", QString midXLabel = "",
+                        QString maxXLabel = "", QString minYLabel = "",
+                        QString midYLabel = "", QString maxYLabel = "");
+
+  void setConfigEnabled(int configId, bool enabled) {
+    m_configProperties[configId].enabled = enabled;
+    m_configList->item(configId)->setCheckState(enabled ? Qt::Checked
+                                                        : Qt::Unchecked);
+  }
+  bool isConfigEnabled(int configId) {
+    return m_configProperties[configId].enabled;
+  };
+
+  void setConfigCurve(int configId, QList<TPointD> curve) {
+    m_configProperties[configId].curve = curve;
+    m_graph->setCurve(curve);
+  }
+  QList<TPointD> getConfigCurve(int configId) {
+    return m_configProperties[configId].curve;
+  };
+
+  void setConfigDefaultCurve(int configId, QList<TPointD> curve) {
+    m_configProperties[configId].defaultCurve = curve;
+  }
+  QList<TPointD> getConfigDefaultCurve(int configId) {
+    return m_configProperties[configId].defaultCurve;
+  };
+
+  void updateGraph();
+
+  bool isKeepClosed() { return m_keepClosed; }
+  void setKeepClosed(bool keepClosed) { m_keepClosed = keepClosed; }
+
+protected:
+  void mouseReleaseEvent(QMouseEvent *e) override;
+  void hideEvent(QHideEvent *e) override;
+  void showEvent(QShowEvent *) override;
+
+protected slots:
+  void onCurrentRowChanged(int);
+  void onItemChanged(QListWidgetItem *);
+  void onCurveChanged(bool);
+  void resetKeepClosed();
+
+signals:
+  void configStateChanged(int);
+  void configCurveChanged(int, bool);
+};
+
+#endif  // STYLUSCONFIGPOPUP

--- a/toonz/sources/include/tproperty.h
+++ b/toonz/sources/include/tproperty.h
@@ -6,8 +6,11 @@
 #include "tconvert.h"
 #include "tstringid.h"
 #include "tpixel.h"
+#include "tgeometry.h"
 
 #include <cstdint>
+
+#include <QList>
 
 #undef DVAPI
 #undef DVVAR
@@ -39,6 +42,7 @@ class DVAPI TIntPairProperty;
 class DVAPI TStyleIndexProperty;
 class DVAPI TPointerProperty;
 class DVAPI TColorChipProperty;
+class DVAPI TStylusProperty;
 
 class TIStream;
 class TOStream;
@@ -59,6 +63,7 @@ public:
     virtual void visit(TStyleIndexProperty *p) = 0;
     virtual void visit(TPointerProperty *p)    = 0;
     virtual void visit(TColorChipProperty *p)  = 0;
+    virtual void visit(TStylusProperty *p)  = 0;
     virtual ~Visitor() {}
   };
 
@@ -549,6 +554,51 @@ private:
   Range m_range;
   ColorChips m_chips;
   int m_index;
+};
+
+//---------------------------------------------------------
+
+class DVAPI TStylusProperty final : public TProperty {
+public:
+  TStylusProperty(const std::string &name)
+      : TProperty(name)
+      , m_pressureEnabled(false)
+      , m_tiltEnabled(false) {}
+
+  TProperty *clone() const override { return new TStylusProperty(*this); }
+
+  std::string getValueAsString() override { return "-"; }
+  void setValue(const std::wstring &value) {}
+  std::wstring getValue() const { return L"-"; }
+
+  void accept(Visitor &v) override { v.visit(this); }
+
+  // Pressure
+  void setPressureEnabled(bool enabled) { m_pressureEnabled = enabled; }
+  bool isPressureEnabled() { return m_pressureEnabled; }
+
+  void setPressureCurve(QList<TPointD> curve) { m_pressureCurve = curve; }
+  QList<TPointD> getPressureCurve() { return m_pressureCurve; }
+
+  void setDefaultPressureCurve(QList<TPointD> curve) {
+    m_defaultPressureCurve = curve;
+  }
+  QList<TPointD> getDefaultPressureCurve() { return m_defaultPressureCurve; }
+
+  // Tilt
+  void setTiltEnabled(bool enabled) { m_tiltEnabled = enabled; }
+  bool isTiltEnabled() { return m_tiltEnabled; }
+
+  void setTiltCurve(QList<TPointD> curve) { m_tiltCurve = curve; }
+  QList<TPointD> getTiltCurve() { return m_tiltCurve; }
+
+  void setDefaultTiltCurve(QList<TPointD> curve) { m_defaultTiltCurve = curve; }
+  QList<TPointD> getDefaultTiltCurve() { return m_defaultTiltCurve; }
+
+private:
+  bool m_pressureEnabled, m_tiltEnabled;
+  QList<TPointD> m_pressureCurve, m_tiltCurve;
+  QList<TPointD> m_defaultPressureCurve, m_defaultTiltCurve;
 };
 
 //---------------------------------------------------------

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -88,7 +88,7 @@ protected:
 
   TIntPairProperty m_thickness;
   TDoubleProperty m_smooth;
-  TBoolProperty m_pressure;
+  TBoolProperty m_mypaintPressure;
   TDoublePairProperty m_opacity;
   TDoubleProperty m_hardness;
   TDoubleProperty m_modifierSize;
@@ -98,12 +98,14 @@ protected:
   TBoolProperty m_modifierPaintBehind;
   TEnumProperty m_preset;
   TBoolProperty m_snapGrid;
-  TBoolProperty m_tilt;
+  TBoolProperty m_mypaintTilt;
+  TStylusProperty m_sizeStylusProperty, m_opacityStylusProperty;
 
   TPixel32 m_currentColor;
-  bool m_enabledPressure;
-  bool m_enabledTilt;
+  bool m_enabledPressure, m_enabledOPressure;
+  bool m_enabledTilt, m_enabledOTilt;
   int m_minCursorThick, m_maxCursorThick;
+  bool m_isMyPaintStyleSelected;
 
   TPointD m_mousePos,    //!< Current mouse position, in world coordinates.
       m_brushPos,        //!< World position the brush will be painted at.

--- a/toonz/sources/tnztools/mypainttoonzbrush.cpp
+++ b/toonz/sources/tnztools/mypainttoonzbrush.cpp
@@ -280,9 +280,11 @@ void MyPaintToonzBrush::strokeTo(const TPointD &point, double pressure,
         sub->p2.setMedian(sub->p1, segment->p1);
         segment = sub;
       } else {
+        // If initial time is 0.0, let's prevent a large dot from appearing
+        double elapsedTime = p0.time == 0.0 ? 0.5 : segment->p2.time - p0.time;
         brushes[i].strokeTo(m_mypaintSurface, segment->p2.x, segment->p2.y,
                             segment->p2.pressure, segment->p2.tiltX,
-                            segment->p2.tiltY, segment->p2.time - p0.time);
+                            segment->p2.tiltY, elapsedTime);
         if (segment == stack) break;
         p0 = segment->p2;
         --segment;

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -331,6 +331,7 @@ void ToolOptionControlBuilder::visit(TStyleIndexProperty *p) {
       new StyleIndexFieldAndChip(m_tool, p, m_pltHandle, m_toolHandle);
   hLayout()->addWidget(chip, 0);
   m_panel->addControl(chip);
+  hLayout()->addSpacing(5);
 }
 
 //----------------------------------------------------------------------------------
@@ -347,6 +348,26 @@ void ToolOptionControlBuilder::visit(TColorChipProperty *p) {
   ColorChipCombo *chipCombo = new ColorChipCombo(m_tool, p);
   hLayout()->addWidget(chipCombo, 0);
   m_panel->addControl(chipCombo);
+  hLayout()->addSpacing(5);
+}
+
+//-----------------------------------------------------------------------------
+
+void ToolOptionControlBuilder::visit(TStylusProperty *p) {
+  ToolOptionStylusConfigButton *obj =
+      new ToolOptionStylusConfigButton(m_tool, p);
+  obj->setToolTip(p->getQStringName());
+
+  // This should be following another control.  Remove space item added after
+  // last control
+  int x             = hLayout()->count();
+  QLayoutItem *item = hLayout()->itemAt(x - 1);
+  hLayout()->removeItem(item);
+  delete item;
+
+  hLayout()->addWidget(obj, 100);
+  m_panel->addControl(obj);
+  hLayout()->addSpacing(5);
 }
 
 //=============================================================================

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2202,8 +2202,6 @@ void BrushToolOptionsBox::filterControls() {
                      it.key() == "Preset:" || it.key() == "Grid" ||
                      it.key() == "Smooth:" || it.key() == "Paint Behind");
     bool visible = isCommon || (isModifier == showModifiers);
-    // Temporary since Tilt is only available for MyPaint styles
-    if (it.key() == "Tilt") visible = showModifiers;
     it.value()->setVisible(visible);
   }
 
@@ -2215,8 +2213,6 @@ void BrushToolOptionsBox::filterControls() {
                      it.key() == "Preset:" || it.key() == "Grid" ||
                      it.key() == "Smooth:" || it.key() == "Paint Behind");
     bool visible = isCommon || (isModifier == showModifiers);
-    // Temporary since Tilt is only available for MyPaint styles
-    if (it.key() == "Tilt") visible = showModifiers;
     if (QWidget *widget = dynamic_cast<QWidget *>(it.value()))
       widget->setVisible(visible);
   }

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -18,6 +18,7 @@
 #include "toonzqt/checkbox.h"
 #include "toonzqt/doublefield.h"
 #include "toonzqt/popupbutton.h"
+#include "toonzqt/stylusconfigpopup.h"
 
 // TnzLib includes
 #include "toonz/txsheet.h"
@@ -255,6 +256,30 @@ public:
 public slots:
 
   void onValueChanged();
+};
+
+
+//-----------------------------------------------------------------------------
+
+class ToolOptionStylusConfigButton final : public QPushButton,
+                                           public ToolOptionControl {
+  Q_OBJECT
+
+protected:
+  TStylusProperty *m_property;
+
+  StylusConfigPopup *m_stylusConfig;
+  int m_pressureId, m_tiltId;
+
+public:
+  ToolOptionStylusConfigButton(TTool *tool, TStylusProperty *property);
+  void updateStatus() override;
+  TStylusProperty *getProperty() { return m_property; }
+
+public slots:
+  void onClicked();
+  void onConfigStateChanged(int);
+  void onConfigCurveChanged(int, bool);
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -43,10 +43,11 @@ struct BrushData final : public TPersist {
 
   std::wstring m_name;
   double m_min, m_max, m_smooth, m_hardness, m_opacityMin, m_opacityMax;
-  bool m_pencil, m_pressure, m_tilt;
+  bool m_pencil, m_pressure, m_tilt, m_opressure, m_otilt, m_mypaintPressure, m_mypaintTilt;
   int m_drawOrder;
   double m_modifierSize, m_modifierOpacity;
   bool m_modifierEraser, m_modifierLockAlpha, m_modifierPaintBehind;
+  QList<TPointD> m_pressureCurve, m_opressureCurve, m_tiltCurve, m_otiltCurve;
 
   BrushData();
   BrushData(const std::wstring &name);

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -130,7 +130,6 @@ set(MOC_HEADERS
     convertfolderpopup.h
     exportcameratrackpopup.h
     motionpathpanel.h
-    graphwidget.h
     ../stopmotion/stopmotion.h
     ../stopmotion/stopmotioncontroller.h
     ../stopmotion/webcam.h
@@ -383,7 +382,6 @@ set(SOURCES
     ObjectTracker.cpp
     predict3d.cpp
     motionpathpanel.cpp
-    graphwidget.cpp
     ../stopmotion/stopmotion.cpp
     ../stopmotion/stopmotioncontroller.cpp
     ../stopmotion/webcam.cpp

--- a/toonz/sources/toonz/icons/dark/actions/16/config.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/config.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   xml:space="preserve"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+   id="svg3"
+   sodipodi:docname="config.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs7" /><sodipodi:namedview
+   id="namedview5"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:zoom="42.294118"
+   inkscape:cx="8.5"
+   inkscape:cy="8.488178"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg3"><inkscape:grid
+     type="xygrid"
+     id="grid824" /></sodipodi:namedview>
+    
+<g
+   id="g10"
+   transform="matrix(0.02448979,0,0,0.02448979,1.7306123,1.7306123)"><line
+     fill="none"
+     y1="501"
+     x1="303.10001"
+     y2="501"
+     x2="302.10001"
+     id="line2" /><g
+     id="g8"><path
+       id="path4-9"
+       style="stroke-width:0.0285714"
+       d="M 6.6855469,1 V 2.3808594 C 6.0569756,2.5351451 5.4680244,2.7919086 4.9394531,3.1347656 L 3.9628906,2.1621094 2.109375,4.0078125 3.1171875,5.0136719 C 3.0371875,5.1451004 2.9650558,5.2769197 2.8964844,5.4140625 2.6821987,5.8226338 2.5196317,6.2721318 2.4082031,6.7207031 H 1 v 2.6191407 h 1.4375 c 0.042857,0.1714285 0.093248,0.3392411 0.1503906,0.5078124 0.00286,0.011429 0.00886,0.023728 0.011719,0.035156 0,0.00286 0.00391,0.006 0.00391,0.011719 0.14,0.4057138 0.3220648,0.7912948 0.5449219,1.1484378 l -1.0136719,1.007812 1.8535156,1.845703 1.0039063,-0.996093 c 0.522857,0.328571 1.1016073,0.576038 1.71875,0.724609 V 15 H 9.3144531 V 13.654297 C 9.9630244,13.51144 10.571473,13.263828 11.117188,12.923828 l 0.919921,0.914063 1.853516,-1.845703 -0.916016,-0.91211 c 0.342857,-0.545714 0.596474,-1.1511607 0.742188,-1.7968749 H 15 V 9.2792969 6.6601562 H 13.705078 C 13.55365,6.0201564 13.296886,5.4219084 12.951172,4.8847656 L 13.890625,3.9511719 12.037109,2.1054688 11.082031,3.0566406 C 10.544889,2.7280693 9.9506918,2.4876562 9.3164062,2.3476562 V 1 Z m 1.34375,4.7832031 c 1.2193343,0 2.2304691,1.0059132 2.2304691,2.2167969 0,1.2108837 -1.013108,2.216797 -2.2304691,2.216797 C 6.8119357,10.216797 5.796875,9.2325417 5.796875,8 c 0,-1.2325417 1.0130876,-2.2167969 2.2324219,-2.2167969 z"
+       transform="matrix(35.000008,0,0,35.000008,-24.000005,-24.000008)" /></g></g></svg>

--- a/toonz/sources/toonz/motionpathpanel.cpp
+++ b/toonz/sources/toonz/motionpathpanel.cpp
@@ -14,7 +14,7 @@
 #include "tools/toolhandle.h"
 #include "tools/toolcommandids.h"
 #include "tproperty.h"
-#include "graphwidget.h"
+#include "toonzqt/graphwidget.h"
 #include "menubarcommandids.h"
 #include "tstroke.h"
 #include "tgeometry.h"

--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.h
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.h
@@ -33,6 +33,7 @@ private:
   void visit(TStyleIndexProperty* p) override {}
   void visit(TPointerProperty* p) override {}
   void visit(TColorChipProperty* p) override {}
+  void visit(TStylusProperty* p) override {}
 };
 
 //=============================================================================

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -55,6 +55,8 @@
     <file>icons/dark/actions/16/plugins.svg</file>
     <file>icons/dark/actions/16/downloads.svg</file>
 
+    <file>icons/dark/actions/16/config.svg</file>
+
     <!-- File / Common -->
 		<file>icons/dark/actions/16/menu.svg</file>
 		<file>icons/dark/actions/16/export.svg</file>

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -72,6 +72,7 @@ set(MOC_HEADERS
     ../include/toonzqt/validatedchoicedialog.h
     ../include/toonzqt/insertfxpopup.h
     ../include/toonzqt/graphwidget.h
+    ../include/toonzqt/stylusconfigpopup.h
 )
 
 set(HEADERS
@@ -201,9 +202,10 @@ set(SOURCES
     plugin_param_view_interface.cpp
     plugin_ui_page_interface.cpp
     toonz_params.cpp
-	lutcalibrator.cpp
+    lutcalibrator.cpp
     insertfxpopup.cpp
     graphwidget.cpp
+    stylusconfigpopup.cpp
 )
 
 set(RESOURCES toonzqt.qrc)

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -71,6 +71,7 @@ set(MOC_HEADERS
     ../include/toonzqt/updatechecker.h
     ../include/toonzqt/validatedchoicedialog.h
     ../include/toonzqt/insertfxpopup.h
+    ../include/toonzqt/graphwidget.h
 )
 
 set(HEADERS
@@ -202,6 +203,7 @@ set(SOURCES
     toonz_params.cpp
 	lutcalibrator.cpp
     insertfxpopup.cpp
+    graphwidget.cpp
 )
 
 set(RESOURCES toonzqt.qrc)

--- a/toonz/sources/toonzqt/graphwidget.cpp
+++ b/toonz/sources/toonzqt/graphwidget.cpp
@@ -1,24 +1,13 @@
-#include "graphwidget.h"
-#include "tapp.h"
-//#include "toonz/txsheethandle.h"
-//#include "toonz/txsheet.h"
+#include "toonzqt/graphwidget.h"
 #include "toonz/tobjecthandle.h"
-//#include "toonz/tstageobjecttree.h"
-//#include "toonz/tstageobjectcmd.h"
-//#include "toonzqt/menubarcommand.h"
-//#include "toonz/tscenehandle.h"
 #include "toonzqt/gutil.h"
-//#include "toonzqt/menubarcommand.h"
-//#include "menubarcommandids.h"
-//#include "tstroke.h"
 #include "tgeometry.h"
-
-//#include "pane.h"
 
 #include <QPixmap>
 #include <QPainter>
 #include <QPainterPath>
 #include <QApplication>
+#include <QHBoxLayout>
 
 //-----------------------------------------------------------------------------
 namespace {
@@ -114,13 +103,23 @@ GraphWidget::GraphWidget(QWidget* parent)
     //, m_histogramView(histogramView)
     , m_currentControlPointIndex(-1)
     , m_mouseButton(Qt::NoButton)
+    , m_minXValue(0.0)
     , m_maxXValue(255.0)
+    , m_minYValue(0.0)
     , m_maxYValue(255.0)
+    , m_xyOffset(0.0, 0.0)
+    , m_cpMargin(20.0)
     , m_LeftRightMargin(0)
     , m_TopMargin(0)
     , m_BottomMargin(0)
+    , m_constrainToBounds(true)
     , m_isLinear(false)
-    , m_isEnlarged(false) {
+    , m_isEnlarged(false)
+    , m_lockExtremePoints(true)
+    , m_lockExtremeXPoints(false)
+    , m_cursorPos(-1, -1)
+    , m_gridSpacing(8)
+    , m_isDragging(false) {
   // setFixedSize(m_curveHeight + 2 * m_LeftRightMargin,
   //             m_curveHeight + m_TopMargin + m_BottomMargin);
   setAttribute(Qt::WA_KeyCompression);
@@ -139,10 +138,51 @@ QSize GraphWidget::minimumSizeHint() const { return QSize(100, 100); }
 
 //-----------------------------------------------------------------------------
 
+//-----------------------------------------------------------------------------
+
 void GraphWidget::setPoints(QList<TPointD> points) {
+  double xMax = m_maxXValue + m_xyOffset.x();
+
   if (!m_points.isEmpty()) m_points.clear();
-  for (const TPointD& point : points)
-    m_points.push_back(QPointF(point.x, point.y));
+
+  if (m_isLinear) {
+    int n = points.count();
+
+    // First point
+    setPoint(0, QPointF(-40, points[0].y + m_xyOffset.y()));
+    setPoint(1, QPointF(-20, points[0].y + m_xyOffset.y()));
+    setPoint(2, QPointF(-20, points[0].y + m_xyOffset.y()));
+    setPoint(
+        3, QPointF(points[0].x + m_xyOffset.x(), points[0].y + m_xyOffset.y()));
+    setPoint(
+        4, QPointF(points[0].x + m_xyOffset.x(), points[0].y + m_xyOffset.y()));
+
+    int x = 5;
+    for (int i = 1; i <= (n - 2); i++) {
+      setPoint(x++, QPointF(points[i].x + m_xyOffset.x(),
+                            points[i].y + m_xyOffset.y()));
+      setPoint(x++, QPointF(points[i].x + m_xyOffset.x(),
+                            points[i].y + m_xyOffset.y()));
+      setPoint(x++, QPointF(points[i].x + m_xyOffset.x(),
+                            points[i].y + m_xyOffset.y()));
+    }
+
+    // Last point
+    setPoint(x, QPointF(points[n - 1].x + m_xyOffset.x(),
+                        points[n - 1].y + m_xyOffset.y()));
+    setPoint(x + 1, QPointF(points[n - 1].x + m_xyOffset.x(),
+                            points[n - 1].y + m_xyOffset.y()));
+    setPoint(x + 2, QPointF(xMax + 20, points[n - 1].y + m_xyOffset.y()));
+    setPoint(x + 3, QPointF(xMax + 20, points[n - 1].y + m_xyOffset.y()));
+    setPoint(x + 4, QPointF(xMax + 40, points[n - 1].y + m_xyOffset.y()));
+  } else {
+    for (const TPointD& point : points)
+      m_points.push_back(
+          QPointF(point.x + m_xyOffset.x(), point.y + m_xyOffset.y()));
+  }
+
+  m_currentControlPointIndex = -1;
+
   // update slider position according to the first and the last control points
   int firstIndex = 3;
   int lastIndex  = m_points.size() - 4;
@@ -156,8 +196,16 @@ void GraphWidget::setPoints(QList<TPointD> points) {
 QList<TPointD> GraphWidget::getPoints() {
   QList<TPointD> points;
   if (m_points.isEmpty()) return points;
-  for (const QPointF& point : m_points)
-    points.push_back(TPointD(point.x(), point.y()));
+  if (m_isLinear) {
+    int n = ((m_points.count() - 1) / 3) - 1;
+    for (int i = 0; i < n; i++)
+      points.push_back(TPointD(m_points[(i + 1) * 3].x() - m_xyOffset.x(),
+                               m_points[(i + 1) * 3].y() - m_xyOffset.y()));
+  } else {
+    for (const QPointF& point : m_points)
+      points.push_back(
+          TPointD(point.x() - m_xyOffset.x(), point.y() - m_xyOffset.y()));
+  }
   return points;
 }
 
@@ -167,8 +215,11 @@ QPointF GraphWidget::convertPointToLocal(QPointF point) {
   float daWidth  = (float)width();
   float daHeight = (float)height();
 
-  float outX = std::max(0.0, (point.x() / m_maxXValue) * daWidth - 1.0);
-  float outY = (point.y() / m_maxXValue) * daHeight;
+  double xMax = m_maxXValue + m_xyOffset.x();
+  double yMax = m_maxYValue + m_xyOffset.y();
+
+  float outX = std::max(0.0, (point.x() / xMax) * daWidth - 1.0);
+  float outY = (point.y() / yMax) * daHeight;
 
   return QPointF(outX, outY);
 }
@@ -179,8 +230,11 @@ QPointF GraphWidget::convertPointFromLocal(QPointF point) {
   float daWidth  = (float)width();
   float daHeight = (float)height();
 
-  float outX = (point.x() / daWidth) * m_maxXValue;
-  float outY = (point.y() / daHeight) * m_maxYValue;
+  double xMax = m_maxXValue + m_xyOffset.x();
+  double yMax = m_maxYValue + m_xyOffset.y();
+
+  float outX = (point.x() / daWidth) * xMax;
+  float outY = (point.y() / daHeight) * yMax;
 
   return QPointF(outX, outY);
 }
@@ -243,21 +297,25 @@ void GraphWidget::setLinear(bool isLinear) {
 
 QPointF GraphWidget::checkPoint(const QPointF p) {
   QPointF checkedP = p;
+  double xMax      = m_maxXValue + m_xyOffset.x();
+  double yMax      = m_maxYValue + m_xyOffset.y();
   if (p.x() < 0)
     checkedP.setX(0);
-  else if (p.x() > m_maxXValue)
-    checkedP.setX(m_maxXValue);
+  else if (p.x() > xMax)
+    checkedP.setX(xMax);
   if (p.y() < 0)
     checkedP.setY(0);
-  else if (p.y() > m_maxYValue)
-    checkedP.setY(m_maxYValue);
+  else if (p.y() > yMax)
+    checkedP.setY(yMax);
   return checkedP;
 }
 
 //-----------------------------------------------------------------------------
 
 QPointF GraphWidget::getVisibleHandlePos(int index) {
-  QRectF rect(0.0, 0.0, m_maxXValue, m_maxYValue);
+  double xMax = m_maxXValue + m_xyOffset.x();
+  double yMax = m_maxYValue + m_xyOffset.y();
+  QRectF rect(0.0, 0.0, xMax, yMax);
   QPointF handlePos(m_points.at(index));
   // handlePos = convertPointToLocal(handlePos);
   if (isCentralControlPoint(index) || rect.contains(handlePos))
@@ -280,15 +338,15 @@ QPointF GraphWidget::getVisibleHandlePos(int index) {
   } else {  // isRightControlPoint
     QPointF cp = m_points.at(index - 1);
     QVector2D rHandle(handlePos - cp);
-    if (handlePos.x() > m_maxXValue) {
-      float ratio = (m_maxXValue - cp.x()) / rHandle.x();
+    if (handlePos.x() > xMax) {
+      float ratio = (xMax - cp.x()) / rHandle.x();
       handlePos   = cp + rHandle.toPointF() * ratio;
     }
     if (handlePos.y() < 0) {
       float ratio = -cp.y() / rHandle.y();
       handlePos   = cp + rHandle.toPointF() * ratio;
-    } else if (handlePos.y() > m_maxYValue) {
-      float ratio = (m_maxYValue - cp.y()) / rHandle.y();
+    } else if (handlePos.y() > yMax) {
+      float ratio = (yMax - cp.y()) / rHandle.y();
       handlePos   = cp + rHandle.toPointF() * ratio;
     }
   }
@@ -333,10 +391,9 @@ int GraphWidget::getClosestPointIndex(QPointF& pos, double& minDistance2) {
     if (m_isLinear && !isCentralControlPoint(i)) continue;
     QPointF visiblePoint = getVisibleHandlePos(i);
 
-    pointType type =
-        (isCentralControlPoint(i))
-            ? ControlPoint
-            : (visiblePoint == m_points.at(i)) ? Handle : PseudoHandle;
+    pointType type = (isCentralControlPoint(i))         ? ControlPoint
+                     : (visiblePoint == m_points.at(i)) ? Handle
+                                                        : PseudoHandle;
 
     double distance2 = qtDistance2(convertPointToLocal(pos),
                                    convertPointToLocal(visiblePoint));
@@ -368,7 +425,7 @@ void GraphWidget::movePoint(int index, const QPointF delta) {
 //-----------------------------------------------------------------------------
 
 void GraphWidget::setPoint(int index, const QPointF p) {
-  QPointF newP                  = p;
+  QPointF newP = p;
   if (m_constrainToBounds) newP = checkPoint(p);
   m_points.removeAt(index);
   m_points.insert(index, newP);
@@ -410,7 +467,7 @@ void GraphWidget::moveCurrentControlPoint(QPointF delta) {
         setPoint(m_currentControlPointIndex + 2, cp + newRHandle.toPointF());
       }
     }
-    emit controlPointChanged(true);
+    emit controlPointChanged(m_isDragging);
   }
   // in case moving the right handle
   else {
@@ -434,11 +491,12 @@ void GraphWidget::moveCurrentControlPoint(QPointF delta) {
         setPoint(m_currentControlPointIndex - 2, cp + newLHandle.toPointF());
       }
     }
-    emit controlPointChanged(true);
+    emit controlPointChanged(m_isDragging);
   }
   update();
-  emit updateCurrentPosition(m_currentControlPointIndex,
-                             m_points.at(m_currentControlPointIndex));
+  emit updateCurrentPosition(
+      m_currentControlPointIndex,
+      m_points.at(m_currentControlPointIndex) - m_xyOffset);
 }
 
 //-----------------------------------------------------------------------------
@@ -459,9 +517,9 @@ void GraphWidget::moveCentralControlPoint(int index, QPointF delta) {
   double nextDistance = nextP.x() - (p.x() + d.x());
   double precDistance = (p.x() + d.x()) - precP.x();
 
-  if (nextDistance < m_cpMargin)
+  if (index != (pointCount - 4) && nextDistance < m_cpMargin)
     d = QPointF(nextP.x() - p.x() - m_cpMargin, d.y());
-  else if (precDistance < m_cpMargin)
+  else if (index != 3 && precDistance < m_cpMargin)
     d = QPointF(precP.x() - p.x() + m_cpMargin, d.y());
 
   if (d.isNull()) return;
@@ -471,6 +529,8 @@ void GraphWidget::moveCentralControlPoint(int index, QPointF delta) {
     movePoint(index - 1, dY);
     movePoint(index - 2, dY);
     movePoint(index - 3, dY);
+    // Only allow vertical movement if enabled
+    if (m_lockExtremeXPoints) d.setX(0);
   }
 
   if (index == pointCount - 4) {
@@ -478,16 +538,20 @@ void GraphWidget::moveCentralControlPoint(int index, QPointF delta) {
     movePoint(index + 1, dY);
     movePoint(index + 2, dY);
     movePoint(index + 3, dY);
+    // Only allow vertical movement if enabled
+    if (m_lockExtremeXPoints) d.setX(0);
   }
   if (index > 3) movePoint(index - 1, d);
   if (index < pointCount - 4) movePoint(index + 1, d);
   movePoint(index, d);
-  emit controlPointChanged(true);
+  emit controlPointChanged(m_isDragging);
 }
 
 //-----------------------------------------------------------------------------
 
 void GraphWidget::addControlPoint(double percent) {
+  double xMax       = m_maxXValue + m_xyOffset.x();
+  double yMax       = m_maxYValue + m_xyOffset.y();
   QPainterPath path = getPainterPath();
   QPointF p         = convertPointFromLocal(path.pointAtPercent(percent));
 
@@ -525,12 +589,10 @@ void GraphWidget::addControlPoint(double percent) {
 
   int newControlPointIndex = beforeControlPointIndex + 3;
   m_points.insert(newControlPointIndex - 1,
-                  QPointF(p.x() - (m_maxXValue * 0.063),
-                          p.y() - (m_maxYValue * 0.063) * m));
+                  QPointF(p.x() - (xMax * 0.063), p.y() - (yMax * 0.063) * m));
   m_points.insert(newControlPointIndex, p);
   m_points.insert(newControlPointIndex + 1,
-                  QPointF(p.x() + (m_maxXValue * 0.063),
-                          p.y() + (m_maxYValue * 0.063) * m));
+                  QPointF(p.x() + (xMax * 0.063), p.y() + (yMax * 0.063) * m));
 
   m_currentControlPointIndex = newControlPointIndex;
   m_preMousePos              = p;
@@ -554,13 +616,17 @@ void GraphWidget::selectNextControlPoint() {
   int firstVisibleControlPoint = 3;
   int lastVisibleControlPoint  = m_points.size() - 4;
 
-  m_currentControlPointIndex++;
+  if (m_isLinear)
+    m_currentControlPointIndex += 3;
+  else
+    m_currentControlPointIndex++;
   if (m_currentControlPointIndex < firstVisibleControlPoint ||
       m_currentControlPointIndex > lastVisibleControlPoint)
     m_currentControlPointIndex = firstVisibleControlPoint;
 
-  emit updateCurrentPosition(m_currentControlPointIndex,
-                             m_points.at(m_currentControlPointIndex));
+  emit updateCurrentPosition(
+      m_currentControlPointIndex,
+      m_points.at(m_currentControlPointIndex) - m_xyOffset);
   update();
 }
 
@@ -574,27 +640,70 @@ void GraphWidget::selectPreviousControlPoint() {
   int firstVisibleControlPoint = 3;
   int lastVisibleControlPoint  = m_points.size() - 4;
 
-  m_currentControlPointIndex--;
+  if (m_isLinear)
+    m_currentControlPointIndex -= 3;
+  else
+    m_currentControlPointIndex--;
   if (m_currentControlPointIndex < firstVisibleControlPoint ||
       m_currentControlPointIndex > lastVisibleControlPoint)
     m_currentControlPointIndex = lastVisibleControlPoint;
 
-  emit updateCurrentPosition(m_currentControlPointIndex,
-                             m_points.at(m_currentControlPointIndex));
+  emit updateCurrentPosition(
+      m_currentControlPointIndex,
+      m_points.at(m_currentControlPointIndex) - m_xyOffset);
   update();
 }
 
 //-----------------------------------------------------------------------------
 
+void GraphWidget::initializeSpline() {
+  double xMax = m_maxXValue + m_xyOffset.x();
+  double yMax = m_maxYValue + m_xyOffset.y();
+
+  m_points.clear();
+
+  double minY = 0, maxY = yMax;
+  double minHYAdj = 0.063, maxHYAdj = 0.937;
+
+  // First point
+  setPoint(0, QPointF(-40, minY));
+  setPoint(1, QPointF(-20, minY));
+  setPoint(2, QPointF(-20, minY));
+  setPoint(3, QPointF(0, minY));
+  setPoint(4, QPointF(xMax * 0.063, yMax * minHYAdj));
+
+  // Last point
+  setPoint(5, QPointF(xMax * 0.937, yMax * maxHYAdj));
+  setPoint(6, QPointF(xMax, maxY));
+  setPoint(7, QPointF(xMax + 20, maxY));
+  setPoint(8, QPointF(xMax + 20, maxY));
+  setPoint(9, QPointF(xMax + 40, maxY));
+  update();
+
+  m_currentControlPointIndex = -1;
+
+  emit controlPointChanged(false);
+}
+
+//-----------------------------------------------------------------------------
+
 void GraphWidget::removeControlPoint(int index) {
+  double xMax = m_maxXValue + m_xyOffset.x();
+  double yMax = m_maxYValue + m_xyOffset.y();
+
   // Don't delete the first cubic
+  double minY = 0, maxY = yMax;
+  double minHYAdj = 0.063, maxHYAdj = 0.937;
   if (index <= 4) {
-    setPoint(0, QPointF(-40, 0));
-    setPoint(1, QPointF(-20, 0));
-    setPoint(2, QPointF(-20, 0));
-    setPoint(3, QPointF(0, 0));
-    setPoint(4, QPointF(m_maxXValue * 0.063, m_maxYValue * 0.063));
+    setPoint(0, QPointF(-40, minY));
+    setPoint(1, QPointF(-20, minY));
+    setPoint(2, QPointF(-20, minY));
+    setPoint(3, QPointF(0, minY));
+    setPoint(4, QPointF(xMax * 0.063, yMax * minHYAdj));
     update();
+    emit updateCurrentPosition(
+        m_currentControlPointIndex,
+        m_points.at(m_currentControlPointIndex) - m_xyOffset);
     emit controlPointChanged(false);
     return;
   }
@@ -602,12 +711,15 @@ void GraphWidget::removeControlPoint(int index) {
   // Don't delete the last cubic
   if (index >= m_points.size() - 5) {
     int i = m_points.size() - 5;
-    setPoint(i, QPointF(m_maxXValue * 0.937, m_maxYValue * 0.937));
-    setPoint(i + 1, QPointF(m_maxXValue, m_maxYValue));
-    setPoint(i + 2, QPointF(m_maxXValue + 20, m_maxYValue));
-    setPoint(i + 3, QPointF(m_maxXValue + 20, m_maxYValue));
-    setPoint(i + 4, QPointF(m_maxXValue + 40, m_maxYValue));
+    setPoint(i, QPointF(xMax * 0.937, yMax * maxHYAdj));
+    setPoint(i + 1, QPointF(xMax, maxY));
+    setPoint(i + 2, QPointF(xMax + 20, maxY));
+    setPoint(i + 3, QPointF(xMax + 20, maxY));
+    setPoint(i + 4, QPointF(xMax + 40, maxY));
     update();
+    emit updateCurrentPosition(
+        m_currentControlPointIndex,
+        m_points.at(m_currentControlPointIndex) - m_xyOffset);
     emit controlPointChanged(false);
     return;
   }
@@ -625,10 +737,10 @@ void GraphWidget::removeControlPoint(int index) {
   m_points.removeAt(firstIndex);
 
   emit controlPointRemoved(firstIndex + 1);
-  m_currentControlPointIndex = firstIndex - 2;
+  m_currentControlPointIndex = -1;
 
   emit updateCurrentPosition(m_currentControlPointIndex,
-                             m_points.at(m_currentControlPointIndex));
+                             QPointF(0, 0) - m_xyOffset);
 
   update();
 }
@@ -678,6 +790,27 @@ QPainterPath GraphWidget::getPainterPath() {
 
 //-----------------------------------------------------------------------------
 
+QPoint GraphWidget::clipToBorder(const QPoint p) {
+  QPoint tempPos = p;
+  int x          = tempPos.x();
+  int y          = tempPos.y();
+
+  if (x < 0)
+    x = 0;
+  else if (x > width())
+    x = width();
+  if (y < 0)
+    y = 0;
+  else if (y > height())
+    y = height();
+  tempPos.setX(x);
+  tempPos.setY(y);
+
+  return tempPos;
+}
+
+//-----------------------------------------------------------------------------
+
 void GraphWidget::paintEvent(QPaintEvent* e) {
   QPainter painter(this);
 
@@ -685,15 +818,16 @@ void GraphWidget::paintEvent(QPaintEvent* e) {
   painter.setRenderHint(QPainter::Antialiasing, false);
   painter.setPen(m_graphColor);
 
+  // Draw Grid
   QRectF r = rect().adjusted(m_LeftRightMargin, m_TopMargin, -m_LeftRightMargin,
                              -m_BottomMargin);
-  int step = width() / 8;
-  for (int i = 1; i < 8; i++) {
+  double step = r.width() / m_gridSpacing;
+  for (int i = 1; i < m_gridSpacing; i++) {
     painter.drawLine(QPoint(step * i, 0), QPoint(step * i, height()));
   }
 
-  step = height() / 8;
-  for (int i = 1; i < 8; i++) {
+  step = r.height() / m_gridSpacing;
+  for (int i = 1; i < m_gridSpacing; i++) {
     painter.drawLine(QPoint(0, step * i), QPoint(width(), step * i));
   }
 
@@ -701,6 +835,7 @@ void GraphWidget::paintEvent(QPaintEvent* e) {
   painter.translate(m_LeftRightMargin + 1, height() - m_BottomMargin);
   painter.scale(scale, -scale);
 
+  // Draw Spline
   QPainterPath path = getPainterPath();
   if (path.isEmpty()) return;
   painter.setRenderHint(QPainter::Antialiasing, true);
@@ -714,14 +849,23 @@ void GraphWidget::paintEvent(QPaintEvent* e) {
   painter.setBrush(Qt::NoBrush);
   painter.drawPath(path);
 
+  // Draw Control Points
   int n     = m_points.size();
   QPointF p = convertPointToLocal(m_points.at(3));
+
+  double minDistance;
+  int highlightPointIndex = getClosestPointIndex(m_cursorPos, minDistance);
+  if (m_cursorPos == QPointF(-1, -1) || minDistance > 20.0 ||
+      (m_lockExtremePoints &&
+       (highlightPointIndex == 3 || highlightPointIndex == (n - 4))))
+    highlightPointIndex = -1;
+
   for (int i = 3; i < n - 3; i++) {
     QBrush brush(Qt::white);
-    int rad       = (m_isEnlarged) ? 1 : 2;
+    int rad       = 4;  //(m_isEnlarged) ? 1 : 2;
     QPointF nextP = convertPointToLocal(m_points.at(i + 1));
     if (isCentralControlPoint(i))
-      rad = (m_isEnlarged) ? 2 : 3;
+      rad = 5;  //(m_isEnlarged) ? 2 : 3;
     else if (m_isLinear) {
       p = nextP;
       continue;
@@ -738,10 +882,12 @@ void GraphWidget::paintEvent(QPaintEvent* e) {
 
       handlePos = convertPointToLocal(getVisibleHandlePos(i));
     }
-
-    painter.setBrush((m_currentControlPointIndex != i)
-                         ? m_nonSelectedPointColor
-                         : (p == handlePos) ? m_selectedPointColor : Qt::blue);
+    painter.setBrush(highlightPointIndex == i
+                         ? Qt::yellow
+                         : ((m_currentControlPointIndex != i)
+                                ? m_nonSelectedPointColor
+                            : (p == handlePos) ? m_selectedPointColor
+                                               : Qt::blue));
     painter.setPen(m_splineColor);
 
     QRectF pointRect(handlePos.x() - rad, handlePos.y() - rad, 2 * rad,
@@ -755,27 +901,19 @@ void GraphWidget::paintEvent(QPaintEvent* e) {
 
 void GraphWidget::mouseMoveEvent(QMouseEvent* e) {
   QPoint tempPos = e->pos();
-  int x          = tempPos.x();
-  int y          = tempPos.y();
 
-  if (m_constrainToBounds) {
-    if (x < 0)
-      x = 0;
-    else if (x > width())
-      x = width();
-    if (y < 0)
-      y = 0;
-    else if (y > height())
-      y = height();
-    tempPos.setX(x);
-    tempPos.setY(y);
-  }
+  if (m_constrainToBounds) tempPos = clipToBorder(tempPos);
+
   QPointF posF = viewToStrokePoint(QPointF(tempPos));
+  m_cursorPos  = posF;
   if (m_mouseButton == Qt::LeftButton && m_currentControlPointIndex != -1) {
+    m_isDragging = true;
     moveCurrentControlPoint(posF - m_preMousePos);
     m_preMousePos = posF;
   } else if (m_currentControlPointIndex == -1)
-    emit updateCurrentPosition(-1, posF);
+    emit updateCurrentPosition(-1, posF - m_xyOffset);
+
+  update();
 }
 
 //-----------------------------------------------------------------------------
@@ -783,8 +921,13 @@ void GraphWidget::mouseMoveEvent(QMouseEvent* e) {
 void GraphWidget::mousePressEvent(QMouseEvent* e) {
   m_mouseButton = e->button();
   setFocus();
+  m_isDragging = false;
   if (m_mouseButton == Qt::LeftButton) {
-    QPointF posF = viewToStrokePoint(QPointF(e->pos()));
+    QPoint tempPos = e->pos();
+
+    if (m_constrainToBounds) tempPos = clipToBorder(tempPos);
+
+    QPointF posF = viewToStrokePoint(QPointF(tempPos));
     double minDistance;
     int controlPointIndex = getClosestPointIndex(posF, minDistance);
     if (m_lockExtremePoints) {
@@ -795,7 +938,7 @@ void GraphWidget::mousePressEvent(QMouseEvent* e) {
       }
     }
 
-    if (minDistance <= 20) {
+    if (minDistance <= 20.0) {
       m_currentControlPointIndex = controlPointIndex;
       m_preMousePos              = posF;
     } else {
@@ -808,7 +951,8 @@ void GraphWidget::mousePressEvent(QMouseEvent* e) {
                                   ? posF
                                   : m_points.at(m_currentControlPointIndex);
 
-    emit updateCurrentPosition(m_currentControlPointIndex, currentPointPos);
+    emit updateCurrentPosition(m_currentControlPointIndex,
+                               currentPointPos - m_xyOffset);
     update();
   }
 }
@@ -816,10 +960,11 @@ void GraphWidget::mousePressEvent(QMouseEvent* e) {
 //-----------------------------------------------------------------------------
 
 void GraphWidget::mouseReleaseEvent(QMouseEvent* e) {
-  // fx preview updates here ( it does not update while mouse dragging )
-  if (m_mouseButton == Qt::LeftButton && m_currentControlPointIndex != -1 &&
-      e->button() == Qt::LeftButton)
+  if (m_isDragging) {
+    // Signal we're done changing
+    m_isDragging = false;
     emit controlPointChanged(false);
+  }
   m_mouseButton = Qt::NoButton;
 }
 
@@ -884,4 +1029,181 @@ void GraphWidget::focusOutEvent(QFocusEvent* fe) {
   QWidget::focusOutEvent(fe);
   qApp->removeEventFilter(this);
   update();
+}
+
+//=============================================================================
+// Graph GUI
+//-----------------------------------------------------------------------------
+
+GraphGUIWidget::GraphGUIWidget(QWidget* parent)
+    : QWidget(parent), m_updating(false) {
+  // Build default.  Will be customized later
+  m_graph = new GraphWidget();
+  m_graph->setMinXValue(0.0);
+  m_graph->setMaxXValue(100.0);
+  m_graph->setMinYValue(0.0);
+  m_graph->setMaxYValue(100.0);
+  m_graph->initializeSpline();
+
+  m_minXLabel = new QLabel(tr("0"));
+  m_midXLabel = new QLabel(tr("X"));
+  m_maxXLabel = new QLabel(tr("100"));
+  m_minYLabel = new QLabel(tr("0"));
+  m_midYLabel = new QLabel(tr("Y"));
+  m_maxYLabel = new QLabel(tr("100"));
+
+  m_resetBtn = new QPushButton(tr("Reset Curve"));
+
+  m_outValue = new DVGui::DoubleLineEdit(this);
+  m_outValue->setMaximumWidth(40);
+  m_outValue->setDecimals(2);
+  m_outValue->setEnabled(false);
+  m_outValue->setValue(0);
+
+  QVBoxLayout* midYLayout = new QVBoxLayout();
+  midYLayout->setContentsMargins(0, 0, 0, 0);
+  midYLayout->setSpacing(2);
+  midYLayout->addWidget(m_midYLabel);
+  midYLayout->addWidget(m_outValue);
+
+  QFrame* midYFrame = new QFrame(this);
+  midYFrame->setLayout(midYLayout);
+
+  m_inValue = new DVGui::DoubleLineEdit(this);
+  m_inValue->setMaximumWidth(40);
+  m_inValue->setDecimals(2);
+  m_inValue->setEnabled(false);
+  m_inValue->setValue(0);
+
+  QHBoxLayout* midXLayout = new QHBoxLayout();
+  midXLayout->setContentsMargins(0, 0, 0, 0);
+  midXLayout->setSpacing(2);
+  midXLayout->addWidget(m_midXLabel);
+  midXLayout->addWidget(m_inValue);
+
+  QFrame* midXFrame = new QFrame(this);
+  midXFrame->setLayout(midXLayout);
+
+  QHBoxLayout* graphLayout = new QHBoxLayout();
+  graphLayout->setContentsMargins(0, 0, 0, 0);
+  graphLayout->setSpacing(0);
+  graphLayout->addWidget(m_graph);
+
+  QFrame* graphFrame = new QFrame(this);
+  graphFrame->setLayout(graphLayout);
+  graphFrame->setObjectName("GraphAreaFrame");
+
+  QGridLayout* graphGUILayout = new QGridLayout();
+  graphGUILayout->setContentsMargins(3, 3, 3, 3);
+  graphGUILayout->setHorizontalSpacing(3);
+  graphGUILayout->setVerticalSpacing(3);
+  {
+    graphGUILayout->addWidget(m_maxYLabel, 0, 0, Qt::AlignTop | Qt::AlignRight);
+    graphGUILayout->addWidget(midYFrame, 1, 0,
+                              Qt::AlignVCenter | Qt::AlignRight);
+    graphGUILayout->addWidget(m_minYLabel, 2, 0,
+                              Qt::AlignBottom | Qt::AlignRight);
+    graphGUILayout->addWidget(graphFrame, 0, 1, 3, 3);
+    graphGUILayout->addWidget(m_minXLabel, 3, 1, Qt::AlignTop | Qt::AlignLeft);
+    graphGUILayout->addWidget(midXFrame, 3, 2, Qt::AlignHCenter);
+    graphGUILayout->addWidget(m_maxXLabel, 3, 3, Qt::AlignTop | Qt::AlignRight);
+    graphGUILayout->addWidget(m_resetBtn, 4, 1, 1, 3, Qt::AlignCenter);
+  }
+  setLayout(graphGUILayout);
+
+  bool ret = connect(m_graph, SIGNAL(controlPointAdded(int)), this,
+                     SLOT(onCurvePointAdded(int)));
+
+  ret = ret && connect(m_graph, SIGNAL(controlPointChanged(bool)), this,
+                       SLOT(onCurveChanged(bool)));
+
+  ret = ret && connect(m_graph, SIGNAL(controlPointRemoved(int)), this,
+                       SLOT(onCurvePointRemoved(int)));
+
+  ret = ret && connect(m_graph, SIGNAL(updateCurrentPosition(int, QPointF)),
+                       this, SLOT(onUpdateCurrentPosition(int, QPointF)));
+
+  ret =
+      ret && connect(m_resetBtn, SIGNAL(clicked()), this, SLOT(onCurveReset()));
+
+  ret = ret && connect(m_outValue, SIGNAL(editingFinished()), this,
+                       SLOT(onOutValueChanged()));
+
+  ret = ret && connect(m_inValue, SIGNAL(editingFinished()), this,
+                       SLOT(onInValueChanged()));
+
+  assert(ret);
+}
+
+//-----------------------------------------------------------------------------
+
+void GraphGUIWidget::onCurvePointAdded(int index) { emit curveChanged(false); }
+
+//-----------------------------------------------------------------------------
+
+void GraphGUIWidget::onCurveChanged(bool isDragging) {
+  emit curveChanged(isDragging);
+}
+
+//-----------------------------------------------------------------------------
+
+void GraphGUIWidget::onCurvePointRemoved(int index) {
+  emit curveChanged(false);
+}
+
+//-----------------------------------------------------------------------------
+
+void GraphGUIWidget::onUpdateCurrentPosition(int index, QPointF pt) {
+  if (index >= 0) {
+    m_updating = true;
+    m_outValue->setValue(std::roundf(pt.y() * 100.0) / 100.0);
+    m_inValue->setValue(std::roundf(pt.x() * 100.0) / 100.0);
+    m_updating = false;
+    m_outValue->setEnabled(true);
+    m_inValue->setEnabled(true);
+  } else {
+    m_updating = true;
+    m_outValue->setValue(0);
+    m_inValue->setValue(0);
+    m_updating = false;
+    m_outValue->setEnabled(false);
+    m_inValue->setEnabled(false);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void GraphGUIWidget::onCurveReset() {
+  if (m_defaultCurve.count())
+    m_graph->setPoints(m_defaultCurve);
+  else
+    m_graph->initializeSpline();
+
+  onUpdateCurrentPosition(-1, QPointF(0, 0));
+
+  emit curveChanged(false);
+}
+
+void GraphGUIWidget::onOutValueChanged() {
+  if (m_updating) return;
+
+  int index = m_graph->getCurrentControlPointIndex();
+  if (index < 0) return;
+
+  TPointD oldPt = m_graph->getControlPoint(index);
+  double delta  = m_outValue->getValue() - oldPt.y;
+
+  m_graph->moveCurrentControlPoint(QPointF(0, delta));
+}
+
+void GraphGUIWidget::onInValueChanged() {
+  if (m_updating) return;
+
+  int index = m_graph->getCurrentControlPointIndex();
+  if (index < 0) return;
+
+  TPointD oldPt = m_graph->getControlPoint(index);
+  double delta  = m_inValue->getValue() - oldPt.x;
+
+  m_graph->moveCurrentControlPoint(QPointF(delta, 0));
 }

--- a/toonz/sources/toonzqt/stylusconfigpopup.cpp
+++ b/toonz/sources/toonzqt/stylusconfigpopup.cpp
@@ -1,0 +1,226 @@
+#include "toonzqt/stylusconfigpopup.h"
+
+#include "tstroke.h"
+
+#include <QTimer>
+#include <QGridLayout>
+#include <QLabel>
+
+//***********************************************************************************
+//    Stylus Configuration Popup
+//***********************************************************************************
+
+StylusConfigPopup::StylusConfigPopup(QString title, QWidget *parent)
+    : QWidget(parent, Qt::Popup)
+    , m_configList(0)
+    , m_graph(0)
+    , m_currentIndex(0)
+    , m_configProperties(0)
+    , m_keepClosed(false)
+    , m_keepClosedTimer(0) {
+  setObjectName("StylusConfigPopup");
+
+  m_keepClosedTimer = new QTimer(this);
+  m_keepClosedTimer->setSingleShot(true);
+
+  m_graphTitleLabel = new QLabel(title, this);
+
+  m_configList = new QListWidget(this);
+  m_configList->setMaximumWidth(170);
+  m_configList->setCurrentRow(0);
+
+  m_graph = new GraphGUIWidget();
+  m_graph->setMaximumGraphSize(200, 200);
+  m_graph->setMaxXValue(100.0);
+  m_graph->setMaxYValue(100.0);
+  m_graph->setCpMargin(5);
+  m_graph->setGridSpacing(4);
+  m_graph->setLinear(true);
+  m_graph->setLockExtremePoints(false);
+  m_graph->initializeSpline();
+
+  m_graph->setMidXLabel(tr("Input"));
+  m_graph->setMidYLabel(tr("Output"));
+
+  m_graph->setEnabled(false);
+  
+  QGridLayout *mainLayout = new QGridLayout();
+  mainLayout->setContentsMargins(5, 5, 5, 5);
+  mainLayout->setHorizontalSpacing(6);
+  mainLayout->setVerticalSpacing(6);
+  {
+    mainLayout->addWidget(m_graphTitleLabel, 0, 0, 1, 2, Qt::AlignHCenter);
+    mainLayout->addWidget(m_configList, 1, 0);
+    mainLayout->addWidget(m_graph, 1, 1);
+  }
+  setLayout(mainLayout);
+
+  bool ret = connect(m_configList, SIGNAL(currentRowChanged(int)), this,
+                     SLOT(onCurrentRowChanged(int)));
+
+  ret = ret && connect(m_configList, SIGNAL(itemChanged(QListWidgetItem *)),
+                       this, SLOT(onItemChanged(QListWidgetItem *)));
+
+  ret = ret && connect(m_graph, SIGNAL(curveChanged(bool)), this,
+                       SLOT(onCurveChanged(bool)));
+
+  ret = ret && connect(m_keepClosedTimer, SIGNAL(timeout()), this,
+                       SLOT(resetKeepClosed()));
+
+  assert(ret);
+}
+
+//-----------------------------------------------------------------------------
+
+int StylusConfigPopup::addConfiguration(QString name) {
+  QListWidgetItem *configItem = new QListWidgetItem(name);
+  configItem->setFlags(configItem->flags() | Qt::ItemIsUserCheckable);
+  configItem->setCheckState(Qt::Unchecked);
+  m_configList->addItem(configItem);
+
+  GraphProperties configuration;
+  configuration.enabled          = false;
+  configuration.minX             = 0.0;
+  configuration.maxX             = 100.0;
+  configuration.minY             = 0.0;
+  configuration.maxY             = 100.0;
+  configuration.defaultCurve =
+      QList<TPointD>{TPointD(0.0, 0.0), TPointD(100.0, 100.0)};
+  configuration.curve = configuration.defaultCurve;
+
+  m_configProperties.push_back(configuration);
+
+  if (m_configList->count() == 1) {
+    m_configList->setCurrentRow(0);
+  }
+
+  return m_configProperties.size() - 1;
+}
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::setConfiguration(int configId, double minX, double maxX,
+                                         double minY, double maxY,
+                                         QList<TPointD> defaultCurve,
+                                         QString minXLabel, QString midXLabel,
+                                         QString maxXLabel, QString minYLabel,
+                                         QString midYLabel, QString maxYLabel) {
+  if (configId >= m_configList->count()) return;
+
+  m_configProperties[configId].enabled          = false;
+  m_configProperties[configId].minX             = minX;
+  m_configProperties[configId].maxX             = maxX;
+  m_configProperties[configId].minY             = minY;
+  m_configProperties[configId].maxY             = maxY;
+  m_configProperties[configId].defaultCurve     = defaultCurve;
+  m_configProperties[configId].curve            = defaultCurve;
+  m_configProperties[configId].minXLabel        = minXLabel;
+  m_configProperties[configId].midXLabel        = midXLabel;
+  m_configProperties[configId].maxXLabel        = maxXLabel;
+  m_configProperties[configId].minYLabel        = minYLabel;
+  m_configProperties[configId].midYLabel        = midYLabel;
+  m_configProperties[configId].maxYLabel        = maxYLabel;
+}
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::onCurrentRowChanged(int row) {
+  m_currentIndex = row;
+
+  updateGraph();
+}
+
+void StylusConfigPopup::updateGraph() {
+  if (m_currentIndex < 0) {
+    m_graph->setEnabled(false);
+    return;
+  }
+
+  QString minXLabel = m_configProperties[m_currentIndex].minXLabel;
+  QString midXLabel = m_configProperties[m_currentIndex].midXLabel;
+  QString maxXLabel = m_configProperties[m_currentIndex].maxXLabel;
+  QString minYLabel = m_configProperties[m_currentIndex].minYLabel;
+  QString midYLabel = m_configProperties[m_currentIndex].midYLabel;
+  QString maxYLabel = m_configProperties[m_currentIndex].maxYLabel;
+
+  m_graph->setMinXLabel(
+      minXLabel.isEmpty()
+          ? QString().asprintf("%+.2f", m_configProperties[m_currentIndex].minX)
+          : minXLabel);
+  if (!midXLabel.isEmpty()) m_graph->setMidXLabel(midXLabel);
+  m_graph->setMaxXLabel(
+      maxXLabel.isEmpty()
+          ? QString().asprintf("%+.2f", m_configProperties[m_currentIndex].maxX)
+          : maxXLabel);
+  m_graph->setMinXValue(m_configProperties[m_currentIndex].minX);
+  m_graph->setMaxXValue(m_configProperties[m_currentIndex].maxX);
+
+  m_graph->setMinYLabel(
+      minYLabel.isEmpty()
+          ? QString().asprintf("%+.2f", m_configProperties[m_currentIndex].minY)
+          : minYLabel);
+  if (!midYLabel.isEmpty()) m_graph->setMidXLabel(midYLabel);
+  m_graph->setMaxYLabel(
+      maxYLabel.isEmpty()
+          ? QString().asprintf("%+.2f", m_configProperties[m_currentIndex].maxY)
+          : maxYLabel);
+  m_graph->setMinYValue(m_configProperties[m_currentIndex].minY);
+  m_graph->setMaxYValue(m_configProperties[m_currentIndex].maxY);
+
+  double cpMargin = std::min(m_configProperties[m_currentIndex].maxX,
+                             m_configProperties[m_currentIndex].maxY) /
+                    20;
+  if (cpMargin > 20) cpMargin = 20;
+  m_graph->setCpMargin(cpMargin);
+
+  m_graph->setDefaultCurve(m_configProperties[m_currentIndex].defaultCurve);
+  m_graph->setCurve(m_configProperties[m_currentIndex].curve);
+
+  QListWidgetItem *config = m_configList->item(m_currentIndex);
+  m_graph->setEnabled(config->checkState() == Qt::Checked);
+}
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::onItemChanged(QListWidgetItem *config) {
+  int configId                         = m_configList->row(config);
+  m_configProperties[configId].enabled = config->checkState() == Qt::Checked;
+
+  if (configId == m_currentIndex)
+    m_graph->setEnabled(m_configProperties[configId].enabled);
+
+  emit configStateChanged(configId);
+}
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::onCurveChanged(bool isDragging) {
+  if (m_currentIndex < 0) return;
+  m_configProperties[m_currentIndex].curve = m_graph->getCurve();
+
+  emit configCurveChanged(m_currentIndex, isDragging);
+}
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::mouseReleaseEvent(QMouseEvent *e) {
+  // hide();
+}
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::hideEvent(QHideEvent *e) {
+  m_keepClosedTimer->start(300);
+  m_keepClosed = true;
+}
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::showEvent(QShowEvent*) { updateGraph(); }
+
+//-----------------------------------------------------------------------------
+
+void StylusConfigPopup::resetKeepClosed() {
+  if (m_keepClosedTimer) m_keepClosedTimer->stop();
+  m_keepClosed = false;
+}


### PR DESCRIPTION
This introduces a new popup providing stylus adjustment graphs allowing for customization over how the pen responds to things like pressure and tilt.

A new configuration button provides access to the popup on the `Raster Tool` toolbar for standard styles (left), and on each MyPaint style setting (right):
<img width="1745" height="301" alt="image" src="https://github.com/user-attachments/assets/9565d759-9d1e-46d8-ba35-ed3fa99c468a" />

Popups provide the following options (Left: Standard Raster Styles; Right: MyPaint Styles):
<img width="1850" height="602" alt="image" src="https://github.com/user-attachments/assets/105eb6dc-7586-4206-8adb-eae7e5dd41fd" />

Some notes:
- `Tilt` (`Declination` for MyPaint) input range is 0° (horizontal, laying down) - 90° (vertical, upright). Most tablets that are tilt sensitive support up to 60°, from the vertical, which translates to 30° on the graph. 
- For standard styles, the `Pressure` and `Tilt` options in the `Size` and `Opacity` popups are independent of each other.
- MyPaint default curves are based on the original brush settings (from the `.myb` file).
- The MyPaint configurations are available anywhere a MyPaint style is used (Raster/Smart Raster) and configured for pressure and tilt sensitivity.
- Brush Presets and MyPaint style curve changes are saved in such a way that the preset/palette can still be opened in prior versions of T2D.  However, if the preset/palette is updated and saved in prior versions, the curve data will be lost.
