### PR TITLE
Fix Hook Tool status bar message when active

### DIFF
--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -341,7 +341,9 @@ std::unordered_map<std::string, QString> StatusBar::makeMap(
                tr("Bend Tool: Bends vector shapes around the first click")});
   lMap.insert({"T_Iron", tr("Iron Tool: Smooths vector lines")});
   lMap.insert({"T_Cutter", tr("Cutter Tool: Splits vector lines")});
-  lMap.insert({"T_Hook", ""});
+  lMap.insert(
+      {"T_Hook", tr("Hook Tool: Create reference points to aid in movement "
+                    "or to link other objects by them")});
   lMap.insert(
       {"T_Skeleton", tr("Skeleton Tool: Allows to build a skeleton and animate "
                         "in a cut-out workflow")});


### PR DESCRIPTION
Same as #1926, but the message is also displayed when the Hook Tool is selected.