### PR TITLE
Fix backing up of scene icon

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -366,7 +366,10 @@ void TSystem::copyFile(const TFilePath &dst, const TFilePath &src,
   touchParentDir(dst);
 
   const QString &qDst = toQString(dst);
-  if (overwrite && QFile::exists(qDst)) QFile::remove(qDst);
+  if (QFile::exists(qDst)) {
+    if (!overwrite) return;
+    QFile::remove(qDst);
+  }
 
   if (!QFile::copy(toQString(src), qDst))
     throw TSystemException(dst, "can't copy file!");
@@ -859,13 +862,15 @@ void TSystem::copyFileOrLevel_throw(const TFilePath &dst,
     TFilePath srciconname(src.withParentDir(srciconDir)
                               .withName(src.getName() + " ")
                               .withType("png"));
-    TFilePath dsticonname(dst.withParentDir(dsticonDir)
-                              .withName(dst.getName() + " ")
-                              .withType("png"));
+    bool isBakFile = dst.getType() == "bak";
+    TFilePath dest = isBakFile ? dst.withType("") : dst;
+    TFilePath dsticonname(dest.withParentDir(dsticonDir)
+                              .withName(dest.getName() + " ")
+                              .withType(isBakFile ? "png.bak" : "png"));
 
     if (TSystem::doesExistFileOrLevel(src) &&
         TSystem::doesExistFileOrLevel(srciconname))
-      TSystem::copyFile(dsticonname, srciconname, false);
+      TSystem::copyFile(dsticonname, srciconname);
   }
     
   if (src.isLevelName()) {


### PR DESCRIPTION
This fixes 2 issues when backing up scene icons while saving:

1. Incorrectly named scene icon backup as `ABC.tnz png` instead of `ABC .png.bak`
2. Fixed the error `Exception thrown at 0x00007FF9CD1A5369 in Tahoma2D.exe: Microsoft C++ exception: TSystemException at memory location 0x000000806BFBAFC0.` when it fails to copy over an existing backup file by removing the target file first.
   This error could be thrown whenever the copy was configured not to overwrite.  For this case, not really used, I've modified the logic it skip copying if the target file already exists. 

