### PR TITLE
Timeline/Xsheet Pegbars

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2399,6 +2399,9 @@ XsheetViewer {
   qproperty-FolderColumnColor: #c4a972;
   qproperty-FolderColumnBorderColor: #b5934e;
   qproperty-SelectedFolderColumnColor: #dbaf8b;
+  qproperty-PegbarColumnColor: #9f6e3c;
+  qproperty-PegbarColumnBorderColor: #7a542e;
+  qproperty-SelectedPegbarColumnColor: #b87959;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -2399,6 +2399,9 @@ XsheetViewer {
   qproperty-FolderColumnColor: #c4a972;
   qproperty-FolderColumnBorderColor: #b5934e;
   qproperty-SelectedFolderColumnColor: #dbaf8b;
+  qproperty-PegbarColumnColor: #9f6e3c;
+  qproperty-PegbarColumnBorderColor: #7a542e;
+  qproperty-SelectedPegbarColumnColor: #b87959;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2396,9 +2396,12 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #a8b2c0;
   qproperty-SoundColumnHlColor: #f5ffe6;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
-  qproperty-FolderColumnColor: #e7c9a9;
-  qproperty-FolderColumnBorderColor: #cfa375;
-  qproperty-SelectedFolderColumnColor: #d2a9a1;
+  qproperty-FolderColumnColor: #f0d08f;
+  qproperty-FolderColumnBorderColor: #dfb154;
+  qproperty-SelectedFolderColumnColor: #d8ad8f;
+  qproperty-PegbarColumnColor: #dfb081;
+  qproperty-PegbarColumnBorderColor: #c68a4d;
+  qproperty-SelectedPegbarColumnColor: #cc9785;
   qproperty-ActiveCameraColor: #79b5ee;
   qproperty-SelectedActiveCameraColor: #869bd1;
   qproperty-OtherCameraColor: #6eb7c2;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -2399,6 +2399,9 @@ XsheetViewer {
   qproperty-FolderColumnColor: #c4a972;
   qproperty-FolderColumnBorderColor: #b5934e;
   qproperty-SelectedFolderColumnColor: #dbaf8b;
+  qproperty-PegbarColumnColor: #9f6e3c;
+  qproperty-PegbarColumnBorderColor: #7a542e;
+  qproperty-SelectedPegbarColumnColor: #b87959;
   qproperty-ActiveCameraColor: #4073a3;
   qproperty-SelectedActiveCameraColor: #617db8;
   qproperty-OtherCameraColor: #5e9aa3;

--- a/stuff/config/qss/Medium/less/Medium.less
+++ b/stuff/config/qss/Medium/less/Medium.less
@@ -464,6 +464,7 @@
 @xsheet-SoundColumnTrack-color:             rgba(0,0,0,0.8);
 @xsheet-SoundPreviewTool-color:             darken(@xsheet-SoundColumnTrack-color, 20);
 @xsheet-FolderColumn-color:                 #c4a972;
+@xsheet-PegbarColumn-color:                 #9f6e3c;
 @xsheet-ActiveCamera-color:                 #4073a3;
 @xsheet-OtherCamera-color:                  #5e9aa3;
 

--- a/stuff/config/qss/Medium/less/layouts/xsheet.less
+++ b/stuff/config/qss/Medium/less/layouts/xsheet.less
@@ -163,6 +163,10 @@ XsheetViewer {
   qproperty-FolderColumnColor: @xsheet-FolderColumn-color;
   qproperty-FolderColumnBorderColor: desaturate(darken(@xsheet-FolderColumn-color, @columnBorderDarkness), @columnBorderDesaturation);
   qproperty-SelectedFolderColumnColor: mix(shade(@xsheet-FolderColumn-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);
+
+  qproperty-PegbarColumnColor: @xsheet-PegbarColumn-color;
+  qproperty-PegbarColumnBorderColor: desaturate(darken(@xsheet-PegbarColumn-color, @columnBorderDarkness), @columnBorderDesaturation);
+  qproperty-SelectedPegbarColumnColor: mix(shade(@xsheet-PegbarColumn-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);
  
   qproperty-ActiveCameraColor: @xsheet-ActiveCamera-color;
   qproperty-SelectedActiveCameraColor: mix(shade(@xsheet-ActiveCamera-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);

--- a/stuff/config/qss/Medium/less/themes/Light.less
+++ b/stuff/config/qss/Medium/less/themes/Light.less
@@ -211,7 +211,8 @@
 @xsheet-MeshColumn-color:                   #b8a2cf;
 @xsheet-SoundColumn-color:                  #aad6d6;
 @xsheet-SoundTextColumn-color:              #c2c2c2;
-@xsheet-FolderColumn-color:                 #e7c9a9;
+@xsheet-FolderColumn-color:                 #f0d08f;
+@xsheet-PegbarColumn-color:                 #dfb081;
 @xsheet-ActiveCamera-color:                 #79b5ee;
 @xsheet-OtherCamera-color:                  #6eb7c2;
 

--- a/stuff/config/qss/Medium/less/themes/Neutral.less
+++ b/stuff/config/qss/Medium/less/themes/Neutral.less
@@ -233,6 +233,8 @@
 @xsheet-SoundColumn-color:                  #749e9e;
 @xsheet-SoundColumnHL-color:                #f5ffe6;
 @xsheet-SoundColumnTrack-color:             rgba(0,0,0,0.8);
+@xsheet-FolderColumn-color:                 #dbbd81;
+@xsheet-PegbarColumn-color:                 #be8a56;
 @xsheet-ActiveCamera-color:                 rgb(100, 145, 190);
 @xsheet-OtherCamera-color:                  rgb(143, 156, 158);
 

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2396,9 +2396,12 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #98a8b5;
   qproperty-SoundColumnHlColor: #f5ffe6;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
-  qproperty-FolderColumnColor: #c4a972;
-  qproperty-FolderColumnBorderColor: #a58545;
-  qproperty-SelectedFolderColumnColor: #e1b28d;
+  qproperty-FolderColumnColor: #dbbd81;
+  qproperty-FolderColumnBorderColor: #ca9e45;
+  qproperty-SelectedFolderColumnColor: #f7c59a;
+  qproperty-PegbarColumnColor: #be8a56;
+  qproperty-PegbarColumnBorderColor: #906437;
+  qproperty-SelectedPegbarColumnColor: #dc9673;
   qproperty-ActiveCameraColor: #6491be;
   qproperty-SelectedActiveCameraColor: #899cd3;
   qproperty-OtherCameraColor: #8f9c9e;

--- a/stuff/profiles/layouts/settings/commandbar.xml
+++ b/stuff/profiles/layouts/settings/commandbar.xml
@@ -4,6 +4,7 @@
     <command>MI_NewToonzRasterLevel</command>
     <command>MI_NewVectorLevel</command>
     <command>MI_NewNoteLevel</command>
+    <command>MI_NewPegbar</command>
     <command>MI_NewFolder</command>
     <separator/>
     <command>MI_CreateBlankDrawing</command>

--- a/stuff/profiles/layouts/settings/quicktoolbar.xml
+++ b/stuff/profiles/layouts/settings/quicktoolbar.xml
@@ -9,6 +9,7 @@
     <command>MI_NewToonzRasterLevel</command>
     <command>MI_NewVectorLevel</command>
     <command>MI_NewNoteLevel</command>
+    <command>MI_NewPegbar</command>
     <command>MI_NewFolder</command>
     <separator/>
     <command>MI_CreateBlankDrawing</command>

--- a/toonz/sources/include/toonz/tstageobjectcmd.h
+++ b/toonz/sources/include/toonz/tstageobjectcmd.h
@@ -46,7 +46,7 @@ DVAPI void setSplineParent(TStageObjectSpline *spline, TStageObject *parentObj,
 DVAPI void addNewCamera(TXsheetHandle *xshHandle, TObjectHandle *objHandle,
                         QPointF initialPos = QPointF());
 DVAPI void addNewPegbar(TXsheetHandle *xshHandle, TObjectHandle *objHandle,
-                        QPointF initialPos = QPointF());
+                        QPointF initialPos = QPointF(), int col = 0);
 DVAPI void setAsActiveCamera(TXsheetHandle *xshHandle,
                              TObjectHandle *objHandle);
 DVAPI TStageObjectSpline *addNewSpline(TXsheetHandle *xshHandle,

--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -32,6 +32,7 @@ class TXshPaletteColumn;
 class TXshZeraryFxColumn;
 class TXshMeshColumn;
 class TXshFolderColumn;
+class TXshPegbarColumn;
 class TXsheet;
 class TXshCell;
 class TFx;
@@ -125,7 +126,8 @@ Constructs a TXshColumn with default value.
     eZeraryFxType,
     ePaletteType,
     eMeshType,
-    eFolderType
+    eFolderType,
+    ePegbarType
   };
 
   virtual ColumnType getColumnType() const = 0;
@@ -147,6 +149,7 @@ Constructs a TXshColumn with default value.
   virtual TXshZeraryFxColumn *getZeraryFxColumn() { return 0; }
   virtual TXshMeshColumn *getMeshColumn() { return 0; }
   virtual TXshFolderColumn *getFolderColumn() { return 0; }
+  virtual TXshPegbarColumn *getPegbarColumn() { return 0; }
 
   virtual int getMaxFrame(bool ignoreLastStop = false) const = 0;
 

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -519,6 +519,9 @@ in TXsheetImp.
           \b TColumnSetT::getColumnCount().
           \sa getColumn() and getMaxFrame().
    */
+
+  TStageObjectId getColumnObjectId(int index) const;
+
   int getColumnCount() const;
   /*! Returns first not empty column index in xsheet.
    */
@@ -617,6 +620,8 @@ in TXsheetImp.
   void shiftCellMarks(int row, int col, int rowCount);
  
   void shiftMarkers(int row, int col, int rowCount);
+
+  bool isPegbarColumn(int col);
 
 protected:
   bool checkCircularReferences(TXsheet *childCandidate);

--- a/toonz/sources/include/toonz/txshleveltypes.h
+++ b/toonz/sources/include/toonz/txshleveltypes.h
@@ -28,7 +28,8 @@ enum TXshLevelType {
   SND_XSHLEVEL      = 3 << 7,
   SND_TXT_XSHLEVEL  = 4 << 7,
   MESH_XSHLEVEL     = 5 << 7,
-  FOLDER_XSHLEVEL   = 6 << 7
+  FOLDER_XSHLEVEL   = 6 << 7,
+  PEGBAR_XSHLEVEL   = 7 << 7
 };
 
 #endif

--- a/toonz/sources/include/toonz/txshpegbarcolumn.h
+++ b/toonz/sources/include/toonz/txshpegbarcolumn.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifndef TXSHPEGBARCOLUMN_INCLUDED
+#define TXSHPEGBARCOLUMN_INCLUDED
+
+#include "toonz/txshcolumn.h"
+#include "tstageobjectid.h"
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZLIB_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+
+//=============================================================================
+//! The TXshPegbarColumn class provides a pegbar column in xsheet and allows
+//! its management through cell concept.
+/*!Inherits \b TXshCellColumn. */
+//=============================================================================
+
+class DVAPI TXshPegbarColumn final : public TXshCellColumn {
+  PERSIST_DECLARATION(TXshPegbarColumn)
+
+  TStageObjectId m_pegbarObjectId;
+
+public:
+  TXshPegbarColumn();
+  ~TXshPegbarColumn();
+
+  TXshColumn::ColumnType getColumnType() const override;
+  TXshPegbarColumn* getPegbarColumn() override { return this; }
+
+  // Technically level pegbar columns are always empty but needs to be regarded
+  // as not
+  bool isEmpty() const override { return false; }
+
+  bool canSetCell(const TXshCell& cell) const override;
+
+  TXshColumn* clone() const override;
+
+  void loadData(TIStream& is) override;
+  void saveData(TOStream& os) override;
+
+  TStageObjectId getPegbarObjectId() { return m_pegbarObjectId; }
+  void setPegbarObjectId(TStageObjectId pegbarObjectId) {
+    m_pegbarObjectId = pegbarObjectId;
+  }
+};
+
+#ifdef _WIN32
+template class DV_EXPORT_API TSmartPointerT<TXshPegbarColumn>;
+#endif
+typedef TSmartPointerT<TXshPegbarColumn> TXshPegbarColumnP;
+
+#endif  // TXSHPEGBARCOLUMN_INCLUDED

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -946,9 +946,9 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
     pos = getMatrix() * pos;
     int columnIndex = getViewer()->posToColumnIndex(e.m_pos, 5.0, false);
     if (columnIndex >= 0) {
-      TStageObjectId id      = TStageObjectId::ColumnId(columnIndex);
       int currentColumnIndex = getColumnIndex();
       TXsheet *xsh           = getXsheet();
+      TStageObjectId id      = xsh->getColumnObjectId(columnIndex);
 
       if (m_autoSelect.getValue() == L"Pegbar") {
         TStageObjectId id2 = id;
@@ -963,9 +963,10 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
           if (e.isShiftPressed()) {
             TXsheetHandle *xshHandle =
                 TTool::getApplication()->getCurrentXsheet();
+            TXsheet *xsh = xshHandle->getXsheet();
             TStageObjectId curColId =
-                TStageObjectId::ColumnId(currentColumnIndex);
-            TStageObjectId colId = TStageObjectId::ColumnId(columnIndex);
+                xsh->getColumnObjectId(currentColumnIndex);
+            TStageObjectId colId = xsh->getColumnObjectId(columnIndex);
             TStageObjectCmd::setParent(curColId, colId, "", xshHandle);
             m_what = None;
             xshHandle->notifyXsheetChanged();
@@ -1510,10 +1511,7 @@ m_foo.setFxHandle(getApplication()->getCurrentFx());
   if (objId == TStageObjectId::NoneId) {
     int index    = getColumnIndex();
     TXsheet *xsh = TTool::getApplication()->getCurrentXsheet()->getXsheet();
-    if (index == -1)
-      objId = TStageObjectId::CameraId(xsh->getCameraColumnIndex());
-    else
-      objId = TStageObjectId::ColumnId(index);
+    objId        = xsh->getColumnObjectId(index);
   }
   TTool::getApplication()->getCurrentObject()->setObjectId(objId);
 }

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -930,8 +930,8 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
   // find the nearest level before it
   if (levelType == NO_XSHLEVEL &&
       !m_application->getCurrentFrame()->isEditingLevel()) {
-    if (!column ||
-        (column && !column->getSoundColumn() && !column->getFolderColumn())) {
+    if (!column || (column && !column->getSoundColumn() &&
+                    !column->getFolderColumn() && !column->getPegbarColumn())) {
       TXshCell cell = xsh->getCell(rowIndex, columnIndex);
       xl            = cell.isEmpty() ? 0 : (TXshLevel *)(&cell.m_level);
       sl            = cell.isEmpty() ? 0 : cell.getSimpleLevel();
@@ -954,7 +954,8 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
     if (levelType == NO_XSHLEVEL &&
         !m_application->getCurrentFrame()->isEditingLevel()) {
       if (!column ||
-          (column && !column->getSoundColumn() && !column->getFolderColumn())) {
+          (column && !column->getSoundColumn() && !column->getFolderColumn() &&
+           !column->getPegbarColumn())) {
             int r0, r1;
             xsh->getCellRange(columnIndex, r0, r1);
             for (int r = std::min(r1, rowIndex); r > r0; r--) {
@@ -1035,6 +1036,10 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
     else if (column->getFolderColumn())
       return (enable(false),
               QObject::tr("It is not possible to edit the folder column."));
+
+    else if (column->getPegbarColumn())
+      return (enable(false),
+              QObject::tr("It is not possible to edit the pegbar column."));
 
     if (toolType == TTool::ColumnTool) {
       // Check column target

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1017,7 +1017,8 @@ void ArrowToolOptionsBox::updateStageObjectComboItems() {
     if (id == xsh->getStageObjectTree()->getMotionPathViewerId()) continue;
     if (id.isColumn()) {
       int columnIndex = id.getIndex();
-      if (xsh->isColumnEmpty(columnIndex) || xsh->isFolderColumn(columnIndex))
+      if (xsh->isColumnEmpty(columnIndex) || xsh->isFolderColumn(columnIndex) ||
+          xsh->isPegbarColumn(columnIndex))
         continue;
     }
     TStageObject *pegbar = xsh->getStageObject(id);

--- a/toonz/sources/toonz/Resources/pegbar_header.svg
+++ b/toonz/sources/toonz/Resources/pegbar_header.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40"
+   height="30"
+   version="1.1"
+   xml:space="preserve"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+   id="svg1"
+   sodipodi:docname="pegbar_header.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="true"
+   inkscape:zoom="29.9"
+   inkscape:cx="19.983278"
+   inkscape:cy="15"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg1"><inkscape:grid
+     id="grid1"
+     units="px"
+     originx="0"
+     originy="0"
+     spacingx="1"
+     spacingy="1"
+     empcolor="#0099e5"
+     empopacity="0.30196078"
+     color="#0099e5"
+     opacity="0.14901961"
+     empspacing="5"
+     enabled="true"
+     visible="true" /></sodipodi:namedview>
+    <rect
+   style="fill:#ffffff;stroke:#000000;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;fill-opacity:0.80000001"
+   id="rect2"
+   width="40"
+   height="30"
+   x="0"
+   y="0"
+   ry="0.16516964" /><rect
+   x="0"
+   y="0"
+   width="20"
+   height="20"
+   style="fill-opacity:0"
+   id="rect1" />
+    <g
+   transform="matrix(1.5555556,0,0,1.3333333,2.8888889,3)"
+   id="g1">
+        <path
+   d="M 20,9 C 20,7.344 18.656,6 17,6 H 5 C 3.344,6 2,7.344 2,9 c 0,1.656 1.344,3 3,3 h 12 c 1.656,0 3,-1.344 3,-3 z M 18,9 C 18,8.448 17.552,8 17,8 h -2 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 2 c 0.552,0 1,-0.448 1,-1 z m -6,0 c 0,-0.552 -0.448,-1 -1,-1 -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 0.552,0 1,-0.448 1,-1 z M 8,9 C 8,8.448 7.552,8 7,8 H 5 C 4.448,8 4,8.448 4,9 4,9.552 4.448,10 5,10 H 7 C 7.552,10 8,9.552 8,9 Z"
+   style="fill:#000000"
+   id="path1" />
+    </g>
+</svg>

--- a/toonz/sources/toonz/cellkeyframeselection.cpp
+++ b/toonz/sources/toonz/cellkeyframeselection.cpp
@@ -123,7 +123,7 @@ void TCellKeyframeSelection::selectCellsKeyframes(int r0, int c0, int r1,
     for (r = r0; r <= r1; r++) {
       TStageObjectId id =
           c < 0 ? TStageObjectId::CameraId(xsh->getCameraColumnIndex())
-                : TStageObjectId::ColumnId(c);
+                : xsh->getColumnObjectId(c);
       TStageObject *stObj = xsh->getStageObject(id);
       if (stObj->isKeyframe(r)) m_keyframeSelection->select(r, c);
     }
@@ -136,7 +136,7 @@ void TCellKeyframeSelection::selectCellKeyframe(int row, int col) {
   TXsheet *xsh = m_xsheetHandle->getXsheet();
   TStageObjectId id =
       col < 0 ? TStageObjectId::CameraId(xsh->getCameraColumnIndex())
-              : TStageObjectId::ColumnId(col);
+              : xsh->getColumnObjectId(col);
   TStageObject *stObj = xsh->getStageObject(id);
   m_keyframeSelection->clear();
   if (stObj->isKeyframe(row)) m_keyframeSelection->select(row, col);

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -2136,8 +2136,8 @@ void TCellSelection::shiftKeyframes(int direction) {
     if (!column || column->isLocked()) continue;
 
     TStageObjectId colId =
-        col < 0 ? TStageObjectId::ColumnId(xsh->getCameraColumnIndex())
-                : TStageObjectId::ColumnId(col);
+        col < 0 ? TStageObjectId::CameraId(xsh->getCameraColumnIndex())
+                : xsh->getColumnObjectId(col);
     TStageObject *colObj = xsh->getStageObject(colId);
     TStageObject::KeyframeMap keyframes;
     colObj->getKeyframes(keyframes);

--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -66,8 +66,7 @@ void TKeyframeData::setKeyframes(std::set<Position> positions, TXsheet *xsh,
   for (it = positions.begin(); it != positions.end(); ++it) {
     int row              = it->first;
     int col              = it->second;
-    TStageObject *pegbar = xsh->getStageObject(
-        col >= 0 ? TStageObjectId::ColumnId(col) : cameraId);
+    TStageObject *pegbar = xsh->getStageObject(col >= 0 ? xsh->getColumnObjectId(col) : cameraId);
     assert(pegbar);
     m_isPegbarsCycleEnabled[col] = pegbar->isCycleEnabled();
     if (pegbar->isKeyframe(row)) {
@@ -117,8 +116,7 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
     TXshColumn *column = xsh->getColumn(col);
     if (column && (column->getSoundColumn() || column->getFolderColumn()))
       continue;
-    TStageObject *pegbar = xsh->getStageObject(
-        col >= 0 ? TStageObjectId::ColumnId(col) : cameraId);
+    TStageObject *pegbar = xsh->getStageObject(col >= 0 ? xsh->getColumnObjectId(col) : cameraId);
     if (xsh->getColumn(col) && xsh->getColumn(col)->isLocked()) continue;
     keyFrameChanged = true;
     assert(pegbar);
@@ -196,7 +194,7 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
   for (auto const pegbar : m_isPegbarsCycleEnabled) {
     int const col = pegbar.first;
     TStageObjectId objectId =
-        (col >= 0) ? TStageObjectId::ColumnId(col) : cameraId;
+        (col >= 0) ? xsh->getColumnObjectId(col) : cameraId;
     xsh->getStageObject(objectId)->enableCycle(pegbar.second);
   }
   return true;

--- a/toonz/sources/toonz/keyframemover.cpp
+++ b/toonz/sources/toonz/keyframemover.cpp
@@ -49,7 +49,7 @@ void KeyframeMover::setKeyframes() {
   for (auto const &key : m_lastKeyframes) {
     int c = key.second;
     TStageObjectId objId =
-        c >= 0 ? TStageObjectId::ColumnId(c)
+        c >= 0 ? xsh->getColumnObjectId(c)
                : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
     TStageObject *stObj = xsh->getStageObject(objId);
     TStageObject::KeyframeMap keyframes;
@@ -68,7 +68,7 @@ void KeyframeMover::getKeyframes() {
   for (auto const &pos : m_startSelectedKeyframes) {
     int c = pos.second;
     TStageObjectId objId =
-        c >= 0 ? TStageObjectId::ColumnId(c)
+        c >= 0 ? xsh->getColumnObjectId(c)
                : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
     TStageObject *stObj = xsh->getStageObject(objId);
     assert(stObj->isKeyframe(pos.first));
@@ -118,7 +118,7 @@ bool KeyframeMover::moveKeyframes(
       int c = posIt->second;
       int r = posIt->first;
       TStageObjectId objId =
-          c >= 0 ? TStageObjectId::ColumnId(c)
+          c >= 0 ? xsh->getColumnObjectId(c)
                  : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
       TStageObject *stObj = xsh->getStageObject(objId);
       if (r + dr < 0) {
@@ -144,7 +144,7 @@ bool KeyframeMover::moveKeyframes(
         int c = revIt->second;
         int r = revIt->first;
         TStageObjectId objId =
-            c >= 0 ? TStageObjectId::ColumnId(c)
+            c >= 0 ? xsh->getColumnObjectId(c)
                    : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
         TStageObject *stObj = xsh->getStageObject(objId);
         if (m_qualifiers & eCopyKeyframes) {
@@ -159,7 +159,7 @@ bool KeyframeMover::moveKeyframes(
         int c = posIt->second;
         int r = posIt->first;
         TStageObjectId objId =
-            c >= 0 ? TStageObjectId::ColumnId(c)
+            c >= 0 ? xsh->getColumnObjectId(c)
                    : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
         TStageObject *stObj = xsh->getStageObject(objId);
         if (m_qualifiers & eCopyKeyframes) {
@@ -184,7 +184,7 @@ bool KeyframeMover::moveKeyframes(
     int c = posIt->second;
     int r = posIt->first;
     TStageObjectId objId =
-        c >= 0 ? TStageObjectId::ColumnId(c)
+        c >= 0 ? xsh->getColumnObjectId(c)
                : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
     TStageObject *stObj    = xsh->getStageObject(objId);
     if (r + dr < 0) dr     = -r;
@@ -199,7 +199,7 @@ bool KeyframeMover::moveKeyframes(
     int c = posIt->second;
     int r = posIt->first;
     TStageObjectId objId =
-        c >= 0 ? TStageObjectId::ColumnId(c)
+        c >= 0 ? xsh->getColumnObjectId(c)
                : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
     TStageObject *stObj = xsh->getStageObject(objId);
 

--- a/toonz/sources/toonz/keyframeselection.cpp
+++ b/toonz/sources/toonz/keyframeselection.cpp
@@ -50,7 +50,7 @@ bool shiftKeyframesWithoutUndo(int r0, int r1, int c0, int c1, bool cut,
   int x;
   for (x = c0; x <= c1; x++) {
     TStageObject *stObj = xsh->getStageObject(
-        x >= 0 ? TStageObjectId::ColumnId(x)
+        x >= 0 ? xsh->getColumnObjectId(x)
                : TStageObjectId::CameraId(xsh->getCameraColumnIndex()));
     std::set<int> keyToShift;
     int kr0, kr1;
@@ -107,8 +107,7 @@ bool deleteKeyframesWithoutUndo(
   for (; it != positions->end(); ++it) {
     int row              = it->first;
     int col              = it->second;
-    TStageObject *pegbar = xsh->getStageObject(
-        col >= 0 ? TStageObjectId::ColumnId(col) : cameraId);
+    TStageObject *pegbar = xsh->getStageObject(col >= 0 ? xsh->getColumnObjectId(col) : cameraId);
     if (xsh->getColumn(col) && xsh->getColumn(col)->isLocked()) continue;
     areAllColumnLocked = false;
     assert(pegbar);
@@ -341,7 +340,7 @@ void TKeyframeSelection::setKeyframes() {
   Position pos         = *m_positions.begin();
   int row              = pos.first;
   int col              = pos.second;
-  TStageObjectId id    = col < 0 ? cameraId : TStageObjectId::ColumnId(col);
+  TStageObjectId id    = col < 0 ? cameraId : xsh->getColumnObjectId(col);
   TStageObject *pegbar = xsh->getStageObject(id);
   if (!pegbar) return;
   if (pegbar->isKeyframe(row)) {

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2145,6 +2145,8 @@ void MainWindow::defineActions() {
 
   createMenuLevelAction(MI_NewFolder, QT_TR_NOOP("New Folder"), "",
                         "new_folder_column");
+  createMenuLevelAction(MI_NewPegbar, QT_TR_NOOP("New Pegbar"), "",
+                        "pegbar");
 
   // Menu - Scene
 

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -458,6 +458,7 @@ void TopBar::loadMenubar() {
     addMenuItem(newMenu, MI_NewVectorLevel);
     addMenuItem(newMenu, MI_NewNoteLevel);
     newMenu->addSeparator();
+    addMenuItem(newMenu, MI_NewPegbar);
     addMenuItem(newMenu, MI_NewFolder);
   }
   addMenuItem(levelMenu, MI_LoadLevel);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -535,6 +535,7 @@
 #define MI_OpenAlignmentPanel "MI_OpenAlignmentPanel"
 
 #define MI_NewFolder "MI_NewFolder"
+#define MI_NewPegbar "MI_NewPegbar"
 
 #define MI_ShowSymmetryGuide "MI_ShowSymmetryGuide"
 #define MI_ShowPerspectiveGrids "MI_ShowPerspectiveGrids"

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -504,9 +504,10 @@ void TApp::onImageChanged() {
 void TApp::onXsheetSwitched() {
   // update current object
   int columnIndex = m_currentColumn->getColumnIndex();
-  if (columnIndex >= 0)
-    m_currentObject->setObjectId(TStageObjectId::ColumnId(columnIndex));
-
+  if (columnIndex >= 0) {
+    TXsheet *xsh = getCurrentXsheet()->getXsheet();
+    m_currentObject->setObjectId(xsh->getColumnObjectId(columnIndex));
+  }
   // update xsheetlevel
   updateXshLevel();
 
@@ -558,13 +559,12 @@ void TApp::onColumnIndexSwitched() {
 
   // update current object
   int columnIndex = m_currentColumn->getColumnIndex();
+  TXsheet *xsh    = getCurrentXsheet()->getXsheet();
   if (columnIndex >= 0)
-    m_currentObject->setObjectId(TStageObjectId::ColumnId(columnIndex));
-  else {
-    TXsheet *xsh = getCurrentXsheet()->getXsheet();
+    m_currentObject->setObjectId(xsh->getColumnObjectId(columnIndex));
+  else
     m_currentObject->setObjectId(
         TStageObjectId::CameraId(xsh->getCameraColumnIndex()));
-  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -774,5 +774,6 @@
 		<file>Resources/savescreen.png</file>
 		<file>Resources/scrub.png</file>
 		<file>Resources/vcroot.svg</file>
-  </qresource>
+		<file>Resources/pegbar_header.svg</file>
+	</qresource>
 </RCC>

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -851,7 +851,8 @@ void RenameCellField::renameCell() {
   TXsheet *xsheet = m_viewer->getXsheet();
 
   if (xsheet->getColumn(m_col) &&
-      xsheet->getColumn(m_col)->getFolderColumn())
+      (xsheet->getColumn(m_col)->getFolderColumn() ||
+       xsheet->getColumn(m_col)->getPegbarColumn()))
     return;
 
   // renaming note level column
@@ -1354,17 +1355,19 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
     bool isPaletteColumn   = false;
     bool isSoundTextColumn = false;
     bool isFolderColumn    = false;
+    bool isPegbarColumn    = false;
     bool showLevelName     = true;
     if (isColumn) {
       isSoundColumn     = column->getSoundColumn() != 0;
       isPaletteColumn   = column->getPaletteColumn() != 0;
       isSoundTextColumn = column->getSoundTextColumn() != 0;
       isFolderColumn    = column->getFolderColumn() != 0;
+      isPegbarColumn    = column->getPegbarColumn() != 0;
       if (Preferences::instance()->getLevelNameDisplayType() ==
           Preferences::ShowLevelNameOnColumnHeader)
-        showLevelName =
-            (isSoundColumn || isPaletteColumn || isSoundTextColumn ||
-             isFolderColumn || !checkContainsSingleLevel(column));
+        showLevelName = (isSoundColumn || isPaletteColumn ||
+                         isSoundTextColumn || isFolderColumn ||
+                         isPegbarColumn || !checkContainsSingleLevel(column));
     }
     // check if the column is reference
     bool isReference = true;
@@ -1378,6 +1381,8 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
       drawSoundTextColumn(p, r0, r1, col);
     else if (isFolderColumn)
       drawFolderColumn(p, r0, r1, col);
+    else if (isPegbarColumn)
+      drawPegbarColumn(p, r0, r1, col);
     else {
       // for each frame
       for (row = r0; row <= r1; row++) {
@@ -3280,6 +3285,69 @@ void CellArea::drawFolderColumn(QPainter &p, int r0, int r1, int col) {
 
 //-----------------------------------------------------------------------------
 
+void CellArea::drawPegbarColumn(QPainter &p, int r0, int r1, int col) {
+  const Orientation *o = m_viewer->orientation();
+  TXsheet *xsh         = m_viewer->getXsheet();
+
+  int rStart = r0;
+  int rEnd   = r1;
+
+  QColor cellColor = m_viewer->getPegbarColumnColor();
+
+  QColor selectedCellColor = m_viewer->getSelectedPegbarColumnColor();
+  QColor sideColor         = m_viewer->getPegbarColumnBorderColor();
+
+  TCellSelection *cellSelection     = m_viewer->getCellSelection();
+  TColumnSelection *columnSelection = m_viewer->getColumnSelection();
+  bool isColSelected                = columnSelection->isColumnSelected(col);
+
+  // for each row
+  for (int row = rStart; row <= rEnd; row++) {
+    QPoint xy = m_viewer->positionToXY(CellPosition(row, col));
+    int x     = xy.x();
+    int y     = xy.y();
+    if (row == 0) {
+      if (o->isVerticalTimeline())
+        xy.setY(xy.y() + 1);
+      else
+        xy.setX(xy.x() + 1);
+    }
+
+    QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
+    QRect cellRect =
+        o->rect((col < 0) ? PredefinedRect::CAMERA_CELL : PredefinedRect::CELL)
+            .translated(QPoint(x, y));
+    cellRect.adjust(0, 0, -frameAdj.x(), -frameAdj.y());
+    QRect rect = cellRect.adjusted(
+        0, 0, -1, (m_viewer->orientation()->isVerticalTimeline() ? -1 : 0));
+
+    bool isSelected = isColSelected || cellSelection->isCellSelected(row, col);
+    QColor tmpCellColor = (isSelected) ? selectedCellColor : cellColor;
+    tmpCellColor.setAlpha(50);
+
+    if (o->isVerticalTimeline())
+      // Paint the cell edge-to-edge, we use LightLineColor with low opacity
+      // to pick up the hue of the cell color to make the separator line more
+      // pleasing to the eye.
+      p.fillRect(rect.adjusted(0, 0, 0, 1), QBrush(tmpCellColor));
+    else
+      p.fillRect(rect, QBrush(tmpCellColor));
+
+    // cell mark
+    int markId = xsh->getColumn(col)->getCellColumn()->getCellMark(row);
+    drawCellMarker(p, markId, rect, false);
+
+    drawFrameSeparator(p, row, col, false, false);
+
+    if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
+        !o->isVerticalTimeline() && row == m_viewer->getCurrentRow() &&
+        Preferences::instance()->isCurrentTimelineIndicatorEnabled())
+      drawCurrentTimeIndicator(p, xy);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
 void CellArea::drawKeyframe(QPainter &p, const QRect toBeUpdated) {
   const Orientation *o = m_viewer->orientation();
   int r0, r1, c0, c1;  // range of visible rows and columns
@@ -4343,7 +4411,9 @@ void CellArea::mouseDoubleClickEvent(QMouseEvent *event) {
   int col                   = cellPosition.layer();
   // Se la colonna e' sound non devo fare nulla
   TXshColumn *column = m_viewer->getXsheet()->getColumn(col);
-  if (column && (column->getSoundColumn() || column->getFolderColumn())) return;
+  if (column && (column->getSoundColumn() || column->getFolderColumn() ||
+                 column->getPegbarColumn()))
+    return;
 
   // Se ho cliccato su una nota devo aprire il popup
   TXshNoteSet *notes = m_viewer->getXsheet()->getNotes();
@@ -4454,7 +4524,7 @@ void CellArea::contextMenuEvent(QContextMenuEvent *event) {
     if (col < 0)
       objectId = TStageObjectId::CameraId(xsh->getCameraColumnIndex());
     else {  // Set the current column and the current object
-      objectId = TStageObjectId::ColumnId(col);
+      objectId = xsh->getColumnObjectId(col);
       m_viewer->setCurrentColumn(col);
     }
     TApp::instance()->getCurrentObject()->setObjectId(objectId);
@@ -4624,6 +4694,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
   bool soundCellsSelected     = m_viewer->areSoundCellsSelected();
   bool soundTextCellsSelected = m_viewer->areSoundTextCellsSelected();
   bool folderCellsSelected    = m_viewer->areFolderCellsSelected();
+  bool pegbarCellsSelected    = m_viewer->arePegbarCellsSelected();
   bool cameraCellsSelected    = m_viewer->areCameraCellsSelected();
 
   menu.addSeparator();
@@ -4694,7 +4765,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
       }
 
       if (!soundTextCellsSelected && !soundCellsSelected &&
-          !folderCellsSelected) {
+          !folderCellsSelected && !pegbarCellsSelected) {
         menu.addAction(cmdManager->getAction(MI_LoopFrames));
         menu.addAction(cmdManager->getAction(MI_RemoveFrameLoop));
       }
@@ -4855,13 +4926,13 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
       menu.addMenu(lipSyncMenu);
 
   } else {
-    if (!folderCellsSelected) {
+    if (!folderCellsSelected && !pegbarCellsSelected) {
       menu.addAction(cmdManager->getAction(MI_CreateBlankDrawing));
       menu.addSeparator();
       menu.addAction(cmdManager->getAction(MI_FillEmptyCell));
       menu.addAction(cmdManager->getAction(MI_StopFrameHold));
     }
-    if (cameraCellsSelected) {
+    if (cameraCellsSelected || pegbarCellsSelected) {
       menu.addSeparator();
       menu.addAction(cmdManager->getAction(MI_SetKeyframes));
       menu.addAction(cmdManager->getAction(MI_ShiftKeyframesDown));

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -130,6 +130,7 @@ class CellArea final : public QWidget {
   void drawSoundTextColumn(QPainter &p, int r0, int r1, int col);
   void drawPaletteCell(QPainter &p, int row, int col, bool isReference = false);
   void drawFolderColumn(QPainter &p, int r0, int r1, int col);
+  void drawPegbarColumn(QPainter &p, int r0, int r1, int col);
 
   void drawKeyframe(QPainter &p, const QRect toBeUpdated);
   void drawKeyframeLine(QPainter &p, int col, const NumberRange &rows) const;

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -395,6 +395,7 @@ public:
   void drawPaletteColumnHead(QPainter &p, int col);
   void drawSoundTextColumnHead(QPainter &p, int col);
   void drawFolderColumnHead(QPainter &p, int col);
+  void drawPegbarColumnHead(QPainter &p, int col);
   void drawCurrentColumnFocus(QPainter &p, int col);
 
   QPixmap getColumnIcon(int columnIndex);

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1363,7 +1363,7 @@ public:
     TStageObjectId cameraId =
         TStageObjectId::CameraId(xsh->getCameraColumnIndex());
 
-    TStageObjectId objId = col >= 0 ? TStageObjectId::ColumnId(col) : cameraId;
+    TStageObjectId objId = col >= 0 ? xsh->getColumnObjectId(col) : cameraId;
     if (xsh->getColumn(col) && xsh->getColumn(col)->isLocked()) {
       m_enable = false;
       return;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -159,6 +159,9 @@ void XsheetViewer::getColumnColor(QColor &color, QColor &sideColor, int index,
   } else if (xsh->getColumn(index)->getFolderColumn()) {
     color     = m_folderColumnColor;
     sideColor = m_folderColumnBorderColor;
+  } else if (xsh->getColumn(index)->getPegbarColumn()) {
+    color     = m_pegbarColumnColor;
+    sideColor = m_pegbarColumnBorderColor;
   }
   //  if (xsh->getColumn(index)->isMask()) color = QColor(255, 0, 255);
 }
@@ -577,7 +580,7 @@ int XsheetViewer::getCurrentRow() const {
 TStageObjectId XsheetViewer::getObjectId(int col) const {
   TXsheet *xsh = getXsheet();
   if (col < 0) return TStageObjectId::CameraId(xsh->getCameraColumnIndex());
-  return TStageObjectId::ColumnId(col);
+  return xsh->getColumnObjectId(col);
 }
 //-----------------------------------------------------------------------------
 
@@ -592,8 +595,8 @@ void XsheetViewer::setCurrentColumn(int col) {
     if (col >= 0 && objectHandle->isSpline()) objectHandle->setIsSpline(false);
     updateCellColumnAree();
     if (col >= 0) {
-      objectHandle->setObjectId(TStageObjectId::ColumnId(col));
-      TXsheet *xsh       = getXsheet();
+      TXsheet *xsh = getXsheet();
+      objectHandle->setObjectId(xsh->getColumnObjectId(col));
       TXshColumn *column = xsh->getColumn(col);
       if (!column) return;
       // switching the current fx
@@ -1099,6 +1102,23 @@ bool XsheetViewer::areFolderCellsSelected() {
     TXshColumn *column = getXsheet()->getColumn(j);
     if (column && (column->isEmpty() ||
                    column->getColumnType() == TXshColumn::eFolderType))
+      continue;
+    return false;
+  }
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+bool XsheetViewer::arePegbarCellsSelected() {
+  int r0, c0, r1, c1;
+  getCellSelection()->getSelectedCells(r0, c0, r1, c1);
+  if (c0 < 0) return false;
+  int i, j;
+  for (j = c0; j <= c1; j++) {
+    TXshColumn *column = getXsheet()->getColumn(j);
+    if (column && (column->isEmpty() ||
+                   column->getColumnType() == TXshColumn::ePegbarType))
       continue;
     return false;
   }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -385,6 +385,17 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   Q_PROPERTY(QColor SelectedFolderColumnColor READ getSelectedFolderColumnColor
                  WRITE setSelectedFolderColumnColor)
 
+  // Pegbar column
+  QColor m_pegbarColumnColor;
+  QColor m_pegbarColumnBorderColor;
+  QColor m_selectedPegbarColumnColor;
+  Q_PROPERTY(QColor PegbarColumnColor READ getPegbarColumnColor WRITE
+                 setPegbarColumnColor)
+  Q_PROPERTY(QColor PegbarColumnBorderColor READ getPegbarColumnBorderColor
+                 WRITE setPegbarColumnBorderColor)
+  Q_PROPERTY(QColor SelectedPegbarColumnColor READ getSelectedPegbarColumnColor
+                 WRITE setSelectedPegbarColumnColor)
+
   // Implicit Cell alpha
   int m_implicitCellAlpha;
   Q_PROPERTY(int ImplicitCellAlpha READ getImplicitCellAlpha WRITE
@@ -702,6 +713,7 @@ public:
   bool areSoundCellsSelected();
   bool areSoundTextCellsSelected();
   bool areFolderCellsSelected();
+  bool arePegbarCellsSelected();
   bool areCameraCellsSelected();
 
   XsheetGUI::DragTool *getDragTool() const { return m_dragTool; };
@@ -1057,6 +1069,23 @@ public:
   }
   QColor getSelectedFolderColumnColor() const {
     return m_selectedFolderColumnColor;
+  }
+  // Pegbar column
+  void setPegbarColumnColor(const QColor &color) {
+    m_pegbarColumnColor = color;
+  }
+  void setPegbarColumnBorderColor(const QColor &color) {
+    m_pegbarColumnBorderColor = color;
+  }
+  void setSelectedPegbarColumnColor(const QColor &color) {
+    m_selectedPegbarColumnColor = color;
+  }
+  QColor getPegbarColumnColor() const { return m_pegbarColumnColor; }
+  QColor getPegbarColumnBorderColor() const {
+    return m_pegbarColumnBorderColor;
+  }
+  QColor getSelectedPegbarColumnColor() const {
+    return m_selectedPegbarColumnColor;
   }
 
   // Implicit Cell Alpha

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MOC_HEADERS
     ../include/toonz/txshsimplelevel.h
     ../include/toonz/txshsoundcolumn.h
     ../include/toonz/brushtipmanager.h
+    ../include/toonz/txshpegbarcolumn.h
 )
 
 set(HEADERS
@@ -330,6 +331,7 @@ set(SOURCES
     navigationtags.cpp
     txshfoldercolumn.cpp
     brushtipmanager.cpp
+    txshpegbarcolumn.cpp
 )
 
 if(BUILD_TARGET_WIN)

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -777,7 +777,8 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     }
 
     if (column && !column->isEmpty() && !column->getSoundColumn() &&
-        !column->getFolderColumn() && !column->isMask()) {
+        !column->getFolderColumn() && !column->getPegbarColumn() &&
+        !column->isMask()) {
 
       if (!column->isPreviewVisible() && checkPreviewVisibility) {
         if (!isMask && column->getColumnType() != TXshColumn::eMeshType) {

--- a/toonz/sources/toonzlib/tstageobjecttree.cpp
+++ b/toonz/sources/toonzlib/tstageobjecttree.cpp
@@ -3,6 +3,8 @@
 #include "toonz/tstageobjecttree.h"
 #include "toonz/tstageobjectspline.h"
 #include "toonz/tstageobject.h"
+#include "toonz/txshpegbarcolumn.h"
+
 #include "tgrammar.h"
 #include "ttokenizer.h"
 #include "tconvert.h"
@@ -433,7 +435,24 @@ void TStageObjectTree::loadData(TIStream &is, TXsheet *xsh) {
         m_imp->m_groupIdCount = pegbar->getGroupId();
       is.matchEndTag();
 
-      std::string name = pegbar->getName();
+      // If there isn't a pegbar column for this pegbar, create it now
+      // Assume columns have already been loaded
+      if (id.isPegbar()) {
+        bool found = false;
+        int cols   = xsh->getColumnCount();
+        for (int i = 0; i < cols; i++) {
+          if (!xsh->getColumn(i) || !xsh->getColumn(i)->getPegbarColumn() ||
+              xsh->getColumn(i)->getPegbarColumn()->getPegbarObjectId() != id)
+            continue;
+          found = true;
+        }
+        if (!found) {
+          TXshPegbarColumn *pegbarCol = new TXshPegbarColumn();
+          pegbarCol->setXsheet(xsh);
+          pegbarCol->setPegbarObjectId(id);
+          xsh->insertColumn(cols, pegbarCol);
+        }
+      }
     } else if (tagName == "grid_dimension") {
       is >> m_imp->m_dagGridDimension;
       is.matchEndTag();

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -35,6 +35,7 @@
 #include "toonz/expressionreferencemonitor.h"
 #include "toonz/navigationtags.h"
 #include "toonz/txshfoldercolumn.h"
+#include "toonz/txshpegbarcolumn.h"
 
 #include "toonz/txsheet.h"
 #include "toonz/preferences.h"
@@ -254,7 +255,7 @@ int TXsheet::getFrameCount() const {
       continue;
     }
 
-    TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(c));
+    TStageObject *pegbar = getStageObject(getColumnObjectId(c));
     if (!pegbar) continue;
     if (!pegbar->getKeyframeRange(r0, r1)) continue;
     frameCount = std::max(frameCount, (r1 + 1));
@@ -1687,6 +1688,19 @@ TXshColumn *TXsheet::getColumn(int col) const {
 
 //-----------------------------------------------------------------------------
 
+TStageObjectId TXsheet::getColumnObjectId(int col) const {
+  if (col < 0) return TStageObjectId::ColumnId(m_cameraColumnIndex);
+
+  TXshColumn *column = getColumn(col);
+
+  if (column && column->getPegbarColumn())
+    return column->getPegbarColumn()->getPegbarObjectId();
+
+  return TStageObjectId::ColumnId(col);
+}
+
+//-----------------------------------------------------------------------------
+
 int TXsheet::getColumnCount() const {
   return m_imp->m_columnSet.getColumnCount();
 }
@@ -2279,6 +2293,15 @@ bool TXsheet::isFolderColumn(int col) {
   if (!column) return false;
 
   return column->getFolderColumn() ? true : false;
+}
+
+//---------------------------------------------------------
+
+bool TXsheet::isPegbarColumn(int col) {
+  TXshColumn *column = getColumn(col);
+  if (!column) return false;
+
+  return column->getPegbarColumn() ? true : false;
 }
 
 //---------------------------------------------------------

--- a/toonz/sources/toonzlib/txshpegbarcolumn.cpp
+++ b/toonz/sources/toonzlib/txshpegbarcolumn.cpp
@@ -1,0 +1,77 @@
+
+
+#include "toonz/txshpegbarcolumn.h"
+
+// TnzLib includes
+#include "toonz/txshcell.h"
+
+#include "tstream.h"
+
+PERSIST_IDENTIFIER(TXshPegbarColumn, "pegbarColumn")
+
+//=============================================================================
+
+TXshPegbarColumn::TXshPegbarColumn() {}
+
+//-----------------------------------------------------------------------------
+
+TXshPegbarColumn::~TXshPegbarColumn() {}
+
+//-----------------------------------------------------------------------------
+
+TXshColumn::ColumnType TXshPegbarColumn::getColumnType() const {
+  return ePegbarType;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshPegbarColumn::canSetCell(const TXshCell& cell) const { return false; }
+
+//-----------------------------------------------------------------------------
+
+TXshColumn* TXshPegbarColumn::clone() const {
+  TXshPegbarColumn* column = new TXshPegbarColumn();
+  column->setXsheet(getXsheet());
+  column->setStatusWord(getStatusWord());
+  column->m_cells          = m_cells;
+  column->m_first          = m_first;
+  column->m_pegbarObjectId = m_pegbarObjectId;
+  column->setFolderIdStack(getFolderIdStack());
+  return column;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshPegbarColumn::loadData(TIStream& is) {
+  std::string tagName;
+  while (is.openChild(tagName)) {
+    if (tagName == "status") {
+      int status;
+      is >> status;
+      setStatusWord(status);
+    } else if (tagName == "pegbarObjectId") {
+      std::string idStr;
+      is >> idStr;
+      TStageObjectId id = toStageObjectId(idStr);
+      setPegbarObjectId(id);
+    } else if (loadCellMarks(tagName, is)) {
+      // do nothing
+    } else if (loadFolderInfo(tagName, is)) {
+      // do nothing
+    } else
+      throw TException("TXshPegbarColumn, unknown tag: " + tagName);
+    is.closeChild();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshPegbarColumn::saveData(TOStream& os) {
+  os.child("status") << getStatusWord();
+  os.child("pegbarObjectId") << m_pegbarObjectId.toString();
+
+  // cell marks
+  saveCellMarks(os);
+  // folder info
+  saveFolderInfo(os);
+}

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -895,7 +895,10 @@ void FunctionTreeModel::refreshStageObjects(TXsheet *xsh) {
   for (i = 0; i < iCount; ++i) {
     TStageObject *pegbar = ptree->getStageObject(i);
     TStageObjectId id    = pegbar->getId();
-    if (id.isColumn() && xsh->isColumnEmpty(id.getIndex())) continue;
+    int col              = id.getIndex();
+    if (id.isColumn() && (xsh->isColumnEmpty(col) || xsh->isFolderColumn(col) ||
+                          xsh->isPegbarColumn(col)))
+      continue;
     if (id == ptree->getMotionPathViewerId()) continue;
 
     newItems.push_back(new StageObjectChannelGroup(pegbar));

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -26,6 +26,7 @@
 #include "toonz/tproject.h"
 #include "toonz/tscenehandle.h"
 #include "toonz/sceneproperties.h"
+#include "toonz/txshpegbarcolumn.h"
 
 // TnzBase includes
 #include "tparamcontainer.h"
@@ -673,7 +674,16 @@ void FunctionViewer::doSwitchCurrentObject(TStageObject *obj) {
   TStageObjectId id = obj->getId();
   if (id.isColumn())
     m_columnHandle->setColumnIndex(id.getIndex());
-  else
+  else if (id.isPegbar()) {
+    TXsheet *xsh = m_xshHandle->getXsheet();
+    for (int i = 0; i < xsh->getColumnCount(); i++) {
+      if (!xsh->getColumn(i) || !xsh->getColumn(i)->getPegbarColumn() ||
+          xsh->getColumn(i)->getPegbarColumn()->getPegbarObjectId() != id)
+        continue;
+      m_columnHandle->setColumnIndex(i);
+      break;
+    }
+  } else
     m_objectHandle->setObjectId(id);
 }
 

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -1549,8 +1549,8 @@ void FxSchematicScene::onSwitchCurrentFx(TFx *fx) {
     int columnIndex = fx->getReferenceColumnIndex();
     if (columnIndex >= 0) {
       m_columnHandle->setColumnIndex(columnIndex);
-      m_app->getCurrentObject()->setObjectId(
-          TStageObjectId::ColumnId(columnIndex));
+      TXsheet *xsh = m_app->getCurrentXsheet()->getXsheet();
+      m_app->getCurrentObject()->setObjectId(xsh->getColumnObjectId(columnIndex));
     }
 
     SwatchViewer::suspendRendering(false);
@@ -1585,7 +1585,8 @@ void FxSchematicScene::onCurrentFxSwitched() {
 
 void FxSchematicScene::onCurrentColumnChanged(int index) {
   m_app->getCurrentColumn()->setColumnIndex(index);
-  m_app->getCurrentObject()->setObjectId(TStageObjectId::ColumnId(index));
+  TXsheet *xsh = m_app->getCurrentXsheet()->getXsheet();
+  m_app->getCurrentObject()->setObjectId(xsh->getColumnObjectId(index));
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -30,6 +30,7 @@
 #include "toonz/hook.h"
 #include "toonz/preferences.h"
 #include "toonz/txshsimplelevel.h"
+#include "toonz/txshpegbarcolumn.h"
 
 // TnzQt includes
 #include "toonzqt/gutil.h"
@@ -1500,7 +1501,19 @@ void StageSchematicNode::onClicked() {
   emit currentObjectChanged(id, false);
   if (id.isColumn())
     emit currentColumnChanged(id.getIndex());
-  else if (id.isCamera() || id.isPegbar() || id.isTable())
+  else if (id.isPegbar()) {
+    StageSchematicScene *stageScene =
+        dynamic_cast<StageSchematicScene *>(scene());
+    TXsheet *xsh = stageScene->getXsheet();
+    for (int i = 0; i < xsh->getColumnCount(); i++) {
+      if (!xsh->getColumn(i) || !xsh->getColumn(i)->getPegbarColumn() ||
+          xsh->getColumn(i)->getPegbarColumn()->getPegbarObjectId() != id)
+        continue;
+      emit currentColumnChanged(i);
+      break;
+    }
+    emit editObject();
+  } else if (id.isCamera() || id.isTable())
     emit editObject();
 }
 
@@ -1580,7 +1593,7 @@ StageSchematicPegbarNode::StageSchematicPegbarNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
     : StageSchematicNode(scene, pegbar, 90, 18, false, false) {
   SchematicViewer *viewer = scene->getSchematicViewer();
-  std::string name        = m_stageObject->getFullName();
+  std::string name        = m_stageObject->getName();
   std::string id          = m_stageObject->getId().toString();
   m_name                  = QString::fromStdString(name);
   m_nameItem              = new SchematicName(this, 72, 20);

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -643,7 +643,7 @@ StageSchematicNode *StageSchematicScene::createStageSchematicNode(
     } else {
       TXshColumn *column = m_xshHandle->getXsheet()->getColumn(columnIndex);
       if (!column || column->getSoundColumn() || column->getSoundTextColumn() ||
-          column->getFolderColumn())
+          column->getFolderColumn() || column->getPegbarColumn())
         return 0;
     }
   }


### PR DESCRIPTION
This adds the ability to display and set keys on Schematic Pegbars directly from the Timeline/Xsheet.

<img width="2461" height="892" alt="image" src="https://github.com/user-attachments/assets/e035d798-ffb4-44ce-a63f-76d1021dd905" />


Options to create pegbars have been added to the following locations
   - `New Pegbar` button on Quicktool bar (<img width="30" height="30" alt="image" src="https://github.com/user-attachments/assets/1dce6817-4b8d-4563-9348-a51296916e4e" />)
   - Menu option `Level` -> `New` -> `New Pegbar` (Can assign a shortcut)
   - Layer/Column header right-click context menu `New Pegbar`

Older scenes with pegbars will be automatically converted to show pegbars on the timeline/xsheet.  When created in this manner, they will initially appear on the top/right most layer/column of the timeline/xsheet.
   
Compatibility:
- Saving new or converted scenes with visible timeline pegbars cannot be opened in prior T2D versions.  To allow a scene to load in prior versions, you need to edit the TNZ file and remove all `<pegbarColumn>`...`</pegbarColumn>`


Aside:
A separate PR is planned to add the parent indicator to the Timeline.
Will also look into narrowing the Pegbar and Folder columns on the Xsheet.