### PR TITLE
Add marker and soft round vector styles.

### DIFF
--- a/toonz/sources/colorfx/colorfx.cpp
+++ b/toonz/sources/colorfx/colorfx.cpp
@@ -66,6 +66,9 @@ void initColorFx() {
 
   add(new TMatrioskaStrokeStyle());
 
+  add(new TMarkerStrokeStyle());
+  add(new TSoftRoundStrokeStyle());
+  
 #ifdef _DEBUG
   add(new OutlineViewerStyle());
 #endif

--- a/toonz/sources/colorfx/strokestyles.h
+++ b/toonz/sources/colorfx/strokestyles.h
@@ -1345,3 +1345,77 @@ public:
 };
 
 #endif  // STROKESTYLES_H
+
+//-------------------------------------------------------------------
+
+class TMarkerStrokeStyle final : public TSolidColorStyle {
+  TPixel32 m_color;
+
+public:
+  TMarkerStrokeStyle(TPixel32 color = TPixel32(0, 0, 0, 128));
+
+  void invalidate() {}
+
+  TColorStyle *clone() const override;
+
+  bool hasMainColor() const override { return true; }
+  TPixel32 getMainColor() const override { return m_color; }
+  void setMainColor(const TPixel32 &color) override { m_color = color; TSolidColorStyle::setMainColor(color); }
+
+  void drawStroke(const TColorFunction *cf, TStrokeOutline *outline,
+                  const TStroke *stroke) const override;
+
+  bool isRegionStyle() const override { return true; }
+  bool isStrokeStyle() const override { return true; }
+
+  QString getDescription() const override {
+    return QCoreApplication::translate("TMarkerStrokeStyle", "Marker");
+  }
+  std::string getBrushIdName() const override { return "TMarkerStrokeStyle"; }
+
+  void loadData(TInputStreamInterface &is) override { is >> m_color; TSolidColorStyle::setMainColor(m_color); }
+  void saveData(TOutputStreamInterface &os) const override { os << m_color; }
+
+  int getTagId() const override { return 142; };
+};
+
+//-------------------------------------------------------------------
+
+class TSoftRoundStrokeStyle final : public TOptimizedStrokeStyleT<PointsAndDoubles> {
+  TPixel32 m_color;
+  double m_hardness;
+  double m_fade;
+
+public:
+TSoftRoundStrokeStyle(TPixel32 color = TPixel32(0, 0, 0, 128), double hardness = 75, double fade = 1.75);
+
+  void invalidate() {}
+
+  TColorStyle *clone() const override;
+
+  bool hasMainColor() const override { return true; }
+  TPixel32 getMainColor() const override { return m_color; }
+  void setMainColor(const TPixel32 &color) override { m_color = color; }
+
+  void computeData(PointsAndDoubles &data, const TStroke *stroke,
+    const TColorFunction *cf) const override;
+  void drawStroke(const TColorFunction *cf, PointsAndDoubles &data,
+    const TStroke *stroke) const override;
+
+  int getParamCount() const override;
+  TColorStyle::ParamType getParamType(int index) const override;
+  QString getParamNames(int index) const override;
+  void getParamRange(int index, double &min, double &max) const override;
+  double getParamValue(TColorStyle::double_tag, int index) const override;
+  void setParamValue(int index, double value) override;
+
+  QString getDescription() const override {
+    return QCoreApplication::translate("TSoftRoundStrokeStyle", "Soft Round");
+  }
+  std::string getBrushIdName() const override { return "TSoftRoundStrokeStyle"; }
+
+  void loadData(TInputStreamInterface &is) override { is >> m_color >> m_hardness >> m_fade; }
+  void saveData(TOutputStreamInterface &os) const override { os << m_color << m_hardness << m_fade; }
+
+  int getTagId() const override { return 143; };
+};


### PR DESCRIPTION
<img width="1715" height="947" alt="image" src="https://github.com/user-attachments/assets/6adf0271-9d9f-4370-b1f8-7b7ef652e832" />

Adds two new custom vector styles, Marker and Soft Round. Marker is a simplified version of standard vectors that can overlap with itself. It's much cheaper than standard vectors, especially when semitransparent or when using onion skins. If opaque it looks identical to standard vectors in a output render. It supports both lines and fills. If you have performance issues with standard vectors give this a try.

Soft Round is meant to simulate the look of a simple soft round raster brush. The hardness and endcap fade is configurable. It looks a little odd at higher line widths but is nearly indistinguishable from a real soft round for most linework. It only supports lines like most custom vector styles. It's also cheaper than standard vectors or raster pattern brushes, so it can be used to get a soft brush look without the performance impact.

EDIT: I'd recommend enabling `Break` on the vector brush tool to improve the look of joins as well.