### PR TITLE
Restore disabled file writer types

### DIFF
--- a/toonz/sources/common/tiio/tiio_std.cpp
+++ b/toonz/sources/common/tiio/tiio_std.cpp
@@ -18,7 +18,7 @@ void Tiio::defineStd() {
   declare("jpeg", TFileType::RASTER_IMAGE);
 
   defineReaderMaker("bmp", Tiio::makeBmpReader);
-  defineWriterMaker("bmp", Tiio::makeBmpWriter, false);
+  defineWriterMaker("bmp", Tiio::makeBmpWriter, true);
   declare("bmp", TFileType::RASTER_IMAGE);
   defineWriterProperties("bmp", new BmpWriterProperties());
 }

--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -122,7 +122,7 @@ void initImageIo(bool lightVersion) {
   Tiio::defineWriterProperties("png", new Tiio::PngWriterProperties());
 
   Tiio::defineReaderMaker("tga", Tiio::makeTgaReader);
-  Tiio::defineWriterMaker("tga", Tiio::makeTgaWriter, false);
+  Tiio::defineWriterMaker("tga", Tiio::makeTgaWriter, true);
   TFileType::declare("tga", TFileType::RASTER_IMAGE);
   Tiio::defineWriterProperties("tga", new Tiio::TgaWriterProperties());
 
@@ -141,12 +141,12 @@ void initImageIo(bool lightVersion) {
 #endif
 
   Tiio::defineReaderMaker("sgi", Tiio::makeSgiReader);
-  Tiio::defineWriterMaker("sgi", Tiio::makeSgiWriter, false);
+  Tiio::defineWriterMaker("sgi", Tiio::makeSgiWriter, true);
   TFileType::declare("sgi", TFileType::RASTER_IMAGE);
   Tiio::defineWriterProperties("sgi", new Tiio::SgiWriterProperties());
 
   Tiio::defineReaderMaker("rgb", Tiio::makeSgiReader);
-  Tiio::defineWriterMaker("rgb", Tiio::makeSgiWriter, false);
+  Tiio::defineWriterMaker("rgb", Tiio::makeSgiWriter, true);
   TFileType::declare("rgb", TFileType::RASTER_IMAGE);
   Tiio::defineWriterProperties("rgb", new Tiio::SgiWriterProperties());
 

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -45,7 +45,7 @@
 #include <QCheckBox>
 
 /*-- Format --*/
-TEnv::StringVar ConvertPopupFileFormat("ConvertPopupFileFormat", "tga");
+TEnv::StringVar ConvertPopupFileFormat("ConvertPopupFileFormat", "tif");
 /*-- 背景色 --*/
 TEnv::IntVar ConvertPopupBgColorR("ConvertPopupBgColorR", 255);
 TEnv::IntVar ConvertPopupBgColorG("ConvertPopupBgColorG", 255);
@@ -382,7 +382,7 @@ ConvertPopup::ConvertPopup(bool specifyInput)
     m_convertFileFld->setFileMode(QFileDialog::ExistingFile);
     QStringList filter;
     filter << "tif"
-           << "tiff"
+//           << "tiff"
            << "png"
            << "tga"
            << "tlv"


### PR DESCRIPTION
This fixes #1935 which was due to certain render/convert file types being disabled when T2D was first implemented.

This PR will restore the following options: BMP, RBA, SGI and TGA.