### PR TITLE
Fix SVG stroke-width at lower resolutions

### DIFF
--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -2248,8 +2248,6 @@ TStroke *buildStroke(NSVGpath *path, float *xform, float width, int lineCap,
 //-----------------------------------------------------------------------------
 
 TImageP TImageReaderSvg::load() {
-  static int devPixRatio = QApplication::primaryScreen()->devicePixelRatio();
-
   NSVGimage *svgImg =
       nsvgParseFromFile(m_path.getQString().toStdString().c_str());
   if (!svgImg) return TImageP();
@@ -2272,8 +2270,7 @@ TImageP TImageReaderSvg::load() {
     bool applyFill = shape->hasFillInfo && !shape->hasFillNone;
     bool autoclose = applyFill && !path->closed && shape->hasStrokeNone;
 
-    float strokeWidth =
-        !shape->hasStrokeNone ? shape->strokeWidth / devPixRatio : 0;
+    float strokeWidth = !shape->hasStrokeNone ? (shape->strokeWidth * 0.5) : 0;
 
     inkIndex   = !shape->hasStrokeNone ? findColor(plt, shape->strokeColor) : 1;
     paintIndex = !shape->hasFillNone ? findColor(plt, shape->fillColor) : 0;


### PR DESCRIPTION
This fixes SVG stroke's importing too wide at lower resolutions.