### PR TITLE
Fix key movement lag while in Plastic Tool

### DIFF
--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -949,8 +949,6 @@ void PlasticTool::onChange() {
   TTool::Viewer *viewer = getViewer();
   if (viewer)                 // This goes through paintEvent(),
     viewer->invalidateAll();  // \a unlike TTool::invalidate()
-
-  TTool::m_application->getCurrentXsheet()->notifyXsheetChanged();
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
This fixes an issue where moving keys while on a mesh level in the Plastic tool causes excessive lag in the key movement.  Doesn't happen if you are on a different level and/or a different tool.

This was related to changes made in #1976.  Upon further testing, the code change causing the lag was not really needed so I've removed it.
