### PR TITLE
Fix Zerary Fx input preview status in Schematic

### DIFF
--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -628,17 +628,26 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
     painter->restore();
   }
 
+  bool is_enabled       = m_parent->isEnabled();
+  TZeraryColumnFx *zcFx = dynamic_cast<TZeraryColumnFx *>(m_parent->getFx());
+  if (zcFx) {
+    TXshZeraryFxColumn *col = zcFx->getColumn();
+    if (col) is_enabled = col->isRendered();
+  }
+
   QColor nodeColor;
   SchematicViewer *viewer = sceneFx->getSchematicViewer();
-  viewer->getNodeColor(m_type, nodeColor);
+  if (!is_enabled && zcFx)
+    nodeColor = viewer->getReferenceColumnColor();
+  else
+    viewer->getNodeColor(m_type, nodeColor);
 
   painter->setBrush(nodeColor);
   painter->setPen(Qt::NoPen);
   painter->drawRect(0, 0, m_width, m_height);
 
   // draw diagonal line for disabled fx
-  bool is_enabled = m_parent->isEnabled();
-  if (!is_enabled) {
+  if (!is_enabled && !zcFx) {
     painter->save();
     painter->setPen(QColor(255, 0, 0, 255));
     painter->drawLine(QPointF(0, m_height), QPointF(m_width, 0));
@@ -900,9 +909,19 @@ void FxPainter::paint_small(QPainter *painter) {
     painter->restore();
   }
 
+  bool is_enabled       = m_parent->getFx()->getAttributes()->isEnabled();
+  TZeraryColumnFx *zcFx = dynamic_cast<TZeraryColumnFx *>(m_parent->getFx());
+  if (zcFx) {
+    TXshZeraryFxColumn *col = zcFx->getColumn();
+    if (col) is_enabled = col->isRendered();
+  }
+
   QColor nodeColor;
   SchematicViewer *viewer = sceneFx->getSchematicViewer();
-  viewer->getNodeColor(m_type, nodeColor);
+  if (!is_enabled && zcFx)
+    nodeColor = viewer->getReferenceColumnColor();
+  else
+    viewer->getNodeColor(m_type, nodeColor);
 
   painter->setBrush(nodeColor);
   painter->setPen(Qt::NoPen);
@@ -944,13 +963,7 @@ void FxPainter::paint_small(QPainter *painter) {
   }
 
   // diagonal line for disabled fx
-  bool is_enabled = false;
-  if (TZeraryColumnFx *zcFx =
-          dynamic_cast<TZeraryColumnFx *>(m_parent->getFx()))
-    is_enabled = zcFx->getColumn()->isPreviewVisible();
-  else
-    is_enabled = m_parent->getFx()->getAttributes()->isEnabled();
-  if (!is_enabled) {
+  if (!is_enabled && !zcFx) {
     painter->save();
     painter->setPen(QColor(255, 0, 0, 255));
     painter->drawLine(QPointF(10, m_height), QPointF(m_width - 10, 0));


### PR DESCRIPTION
This fixes a visual issue with a column node appearing as if it's disconnected or preview mode is disabled when connected to the 1st/top-most input port of any Zerary Fx node, a column based fx, like ParticlesFx.

The connected node is actually connected and treated as an active node for the purposes of previewing, but the logic was not correctly detecting it's preview status when connected to a zerary fx node.

Additionally. the following changes were also made:
- I changed the look of a disabled Zerary Fx node to match other preview disabled column nodes (gray'd out) instead of the red X that normal Fx use. This matches the look in the timeline.
- When a Zerary Fx's Preview is disabled, all connected column nodes are also disabled automatically if the column node is not connected to any other fx.  This is because normal Fx will still forward images from input nodes, but Zerary Fx don't.
