### PR TITLE
Revert "Fix fill loss due to ghost grouping changes"

### DIFF
--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -2502,15 +2502,7 @@ void addIntersection(IntersectionData &intData, const vector<VIStroke *> &s,
 
   point = s[ii]->m_s->getPoint(intersection.first);
 
-  int gid1 = s[ii]->m_groupId.m_id[0];
-  for (p = intData.m_intList.first(); p; p = p->next()) {
-    int i          = p->m_strokeList.first()->m_edge.m_index;
-    int gid2       = i >= 0 ? s[i]->m_groupId.m_id[0]
-                            : intData.m_autocloseMap.at(i)->m_groupId.m_id[0];
-    bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
-
-    if (!sameGroup) continue;
-
+  for (p = intData.m_intList.first(); p; p = p->next())
     if (p->m_intersection == point ||
         (isVectorized &&
          areAlmostEqual(
@@ -2521,7 +2513,6 @@ void addIntersection(IntersectionData &intData, const vector<VIStroke *> &s,
       addBranches(intData, *p, s, ii, jj, intersection, strokeSize);
       return;
     }
-  }
 
   intData.m_intList.pushBack(new Intersection);
 
@@ -2563,18 +2554,13 @@ void TVectorImage::Imp::findIntersections() {
 
     roundStroke(s1);
 
-    int gid1 = strokeArray[i]->m_groupId.m_id[0];
-
     for (it = it_b; it != it_e; ++it) {
-      if (!it->second) continue;
+      if (!it->second || it->second->m_groupId != strokeArray[i]->m_groupId)
+        continue;
 
       TStroke *s2 = it->second->m_s;
-
-      int gid2       = it->second->m_groupId.m_id[0];
-      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
-
       vector<DoublePair> parIntersections;
-      if (sameGroup && intersect(s1, s2, parIntersections, true))
+      if (intersect(s1, s2, parIntersections, true))
         addIntersections(intData, strokeArray, i, it->first, parIntersections,
                          strokeSize, isVectorized);
     }
@@ -2588,19 +2574,16 @@ void TVectorImage::Imp::findIntersections() {
   for (i = 0; i < strokeSize; i++) {
     TStroke *s1 = strokeArray[i]->m_s;
     if (strokeArray[i]->m_isPoint) continue;
-    int gid1 = strokeArray[i]->m_groupId.m_id[0];
     for (j = i; j < strokeSize /*&& (strokeArray[i]->getBBox().x1>=
                                   strokeArray[j]->getBBox().x0)*/
          ;
          j++) {
       TStroke *s2 = strokeArray[j]->m_s;
 
-      int gid2       = strokeArray[j]->m_groupId.m_id[0];
-      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
-
-      if (!sameGroup || strokeArray[j]->m_isPoint ||
+      if (strokeArray[j]->m_isPoint ||
           !(strokeArray[i]->m_isNewForFill || strokeArray[j]->m_isNewForFill))
         continue;
+      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
 
       vector<DoublePair> parIntersections;
       if (s1->getBBox().overlaps(s2->getBBox())) {
@@ -2646,15 +2629,12 @@ void TVectorImage::Imp::findIntersections() {
   for (i = 0; i < strokeSize; i++) {
     TStroke *s1 = strokeArray[i]->m_s;
     if (strokeArray[i]->m_isPoint) continue;
-    int gid1 = strokeArray[i]->m_groupId.m_id[0];
     for (j = i; j < strokeSize; j++) {
+      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
+
       TStroke *s2 = strokeArray[j]->m_s;
-
-      int gid2       = strokeArray[j]->m_groupId.m_id[0];
-      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
-
-      if (!sameGroup || strokeArray[j]->m_isPoint ||
-          !(strokeArray[i]->m_isNewForFill || strokeArray[j]->m_isNewForFill))
+      if (strokeArray[j]->m_isPoint) continue;
+      if (!(strokeArray[i]->m_isNewForFill || strokeArray[j]->m_isNewForFill))
         continue;
 
       double enlarge1 =
@@ -2736,15 +2716,11 @@ void TVectorImage::Imp::findIntersections() {
 
   for (i = strokeSize; i < (int)strokeArray.size(); ++i) {
     TStroke *s1 = strokeArray[i]->m_s;
-    int gid1    = strokeArray[i]->m_groupId.m_id[0];
 
     for (j = i + 1; j < (int)strokeArray.size();
          ++j)  // intersezione segmento-segmento
     {
-      int gid2       = strokeArray[j]->m_groupId.m_id[0];
-      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
-
-      if (!sameGroup) continue;
+      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
 
       TStroke *s2 = strokeArray[j]->m_s;
       vector<DoublePair> parIntersections;
@@ -2755,10 +2731,7 @@ void TVectorImage::Imp::findIntersections() {
     for (j = 0; j < strokeSize; ++j)  // intersezione segmento-curva
     {
       if (strokeArray[j]->m_isPoint) continue;
-      int gid2       = strokeArray[j]->m_groupId.m_id[0];
-      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
-
-      if (!sameGroup) continue;
+      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
 
       TStroke *s2 = strokeArray[j]->m_s;
       vector<DoublePair> parIntersections;

--- a/toonz/sources/common/tvectorimage/tvectorimage.cpp
+++ b/toonz/sources/common/tvectorimage/tvectorimage.cpp
@@ -836,13 +836,10 @@ bool TVectorImage::Imp::selectFill(const TRectD &selArea, TStroke *s,
       if (fillAreas)
         for (UINT i = 0; i < m_regions.size(); i++) {
           TRegion *r1 = m_regions[i];
-          int index, j = 0;
 
-          do index = m_regions[i]->getEdge(j++)->m_index;
-          while (index < 0 && j < (int)m_regions[i]->getEdgeCount());
-          // if index<0, means that the region is purely of autoclose strokes!
-          if (m_insideGroup != TGroupId() && index >= 0 &&
-              !m_insideGroup.isParentOf(m_strokes[index]->m_groupId))
+          if (m_insideGroup != TGroupId() &&
+              !m_insideGroup.isParentOf(
+                  m_strokes[r1->getEdge(0)->m_index]->m_groupId))
             continue;
 
           if ((!onlyUnfilled || r1->getStyle() == 0) && r0->contains(*r1)) {
@@ -2699,21 +2696,27 @@ void TVectorImage::Imp::rearrangeMultiGroup() {
   UINT i, j, k;
   if (m_strokes.size() <= 0) return;
   for (i = 0; i < m_strokes.size() - 1; i++) {
-    if (i + 1 == m_strokes.size()) break;
-
     if (m_strokes[i]->m_groupId.isGrouped() &&
         m_strokes[i + 1]->m_groupId.isGrouped() &&
-        m_strokes[i]->m_groupId == m_strokes[i + 1]->m_groupId)
-      continue;
-
-    // look for other strokes with same group and move them up to bottom of
-    // current set
-    for (j = i + 1; j < m_strokes.size(); j++) {
-      if (m_strokes[j]->m_groupId.isGrouped() &&
-          m_strokes[j]->m_groupId == m_strokes[i]->m_groupId) {
-        moveStrokes(j, 1, i + 1, false);
-        rearrangeMultiGroup();
-        return;
+        m_strokes[i]->m_groupId != m_strokes[i + 1]->m_groupId) {
+      TGroupId &prevId   = m_strokes[i]->m_groupId;
+      TGroupId &idToMove = m_strokes[i + 1]->m_groupId;
+      for (j = i + 1;
+           j < m_strokes.size() && m_strokes[j]->m_groupId == idToMove; j++)
+        ;
+      if (j != m_strokes.size()) {
+        j--;  // now range i+1-j contains the strokes to be moved.
+        // let's compute where to move them (after last
+        for (k = j; k < m_strokes.size() && m_strokes[k]->m_groupId != prevId;
+             k++)
+          ;
+        if (k < m_strokes.size()) {
+          for (; k < m_strokes.size() && m_strokes[k]->m_groupId == prevId; k++)
+            ;
+          moveStrokes(i + 1, j - i, k, false);
+          rearrangeMultiGroup();
+          return;
+        }
       }
     }
   }


### PR DESCRIPTION
This temporarily reverts changes made in #1997 due to some ongoing issues with it and not enough time to test the fixes in #2011 before the upcoming release.

I will reintroduce these changes in a new PR for a 1.6.1 fix release.