### PR TITLE
Minor QoL: Automate the build libtiff stage during cmake generation

### DIFF
--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -144,17 +144,12 @@ EOF
 ```
 Note the generated file must not actually contain `$HOME`, this expands to an absolute path in the generated file.
 
-### Building LibTIFF
+<hr>
+TODO: Make it possible to use the system libtiff.
 
-TODO: make sure we can use the system libtiff instead and remove this section.
-Features from the modified libtiff are needed currently, so this isn't a simple switch.
+Tahoma2D is completely dependent on a tweaked libtiff library that's under the thirdparty directory, which is static linked. The CMake build system will compile for you, but until then, it's stuck on this modified library.
 
-```
-$ cd tahoma2d/thirdparty/tiff-4.2.0
-$ ./configure --with-pic --disable-jbig --disable-webp 
-$ make -j$(nproc)
-$ cd ../../
-```
+
 
 ### Building Tahoma2D
 

--- a/toonz/cmake/FindTIFF.cmake
+++ b/toonz/cmake/FindTIFF.cmake
@@ -1,4 +1,8 @@
 # looks for libtiff(4.2.0 modified)
+#
+# Configures and builds the modified libtiff library
+execute_process(COMMAND ./configure --with-pic --disable-jbig --disable-webp WORKING_DIRECTORY ${SDKROOT}/tiff-4.2.0)
+execute_process(COMMAND make WORKING_DIRECTORY ${SDKROOT}/tiff-4.2.0)
 find_path(
     TIFF_INCLUDE_DIR
     NAMES


### PR DESCRIPTION
This is an extremely minor change, but I think is convenient specially for package maintainers in other linux distros. It just builds the libtiff library for you when creating the makefiles or ninja files when you run the cmake command.

It does exactly what you would have done yourself, it be nice to see this done for you. One less step to worry about. It built without issue on my fedora box.