### PR TITLE
Fix missing MSVC DLLs

### DIFF
--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -1,3 +1,5 @@
+@echo off
+
 cd toonz\build
 
 echo ">>> Creating Tahoma2D directory"
@@ -6,10 +8,11 @@ IF EXIST Tahoma2D rmdir /S /Q Tahoma2D
 
 mkdir Tahoma2D
 
-echo ">>> Copy and configure Tahoma2D installation"
+echo ">>> Copy Tahoma2D DLLs"
 
 copy /y RelWithDebInfo\*.* Tahoma2D
 
+echo ">>> Copy ThirdParty DLLs"
 copy /Y ..\..\thirdparty\freeglut\bin\x64\freeglut.dll Tahoma2D
 copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll Tahoma2D
 copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll Tahoma2D
@@ -17,6 +20,7 @@ copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll Tahoma2D
 copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll Tahoma2D
 copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll Tahoma2D
 
+echo ">>> Copy OpenCV DLLs"
 IF EXIST C:\tools\opencv (
    copy /Y "C:\tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" Tahoma2D
 ) ELSE (
@@ -24,16 +28,37 @@ IF EXIST C:\tools\opencv (
 )
 
 IF EXIST ..\..\thirdparty\canon\Header (
+   echo ">>> Copy Canon EDSDK DLLs"
    copy /Y ..\..\thirdparty\canon\Dll\EDSDK.dll Tahoma2D
    copy /Y ..\..\thirdparty\canon\Dll\EdsImage.dll Tahoma2D
 )
 
 IF EXIST ..\..\thirdparty\libgphoto2\include (
+   echo ">>> Copy Libgphoto2 DLLs"
    xcopy /Y /E ..\..\thirdparty\libgphoto2\bin Tahoma2D
 )
 
-REM Remove ILK files
-del Tahoma2D\*.ilk
+echo ">>> Copy MSVC DLLs"
+set VCINSTALLDIR="C:\Program Files\Microsoft Visual Studio\2022\Community\VC"
+IF EXIST "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC" set VCINSTALLDIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC"
+echo "VCINSTALLDIR=%VCINSTALLDIR%"
+
+set VCRUNTIME_PATH=
+for /d /r ""%VCINSTALLDIR%"" %%a in (14.*) do (
+    if exist "%%a\x64" (
+        for /d %%b in ("%%a\x64\*") do (
+            if exist "%%b\vcruntime*.dll" (
+                set "VCRUNTIME_PATH=%%b"
+                goto :done
+            )
+        )
+    )
+)
+:done
+echo "VCRUNTIME_PATH=%VCRUNTIME_PATH%"
+
+copy /Y "%VCRUNTIME_PATH%\vcruntime140_1.dll" Tahoma2D
+copy /Y "%VCRUNTIME_PATH%\msvcp140_1.dll" Tahoma2D
 
 echo ">>> Configuring Tahoma2D.exe for deployment"
 
@@ -42,16 +67,11 @@ set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
 
 REM These are effective when running from Actions/Appveyor
 IF EXIST ..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64 set QT_PATH=..\..\thirdparty\qt\5.15.2_wintab\msvc2019_64
+echo "QT_PATH=%QT_PATH%"
 
-set VCINSTALLDIR="C:\Program Files\Microsoft Visual Studio\2022\Community\VC"
-IF EXIST "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC" set VCINSTALLDIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC"
 
 %QT_PATH%\bin\windeployqt.exe Tahoma2D\Tahoma2D.exe --opengl
 
-xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.42.34433\x64\Microsoft.VC143.CRT Tahoma2D
-xcopy /Y /E /I %VCINSTALLDIR%\Redist\MSVC\14.42.34433\x64\Microsoft.VC143.OpenMP Tahoma2D
-
-del /A- /S Tahoma2D\tahomastuff\*.gitkeep
 
 IF EXIST ..\..\thirdparty\apps\ffmpeg\bin (
    echo ">>> Copying FFmpeg to Tahoma2D\ffmpeg"
@@ -69,15 +89,20 @@ IF EXIST ..\..\thirdparty\apps\rhubarb (
    xcopy /Y /E /I ..\..\thirdparty\apps\rhubarb\res "Tahoma2D\rhubarb\res"
 )
 
+echo ">>> Remove unnecessary files"
+REM Remove ILK files
+del Tahoma2D\*.ilk
+REM Remove github keep files
+del /A- /S Tahoma2D\tahomastuff\*.gitkeep
+
 echo ">>> Creating Tahoma2D Windows Installer"
 IF NOT EXIST installer mkdir installer
 cd installer
 
-rmdir /S /Q program
-rmdir /S /Q stuff
-
+IF EXIST program rmdir /S /Q program
 xcopy /Y /E /I ..\Tahoma2D program
 
+IF EXIST stuff rmdir /S /Q stuff
 xcopy /Y /E /I ..\..\..\stuff stuff
 
 python ..\..\installer\windows\filelist_python3.py %cd%


### PR DESCRIPTION
This fixes an issue where T2D will not start because of missing `vcruntime140_1.dll` or `msvcp140_1.dll` by ensuring they are included in release.

This was fixed once before but the paths were hardcoded and if/when github updated their images with updated version of MSVC, it would no longer be able to find the dlls.  I've modified the build scripts to now search for vcruntime140_1.dll from the MSVC installation folder so it will not be impacted by minor updates.