### PR TITLE
Convert Single Image file to sequence

### DIFF
--- a/toonz/sources/include/tfilepath.h
+++ b/toonz/sources/include/tfilepath.h
@@ -112,6 +112,10 @@ public:
 
     return (m_startSeqInd == '.' ? CUSTOM_PAD : UNDERSCORE_CUSTOM_PAD);
   }
+
+  void convertToSequence() {
+    if (isEmptyFrame() || isNoFrame()) m_frame = 0;
+  }
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -9,6 +9,7 @@
 #include "toonz/txshlevel.h"
 #include "toonz/txshleveltypes.h"
 #include "toonz/imagemanager.h"
+#include "toonz/txsheet.h"
 
 // TnzCore includes
 #include "traster.h"
@@ -316,6 +317,10 @@ The oldFp is used when the current scene path change...
   void renumber(const std::vector<TFrameId> &fids);
 
   bool isFrameReadOnly(TFrameId fid);
+
+  bool isSingleFileLevel();
+  bool canConvertSingleFileToSequence();
+  void convertSingleFileToSequence(TXsheet *xsh);
 
 public:
   // Auxiliary files management: hooks, tpl, etc.

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -151,6 +151,8 @@ protected:
   QRadialGradient m_brushPad;
 
   bool m_enabled;
