### PR TITLE
Fix some Vector Inspector issues + some refactoring

### DIFF
--- a/toonz/sources/common/tvectorimage/tstroke.cpp
+++ b/toonz/sources/common/tvectorimage/tstroke.cpp
@@ -2306,7 +2306,7 @@ void TStroke::addChunkRows(QAbstractItemModel *model, int stroke,
   for (std::ptrdiff_t i = groupIds.size() - 1; i > -1; --i) {
     if (currentGroup == groupIdData[i]) {
       groupIdsString = groupIdsString + "(" + std::to_string(groupIdData[i]) +
-                       (i > 0 ? "." : "") + ")";
+                       ")" + (i > 0 ? "." : "");
 
     } else {
       groupIdsString =

--- a/toonz/sources/toonz/multicolumnsortproxymodel.cpp
+++ b/toonz/sources/toonz/multicolumnsortproxymodel.cpp
@@ -5,36 +5,75 @@ MultiColumnSortProxyModel::MultiColumnSortProxyModel(QObject *parent)
 
 bool MultiColumnSortProxyModel::lessThan(const QModelIndex &left,
                                          const QModelIndex &right) const {
+  int sortColumn = left.column();
+
   int primaryColumn   = 0;  // Stroke column on the VectorInspectorPanel
   int secondaryColumn = 5;  // Quad column on the VectorInspectorPanel
   int tertiaryColumn  = 6;  // P column on the VectorInspectorPanel
 
+  QModelIndex leftIndex  = left.sibling(left.row(), sortColumn);
+  QModelIndex rightIndex = right.sibling(right.row(), sortColumn);
+
+  QString leftValue  = sourceModel()->data(leftIndex).toString();
+  QString rightValue = sourceModel()->data(rightIndex).toString();
+
+  if (leftValue != rightValue) {
+    if (sortColumn == 1) {  // Group Id
+      QStringList leftList = leftValue.split(".");
+      QStringList rightList = rightValue.split(".");
+
+      int min = std::min(leftList.count(), rightList.count());
+      for (int i = 0; i < min; i++) {
+        QString l = leftList[i];
+        QString r = rightList[i];
+        l.remove("(");
+        l.remove(")");
+        r.remove("(");
+        r.remove(")");
+        if (l.toInt() != r.toInt()) return l.toInt() < r.toInt();
+      }
+
+      if (leftList.count() != rightList.count())
+        return leftList.count() < rightList.count();  // Left has less groups
+
+    } else if (sortColumn == 4) // Self Loop
+      return leftValue < rightValue;
+
+    return leftValue.toInt() < rightValue.toInt();
+  }
+
   // A difference in the first column values?
-  QModelIndex leftPrimaryIndex  = left.sibling(left.row(), primaryColumn);
-  QModelIndex rightPrimaryIndex = right.sibling(right.row(), primaryColumn);
+  if (sortColumn != primaryColumn) {
+    leftIndex  = left.sibling(left.row(), primaryColumn);
+    rightIndex = right.sibling(right.row(), primaryColumn);
 
-  QString leftPrimary  = sourceModel()->data(leftPrimaryIndex).toString();
-  QString rightPrimary = sourceModel()->data(rightPrimaryIndex).toString();
+    leftValue  = sourceModel()->data(leftIndex).toString();
+    rightValue = sourceModel()->data(rightIndex).toString();
 
-  if (leftPrimary != rightPrimary) return leftPrimary < rightPrimary;
+    if (leftValue != rightValue) return leftValue.toInt() < rightValue.toInt();
+  }
 
   // No difference, check the secondary column.
-  QModelIndex leftSecondaryIndex  = left.sibling(left.row(), secondaryColumn);
-  QModelIndex rightSecondaryIndex = right.sibling(right.row(), secondaryColumn);
+  if (sortColumn != primaryColumn) {
+    leftIndex  = left.sibling(left.row(), secondaryColumn);
+    rightIndex = right.sibling(right.row(), secondaryColumn);
 
-  QString leftSecondary  = sourceModel()->data(leftSecondaryIndex).toString();
-  QString rightSecondary = sourceModel()->data(rightSecondaryIndex).toString();
+    leftValue  = sourceModel()->data(leftIndex).toString();
+    rightValue = sourceModel()->data(rightIndex).toString();
 
-  // sort as numbers because of double digit values
-  if (leftSecondary != rightSecondary)
-    return leftSecondary.toInt() < rightSecondary.toInt();
+    if (leftValue != rightValue) return leftValue.toInt() < rightValue.toInt();
+  }
 
   // No difference, check the tertiary column.
-  QModelIndex leftTertiaryIndex  = left.sibling(left.row(), tertiaryColumn);
-  QModelIndex rightTertiaryIndex = right.sibling(right.row(), tertiaryColumn);
+  if (sortColumn != primaryColumn) {
+    leftIndex  = left.sibling(left.row(), tertiaryColumn);
+    rightIndex = right.sibling(right.row(), tertiaryColumn);
 
-  QString leftTertiary  = sourceModel()->data(leftTertiaryIndex).toString();
-  QString rightTertiary = sourceModel()->data(rightTertiaryIndex).toString();
+    leftValue  = sourceModel()->data(leftIndex).toString();
+    rightValue = sourceModel()->data(rightIndex).toString();
 
-  return leftTertiary < rightTertiary;
+    if (leftValue != rightValue) return leftValue.toInt() < rightValue.toInt();
+  }
+
+  return leftValue < rightValue;
 }

--- a/toonz/sources/toonz/vectorinspector.h
+++ b/toonz/sources/toonz/vectorinspector.h
@@ -31,6 +31,7 @@ class VectorInspectorPanel final : public QWidget {
   QScrollArea* m_frameArea;
   TVectorImage* m_vectorImage;
   std::vector<int> m_selectedStrokeIndexes;
+  int m_currentImageType;
 
 public:
   VectorInspectorPanel(QWidget* parent       = nullptr,
@@ -64,6 +65,8 @@ public slots:
   void updateSelectToolSelectedRows(const QItemSelection&,
                                     const QItemSelection&);
 
+  void updateStrokeListData();
+
 protected:
   void showEvent(QShowEvent*) override;
   void hideEvent(QHideEvent*) override;
@@ -74,21 +77,21 @@ private slots:
   void sortChanged();
 
 private:
-  MultiColumnSortProxyModel* proxyModel;
-  QFrame* proxyGroupBox;
-  QTreeView* proxyView;
-  QStandardItemModel* sourceModel;
-  QLabel* filterPatternLabel;
-  QLabel* filterSyntaxLabel;
-  QLabel* filterColumnLabel;
-  QLineEdit* filterPatternLineEdit;
-  QComboBox* filterSyntaxComboBox;
-  QComboBox* filterColumnComboBox;
-  bool initiatedByVectorInspector;
-  bool initiatedBySelectTool;
-  bool strokeOrderChangedInProgress;
+  MultiColumnSortProxyModel* m_proxyModel;
+  QFrame* m_proxyGroupBox;
+  QTreeView* m_proxyView;
+  QStandardItemModel* m_sourceModel;
+  QLabel* m_filterPatternLabel;
+  QLabel* m_filterSyntaxLabel;
+  QLabel* m_filterColumnLabel;
+  QLineEdit* m_filterPatternLineEdit;
+  QComboBox* m_filterSyntaxComboBox;
+  QComboBox* m_filterColumnComboBox;
+  bool m_initiatedByVectorInspector;
+  bool m_initiatedBySelectTool;
+  bool m_strokeOrderChangedInProgress;
   bool isSelected(int) const;
-  bool selectingRowsForStroke;
+  bool m_selectingRowsForStroke;
   void changeWindowTitle();
 };
 


### PR DESCRIPTION
Fixed the following with Vector Inspector:

- Sorting columns
   - Fixed crash when a selected line's stroke order was moved up/down
   - Used to always sort by `Stroke Order`, `Quad` and `P`, ignoring the specific column being sorted. Now sorts by the specific column selected. In case of duplicate values it will then sort by `Stroke Order`, `Quad` and `P`
   - Some columns were alphanumerically sorted even though the values were numeric.  Now sorts numbers as numbers.
   - Some code refactoring.