### PR TITLE
Fix reading corrupted PNG crash

### DIFF
--- a/toonz/sources/image/png/tiio_png.cpp
+++ b/toonz/sources/image/png/tiio_png.cpp
@@ -290,6 +290,12 @@ public:
     png_bytep row_pointer = m_rowBuffer.get();
     png_read_row(m_png_ptr, row_pointer, NULL);
 
+    if (setjmp(png_jmpbuf(m_png_ptr))) {
+      // If an error is caught in the previous line, execution jumps here.
+      // We'll keep going in order to load whatever we can read.
+      return;
+    }
+
     writeRow(buffer, x0, x1);
 
     if (m_tempBuffer && m_y == ly) {


### PR DESCRIPTION
This fixes #1981, caused when reading an apparently corrupted/incomplete PNG image.

This crash happens in the png library and causes an immediate shutdown of T2D without generating a report.

Since the png library doesn't throw C++ exceptions, I added a recommended C-style `setjmp` for error handling to catch the issue where it is happening.  Rather than failling to read file and showing nothing, I've allowed whatever it has already captured to load.

I found no issue editing and saving the partially loaded PNG image once it loaded.

From the supplied scene, this is the file I used to test: [bad.zip](https://github.com/user-attachments/files/24175890/bad.zip)
