### PR TITLE
Fix sound cells extender controls and move selection

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -88,7 +88,6 @@ class CellArea final : public QWidget {
   QRect m_levelExtenderRect;
   // upper-directional smart tab
   QRect m_upperLevelExtenderRect;
-  QList<QRect> m_soundLevelModifyRects;
 
   bool m_isPanning;
   bool m_isMousePressed;

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -180,7 +180,11 @@ public:
         r = row;
         for (; r < r1; r++) {
           TXshCell cell = xsh->getCell(r, col);
-          if (cell.isEmpty() || cell.getFrameId().isStopFrame()) break;
+          if (cell.getFrameId().isStopFrame()) break;
+          if (cell.isEmpty()) {
+            r--;
+            break;
+          }
         }
         r1 = r;
         if (m_keySelection) {
@@ -237,8 +241,16 @@ public:
         getViewer()->setCurrentRow(row);
       if (m_keySelection)
         getViewer()->getCellKeyframeSelection()->selectCellKeyframe(row, col);
-      else
-        getViewer()->getCellSelection()->selectCell(row, col);
+      else {
+        TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
+        TXshColumn *column = xsh->getColumn(col);
+        if (!Preferences::instance()->isShowDragBarsEnabled() && column &&
+            column->getSoundColumn() &&
+            column->getSoundColumn()->getLevelRange(row, r0, r1))
+          getViewer()->getCellSelection()->selectCells(r0, col, r1, col);
+        else
+          getViewer()->getCellSelection()->selectCell(row, col);
+      }
     }
     refreshCellsArea();
     refreshRowsArea();


### PR DESCRIPTION
Following fixes and enhancement regarding sound cells:
- Fixed display of sound cell extenders (yellow bars) to cover entire edge when in no-drag bar mode
- Fixed inability to grab sound cell extenders when in no-drag bar mode or when using drag bars and on another level/column or clicking the center of any sound cell
- Fixed contiguous selection (`Shift` + `Ctrl`) of sound cell to stop including an empty cell at the end
- In no-drag bar mode, I've updated click-drag of an unselect sound cell to automatically select entire sound "clip" for movement