### PR TITLE
Fix internal handling of graph points

### DIFF
--- a/toonz/sources/include/toonzqt/graphwidget.h
+++ b/toonz/sources/include/toonzqt/graphwidget.h
@@ -178,6 +178,8 @@ protected:
   void focusInEvent(QFocusEvent* fe) override;
   void focusOutEvent(QFocusEvent* fe) override;
 
+  bool isLinearCurve(QList<TPointD> points);
+
 signals:
   void focusOut();
   void controlPointChanged(bool isDragging);


### PR DESCRIPTION
Related to the new Stylus Settings popups, this fixes the following:
1. Skips removing a graph point referenced by index if the index isn't valid.
2. Fixes the internal handling of anchor points of the graph
3. Detect if input curve is linear and convert to internal non-linear format automatically regardless if graph is configured for linear curves or not.
