### PR TITLE
Fix(Scene Depth/Quicktoolbar): Invisible after startup

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -437,7 +437,7 @@ void XsheetViewer::positionSections() {
 
   if (Preferences::instance()->isShowQuickToolbarEnabled()) {
     m_toolbar->showToolbar(true);
-    int w = visibleRegion().boundingRect().width();
+    int w = geometry().width();
     m_toolbarScrollArea->setGeometry(0, 0, w, XsheetGUI::TOOLBAR_HEIGHT);
     m_toolbar->setFixedWidth(w);
     if (o->isVerticalTimeline()) {
@@ -456,7 +456,7 @@ void XsheetViewer::positionSections() {
 
   if (Preferences::instance()->isShowXsheetBreadcrumbsEnabled()) {
     m_breadcrumbArea->showBreadcrumbs(true);
-    int w = visibleRegion().boundingRect().width();
+    int w = geometry().width();
     if (o->isVerticalTimeline())
       m_breadcrumbScrollArea->setGeometry(0, headerFrame.from(), w,
                                           XsheetGUI::BREADCRUMB_HEIGHT);


### PR DESCRIPTION
A port from OT.

This issue usually happen when the first room contains a vertical xsheet panel (not timeline).
This PR replaces `visibleRegion().boundingRect()` with `geometry()` to make the bars' width can be initialized when first show.