### PR TITLE
Fix fill loss due to ghost grouping changes

### DIFF
--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -2502,7 +2502,17 @@ void addIntersection(IntersectionData &intData, const vector<VIStroke *> &s,
 
   point = s[ii]->m_s->getPoint(intersection.first);
 
-  for (p = intData.m_intList.first(); p; p = p->next())
+  int gid1 = s[ii]->m_groupId.m_id[0];
+  for (p = intData.m_intList.first(); p; p = p->next()) {
+    int i          = p->m_strokeList.first()->m_edge.m_index;
+    int gid2       = i >= 0 ? s[i]->m_groupId.m_id[0]
+                            : (intData.m_autocloseMap.at(i)->m_groupId.m_id.size()
+                                   ? intData.m_autocloseMap.at(i)->m_groupId.m_id[0]
+                                   : gid1);
+    bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
+
+    if (!sameGroup) continue;
+
     if (p->m_intersection == point ||
         (isVectorized &&
          areAlmostEqual(
@@ -2513,6 +2523,7 @@ void addIntersection(IntersectionData &intData, const vector<VIStroke *> &s,
       addBranches(intData, *p, s, ii, jj, intersection, strokeSize);
       return;
     }
+  }
 
   intData.m_intList.pushBack(new Intersection);
 
@@ -2554,13 +2565,20 @@ void TVectorImage::Imp::findIntersections() {
 
     roundStroke(s1);
 
+    int gid1 = strokeArray[i]->m_groupId.m_id[0];
+
     for (it = it_b; it != it_e; ++it) {
-      if (!it->second || it->second->m_groupId != strokeArray[i]->m_groupId)
-        continue;
+      if (!it->second) continue;
 
       TStroke *s2 = it->second->m_s;
+
+      int gid2       = it->second->m_groupId.m_id.size()
+                           ? it->second->m_groupId.m_id[0]
+                           : gid1;
+      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
+
       vector<DoublePair> parIntersections;
-      if (intersect(s1, s2, parIntersections, true))
+      if (sameGroup && intersect(s1, s2, parIntersections, true))
         addIntersections(intData, strokeArray, i, it->first, parIntersections,
                          strokeSize, isVectorized);
     }
@@ -2574,16 +2592,19 @@ void TVectorImage::Imp::findIntersections() {
   for (i = 0; i < strokeSize; i++) {
     TStroke *s1 = strokeArray[i]->m_s;
     if (strokeArray[i]->m_isPoint) continue;
+    int gid1 = strokeArray[i]->m_groupId.m_id[0];
     for (j = i; j < strokeSize /*&& (strokeArray[i]->getBBox().x1>=
                                   strokeArray[j]->getBBox().x0)*/
          ;
          j++) {
       TStroke *s2 = strokeArray[j]->m_s;
 
-      if (strokeArray[j]->m_isPoint ||
+      int gid2       = strokeArray[j]->m_groupId.m_id[0];
+      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
+
+      if (!sameGroup || strokeArray[j]->m_isPoint ||
           !(strokeArray[i]->m_isNewForFill || strokeArray[j]->m_isNewForFill))
         continue;
-      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
 
       vector<DoublePair> parIntersections;
       if (s1->getBBox().overlaps(s2->getBBox())) {
@@ -2629,12 +2650,15 @@ void TVectorImage::Imp::findIntersections() {
   for (i = 0; i < strokeSize; i++) {
     TStroke *s1 = strokeArray[i]->m_s;
     if (strokeArray[i]->m_isPoint) continue;
+    int gid1 = strokeArray[i]->m_groupId.m_id[0];
     for (j = i; j < strokeSize; j++) {
-      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
-
       TStroke *s2 = strokeArray[j]->m_s;
-      if (strokeArray[j]->m_isPoint) continue;
-      if (!(strokeArray[i]->m_isNewForFill || strokeArray[j]->m_isNewForFill))
+
+      int gid2       = strokeArray[j]->m_groupId.m_id[0];
+      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
+
+      if (!sameGroup || strokeArray[j]->m_isPoint ||
+          !(strokeArray[i]->m_isNewForFill || strokeArray[j]->m_isNewForFill))
         continue;
 
       double enlarge1 =
@@ -2716,11 +2740,15 @@ void TVectorImage::Imp::findIntersections() {
 
   for (i = strokeSize; i < (int)strokeArray.size(); ++i) {
     TStroke *s1 = strokeArray[i]->m_s;
+    int gid1    = strokeArray[i]->m_groupId.m_id[0];
 
     for (j = i + 1; j < (int)strokeArray.size();
          ++j)  // intersezione segmento-segmento
     {
-      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
+      int gid2       = strokeArray[j]->m_groupId.m_id[0];
+      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
+
+      if (!sameGroup) continue;
 
       TStroke *s2 = strokeArray[j]->m_s;
       vector<DoublePair> parIntersections;
@@ -2731,7 +2759,10 @@ void TVectorImage::Imp::findIntersections() {
     for (j = 0; j < strokeSize; ++j)  // intersezione segmento-curva
     {
       if (strokeArray[j]->m_isPoint) continue;
-      if (strokeArray[i]->m_groupId != strokeArray[j]->m_groupId) continue;
+      int gid2       = strokeArray[j]->m_groupId.m_id[0];
+      bool sameGroup = (gid1 < 0 && gid2 < 0) || (gid1 == gid2);
+
+      if (!sameGroup) continue;
 
       TStroke *s2 = strokeArray[j]->m_s;
       vector<DoublePair> parIntersections;


### PR DESCRIPTION
This restores the reverted changes made in #1997 with corrections for handling autoclose strokes.

From the original PR.....

This fixes an issue where vector fills may get lost due to grouping changes and stroke order changes.

Background:
Fillable regions are determined by stroke intersections of strokes within the same group. Ungroup strokes are assigned a "ghost group" which is influenced by existing groups and stacking order. When a group is made in the middle of ungrouped strokes, the group strokes are moved to be near each other causing ungrouped strokes below it will have a different ghost group than the ones after the new group.

Issue:
The intersection logic treated ghost groups as unique groups. Creating groups in the middle or even changing the stacking order of groups would cause ghost groupings to change, potentially breaking valid fillable regions for ungrouped strokes.

Resolution:
In order to keep valid fillable regions for ungrouped strokes, I have modified the logic to treat all ghost groups as being in the same group (the ungrouped group). This keeps intersections among ungrouped strokes maintained regardless of where groups are in the stacking order.
