### PR TITLE
Fix to prevent looping 1 frame

### DIFF
--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -870,7 +870,7 @@ void FlipConsole::playNextFrame(QElapsedTimer *timer, qint64 targetInstant) {
     to   = m_stopAt;
   }
 
-  if (m_framesCount == 0 ||
+  if (m_framesCount == 0 || ((m_isLoop || m_isPingPong) && from == to) ||
       (m_isPlay && m_currentFrame == (m_reverse ? from : to))) {
     doButtonPressed(ePause);
     setChecked(m_isPlay ? ePlay : eLoop, false);


### PR DESCRIPTION
This addresses a perceived issue of a frozen T2D when accidentally looping only frame 1

If the user accidentally uses `Loop` or `Ping Pong` and there is only 1 frame to loop, it will immediately stop the action.