### PR TITLE
Github build on macos-15-intel (Sequoia)/Fix Linux build

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -4,9 +4,15 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   macOS:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
+      - name: Use cmake
+        run: cmake --version
       - name: Install Dependencies
         run: |
           ci-scripts/osx/tahoma-install.sh

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -10,6 +10,7 @@ sudo apt-get install -y python2 python3-pip
 sudo apt-get install -y build-essential libgirepository1.0-dev autotools-dev intltool gettext libtool patchelf autopoint libusb-1.0-0 libusb-1.0-0-dev
 sudo apt-get install -y libdeflate-dev
 sudo apt-get install -y libfuse2
+sudo apt-get install -y protobuf-compiler libprotobuf-dev
 
 pip3 install --upgrade pip
 pip3 install numpy

--- a/ci-scripts/osx/tahoma-build.sh
+++ b/ci-scripts/osx/tahoma-build.sh
@@ -15,6 +15,10 @@ if [ -d /usr/local/Cellar/qt@5 ]
 then
    QTVERSION=`ls /usr/local/Cellar/qt@5`
    USEQTLIB="/usr/local/opt/qt@5/lib/"
+elif [ -d /opt/homebrew/opt/qt@5 ]
+then
+   QTVERSION=`ls /opt/homebrew/opt/qt@5`
+   USEQTLIB="/opt/homebrew/opt/qt@5/lib/"
 else
    QTVERSION=`ls /usr/local/Cellar/qt`
    USEQTLIB="/usr/local/opt/qt/lib/"

--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -59,6 +59,7 @@ echo ">>> Configuring to build ffmpeg (shared)"
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 ./configure  --prefix=/usr/local \
+      --extra-libs="-lpthread -lm"
       --enable-shared \
       --enable-pthreads \
       --enable-version3 \

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -4,6 +4,9 @@ export TAHOMA2DVERSION=1.5.4
 if [ -d /usr/local/Cellar/qt@5 ]
 then
    export QTDIR=/usr/local/opt/qt@5
+elif [ -d /opt/homebrew/opt/qt@5 ]
+then
+   export QTDIR=/opt/homebrew/opt/qt@5
 else
    export QTDIR=/usr/local/opt/qt
 fi

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -13,7 +13,7 @@ rm -f '/usr/local/bin/python3-config'
 rm -f '/usr/local/bin/python3.12-config'
 # Remove synlink to nghttp2 in order for latest curl to install
 #brew unlink nghttp2
-brew install boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz gsed
+brew install openjpeg libresample protobuf boost qt@5 clang-format glew lz4 lzo libmypaint jpeg-turbo nasm yasm fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz gsed
 #brew install dav1d
 brew install meson ninja
 brew install automake autoconf gettext pkg-config libtool libusb-compat gd libexif libdeflate


### PR DESCRIPTION
Following has been changed

1. Homebrew has updated causing the `macos-13` builds to take several hours to install dependencies, only to fail during installation and abort the build.  Additionally `macOS-13` is being deprecated by Dec so I'm updating to the next Intel based macOS runner `macos-15-intel` (Sequoia).

Unfortunately I need to skip `macos-14` (Sonoma) as it's not Intel chip based and may require some changes somewhere to build correctly.  It was failing to link to local (not arm64) and system `superlu` library.

Will need help verifying the build as I don't have a Sequoia environment yet.

2. Fix Linux build missing Protobuf library

I will merge this one I see the builds have completed successfully.

