### PR TITLE
Compress high frequency MyPaint pen events

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -120,6 +120,7 @@ protected:
 
   MyPaintToonzBrush *m_toonz_brush;
   QElapsedTimer m_brushTimer;
+  double m_highFreqBrushTimer;
 
   TTileSetFullColor *m_tileSet;
   TTileSaverFullColor *m_tileSaver;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -236,6 +236,7 @@ protected:
   bool m_isMyPaintStyleSelected    = false;
   MyPaintToonzBrush *m_toonz_brush = 0;
   QElapsedTimer m_brushTimer;
+  double m_highFreqBrushTimer;
   int m_minCursorThick, m_maxCursorThick;
 
   bool m_propertyUpdating = false;


### PR DESCRIPTION
With the release of 1.5, I disabled a Qt setting that compressed tablet (pen) events.  I believe this helped reduce the "floaty/laggy" feeling and increased the accuracy of the line because the compression setting was dropping too many points.

It was recently pointed out to me that some MyPaint style's behavior significantly changed since then. I determined it was due to processing too many points when pen event compression was turned off.

For MyPaint styles drawn with pen only, this PR will effectively drop points if they are generated too close too each other.  This restored, to some degree, the original behavior of the affected style(s). It also seems to reduce the hard angles on quick circles that I see with some MyPaint styles.

