### PR TITLE
Fix saving TIF files in scene subfolder

### DIFF
--- a/toonz/sources/include/timageinfo.h
+++ b/toonz/sources/include/timageinfo.h
@@ -68,7 +68,7 @@ public:
       , m_y0(0)
       , m_x1(-1)
       , m_y1(-1)
-      , m_samplePerPixel(0)
+      , m_samplePerPixel(4)
       , m_bitsPerSample(8)
       , m_fileSize(0)
       , m_valid(false) {}
@@ -84,7 +84,7 @@ public:
       , m_y0(0)
       , m_x1(-1)
       , m_y1(-1)
-      , m_samplePerPixel(0)
+      , m_samplePerPixel(4)
       , m_bitsPerSample(8)
       , m_fileSize(0)
       , m_valid(false) {}


### PR DESCRIPTION
This fixes an issue where saving TIF files in scene subfolders (`+extras\scenename\xxx.tif`) results in a crash.  This does not happen with PNG files.

Issue:
T2D generates 32bits/pixel raster images.  For TIF files, the `Bits Per Pixel` is determined by `samplePerPixel` x `bitsPerSample`.  The current defaults for T2D generated images is `samplePerPixel=0` and `bitsPerSample=8`, which causes a calculation error and leads to a crash under certain circumstances, like saving into scene subfolders from untitled folders.

Resolution:
Since T2D creates 32bit raster images by default, I've defaulted the `samplePerPixel=4`.