### PR TITLE
Fix saving escaped apostrophe (linux)

### DIFF
--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -24,13 +24,7 @@ namespace {
 string escape(string v) {
   int i = 0;
   for (;;) {
-// Removing escaping of apostrophe from Windows and OSX as it's not needed and
-// causes problems
-#if defined(LINUX) || defined(FREEBSD)
-    i = v.find_first_of("\\\'\"", i);
-#else
     i = v.find_first_of("\\\"", i);
-#endif
     if (i == (int)string::npos) break;
 //    string h = "\\" + v[i];
     v.insert(i, "\\");


### PR DESCRIPTION
This fixes #1896.

When saving a level with an apostrophe in it, it would put the escape character (`\`) before it in the string stored in the .TNZ file.  Upon reloading, the escaped apostrophe was not being correct handled.  

This issue was actually fixed a long time ago but for Windows and macOS build only.  Linux was intentionally not changed since we couldn't confirm it was a problem or not.  Apparently it is.

I've removed the linux specific logic to escape apostrophes when saving so this no longer happens.