### PR TITLE
Fix Startup popup thumbnail border

### DIFF
--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -1284,7 +1284,7 @@ QPixmap StartupScenesList::createScenePreview(const QString &name,
       painter.drawPixmap((m_iconSize.width() - scaledPixmap.width()) / 2,
                          (m_iconSize.height() - scaledPixmap.height()) / 2,
                          scaledPixmap);
-      QPen pen(Qt::black);
+      QPen pen(palette().text().color());
       pen.setStyle(Qt::DotLine);
       painter.setPen(pen);
       painter.drawRect((m_iconSize.width() - scaledPixmap.width()) / 2,


### PR DESCRIPTION
Thumbnail borders in the Startup popup are black so they show only in Light theme and not in the darker themes.

This fixes the issue by using the theme's text color so it changes with the theme.
