### PR TITLE
Build on macOS-14 (ARM64/M1 Runner)

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   macOS:
-    runs-on: macos-15-intel
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: Setup cmake

--- a/ci-scripts/osx/tahoma-build.sh
+++ b/ci-scripts/osx/tahoma-build.sh
@@ -37,6 +37,6 @@ cmake ../sources  $CANON_FLAG \
       -DWITH_GPHOTO2=ON \
       -DQT_PATH=$USEQTLIB \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.2.0/libtiff/ \
-      -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
+      -DWITH_SYSTEM_SUPERLU=ON
 
 make -j7 # runs 7 jobs in parallel

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -17,3 +17,4 @@ brew install openjpeg libresample protobuf boost qt@5 clang-format glew lz4 lzo 
 #brew install dav1d
 brew install meson ninja
 brew install automake autoconf gettext pkg-config libtool libusb-compat gd libexif libdeflate
+brew install superlu

--- a/toonz/cmake/FindSuperLU.cmake
+++ b/toonz/cmake/FindSuperLU.cmake
@@ -40,6 +40,7 @@ find_library(
         libsuperlu.so
         libsuperlu.a
         libsuperlu_4.1.a
+        libsuperlu.dylib
     HINTS
         ${_lib_hints}
     PATH_SUFFIXES

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -247,6 +247,7 @@ add_definitions(
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 if(BUILD_ENV_APPLE)
+    include_directories("/usr/local/include/")
     set(CMAKE_MACOSX_RPATH ON)
     set(CMAKE_SKIP_BUILD_RPATH FALSE)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)


### PR DESCRIPTION
With a few modifications to the cmake files and build scripts, I was able to successfully build on the macOS-14 action runner which is Apple silicon based (M1).

Need help testing since I do not have a local environment to test this on.

This PR build doesn't have the Canon SDK built into it. To test if Stop Motion with Canon SDK works, please test my repo's build here: https://github.com/manongjohn/tahoma2d/actions/runs/18453887181

If the build is good, I will switch from macOS-15-intel to this for the upcoming release.