### PR TITLE
Write lipsync script file as explicit UTF-8

### DIFF
--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -745,8 +745,9 @@ void LipSyncPopup::runRhubarb() {
         TFilePath(cacheRoot + "/rhubarb/script.txt").getQString();
 
     QFile qFile(scriptPath);
-    if (qFile.open(QIODevice::WriteOnly)) {
+    if (qFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
       QTextStream out(&qFile);
+      out.setCodec("UTF-8");
       out << script;
       qFile.close();
       args << "-d" << scriptPath;


### PR DESCRIPTION
Found this while testing Lip Sync on Windows. No existing issue covers it (that I can tell).

**To reproduce:** open Lip Sync, paste `"Hello," she said — it's a café.` into the Audio Script box, and run. Rhubarb receives `script.txt` with `é` encoded as `0xE9` (cp1252) instead of `0xC3 0xA9` (UTF-8) and exits with an error on any Windows machine not using an English/Western locale.

`QTextStream` without an explicit codec defaults to the system locale. Fix is one line - `out.setCodec("UTF-8")` at `lipsyncpopup.cpp:750` - taken from the same pattern already used in `toonzqt/tipspopup.cpp:114`. Also added `QIODevice::Truncate` so stale content from a previous run doesn't linger if the file already exists.