### PR TITLE
Fix Vector Ungroup/Group undo issue

### DIFF
--- a/toonz/sources/common/tvectorimage/tvectorimage.cpp
+++ b/toonz/sources/common/tvectorimage/tvectorimage.cpp
@@ -3064,6 +3064,21 @@ int TVectorImage::getGroupByRegion(UINT index) const {
 
 //------------------------------------------------------
 
+std::vector<int> TVectorImage::getGroupIdsForStroke(UINT index) const {
+  VIStroke *viStroke = getVIStroke(index);
+  return viStroke->m_groupId.m_id;
+}
+
+//------------------------------------------------------
+
+void TVectorImage::setGroupIdsForStroke(UINT index,
+                                        const std::vector<int> &groupIds) {
+  VIStroke *viStroke       = getVIStroke(index);
+  viStroke->m_groupId.m_id = groupIds;
+}
+
+//------------------------------------------------------
+
 int TVectorImage::pickGroup(const TPointD &pos, bool onEnteredGroup) const {
   if (onEnteredGroup && isInsideGroup() == 0) return -1;
 

--- a/toonz/sources/include/tvectorimage.h
+++ b/toonz/sources/include/tvectorimage.h
@@ -198,6 +198,9 @@ public:
   int getGroupByStroke(UINT index) const;
   int getGroupByRegion(UINT index) const;
 
+  std::vector<int> getGroupIdsForStroke(UINT index) const;
+  void setGroupIdsForStroke(UINT index, const std::vector<int> &groupIds);
+
   /*!
 get the stroke nearest at point
 \note outw is stroke parameter w in [0,1]


### PR DESCRIPTION
This fixes the following Ungroup/Group issues that were reported/found:

1. `Ungroup` undo crash as explained in this comment: https://github.com/tahoma2d/tahoma2d/pull/1997#issuecomment-3710754371
2. `Ungroup` undo of 2 separate groups resulting in 1 combined group

The above cases were due to existing logic which attempted to undo the ungrouping by regrouping the strokes as if you did it yourself.  This resulted in improper groups, which could result in a crash.

Modified the logic to store existing grouping information and use it to restore the original grouping information when undoing.

3. `Group` undo does not work when the `Vector Inspector` panel is active.

When the Vector Inspector panel is active, the active stroke selection is cleared when the group is created which causes missing undo information.  Added logic to detect when this happens and reset the selection, internally.