### PR TITLE
Fix load svg crash

### DIFF
--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2235,6 +2235,7 @@ TImageP TImageReaderSvg::load() {
       if (!s) continue;
       s->setStyle(inkIndex);
       int currentIndex = vimage->addStroke(s);
+      if (currentIndex < 0) continue;
       strokeCount++;
       if (s->isSelfLoop() && !shape->hasFillNone) applyFill = true;
       // Single unconnected stroke shape with fill


### PR DESCRIPTION
This fixes #1910 which is caused when failing to create a vector stroke/shape due to some unsupported feature of the path definition.  In this case, it was filling using a gradient which is not supported.

This PR merely prevents the crash allowing it to load what it can.