+  
+  bool m_active;
 };
 
 //------------------------------------------------------------

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -1393,7 +1393,12 @@ void TypeTool::mouseMove(const TPointD &pos, const TMouseEvent &) {
 bool TypeTool::preLeftButtonDown() {
   if (getViewer() && getViewer()->getGuidedStrokePickerMode()) return false;
 
-  if (m_validFonts && !m_active) touchImage();
+  m_active = false;
+  if (m_validFonts) {
+    if (!touchImage()) return false;
+  }
+  m_active = true;
+
   return true;
 }
 
@@ -1409,12 +1414,17 @@ void TypeTool::leftButtonDown(const TPointD &pos, const TMouseEvent &) {
 
   if (!m_validFonts) return;
 
+  if (!m_active) return;
+
   TImageP img      = getImage(true);
   TVectorImageP vi = img;
   TToonzImageP ti  = img;
   TRasterImageP ri = img;
 
-  if (!vi && !ti && !ri) return;
+  if (!vi && !ti && !ri) {
+    m_active = false;
+    return;
+  }
 
   setSize(m_size.getValue());
 
@@ -1435,7 +1445,6 @@ void TypeTool::leftButtonDown(const TPointD &pos, const TMouseEvent &) {
 
   //  closeImeWindow();
   //  if(m_viewer) m_viewer->enableIme(true);
-  m_active = true;
 
   if (!m_string.empty()) {
     TPointD clickPoint =

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -3269,19 +3269,6 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
         DVGui::warning(QObject::tr("The current level is not editable"));
       return;
     }
-
-    // Do not duplicate frames on Single Frame levels
-    if (level->getSimpleLevel()) {
-      std::vector<TFrameId> fids;
-      level->getSimpleLevel()->getFids(fids);
-      if (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
-                               fids[0].getNumber() == TFrameId::NO_FRAME)) {
-        if (!multiple)
-          DVGui::warning(QObject::tr(
-              "Unable to create a blank drawing on a Single Frame level"));
-        return;
-      }
-    }
   }
 
   ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
@@ -3560,19 +3547,6 @@ void TCellSelection::duplicateFrame(int row, int col, bool multiple) {
 
   TXshSimpleLevel *sl = prevCell.getSimpleLevel();
   if (!sl || sl->isSubsequence() || sl->isReadOnly()) return;
-
-  // Do not duplicate frames on Single Frame levels
-  if (sl) {
-    std::vector<TFrameId> fids;
-    sl->getFids(fids);
-    if (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
-                             fids[0].getNumber() == TFrameId::NO_FRAME)) {
-      if (!multiple)
-        DVGui::warning(QObject::tr(
-            "Unable to duplicate a drawing on a Single Frame level"));
-      return;
-    }
-  }
 
   ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
 

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -325,12 +325,27 @@ void FilmstripFrames::mouseDoubleClickEvent(QMouseEvent *event) {
   // Block movement so we can't create new images
   TXshSimpleLevel *sl = getLevel();
   if (index > 0 && sl) {
+    // For Single Frame levels, don't create anything
+    if (sl && sl->isSingleFileLevel()) {
+      if (sl->canConvertSingleFileToSequence()) {
+        // confirmation dialog
+        int ret = DVGui::MsgBox(
+            QObject::tr(
+                "In order to create a new frame in this Single Frame level, it "
+                "will need to be converted and saved as a new sequenced "
+                "file level.\nWould you like to continue?"),
+            QObject::tr("Ok"), QObject::tr("Cancel"));
+        if (ret == 0 || ret == 2) return;
+        sl->convertSingleFileToSequence(
+            TApp::instance()->getCurrentXsheet()->getXsheet());
+      } else {
+        DVGui::error(QObject::tr("Cannot add frames to a Single Frame level."));
+        return;
+      }
+    }
+
     std::vector<TFrameId> fids;
     sl->getFids(fids);
-    if (fids.empty() ||
-        (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
-                              fids[0].getNumber() == TFrameId::NO_FRAME)))
-      return;
 
     // If we overshoot last frame, move back to 1st empty spot
     int emptyIndex = 0;
@@ -904,12 +919,27 @@ void FilmstripFrames::mousePressEvent(QMouseEvent *event) {
   // If accessed after 1st frame on a Single Frame level
   // Block movement so we can't create new images
   if (index > 0) {
+    // For Single Frame levels, don't create anything
+    if (sl && sl->isSingleFileLevel()) {
+      if (sl->canConvertSingleFileToSequence()) {
+        // confirmation dialog
+        int ret = DVGui::MsgBox(
+            QObject::tr(
+                "In order to create a new frame in this Single Frame level, it "
+                "will need to be converted and saved as a new sequenced "
+                "file level.\nWould you like to continue?"),
+            QObject::tr("Ok"), QObject::tr("Cancel"));
+        if (ret == 0 || ret == 2) return;
+        sl->convertSingleFileToSequence(
+            TApp::instance()->getCurrentXsheet()->getXsheet());
+      } else {
+        DVGui::error(QObject::tr("Cannot add frames to a Single Frame level."));
+        return;
+      }
+    }
+
     std::vector<TFrameId> fids;
     sl->getFids(fids);
-    if (fids.empty() ||
-        (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
-                              fids[0].getNumber() == TFrameId::NO_FRAME)))
-      return;
 
     // If we overshoot last frame, move back to 1st empty spot
     int emptyIndex = 0;
@@ -1202,11 +1232,25 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
   std::vector<TFrameId> fids;
   level->getFids(fids);
   if (fids.empty()) return;
-  // Do not allow movement on Single Frame levels
-  if (fids.empty() ||
-      (fids.size() == 1 && (fids[0].getNumber() == TFrameId::EMPTY_FRAME ||
-                            fids[0].getNumber() == TFrameId::NO_FRAME)))
-    return;
+
+  // For Single Frame levels, don't create anything
+  if (level->isSingleFileLevel()) {
+    if (level->canConvertSingleFileToSequence()) {
+      // confirmation dialog
+      int ret = DVGui::MsgBox(
+          QObject::tr(
+              "In order to create a new frame in this Single Frame level, it "
+              "will need to be converted and saved as a new sequenced "
+              "file level.\nWould you like to continue?"),
+          QObject::tr("Ok"), QObject::tr("Cancel"));
+      if (ret == 0 || ret == 2) return;
+      level->convertSingleFileToSequence(
+          TApp::instance()->getCurrentXsheet()->getXsheet());
+    } else {
+      DVGui::error(QObject::tr("Cannot add frames to a Single Frame level."));
+      return;
+    }
+  }
 
   // If on a level frame pass the frame id after the last frame to allow
   // creating a new frame with the down arrow key


### PR DESCRIPTION
A `Single Image` level is an editable raster file (png, tif/tiff, jpg, bmp, etc) whose filename does not contain a frame number in it. Because of this, additional drawings cannot be added to this level.

This PR provides the user an option to convert it into a sequenced file:
<img width="1485" height="273" alt="image" src="https://github.com/user-attachments/assets/d2666326-326a-4072-a1e7-ef4f82333e99" />

User will be prompted under the following conditions for editable `Single Image` levels:
- Duplication of the frame
- Creation of a new blank frame
- Creation of a new frame when `Auto-Creation` is enabled while using Raster Brush Tool, Geometric Tool or Type Tool
- Pasting selection into the same column in an empty or held frame w/ `Creation In Hold Cells` enabled.

If conversion is accepted, the following will happen internally, but not immediately saved:

- The `Single Frame` drawing will be converted to Frame 0 (zero).
- Any occurrence of the exposed frame in the timeline/xsheet will be replaced with the new Frame 0
- The filename will be changed to allow for Frame number (i.e. `ABC.png` -> `ABC..png`)

When the level is saved, the sequenced file will be saved in the same folder as the original Single Image file.
