### PR TITLE
Fix controlling Smart Raster/Vector brush resize

### DIFF
--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2577,12 +2577,13 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
                              m_brushPos + TPointD(radius, radius));
 
   } else {
-    m_mousePos = pos;
     m_brushPos = getCenteredCursorPos(pos);
-    m_windowMousePos = -e.m_pos;
 
     invalidateRect += TRectD(pos - halfThick, pos + halfThick);
   }
+
+  m_mousePos       = pos;
+  m_windowMousePos = -e.m_pos;
 
   invalidate(invalidateRect.enlarge(2));
 

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1904,9 +1904,7 @@ void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
                              m_brushPos + TPointD(radius, radius));
 
   } else {
-    m_mousePos = pos;
     m_brushPos = pos;
-    m_windowMousePos = -e.m_pos;
 
     TPointD snapThick(6.0 * m_pixelSize, 6.0 * m_pixelSize);
     // In order to clear the previous snap indicator
@@ -1927,6 +1925,9 @@ void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
     invalidateRect += TRectD(pos - halfThick, pos + halfThick);
   }
+
+  m_mousePos       = pos;
+  m_windowMousePos = -e.m_pos;
 
   invalidate(invalidateRect.enlarge(2));
 


### PR DESCRIPTION
This fixes an issue where tracking of mouse was incorrect when resizing the Smart Raster/Vector brush which made it difficult to control the size of both the min and max sizes.