### PR TITLE
Fix File Browser Rename logic and UI

### DIFF
--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -274,12 +274,14 @@ class RenameAsToonzPopup final : public DVGui::Dialog {
   Q_OBJECT
   QPushButton *m_okBtn, *m_cancelBtn;
   DVGui::LineEdit *m_name;
-  QCheckBox *m_overwrite;
+  QCheckBox *m_createCopy;
+  QString m_origName;
+  int m_frames;
 
 public:
   RenameAsToonzPopup(const QString name = "", int frames = -1);
 
-  bool doOverwrite() { return m_overwrite->isChecked(); }
+  bool doCreatecopy() { return m_createCopy->isChecked(); }
   QString getName() { return m_name->text(); }
 
 private:


### PR DESCRIPTION
While porting OT fixes, there was a fix to the file browser rename logic that blocked a rename if the new name already existed.  It was limited in scope in that it only applied to when a copy-rename was performed and not when a file was truly renamed.

I decided to fix it a different way and while at it, made some additional changes which are as follows:
- If the new file name exists during  a rename or a copy-rename, it will prompt to overwrite the existing file or not. If overwritten, the file is removed before the rename/copy-rename is performed.
- Added logic to detect if the new name is exactly the same as the old name and throw a warning asking for a new name.
- When renaming `TLV` files (Smart Raster), the associated `TPL` file (palette) is renamed also. 
- Fixed the logic determining if the file being renamed is a single file or a file sequence.
- Removed redundant logic that handled file sequence renaming since the T2D's copy and rename file functions already did this. The old logic wasn't really being reached correctly due to incorrect file detection.
- Synced changes with `scenebrowser.cpp` (Preproduction Board), though `Rename` is not an option for  TNZ files

Modified the rename popup as follows:
- Changed the wording on the popup dialog
- Changed `Delete Original Files` option to `Create copy and rename`. The default is unchecked to perform a true rename, where as the prior default was to copy-rename

<img width="1016" height="404" alt="image" src="https://github.com/user-attachments/assets/38261393-e97f-431e-a9e8-c9aa36783c9b" />

