### PR TITLE
Stylus Settings Popup (Smart Raster - Standard Brush, Vector) 

### DIFF
--- a/toonz/sources/include/toonzqt/stylusconfigpopup.h
+++ b/toonz/sources/include/toonzqt/stylusconfigpopup.h
@@ -22,6 +22,28 @@ class GraphGUIWidget;
 #define DVVAR DV_IMPORT_VAR
 #endif
 
+#define DEFAULTLINEARCURVE                                             \
+  QList<TPointD> { TPointD(0.0, 0.0), TPointD(100.0, 100.0) }
+
+#define DEFAULTNONLINEARCURVE                                          \
+  QList<TPointD> {                                                             \
+    TPointD(-40.0, 0.0), TPointD(-20.0, 0.0), TPointD(-20.0, 0.0),             \
+        TPointD(0.0, 0.0), TPointD(6.3, 6.3), TPointD(93.7, 93.7),             \
+        TPointD(100.0, 100.0), TPointD(120.0, 100.0), TPointD(120.0, 100.0),   \
+        TPointD(140.0, 100.0)                                                  \
+  }
+
+#define DEFAULTLINEARTILTCURVE                                                 \
+  QList<TPointD> { TPointD(30.0, 0.0), TPointD(90.0, 100.0) }
+
+#define DEFAULTNONLINEARTILTCURVE                                              \
+  QList<TPointD> {                                                             \
+    TPointD(-10.0, 0.0), TPointD(10.0, 0.0), TPointD(10.0, 0.0),               \
+        TPointD(30.0, 0.0), TPointD(34.0, 7.0), TPointD(86.0, 93.0),           \
+        TPointD(90.0, 100.0), TPointD(110.0, 100.0), TPointD(110.0, 100.0),    \
+        TPointD(130.0, 100.0)                                                  \
+  }
+
 //=============================================================================
 //
 // StylusConfigTarget
