### PR TITLE
Fixes for Preproduction Board and File Browser

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -851,6 +851,23 @@ bool TSystem::doesExistFileOrLevel(const TFilePath &fp) {
 
 void TSystem::copyFileOrLevel_throw(const TFilePath &dst,
                                     const TFilePath &src) {
+  if (src.getType() == "tnz") {
+    // Special case: copy scene file icon, if present
+    TFilePath srciconDir = src.getParentDir() + "sceneIcons";
+    TFilePath dsticonDir = src.getParentDir() + "sceneIcons";
+
+    TFilePath srciconname(src.withParentDir(srciconDir)
+                              .withName(src.getName() + " ")
+                              .withType("png"));
+    TFilePath dsticonname(dst.withParentDir(dsticonDir)
+                              .withName(dst.getName() + " ")
+                              .withType("png"));
+
+    if (TSystem::doesExistFileOrLevel(src) &&
+        TSystem::doesExistFileOrLevel(srciconname))
+      TSystem::copyFile(dsticonname, srciconname, false);
+  }
+    
   if (src.isLevelName()) {
     TFilePathSet files;
     files = TSystem::readDirectory(src.getParentDir(), false);
@@ -888,6 +905,23 @@ void TSystem::renameFileOrLevel_throw(const TFilePath &dst,
       TSystem::renameFile(dstpltname, srcpltname, false);
   }
 
+  if (src.getType() == "tnz") {
+    // Special case: rename scene file icon, if present
+    TFilePath srciconDir = src.getParentDir() + "sceneIcons";
+    TFilePath dsticonDir = src.getParentDir() + "sceneIcons";
+
+    TFilePath srciconname(src.withParentDir(srciconDir)
+                              .withName(src.getName() + " ")
+                              .withType("png"));
+    TFilePath dsticonname(dst.withParentDir(dsticonDir)
+                              .withName(dst.getName() + " ")
+                              .withType("png"));
+
+    if (TSystem::doesExistFileOrLevel(src) &&
+        TSystem::doesExistFileOrLevel(srciconname))
+      TSystem::renameFile(dsticonname, srciconname, false);
+  }
+
   if (src.isLevelName()) {
     TFilePathSet files;
     files = TSystem::readDirectory(src.getParentDir(), false);
@@ -907,6 +941,19 @@ void TSystem::renameFileOrLevel_throw(const TFilePath &dst,
 //--------------------------------------------------------------
 
 void TSystem::removeFileOrLevel_throw(const TFilePath &fp) {
+  if (fp.getType() == "tnz") {
+    // Special case: copy scene file icon, if present
+    TFilePath fpiconDir = fp.getParentDir() + "sceneIcons";
+
+    TFilePath fpiconname(fp.withParentDir(fpiconDir)
+                             .withName(fp.getName() + " ")
+                             .withType("png"));
+
+    if (TSystem::doesExistFileOrLevel(fp) &&
+        TSystem::doesExistFileOrLevel(fpiconname))
+      TSystem::deleteFile(fpiconname);
+  }
+
   if (fp.isLevelName()) {
     TFilePathSet files;
     files = TSystem::readDirectory(fp.getParentDir(), false, true, true);
@@ -937,6 +984,19 @@ void TSystem::hideFileOrLevel_throw(const TFilePath &fp) {
 //--------------------------------------------------------------
 
 void TSystem::moveFileOrLevelToRecycleBin_throw(const TFilePath &fp) {
+  if (fp.getType() == "tnz") {
+    // Special case: copy scene file icon, if present
+    TFilePath fpiconDir = fp.getParentDir() + "sceneIcons";
+
+    TFilePath fpiconname(fp.withParentDir(fpiconDir)
+                             .withName(fp.getName() + " ")
+                             .withType("png"));
+
+    if (TSystem::doesExistFileOrLevel(fp) &&
+        TSystem::doesExistFileOrLevel(fpiconname))
+      TSystem::moveFileToRecycleBin(fpiconname);
+  }
+
   if (fp.isLevelName()) {
     TFilePathSet files;
     files = TSystem::readDirectory(fp.getParentDir(), false, true, true);

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -1208,7 +1208,7 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
 
     if (!areFullcolor) menu->addSeparator();
   }
-  if (files.size() == 1 && files[0].getType() != "tnz") {
+  if (files.size() == 1) {
     QAction *action =
         new QAction(QIcon(createQIcon("rename")), tr("Rename"), menu);
     ret = ret && connect(action, SIGNAL(triggered()), this,
@@ -1817,7 +1817,7 @@ void doRenameAsToonzLevel(const QString &fullpath) {
   QString parentPath, name, format;
   int frameCount = -1;
 
-  if (parsePathName(fullpath, parentPath, name, format)) {
+  if (parsePathName(fullpath, parentPath, name, format) && format != "tnz") {
     QStringList pathIn;
     getLevelFiles(parentPath, name, format, pathIn);
     frameCount = pathIn.size();

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -151,8 +151,8 @@ public:
     for (i = 0; i < (int)m_newFiles.size(); i++) {
       TFilePath path = m_newFiles[i];
       if (!TSystem::doesExistFileOrLevel(path)) continue;
-      if (path.getType() == "tnz")
-        TSystem::rmDirTree(path.getParentDir() + (path.getName() + "_files"));
+//      if (path.getType() == "tnz")
+//        TSystem::rmDirTree(path.getParentDir() + (path.getName() + "_files"));
       try {
         TSystem::removeFileOrLevel(path);
       } catch (...) {

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -162,6 +162,8 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WindowFlags flags,
   viewerPanel->setItemViewPlayDelegate(itemViewPlayDelegate);
 
   // m_mainSplitter->setObjectName("SceneBrowserSplitter");
+  m_folderName->setReadOnly(true);
+
   m_folderTreeView->hide();
   m_folderTreeView->setObjectName("DirTreeView");
   box->setObjectName("castFrame");
@@ -1130,7 +1132,7 @@ QMenu *SceneBrowser::getContextMenu(QWidget *parent, int index) {
 
     if (!areFullcolor) menu->addSeparator();
   }
-  if (files.size() == 1 && files[0].getType() != "tnz") {
+  if (files.size() == 1) {
     QAction *action = new QAction(tr("Rename"), menu);
     ret             = ret && connect(action, SIGNAL(triggered()), this,
                                      SLOT(renameAsToonzLevel()));
@@ -1679,7 +1681,7 @@ void doRenameAsToonzLevel(const QString &fullpath) {
   QString parentPath, name, format;
   int frameCount = -1;
 
-  if (parsePathName(fullpath, parentPath, name, format)) {
+  if (parsePathName(fullpath, parentPath, name, format) && format != "tnz") {
     QStringList pathIn;
     getLevelFiles(parentPath, name, format, pathIn);
     frameCount = pathIn.size();
@@ -1884,10 +1886,11 @@ void SceneBrowser::convertToPaintedTlv() {
 //-----------------------------------------------------------------------------
 
 void SceneBrowser::onSceneSwitched() {
-  ToonzScene *scene      = TApp::instance()->getCurrentScene()->getScene();
-  TFilePath scenesFolder = scene->getScenePath().getParentDir();
-  // TFilePath scenesFolder =
-  // TProjectManager::instance()->getCurrentProject()->getScenesPath();
+  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+  TFilePath scenesFolder =
+      scene && scene->isUntitled()
+          ? TProjectManager::instance()->getCurrentProject()->getScenesPath()
+          : scene->getScenePath().getParentDir();
   setFolder(scenesFolder, true);
 }
 
@@ -1921,12 +1924,12 @@ void SceneBrowser::onClickedItem(int index) {
   if (0 <= index && index < (int)m_items.size()) {
     // if the folder is clicked, then move the current folder
     TFilePath fp = m_items[index].m_path;
-    if (m_items[index].m_isFolder) {
-      setFolder(fp, true);
-      QModelIndex index = m_folderTreeView->currentIndex();
-      if (index.isValid()) m_folderTreeView->scrollTo(index);
-    } else
-      emit filePathClicked(fp);
+    // if (m_items[index].m_isFolder) {
+    //   setFolder(fp, true);
+    //   QModelIndex index = m_folderTreeView->currentIndex();
+    //   if (index.isValid()) m_folderTreeView->scrollTo(index);
+    // } else
+    emit filePathClicked(fp);
   }
 }
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1325,7 +1325,7 @@ public:
     TFilePath scenesFolder =
         TProjectManager::instance()->getCurrentProject()->getScenesPath();
     browser->setFolder(scenesFolder, true);
-    browser->enableSingleClickToOpenScenes();
+    browser->enableDoubleClickToOpenScenes();
   }
 } PreproductionBoardFactory;
 


### PR DESCRIPTION
This does the following

- Preproduction Board
  - Fix empty scene list refresh issue when currently loaded scene is untitled (new and unsaved) and/or switching Projects without selecting a scene.  Shows Project scene folder. 
  - Single-click scene no longer automatically loads the scene. Double-click to load.
  - Folder path is Read-Only since changes to it does nothing
  
- Preproduction Board and File Browser
  - Fix crash when undoing `Duplicate` of a scene file
  - Rename/duplicate/delete scene icon when scene file is renamed/duplicated/deleted
  - Added `Rename` option to context menu for TNZ files
