### PR TITLE
Fix loading unknown style id

### DIFF
--- a/toonz/sources/common/tvrender/tcolorstyles.cpp
+++ b/toonz/sources/common/tvrender/tcolorstyles.cpp
@@ -428,9 +428,7 @@ public:
 
   TColorStyle *create(int id, bool &isObsolete) {
     Table::iterator it = m_table.find(id);
-    if (it == m_table.end())
-      throw TException("Unknown color style id; id = " + std::to_string(id));
-
+    if (it == m_table.end()) return 0;
     isObsolete = it->second.m_isObsolete;
 
     return it->second.m_style->clone();
@@ -581,12 +579,20 @@ TColorStyle *TColorStyle::load(TInputStreamInterface &is) {
   }
   bool isObsolete    = false;
   TColorStyle *style = ColorStyleList::instance()->create(id, isObsolete);
+  bool unknownStyle  = false;
+  if (!style) {
+    // unknown style: create a default one
+    style        = ColorStyleList::instance()->create(3, isObsolete);
+    unknownStyle = true;
+  }
   assert(style);
   style->setFlags(flags);
   if (isObsolete)
     style->loadData(id, is);
   else
     style->loadData(is);
+  if (unknownStyle)
+    style->setMainColor(TPixel32(255, 0, 0, style->getMainColor().m));
   style->setName(::to_wstring(name));
   style->setGlobalName(gname);
   style->setOriginalName(origName);


### PR DESCRIPTION
This fixes an issue where a level will not load because the palette contains a style id (internal type) that does not exist in the current version.

When the palette is loaded and the style type does not exist because you opened it in a prior version, it will automatically convert  the style to a `Red` standard style. 

NOTE: This will only be useful for version 1.6 and later after #1983 is merged for version 1.7 as it introduces a new style id. 