### PR TITLE
Fix last Stop Frame Hold

### DIFF
--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -318,7 +318,7 @@ Set column color tag to \b colorTag.
   }
   std::pair<int, int> getLoopForRow(int row);
   std::pair<int, int> getLoopWithRow(int row); 
-  bool isInLoopRange(int row);
+  bool isInLoopRange(int row) const;
 
   bool isLoopedFrame(int row);
   int getLoopedFrame(int row, bool forOnionSkin = false);

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1541,11 +1541,16 @@ TFxTimeRegion TLevelColumnFx::getTimeRegion() const {
   int first = m_levelColumn->getFirstRow();
   int last  = m_levelColumn->getRowCount();
 
-  // For implicit hold, if the last frame is not a stop frame, it's held
-  // indefinitely
-  if (Preferences::instance()->isImplicitHoldEnabled() &&
-      !m_levelColumn->getCell(last - 1).getFrameId().isStopFrame())
+  bool isLastAStopFrame =
+      m_levelColumn->getCell(last - 1).getFrameId().isStopFrame() &&
+      !m_levelColumn->isInLoopRange(last - 1);
+
+  // For implicit hold, if the last frame is not a stopframe or the stopframe is
+  // in a loop, it's held indefinitely
+  if (Preferences::instance()->isImplicitHoldEnabled() && !isLastAStopFrame)
     return TFxTimeRegion(0, (std::numeric_limits<double>::max)());
+
+  if (isLastAStopFrame) last--;
 
   return TFxTimeRegion(first, last);
 }

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -102,8 +102,10 @@ const TXshCell &TXshCellColumn::getCell(int row, bool implicitLookup,
   if (pastEnd) {
     if (!implicitEnabled && !loopsAvailable) return emptyCell;
     r = m_cells.size() - 1;
-    if (implicitEnabled && m_cells[r].getFrameId().isStopFrame())
-      return emptyCell;
+    if (implicitEnabled && m_cells[r].getFrameId().isStopFrame()) {
+      bool insideLoop = loopsAvailable ? isInLoopRange(r) : false;
+      if (!insideLoop) return emptyCell;
+    }
   }
 
   if (m_cells[r].isEmpty() || pastEnd) {
@@ -1167,7 +1169,7 @@ std::pair<int, int> TXshColumn::getLoopWithRow(int row) {
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isInLoopRange(int row) {
+bool TXshColumn::isInLoopRange(int row) const {
   if (!hasLoops()) return false;
 
   for (int i = 0; i < m_loops.size(); i++) {


### PR DESCRIPTION
This fixes the following issues related to the last Stop Frame Hold in a column/layer.

- When the column is used as a source for an Fx (i.e particlesFx), the last Stop Frame was included as one of the frames to render with.
   - Added logic to exclude the last Stop Frame in the frame range in column Fx calculations when not part of looped frames.

- When the last frame is a Stop Frame inside a Looped Frames section, the frames are not looped
   - Added logic to check to see if the last Stop Frame is inside a loop to determine if looping is happening