### PR TITLE
Fix Show Column Parent's Color context menu option

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -71,8 +71,6 @@
 
 #include <QBitmap>
 
-TEnv::IntVar ShowParentColorsInXsheet("ShowParentColorsInXsheet", 1);
-
 //=============================================================================
 
 namespace {
@@ -4046,13 +4044,15 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       QAction *showParentColors =
           new QAction(tr("Show Column Parent Colors"), this);
       showParentColors->setCheckable(true);
-      showParentColors->setChecked(ShowParentColorsInXsheet == 1 ? true
-                                                                 : false);
+      showParentColors->setChecked(
+          Preferences::instance()->isParentColorsInXsheetColumnEnabled());
       showParentColors->setToolTip(
           tr("Show the column parent's color in the Xsheet"));
 
       connect(showParentColors, &QAction::toggled, [=]() {
-        ShowParentColorsInXsheet = showParentColors->isChecked() ? 1 : 0;
+        Preferences::instance()->setValue(
+            parentColorsInXsheetColumn,
+            showParentColors->isChecked() ? true : false);
       });
       menu.addAction(showParentColors);
     }


### PR DESCRIPTION
This fixes the Xsheet's column context menu option `Show Column Parent Colors`.

Apparently this stopped working back in 2022 when the option was refactored to be a `Preferences` setting rather than a localized xsheet setting. The context menu option was not updated to work with the preference setting, but fixed with this PR..