### PR TITLE
SVG load fixes

### DIFF
--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2309,7 +2309,7 @@ TImageP TImageReaderSvg::load() {
         vimage->group(currentIndex, x);
         vimage->enterGroup(startStrokeIndex);
         vimage->selectFill(TRectD(-9999999, -9999999, 9999999, 9999999), 0,
-                           paintIndex, true, true, false);
+                           paintIndex, false, true, false);
         vimage->exitGroup();
       }
       vimage->findRegions();
@@ -2324,10 +2324,10 @@ TImageP TImageReaderSvg::load() {
       if (c > 1) {
         TStroke *s = vimage->getStroke(vimage->getStrokeCount() - 1);
         for (int i = 0; i < s->getControlPointCount(); i++)
-          vimage->fill(s->getControlPoint(i), paintIndex, true);
+          vimage->fill(s->getControlPoint(i), paintIndex, false);
       } else
         vimage->selectFill(TRectD(-9999999, -9999999, 9999999, 9999999), 0,
-                           paintIndex, true, true, false);
+                           paintIndex, false, true, false);
       vimage->exitGroup();
     }
 


### PR DESCRIPTION
After reviewing some new SVG import issues that were discussed on Discord (with samples provided), i've made the following changes:

- Fixed lines loading with border incorrectly when `stroke` data is not present (fill shapes).
- Fixed double application of scale data causing some line thickness to be incorrect
- Fixed application of `transform:rotation` data correcting position of shapes
- Fixed lines from multi-line shapes drawn in the wrong position
- Fixed processing of `path:transform` data found after path data instead of before it.
- Added support to load `stroke-linecap`, `stroke-linejoin` and `stroke-miterlimit` data
- Remove unnecessary variable.
- Autoclose open 0 thickness lines (fill shapes) instead of adding and grouping additional closing line
- Replace transparent lines, used for closing shapes, with 0 thickness lines so they are visible in Viewer when `Show Lines with Thickness 0` is enabled

