### PR TITLE
Fix Export Vector Level Bad Resolution Crash

### DIFF
--- a/toonz/sources/toonz/exportlevelcommand.cpp
+++ b/toonz/sources/toonz/exportlevelcommand.cpp
@@ -305,7 +305,14 @@ TRasterImageP ImageExporter::exportedRasterImage(TVectorImageP vi) {
                        camera.getStageToCameraRef(), TRect(), vi->getPalette());
   rd.m_antiAliasing = !m_opts.m_noAntialias;
 
-  if (!m_glContext.get()) m_glContext.reset(new TOfflineGL(camera.getRes()));
+  if (!m_glContext.get()) {
+    try {
+      m_glContext.reset(new TOfflineGL(camera.getRes()));
+    } catch (...) {
+      DVGui::error(QObject::tr("Unable to generate image. Revise resolution."));
+      return nullptr;
+    }
+  }
 
   // Render the vector image to fullcolor raster
   TRasterImageP ri;

--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -613,6 +613,8 @@ void ExportLevelPopup::updatePreview() {
       sl ? IoCmd::exportedImage(ext, *sl, sl->index2fid(frameIdx), opts)
          : TImageP();
 
+  m_okButton->setEnabled(m_swatch->image().getPointer() != nullptr);
+
   m_swatch->update();
 }
 
@@ -898,12 +900,6 @@ ExportLevelPopup::ExportOptions::ExportOptions(QWidget *parent)
     ret = connect(m_heightFld, SIGNAL(valueChanged()), SIGNAL(optionsChanged()),
                   Qt::QueuedConnection) &&
           ret;
-    ret = connect(m_hResFld, SIGNAL(textChanged(const QString &)),
-                  SIGNAL(optionsChanged()), Qt::QueuedConnection) &&
-          ret;
-    ret = connect(m_vResFld, SIGNAL(textChanged(const QString &)),
-                  SIGNAL(optionsChanged()), Qt::QueuedConnection) &&
-          ret;
 
     ret = connect(m_thicknessTransformMode, SIGNAL(currentIndexChanged(int)),
                   SIGNAL(optionsChanged())) &&
@@ -1043,8 +1039,14 @@ void ExportLevelPopup::ExportOptions::updateXRes() {
   double ly = m_heightFld->getValue(), yres = m_vResFld->getValue(),
          dpi = ly > 0 ? yres / ly : 0;
 
-  m_hResFld->setValue(tround(m_widthFld->getValue() * dpi));
+  int value = tround(m_widthFld->getValue() * dpi);
+
+  if (value == m_hResFld->getValue()) return;
+
+  m_hResFld->setValue(value);
   updateDpi();
+
+  emit optionsChanged();
 }
 
 //-----------------------------------------------------------------------------
@@ -1053,8 +1055,15 @@ void ExportLevelPopup::ExportOptions::updateYRes() {
   double lx = m_widthFld->getValue(), xres = m_hResFld->getValue(),
          dpi = lx > 0 ? xres / lx : 0;
 
-  m_vResFld->setValue(tround(m_heightFld->getValue() * dpi));
+  int value = tround(m_heightFld->getValue() * dpi);
+
+  if (value == m_vResFld->getValue()) return;
+
+  m_vResFld->setValue(value);
+
   updateDpi();
+
+  emit optionsChanged();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a crash in the `Export Level` -> `Export Options` tab when changing resolution values in the `Vector Export Box` section.

As the value in `H Resolution` or `V Resolution` changes, it is immediately attempting to update the preview to the new resolution. When the system cannot handle the creation of an image, it would just crash.

Added logic to trap the image creation error and throw a warning message. The `Export` button will become disabled until a valid resolution is set.