### PR TITLE
Fix image capture default folder

### DIFF
--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -339,9 +339,7 @@ void StopMotion::onSceneSwitched() {
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXsheet *xsh      = TApp::instance()->getCurrentXsheet()->getXsheet();
   setToNextNewLevel();
-  m_filePath = scene->getDefaultLevelPath(OVL_TYPE, m_levelName.toStdWString())
-                   .getParentDir()
-                   .getQString();
+  m_filePath    = "+stopmotion";
   m_frameNumber = 1;
   m_liveViewImageMap.clear();
 


### PR DESCRIPTION
The default capture image location was changed to `+stopmotion` in the early days of T2D, however due to legacy code that wasn't updated, it changes the default to `+extras` on a scene switch, old or new.

This fixes #1973 by ensuring the default is `+stopmotion` on a scene switch.

NOTE: Existing logic remains for older scenes when loaded where it will detect levels that are stop motion captured and use the level's location as the default `+stopmotion` save location.