### PR TITLE
Autoclose: Limit Two Points Spot Research Angle to 0°~36°

### DIFF
--- a/toonz/sources/toonzlib/autoclose.cpp
+++ b/toonz/sources/toonzlib/autoclose.cpp
@@ -544,11 +544,17 @@ void TAutocloser::Imp::findMeetingPoints(
   m_aut_spot_samples = (UINT)m_spotAngle;
 
   m_spotAngle *= (M_PI / 180.0);
-  alfa  = m_spotAngle / m_aut_spot_samples;
-  m_csp = cos(m_spotAngle);
-  m_snp = sin(m_spotAngle);
-  m_csm = cos(-m_spotAngle);
-  m_snm = sin(-m_spotAngle);
+  
+  // spotResearchTwoPoints
+  // Angle Range: 0бу~36бу
+  double limitedAngle = m_spotAngle / 10;
+  m_csp = cos(limitedAngle);
+  m_snp = sin(limitedAngle);
+  m_csm = cos(-limitedAngle);
+  m_snm = sin(-limitedAngle);
+
+  // spotResearchOnePoints
+  alfa = m_spotAngle / m_aut_spot_samples;
   m_csa = cos(alfa);
   m_sna = sin(alfa);
   m_csb = cos(-alfa);


### PR DESCRIPTION
This PR is a continuation of PR #1293

The search process of AutoClose includes the following steps:

1. Two Point Spot Search (creates two triangles)

2. One Point Spot Search (creates a semicircle)

If a closable segment is found in the first step, the second step is skipped.

This PR limits the angle of the Two Point Spot Search to 0°–36°, reducing unnecessary checks and improving performance.

<img width="424" height="402" alt="SpotSearchExample" src="https://github.com/user-attachments/assets/132b2fa4-10f9-41da-881f-05dd296d7ec3" />
