### PR TITLE
Fix scene thumbnail background

### DIFF
--- a/toonz/sources/toonz/preproductionboard.cpp
+++ b/toonz/sources/toonz/preproductionboard.cpp
@@ -742,10 +742,11 @@ QPixmap BoardList::createThumbnail(const TFilePath &fp) {
       source = QPixmap(iconPath.getQString());
   }
 
-  if (source.isNull()) {
-    pixmap.fill(Qt::white);
-  } else {
+  if (isMissing)
     pixmap.fill(Qt::transparent);
+  else
+    pixmap.fill(Qt::white);
+  if (!source.isNull()) {
     QPainter painter(&pixmap);
     QPixmap scaledPixmap =
         source.scaled(m_iconSize, Qt::AspectRatioMode::KeepAspectRatio);

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -1277,7 +1277,7 @@ QPixmap StartupScenesList::createScenePreview(const QString &name,
     QPixmap scenePreview(iconPath.getQString());
     if (!scenePreview.isNull()) {
       QPixmap pixmap(m_iconSize);
-      pixmap.fill(Qt::transparent);
+      pixmap.fill(Qt::white);
       QPainter painter(&pixmap);
       QPixmap scaledPixmap =
           scenePreview.scaled(m_iconSize, Qt::AspectRatioMode::KeepAspectRatio);


### PR DESCRIPTION
This will set the thumbnail backgrounds shown in `Startup` and `Preproduction Board` panels to white so you can see line art drawings with transparent backgrounds more easily.