### PR TITLE
Fix Capture Image using Canon EDSDK Linux

### DIFF
--- a/toonz/sources/stopmotion/canon.h
+++ b/toonz/sources/stopmotion/canon.h
@@ -25,10 +25,10 @@
 class QCamera;
 class QCameraInfo;
 class QDialog;
-class QTimer;
 class QSerialPort;
 
 #include <QThread>
+#include <QTimer>
 
 class Canon : public QObject {
   Q_OBJECT
@@ -72,6 +72,10 @@ private:
   QStringList m_isoOptions, m_shutterSpeedOptions, m_apertureOptions,
       m_exposureOptions, m_whiteBalanceOptions, m_colorTempOptions,
       m_imageQualityOptions, m_pictureStyleOptions;
+
+#ifdef LINUX
+  QTimer* m_eventTimer;
+#endif
 
 public:
   Canon();
@@ -196,6 +200,9 @@ public:
 public slots:
   void onImageReady(const bool&);
   void onFinished();
+#ifdef LINUX
+  void onTimeout();
+#endif
 
 signals:
   // canon signals


### PR DESCRIPTION
This fixes #1769.

Apparently, for Canon EDSDK on Linux, a loop is required to get messages initiated by the camera.  This also allows changes to camera settings on the camera itself to trigger camera information updates in T2D.