### PR TITLE
Fix changing geometry opacity back to 100

### DIFF
--- a/toonz/sources/toonzlib/trasterimageutils.cpp
+++ b/toonz/sources/toonzlib/trasterimageutils.cpp
@@ -101,11 +101,11 @@ TRect fastAddInkStroke(const TRasterImageP &ri, TStroke *stroke, TRectD clip,
 
   if (!rectRender.isEmpty()) {
     if (opacity < 1.0) {
-      int styleId    = stroke->getStyle();
-      TPalette *plt  = ri->getPalette();
-      TPixel32 color = plt->getStyle(styleId)->getMainColor();
-      color.m        = 255 * opacity;
-      TPaletteP newPlt(plt);
+      int styleId      = stroke->getStyle();
+      TPalette *plt    = ri->getPalette();
+      TPixel32 color   = plt->getStyle(styleId)->getMainColor();
+      color.m          = 255 * opacity;
+      TPaletteP newPlt = plt->clone();
       newPlt->getStyle(styleId)->setMainColor(color);
       rasterizeWholeStroke(gl, stroke, newPlt.getPointer(), doAntialiasing);
     } else


### PR DESCRIPTION
This fixes a bug in the Geometric Tool (Raster) where changing the `Opacity` from any value < 100 directly back to 100 after drawing something, doesn't change the opacity back to full.

When Geometric tool draws a shape with an `Opacity` value < 100, it's uses a copy of the original palette with the modified style.  However, it was not using a copy of the palette and would update the original style instead. So,  when immediately going back to 100, it would use the original palette but it had been modified by the prior action. 

Modified the logic to ensure it is using a copy of the palette.
