### PR TITLE
Fix starting Animate Tool mode

### DIFF
--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -1498,6 +1498,8 @@ void EditTool::onActivate() {
     m_scaleConstraint.setValue(::to_wstring(ScaleConstraint.getValue()));
     m_globalKeyframes.setValue(ArrowGlobalKeyFrame ? 1 : 0);
 
+    onPropertyChanged(m_activeAxis.getName());
+
     /*
 m_foo.setTool(this);
 m_foo.setFxHandle(getApplication()->getCurrentFx());


### PR DESCRIPTION
This fixes an issue where if your last session's Animate Tool mode was saved as something other than `Position`, when it is restored, it may say the correct mode (i.e. `Rotation`, `Scale`, etc.) but behaves like `Position` until you change it.

It now does the correct behavior based on the restored mode.
