### PR TITLE
Fix macOS build CMake version

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -7,6 +7,12 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
+      - name: Use cmake
+        run: cmake --version
       - name: Install Dependencies
         run: |
           ci-scripts/osx/tahoma-install.sh


### PR DESCRIPTION
Similar to GitHub Linux runners back in April, GitHub updated CMake to version 4.1.1 on their macOS runners. This is currently causing the opencv build to fail and likely would also impact T2D build.

Workaround, is to downgrade cmake version back to a version that we've used previously. I've opted to use the same version the Linux builds currently use (3.31.6) via `actions-setup-cmake`

Will merge once I see the macOS build was successful.