### PR TITLE
Fix column status toggling and display of folder items

### DIFF
--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -156,7 +156,7 @@ Constructs a TXshColumn with default value.
 Return true if camera stand is visible.
 \sa setCamstandVisible()
 */
-  bool isCamstandVisible() const;
+  bool isCamstandVisible(bool checkFolder = true) const;
   /*!
 Set column status camera stand visibility to \b on.
 \sa isCamstandVisible()
@@ -183,7 +183,7 @@ relevant if camerastandVisible is off.
 Return true if preview is visible.
 \sa setPreviewVisible()
 */
-  bool isPreviewVisible() const;
+  bool isPreviewVisible(bool checkFolder = true) const;
   /*!
 Set column status preview to \b on.
 \sa isPreviewVisible()
@@ -194,7 +194,7 @@ Set column status preview to \b on.
 Return true if column is locked.
 \sa lock()
 */
-  bool isLocked() const;
+  bool isLocked(bool checkFolder = true) const;
   /*!
 Set column status look to \b on.
 \sa isLocked()

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -773,8 +773,8 @@ void TXshColumn::setCamstandNextState() {
 #endif
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isCamstandVisible() const {
-  if (!isParentFolderCamstandVisible()) return false;
+bool TXshColumn::isCamstandVisible(bool checkFolder) const {
+  if (checkFolder && !isParentFolderCamstandVisible()) return false;
   return (m_status & eCamstandVisible) == 0;
 }
 
@@ -821,8 +821,8 @@ int TXshColumn::getColorFilterId() const {
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isPreviewVisible() const {
-  if (!isParentFolderPreviewVisible()) return false;
+bool TXshColumn::isPreviewVisible(bool checkFolder) const {
+  if (checkFolder && !isParentFolderPreviewVisible()) return false;
   return (m_status & ePreviewVisible) == 0;
 }
 
@@ -838,8 +838,8 @@ void TXshColumn::setPreviewVisible(bool on) {
 
 //-----------------------------------------------------------------------------
 
-bool TXshColumn::isLocked() const {
-  if (isParentFolderLocked()) return true;
+bool TXshColumn::isLocked(bool checkFolder) const {
+  if (checkFolder && isParentFolderLocked()) return true;
   return (m_status & eLocked) != 0;
 }
 


### PR DESCRIPTION
This fixes how preview visibility, column visibility and locking states for folder items are managed.

- For column context menu options `xxx This Only` and `xxx Selected`
   - If the selected column is a folder, all contents inside it will be toggled to match the folder's status
   - For Preview/Camera Stand Visibility, if the selected column is a folder item and is toggled ON, all parent folders are turned ON.  The status of other items in parent folders will be toggled OFF only when `xxx This Only` is used.

- Preview/Camera Stand Visibility states of all folder items will now be visible even when the folder is OFF.  In this case, the folder item icons will appear greyed out, but can still be toggled on/off if needed for when the folder is enabled.

- Lock status on folder items will display a greyed out icon when the lock status is inherited from a parent folder.  The icon will remain full color if the column is normally locked regardless of parent folder setting.
