### PR TITLE
Force startup tips window to the top

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -829,6 +829,8 @@ int main(int argc, char *argv[]) {
 
   if (Preferences::instance()->isTipsPopupEnabled()) {
     TipsPopup *tipsPopup = new TipsPopup();
+    tipsPopup->setModal(true); // On startup only, this forces to the top
+    tipsPopup->resize(600, 600);
     tipsPopup->show();
     tipsPopup->raise();
     tipsPopup->activateWindow();

--- a/toonz/sources/toonz/tipspopup.cpp
+++ b/toonz/sources/toonz/tipspopup.cpp
@@ -47,7 +47,6 @@ TipsPopup::TipsPopup()
   tipsFrame->setLayout(tipsLayout);
 
   QScrollArea *tipsArea = new QScrollArea();
-  tipsArea->setMinimumSize(500, 300);
   tipsArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   tipsArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   tipsArea->setWidgetResizable(true);


### PR DESCRIPTION
In order to keep the initial Tips window from appearing behind the Startup popup, this changes the initial Tips window to be a modal window so it appears at the top. This requires users to dismiss it, temporarily or permanently before proceeding.

I've also made the initial Tips window start with larger dimensions.

The Tips window opened from the Help menu remains a normal window.

