### PR TITLE
Fix removing unnecessary files in Windows builds

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -41,12 +41,10 @@ jobs:
       - name: Create Package
         run: |
           ci-scripts\windows\tahoma-buildpkg.bat
-          mkdir artifact
-          cp -r toonz\build\Tahoma2D artifact
       - uses: actions/upload-artifact@v4
         with:
-          name: Tahoma2D-portable-win
-          path: artifact
+          name: Tahoma2D-portable-win.zip
+          path: toonz\build\Tahoma2D-portable-win.zip
       - uses: actions/upload-artifact@v4
         with:
           name: Tahoma2D-install-win.exe

--- a/ci-scripts/windows/tahoma-buildpkg.bat
+++ b/ci-scripts/windows/tahoma-buildpkg.bat
@@ -90,10 +90,8 @@ IF EXIST ..\..\thirdparty\apps\rhubarb (
 )
 
 echo ">>> Remove unnecessary files"
-REM Remove ILK files
-del Tahoma2D\*.ilk
 REM Remove github keep files
-del /A- /S Tahoma2D\tahomastuff\*.gitkeep
+del /A- /S ..\..\stuff\*.gitkeep
 
 echo ">>> Creating Tahoma2D Windows Installer"
 IF NOT EXIST installer mkdir installer


### PR DESCRIPTION
Fixes a minor issue where it fails to remove unnecessary files (i.e. .gitkeep files) when building Windows packages

Due to the way actions\upload-artifact does not include empty directories when compressing the original folder, I've switch it to uploading the ZIP file that is normally created for nightly builds instead of building the zip.  Unfortunately when downloading a PR artifact, it does put it in a ZIP file again, so users testing a Windows PR artifact need to unzip 2x.  