@@ -33,6 +55,7 @@ class DVAPI StylusConfigPopup final : public QWidget {
 
   struct GraphProperties {
     bool enabled;
+    bool useLinearCurve;
     double minX, maxX, minY, maxY;
     QList<TPointD> defaultCurve, curve;
     QString minXLabel, midXLabel, maxXLabel, minYLabel, midYLabel, maxYLabel;
@@ -56,11 +79,12 @@ public:
 
   int addConfiguration(QString name);
 
-  void setConfiguration(int configId, double minX, double maxX, double minY,
-                        double maxY, QList<TPointD> defaultCurve,
-                        QString minXLabel = "", QString midXLabel = "",
-                        QString maxXLabel = "", QString minYLabel = "",
-                        QString midYLabel = "", QString maxYLabel = "");
+  void setConfiguration(int configId, bool useLineaCurve, double minX,
+                        double maxX, double minY, double maxY,
+                        QList<TPointD> defaultCurve, QString minXLabel = "",
+                        QString midXLabel = "", QString maxXLabel = "",
+                        QString minYLabel = "", QString midYLabel = "",
+                        QString maxYLabel = "");
 
   void setConfigEnabled(int configId, bool enabled) {
     m_configProperties[configId].enabled = enabled;
@@ -73,7 +97,6 @@ public:
 
   void setConfigCurve(int configId, QList<TPointD> curve) {
     m_configProperties[configId].curve = curve;
-    m_graph->setCurve(curve);
   }
   QList<TPointD> getConfigCurve(int configId) {
     return m_configProperties[configId].curve;

--- a/toonz/sources/include/tproperty.h
+++ b/toonz/sources/include/tproperty.h
@@ -563,7 +563,8 @@ public:
   TStylusProperty(const std::string &name)
       : TProperty(name)
       , m_pressureEnabled(false)
-      , m_tiltEnabled(false) {}
+      , m_tiltEnabled(false)
+      , m_useLinearCurves(false) {}
 
   TProperty *clone() const override { return new TStylusProperty(*this); }
 
@@ -572,6 +573,9 @@ public:
   std::wstring getValue() const { return L"-"; }
 
   void accept(Visitor &v) override { v.visit(this); }
+
+  bool useLinearCurves() { return m_useLinearCurves; }
+  void setUseLinearCurves(bool useLinear) { m_useLinearCurves = useLinear; }
 
   // Pressure
   void setPressureEnabled(bool enabled) { m_pressureEnabled = enabled; }
@@ -585,6 +589,8 @@ public:
   }
   QList<TPointD> getDefaultPressureCurve() { return m_defaultPressureCurve; }
 
+  double getOutputPressureForInput(double pressure);
+
   // Tilt
   void setTiltEnabled(bool enabled) { m_tiltEnabled = enabled; }
   bool isTiltEnabled() { return m_tiltEnabled; }
@@ -595,8 +601,11 @@ public:
   void setDefaultTiltCurve(QList<TPointD> curve) { m_defaultTiltCurve = curve; }
   QList<TPointD> getDefaultTiltCurve() { return m_defaultTiltCurve; }
 
+  double getOutputTiltForInput(double tilt);
+
 private:
   bool m_pressureEnabled, m_tiltEnabled;
+  bool m_useLinearCurves;
   QList<TPointD> m_pressureCurve, m_tiltCurve;
   QList<TPointD> m_defaultPressureCurve, m_defaultTiltCurve;
 };

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -178,7 +178,9 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
 
   m_thickness.setNonLinearSlider();
 
+  m_sizeStylusProperty.setUseLinearCurves(true);
   m_sizeStylusProperty.setDefaultTiltCurve(DEFAULTSIZETILTCURVE);
+  m_opacityStylusProperty.setUseLinearCurves(true);
   m_opacityStylusProperty.setDefaultTiltCurve(DEFAULTOPACITYTILTCURVE);
 
   m_prop.bind(m_thickness);

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -52,12 +52,10 @@
   QList<TPointD> { TPointD(0.0, 0.0), TPointD(100.0, 100.0) }
 
 #define DEFAULTSIZETILTCURVE                                                   \
-  QList<TPointD> {                                                             \
-    TPointD(0.0, 100.0), TPointD(30.0, 100.0), TPointD(90.0, 0.0)              \
-  }
+  QList<TPointD> { TPointD(30.0, 100.0), TPointD(90.0, 0.0) }
 
 #define DEFAULTOPACITYTILTCURVE                                                \
-  QList<TPointD> { TPointD(0.0, 0.0), TPointD(30.0, 0.0), TPointD(90.0, 100.0) }
+  QList<TPointD> { TPointD(30.0, 0.0), TPointD(90.0, 100.0) }
 
 //----------------------------------------------------------------------------------
 
@@ -180,6 +178,9 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
 
   m_thickness.setNonLinearSlider();
 
+  m_sizeStylusProperty.setDefaultTiltCurve(DEFAULTSIZETILTCURVE);
+  m_opacityStylusProperty.setDefaultTiltCurve(DEFAULTOPACITYTILTCURVE);
+
   m_prop.bind(m_thickness);
   m_prop.bind(m_sizeStylusProperty);
   m_prop.bind(m_modifierSize);
@@ -207,9 +208,6 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_opacityStylusProperty.setId("OpacityStylusConfig");
 
   m_brushTimer.start();
-
-  m_sizeStylusProperty.setDefaultTiltCurve(DEFAULTSIZETILTCURVE);
-  m_opacityStylusProperty.setDefaultTiltCurve(DEFAULTOPACITYTILTCURVE);
 }
 
 //---------------------------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -536,8 +536,8 @@ ToolOptionStylusConfigButton::ToolOptionStylusConfigButton(
   // Tilt
   m_tiltId = m_stylusConfig->addConfiguration(tr("Tilt"));
   m_stylusConfig->setConfiguration(
-      m_tiltId, 0, 90, 0, 100,
-      QList<TPointD>{TPointD(0.0, 0.0), TPointD(90.0, 100.0)}, "0", "", "90",
+      m_tiltId, 30, 90, 0, 100,
+      QList<TPointD>{TPointD(30.0, 0.0), TPointD(90.0, 100.0)}, "30", "", "90",
       "Min", "", "Max");
 
   updateStatus();

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -526,19 +526,23 @@ ToolOptionStylusConfigButton::ToolOptionStylusConfigButton(
   m_stylusConfig =
       new StylusConfigPopup(QString::fromStdString(m_property->getName()), 0);
 
+  bool useLinearCurves = m_property->useLinearCurves();
+  QList<TPointD> defaultPressureCurve =
+      useLinearCurves ? DEFAULTLINEARCURVE : DEFAULTNONLINEARCURVE;
+  QList<TPointD> defaultTiltCurve =
+      useLinearCurves ? DEFAULTLINEARTILTCURVE : DEFAULTNONLINEARTILTCURVE;
+
   // Pressure
   m_pressureId = m_stylusConfig->addConfiguration(tr("Pressure"));
-  m_stylusConfig->setConfiguration(
-      m_pressureId, 0, 100, 0, 100,
-      QList<TPointD>{TPointD(0.0, 0.0), TPointD(100.0, 100.0)}, "0%", "",
-      "100%", "Min", "", "Max");
+  m_stylusConfig->setConfiguration(m_pressureId, useLinearCurves, 0, 100, 0,
+                                   100, defaultPressureCurve, "0%", "", "100%",
+                                   "Min", "", "Max");
 
   // Tilt
   m_tiltId = m_stylusConfig->addConfiguration(tr("Tilt"));
-  m_stylusConfig->setConfiguration(
-      m_tiltId, 30, 90, 0, 100,
-      QList<TPointD>{TPointD(30.0, 0.0), TPointD(90.0, 100.0)}, "30", "", "90",
-      "Min", "", "Max");
+  m_stylusConfig->setConfiguration(m_tiltId, useLinearCurves, 30, 90, 0, 100,
+                                   defaultTiltCurve, "30", "", "90", "Min", "",
+                                   "Max");
 
   updateStatus();
 
@@ -553,22 +557,32 @@ ToolOptionStylusConfigButton::ToolOptionStylusConfigButton(
 //-----------------------------------------------------------------------------
 
 void ToolOptionStylusConfigButton::updateStatus() {
+  bool useLinearCurves = m_property->useLinearCurves();
+  QList<TPointD> defaultPressureCurve =
+      useLinearCurves ? DEFAULTLINEARCURVE : DEFAULTNONLINEARCURVE;
+  QList<TPointD> defaultTiltCurve =
+      useLinearCurves ? DEFAULTLINEARTILTCURVE : DEFAULTNONLINEARTILTCURVE;
+
+  m_stylusConfig->getGraphGUI()->setLinear(useLinearCurves);
+
   // Pressure
   m_stylusConfig->setConfigEnabled(m_pressureId,
                                    m_property->isPressureEnabled());
-  QList<TPointD> curve = m_property->getDefaultPressureCurve();
-  if (!curve.isEmpty())
-    m_stylusConfig->setConfigDefaultCurve(m_pressureId, curve);
-  curve = m_property->getPressureCurve();
-  if (!curve.isEmpty()) m_stylusConfig->setConfigCurve(m_pressureId, curve);
+  QList<TPointD> defaultCurve = m_property->getDefaultPressureCurve();
+  if (defaultCurve.isEmpty()) defaultCurve = defaultPressureCurve;
+  QList<TPointD> curve = m_property->getPressureCurve();
+  m_stylusConfig->setConfigDefaultCurve(m_pressureId, defaultCurve);
+  m_stylusConfig->setConfigCurve(m_pressureId,
+                                 !curve.isEmpty() ? curve : defaultCurve);
 
   // Tilt
   m_stylusConfig->setConfigEnabled(m_tiltId, m_property->isTiltEnabled());
-  curve = m_property->getDefaultTiltCurve();
-  if (!curve.isEmpty()) m_stylusConfig->setConfigDefaultCurve(m_tiltId, curve);
+  defaultCurve = m_property->getDefaultTiltCurve();
+  if (defaultCurve.isEmpty()) defaultCurve = defaultTiltCurve;
   curve = m_property->getTiltCurve();
-  if (!curve.isEmpty()) m_stylusConfig->setConfigCurve(m_tiltId, curve);
-
+  m_stylusConfig->setConfigDefaultCurve(m_tiltId, defaultCurve);
+  m_stylusConfig->setConfigCurve(m_tiltId,
+                                 !curve.isEmpty() ? curve : defaultCurve);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -163,8 +163,8 @@ public:
 
   void loadLastBrush();
 
-  void finishRasterBrush(const TPointD &pos, double pressureVal, double tiltX,
-                         double tiltY);
+  void finishRasterBrush(const TPointD &pos, double pressureVal,
+                         double tiltMagnitude, double tiltX, double tiltY);
   // return true if the pencil mode is active in the Brush / PaintBrush / Eraser
   // Tools.
   bool isPencilModeActive() override;
@@ -184,11 +184,15 @@ protected:
   TEnumProperty m_preset;
   TEnumProperty m_drawOrder;
   TBoolProperty m_pencil;
-  TBoolProperty m_pressure;
+  TBoolProperty m_mypaintPressure;
   TDoubleProperty m_modifierSize;
   TBoolProperty m_modifierLockAlpha;
   TBoolProperty m_snapGrid;
-  TBoolProperty m_tilt;
+  TBoolProperty m_mypaintTilt;
+  TStylusProperty m_sizeStylusProperty;
+
+  bool m_enabledPressure;
+  bool m_enabledTilt;
 
   CMRasterBrush *m_cmRasterBrush;
   TTileSetCM32 *m_tileSet;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -39,8 +39,9 @@ struct VectorBrushData final : public TPersist {
 
   std::wstring m_name;
   double m_min, m_max, m_acc, m_smooth;
-  bool m_breakAngles, m_pressure;
+  bool m_breakAngles, m_pressure, m_tilt;
   int m_cap, m_join, m_miter;
+  QList<TPointD> m_pressureCurve, m_tiltCurve;
 
   VectorBrushData();
   VectorBrushData(const std::wstring &name);
@@ -159,7 +160,7 @@ protected:
   TDoubleProperty m_smooth;
   TEnumProperty m_preset;
   TBoolProperty m_breakAngles;
-  TBoolProperty m_pressure;
+//  TBoolProperty m_pressure;
   TBoolProperty m_snap;
   TBoolProperty m_sendToBack;
   TBoolProperty m_autoFill;
@@ -171,6 +172,10 @@ protected:
   TEnumProperty m_joinStyle;
   TIntProperty m_miterJoinLimit;
   TBoolProperty m_snapGrid;
+  TStylusProperty m_sizeStylusProperty;
+
+  bool m_enabledPressure;
+  bool m_enabledTilt;
 
   VectorBrush m_track;
   VectorBrush m_rangeTrack;

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -4158,7 +4158,7 @@ void SettingsPage::onOpenStylusConfig() {
     }
 
     // Configure graph
-    m_stylusConfig->setConfiguration(j, minX, maxX, -absMaxY, absMaxY,
+    m_stylusConfig->setConfiguration(j, true, minX, maxX, -absMaxY, absMaxY,
                                      defaultCurve);
 
     // Set active curve

--- a/toonz/sources/toonzqt/stylusconfigpopup.cpp
+++ b/toonz/sources/toonzqt/stylusconfigpopup.cpp
@@ -79,14 +79,14 @@ int StylusConfigPopup::addConfiguration(QString name) {
   m_configList->addItem(configItem);
 
   GraphProperties configuration;
-  configuration.enabled          = false;
-  configuration.minX             = 0.0;
-  configuration.maxX             = 100.0;
-  configuration.minY             = 0.0;
-  configuration.maxY             = 100.0;
-  configuration.defaultCurve =
-      QList<TPointD>{TPointD(0.0, 0.0), TPointD(100.0, 100.0)};
-  configuration.curve = configuration.defaultCurve;
+  configuration.enabled        = false;
+  configuration.useLinearCurve = false;
+  configuration.minX           = 0.0;
+  configuration.maxX           = 100.0;
+  configuration.minY           = 0.0;
+  configuration.maxY           = 100.0;
+  configuration.defaultCurve   = DEFAULTNONLINEARCURVE;
+  configuration.curve          = configuration.defaultCurve;
 
   m_configProperties.push_back(configuration);
 
@@ -99,8 +99,9 @@ int StylusConfigPopup::addConfiguration(QString name) {
 
 //-----------------------------------------------------------------------------
 
-void StylusConfigPopup::setConfiguration(int configId, double minX, double maxX,
-                                         double minY, double maxY,
+void StylusConfigPopup::setConfiguration(int configId, bool useLinearCurve,
+                                         double minX, double maxX, double minY,
+                                         double maxY,
                                          QList<TPointD> defaultCurve,
                                          QString minXLabel, QString midXLabel,
                                          QString maxXLabel, QString minYLabel,
@@ -108,6 +109,7 @@ void StylusConfigPopup::setConfiguration(int configId, double minX, double maxX,
   if (configId >= m_configList->count()) return;
 
   m_configProperties[configId].enabled          = false;
+  m_configProperties[configId].useLinearCurve   = useLinearCurve;
   m_configProperties[configId].minX             = minX;
   m_configProperties[configId].maxX             = maxX;
   m_configProperties[configId].minY             = minY;
@@ -142,6 +144,8 @@ void StylusConfigPopup::updateGraph() {
   QString minYLabel = m_configProperties[m_currentIndex].minYLabel;
   QString midYLabel = m_configProperties[m_currentIndex].midYLabel;
   QString maxYLabel = m_configProperties[m_currentIndex].maxYLabel;
+
+  m_graph->setLinear(m_configProperties[m_currentIndex].useLinearCurve);
 
   m_graph->setMinXLabel(
       minXLabel.isEmpty()


### PR DESCRIPTION
Building on #1888, this PR introduces the stylus setting popup for Smart Raster (standard brush) and Vector levels.

Stylus setting allow for `Pressure` and `Tilt` customizations and is available for `Size` options only.

The 1 notable difference between Raster implementation and this PR is the graphs use segmented non-linear curves since Smart Raster (standard brush) and Vectors do not use the MyPaint brush engine.

<img width="881" height="598" alt="image" src="https://github.com/user-attachments/assets/9fe0db67-a1ff-469c-bb80-793708204e0d" />

Additional change:
- Modified the standard `Tilt` range from 0 .. 90 to 30 .. 90
  - QT and most tables only support up to a 60 degree tilt from vertical (30 degree from horizontal).
  - In theory, 0-30 degree from horizontal would never be possible.
- The Vector `Smooth` and `Pressure` (enabled) settings are now separated from the Smart Raster settings when saved.