### PR TITLE
Fix key as last scene frame

### DIFF
--- a/toonz/sources/include/toonz/doubleparamcmd.h
+++ b/toonz/sources/include/toonz/doubleparamcmd.h
@@ -19,6 +19,7 @@
 
 class KeyframesUndo;
 class TSceneHandle;
+class TXsheetHandle;
 
 class DVAPI KeyframeSetter {
   TDoubleParamP m_param;
@@ -41,6 +42,8 @@ class DVAPI KeyframeSetter {
 
 public:
   KeyframeSetter(TDoubleParam *param, int kIndex = -1, bool enableUndo = true);
+  KeyframeSetter(TDoubleParam *param, TXsheetHandle *xsheetHandle,
+                 int kIndex = -1, bool enableUndo = true);
   ~KeyframeSetter();
 
   TDoubleParam *getCurve() const { return m_param.getPointer(); }
@@ -100,7 +103,8 @@ public:
     setter.createKeyframe(frame);
     setter.setValue(value);
   }
-  static void removeKeyframeAt(TDoubleParam *curve, double frame);
+  static void removeKeyframeAt(TDoubleParam *curve, double frame,
+                              TXsheetHandle *xsheetHandle = nullptr);
 
   static void enableCycle(TDoubleParam *curve, bool enabled,
                           TSceneHandle *sceneHandle = nullptr);

--- a/toonz/sources/include/toonz/stageobjectutil.h
+++ b/toonz/sources/include/toonz/stageobjectutil.h
@@ -222,6 +222,7 @@ public:
 
 class DVAPI UndoStageObjectMove final : public TUndo {
   TStageObjectValues m_before, m_after;
+  TXsheetHandle *m_xsheetHandle;
   TObjectHandle
       *m_objectHandle;  // OK: viene usato per notificare i cambiamenti!
 
@@ -229,6 +230,9 @@ public:
   UndoStageObjectMove(const TStageObjectValues &before,
                       const TStageObjectValues &after);
 
+  void setXsheetHandle(TXsheetHandle *xsheetHandle) {
+    m_xsheetHandle = xsheetHandle;
+  }
   void setObjectHandle(TObjectHandle *objectHandle) {
     m_objectHandle = objectHandle;
   }

--- a/toonz/sources/include/toonzqt/functionkeyframenavigator.h
+++ b/toonz/sources/include/toonzqt/functionkeyframenavigator.h
@@ -14,11 +14,16 @@ class FrameNavigator;
 class DVAPI FunctionKeyframeNavigator final : public KeyframeNavigator {
   Q_OBJECT
   TDoubleParamP m_curve;
+  TXsheetHandle *m_xsheetHandle;
 
 public:
   FunctionKeyframeNavigator(QWidget *parent);
 
   void setCurve(TDoubleParam *curve);
+
+  void setXsheetHandle(TXsheetHandle *xsheetHandle) {
+    m_xsheetHandle = xsheetHandle;
+  }
 
 protected:
   bool hasNext() const override;

--- a/toonz/sources/include/toonzqt/functionpanel.h
+++ b/toonz/sources/include/toonzqt/functionpanel.h
@@ -6,6 +6,8 @@
 #include "tcommon.h"
 #include "functiontreeviewer.h"
 
+#include "toonz/txsheethandle.h"
+
 #include <QDialog>
 #include <set>
 #include <cmath>
@@ -92,6 +94,7 @@ private:
   DragTool *m_dragTool;
   FunctionSelection *m_selection;
   TFrameHandle *m_frameHandle;
+  TXsheetHandle *m_xsheetHandle;
   FunctionTreeModel *m_functionTreeModel;
 
   int m_currentFrameStatus;
@@ -131,6 +134,10 @@ public:
 
   void setFrameHandle(TFrameHandle *frameHandle);
   TFrameHandle *getFrameHandle() const { return m_frameHandle; }
+  void setXsheetHandle(TXsheetHandle *xsheetHandle) {
+    m_xsheetHandle = xsheetHandle;
+  }
+  TXsheetHandle *getXsheetHandle() const { return m_xsheetHandle; }
 
   QTransform getViewTransform() const { return m_viewTransform; }
   void setViewTransform(const QTransform &viewTransform) {

--- a/toonz/sources/include/toonzqt/functionselection.h
+++ b/toonz/sources/include/toonzqt/functionselection.h
@@ -8,6 +8,8 @@
 #include "toonzqt/selection.h"
 #include "toonzqt/dvmimedata.h"
 
+#include "toonz/txsheethandle.h"
+
 #include "tdoublekeyframe.h"
 
 #include <QWidget>
@@ -50,6 +52,7 @@ class FunctionSelection final : public QObject, public TSelection {
   // assert(m_selectedSegment<0 || m_selectedKeyframes.size()==1)
 
   TFrameHandle *m_frameHandle;
+  TXsheetHandle *m_xsheetHandle;
   ColumnToCurveMapper *m_columnToCurveMapper;
 
   int getCurveIndex(TDoubleParam *curve) const;
@@ -64,6 +67,9 @@ public:
 
   void setFrameHandle(TFrameHandle *frameHandle) {
     m_frameHandle = frameHandle;
+  }
+  void setXsheetHandle(TXsheetHandle *xsheetHandle) {
+    m_xsheetHandle = xsheetHandle;
   }
 
   // function graph

--- a/toonz/sources/include/toonzqt/functionsheet.h
+++ b/toonz/sources/include/toonzqt/functionsheet.h
@@ -165,6 +165,7 @@ public:
   bool isSyncSize() { return m_syncSize; }
   void setSyncSize(bool on);
   void setXsheetHandle(TXsheetHandle *xshHandle) { m_xshHandle = xshHandle; }
+  TXsheetHandle *getXsheetHandle() const { return m_xshHandle; }
 
   int getFrameZoomFactor() const override;
 

--- a/toonz/sources/include/toonzqt/functiontoolbar.h
+++ b/toonz/sources/include/toonzqt/functiontoolbar.h
@@ -9,6 +9,8 @@
 // TnzQt includes
 #include "toonzqt/lineedit.h"
 
+#include "toonz/txsheethandle.h"
+
 // Qt includes
 #include <QToolBar>
 #include <QAction>
@@ -66,6 +68,7 @@ class FunctionToolbar final : public DVGui::ToolBar, public TParamObserver {
 
   TDoubleParam *m_curve;
   TFrameHandle *m_frameHandle;
+  TXsheetHandle *m_xsheetHandle;
 
   FunctionSelection *m_selection;
 
@@ -81,6 +84,7 @@ public:
 
   void setSelection(FunctionSelection *);
   void setFrameHandle(TFrameHandle *frameHandle);
+  void setXsheetHandle(TXsheetHandle *xsheetHandle);
 
   void onChange(const TParamChange &) override;
 

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -252,6 +252,7 @@ public:
 
     TTool::Application *app   = TTool::getApplication();
     UndoStageObjectMove *undo = new UndoStageObjectMove(m_before, m_after);
+    undo->setXsheetHandle(app->getCurrentXsheet());
     undo->setObjectHandle(app->getCurrentObject());
     TUndoManager::manager()->add(undo);
     app->getCurrentScene()->setDirtyFlag(true);
@@ -1003,6 +1004,7 @@ void EditTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
     TUndoManager::manager()->endBlock();
     delete m_dragTool;
     m_dragTool = 0;
+    TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
     TTool::getApplication()->getCurrentObject()->notifyObjectIdChanged(false);
   }
   m_keyFrameAdded = false;

--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -949,6 +949,8 @@ void PlasticTool::onChange() {
   TTool::Viewer *viewer = getViewer();
   if (viewer)                 // This goes through paintEvent(),
     viewer->invalidateAll();  // \a unlike TTool::invalidate()
+
+  TTool::m_application->getCurrentXsheet()->notifyXsheetChanged();
 }
 
 //------------------------------------------------------------------------

--- a/toonz/sources/tnztools/plastictool_animate.cpp
+++ b/toonz/sources/tnztools/plastictool_animate.cpp
@@ -5,6 +5,7 @@
 
 // TnzLib includes
 #include "toonz/tobjecthandle.h"
+#include "toonz/txsheethandle.h"
 
 #include "plastictool.h"
 
@@ -175,6 +176,7 @@ void PlasticTool::leftButtonUp_animate(const TPointD &pos,
     TUndoManager::manager()->add(undo);
 
     // This is needed to refresh the xsheet (there may be new keyframes)
+    TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
     TTool::getApplication()->getCurrentObject()->notifyObjectIdChanged(false);
   }
 

--- a/toonz/sources/tnztools/skeletonsubtools.cpp
+++ b/toonz/sources/tnztools/skeletonsubtools.cpp
@@ -157,6 +157,7 @@ void DragChannelTool::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
 
     TTool::Application *app   = TTool::getApplication();
     UndoStageObjectMove *undo = new UndoStageObjectMove(m_before, m_after);
+    undo->setXsheetHandle(app->getCurrentXsheet());
     undo->setObjectHandle(app->getCurrentObject());
     TUndoManager::manager()->add(undo);
     app->getCurrentScene()->setDirtyFlag(true);

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1316,6 +1316,7 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
 
   if (addToUndo) {
     UndoStageObjectMove *undo = new UndoStageObjectMove(m_before, after);
+    undo->setXsheetHandle(m_xshHandle);
     undo->setObjectHandle(m_objHandle);
     TUndoManager::manager()->add(undo);
     TUndoManager::manager()->endBlock();

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -798,7 +798,7 @@ void BaseViewerPanel::updateFrameRange() {
   TFrameHandle *fh  = TApp::instance()->getCurrentFrame();
   int frameIndex    = fh->getFrameIndex();
   int maxFrameIndex = fh->getMaxFrameIndex();
-  if (frameIndex > maxFrameIndex) maxFrameIndex = frameIndex;
+//  if (frameIndex > maxFrameIndex) maxFrameIndex = frameIndex;
   m_flipConsole->setFrameRange(1, maxFrameIndex + 1, 1, frameIndex + 1);
 }
 

--- a/toonz/sources/toonzqt/functionkeyframenavigator.cpp
+++ b/toonz/sources/toonzqt/functionkeyframenavigator.cpp
@@ -21,7 +21,7 @@
 #include <QIntValidator>
 
 FunctionKeyframeNavigator::FunctionKeyframeNavigator(QWidget *parent)
-    : KeyframeNavigator(parent) {}
+    : KeyframeNavigator(parent), m_xsheetHandle(0) {}
 
 void FunctionKeyframeNavigator::setCurve(TDoubleParam *curve) {
   if (m_curve.getPointer() == curve) return;
@@ -50,9 +50,10 @@ void FunctionKeyframeNavigator::toggle() {
   int frame    = getCurrentFrame();
   double value = m_curve->getValue(frame);
   if (m_curve->isKeyframe(frame))
-    KeyframeSetter::removeKeyframeAt(m_curve.getPointer(), frame);
+    KeyframeSetter::removeKeyframeAt(m_curve.getPointer(), frame,
+                                     m_xsheetHandle);
   else {
-    KeyframeSetter setter(m_curve.getPointer());
+    KeyframeSetter setter(m_curve.getPointer(), m_xsheetHandle);
     setter.createKeyframe(frame);
   }
 }

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -248,6 +248,7 @@ FunctionPanel::FunctionPanel(QWidget *parent, bool isFloating)
     , m_frameAxisY(50)
     , m_graphViewportY(50)
     , m_frameHandle(0)
+    , m_xsheetHandle(0)
     , m_dragTool(0)
     , m_currentFrameStatus(0)
     , m_selection(0)
@@ -1699,9 +1700,9 @@ void FunctionPanel::openContextMenu(QMouseEvent *e) {
     kf.m_speedOut = -kf.m_speedIn;
     curve->setKeyframe(kf);
   } else if (action == &deleteKeyframeAction) {
-    KeyframeSetter::removeKeyframeAt(curve, kf.m_frame);
+    KeyframeSetter::removeKeyframeAt(curve, kf.m_frame, m_xsheetHandle);
   } else if (action == &insertKeyframeAction) {
-    KeyframeSetter(curve).createKeyframe(tround(frame));
+    KeyframeSetter(curve, m_xsheetHandle).createKeyframe(tround(frame));
   } else if (action == &activateCycleAction) {
     KeyframeSetter::enableCycle(curve, true);
   } else if (action == &deactivateCycleAction) {

--- a/toonz/sources/toonzqt/functionpaneltools.cpp
+++ b/toonz/sources/toonzqt/functionpaneltools.cpp
@@ -111,7 +111,8 @@ MovePointDragTool::MovePointDragTool(FunctionPanel *panel, TDoubleParam *curve)
   TUndoManager::manager()->beginBlock();
 
   if (curve) {
-    KeyframeSetter *setter = new KeyframeSetter(curve);
+    KeyframeSetter *setter =
+        new KeyframeSetter(curve, m_panel->getXsheetHandle());
     m_setters.push_back(setter);
   } else {
     m_groupEnabled           = true;
@@ -255,7 +256,10 @@ void MovePointDragTool::drag(QMouseEvent *e) {
 
 //-----------------------------------------------------------------------------
 
-void MovePointDragTool::release(QMouseEvent *e) {}
+void MovePointDragTool::release(QMouseEvent *e) {
+  if (m_panel->getXsheetHandle())
+    m_panel->getXsheetHandle()->notifyXsheetChanged();
+}
 
 //=============================================================================
 

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -87,6 +87,8 @@ public:
 
     m_sheet->selectCells(m_selectedCells);
 
+    TXsheetHandle *xsheetHandle = m_sheet->getXsheetHandle();
+
     /*---
 シンプルに左のバーをクリックした場合はcolは1つだけ。
 すでに複数Columnが選択されている上でその選択範囲内のセルの左バーをクリックした場合は
@@ -97,7 +99,7 @@ public:
          ++col) {
       TDoubleParam *curve = m_sheet->getCurve(col);
       if (!curve) continue;
-      KeyframeSetter *setter = new KeyframeSetter(curve);
+      KeyframeSetter *setter = new KeyframeSetter(curve, xsheetHandle);
       for (int k = 0; k < curve->getKeyframeCount(); k++) {
         int row = (int)curve->keyframeIndexToFrame(k);
         if (r0 <= row && row <= r1) {
@@ -125,6 +127,7 @@ public:
   void release(int row, int col, QMouseEvent *e) override {
     for (int i = 0; i < (int)m_setters.size(); i++) delete m_setters[i];
     m_setters.clear();
+    m_sheet->getViewer()->getXsheetHandle()->notifyXsheetChanged();
   }
 };
 
@@ -1153,8 +1156,10 @@ void FunctionSheetCellViewer::openContextMenu(QMouseEvent *e) {
   QAction *action = menu.exec(e->globalPos());  // QCursor::pos());
   if (action == &deleteKeyframeAction) {
     KeyframeSetter::removeKeyframeAt(curve, row);
+    m_sheet->getViewer()->getXsheetHandle()->notifyXsheetChanged();
   } else if (action == &insertKeyframeAction) {
     KeyframeSetter(curve).createKeyframe(row);
+    m_sheet->getViewer()->getXsheetHandle()->notifyXsheetChanged();
   } else if (interpActions.contains(action)) {
     selection->setSegmentType((TDoubleKeyframe::Type)action->data().toInt());
   } else if (action == &activateCycleAction)

--- a/toonz/sources/toonzqt/functiontoolbar.cpp
+++ b/toonz/sources/toonzqt/functiontoolbar.cpp
@@ -42,7 +42,11 @@
 //=========================================================================
 
 FunctionToolbar::FunctionToolbar(QWidget *parent)
-    : DVGui::ToolBar(parent), m_frameHandle(0), m_curve(0), m_selection(0) {
+    : DVGui::ToolBar(parent)
+    , m_frameHandle(0)
+    , m_xsheetHandle(0)
+    , m_curve(0)
+    , m_selection(0) {
   setFixedHeight(28);
   setIconSize(QSize(20, 20));
 
@@ -219,6 +223,13 @@ void FunctionToolbar::setFrameHandle(TFrameHandle *frameHandle) {
             SLOT(onFrameSwitched()));
 
   m_keyframeNavigator->setFrameHandle(frameHandle);
+}
+
+//-------------------------------------------------------------------
+
+void FunctionToolbar::setXsheetHandle(TXsheetHandle *xsheetHandle) {
+  m_xsheetHandle = xsheetHandle;
+  if (m_keyframeNavigator) m_keyframeNavigator->setXsheetHandle(xsheetHandle);
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -245,6 +245,7 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
 FunctionViewer::~FunctionViewer() {
   delete m_selection;
   m_toolbar->setFrameHandle(0);
+  m_toolbar->setXsheetHandle(0);
 }
 
 //-----------------------------------------------------------------------------
@@ -394,6 +395,9 @@ void FunctionViewer::setXsheetHandle(TXsheetHandle *xshHandle) {
   m_segmentViewer->setXsheetHandle(xshHandle);
   m_treeView->setXsheetHandle(xshHandle);
   m_numericalColumns->setXsheetHandle(xshHandle);
+  m_toolbar->setXsheetHandle(m_xshHandle);
+  m_functionGraph->setXsheetHandle(m_xshHandle);
+  m_selection->setXsheetHandle(m_xshHandle);
 
   if (m_xshHandle && isVisible()) {
     TXsheet *xsh = m_xshHandle->getXsheet();

--- a/toonz/sources/toonzqt/keyframenavigator.cpp
+++ b/toonz/sources/toonzqt/keyframenavigator.cpp
@@ -257,6 +257,7 @@ void ViewerKeyframeNavigator::toggle() {
     undo->setObjectHandle(m_objectHandle);
     TUndoManager::manager()->add(undo);
   }
+  m_xsheetHandle->notifyXsheetChanged();
   m_objectHandle->notifyObjectIdChanged(false);
 }
 


### PR DESCRIPTION
This fixes an issue where play back doesn't treat the last key as the end of the scene when it's made past the last exposed frame.

This usually happens when the key is the last thing created just before play back.  It wasn't updating the viewer's controls with the new end of scene frame.