### PR TITLE
Fix Function Editor UI issues

### DIFF
--- a/toonz/sources/include/toonzqt/functionsheet.h
+++ b/toonz/sources/include/toonzqt/functionsheet.h
@@ -29,12 +29,14 @@ class FunctionSelection;
 
 class FunctionSheetButtonArea final : public QWidget {
   Q_OBJECT
-  QPushButton *m_syncSizeBtn;
+  QPushButton *m_syncSizeBtn, *m_syncHeaderBtn;
 
 public:
   FunctionSheetButtonArea(QWidget *parent);
+  void setSyncHeaderBtnState(bool);
   void setSyncSizeBtnState(bool);
 signals:
+  void syncHeaderBtnToggled(bool);
   void syncSizeBtnToggled(bool);
 };
 
@@ -162,6 +164,7 @@ public:
     update();
   }
 
+  void setSyncHeader(bool on);
   bool isSyncSize() { return m_syncSize; }
   void setSyncSize(bool on);
   void setXsheetHandle(TXsheetHandle *xshHandle) { m_xshHandle = xshHandle; }
@@ -183,6 +186,9 @@ public slots:
 
   void onSyncSizeBtnToggled(bool);
   void onZoomScaleChanged();
+
+signals:
+  void syncHeaderBtnToggled(bool);
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/functionviewer.h
+++ b/toonz/sources/include/toonzqt/functionviewer.h
@@ -128,6 +128,8 @@ public:
   // refer to the preferences' "Current Column Color"
   QColor getCurrentTextColor() const;
 
+  void showToggleMode(int toggleMode);
+
 signals:
 
   void curveChanged();
@@ -186,6 +188,8 @@ private:
   TDoubleParam *m_curve;
   FunctionSelection *m_selection;
 
+  bool m_syncHeader = false;
+
 private:
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;
@@ -198,10 +202,14 @@ public:  //  :(
     emit curveIo(type, curve, name);
   }  //!< \deprecated  Should not be public.
 
+  void adjustHeader();
+
 private slots:
 
   void propagateExternalSetFrame();  //!< Forwards m_frameHandle's setFrame()
                                      //! invocations to m_localFrame.
+
+  void onSyncHeaderBtnToggled(bool);
 };
 
 #endif  // FUNCTIONEDITORVIEWER_H

--- a/toonz/sources/toonz/icons/dark/actions/17/syncheader.svg
+++ b/toonz/sources/toonz/icons/dark/actions/17/syncheader.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="17"
+   height="17"
+   version="1.1"
+   xml:space="preserve"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+   id="svg12"
+   sodipodi:docname="syncheader.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata
+   id="metadata18"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+   id="defs16">
+        
+    
+            
+            
+        
+                
+            </defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   id="namedview14"
+   showgrid="true"
+   inkscape:zoom="32"
+   inkscape:cx="7.734375"
+   inkscape:cy="13.640625"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg12"
+   inkscape:showpageshadow="2"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"><inkscape:grid
+     type="xygrid"
+     id="grid828"
+     originx="0"
+     originy="0"
+     spacingy="1"
+     spacingx="1"
+     units="px" /></sodipodi:namedview>
+    <path
+   sodipodi:nodetypes="scsccccsssssssssccccssssscss"
+   inkscape:connector-curvature="0"
+   id="path5"
+   style="fill-rule:nonzero;fill:#000000;fill-opacity:0.80000001"
+   d="m 16,12.033 c 0,0.522 -0.207,1.022 -0.576,1.391 C 15.054,13.792 14.555,14 14.032,14 H 6 v 2 L 1,12 c 1,0 11.968,0 11.968,0 C 13.538,12 14,11.538 14,10.969 V 9.999 C 14,9.447 14.447,9 14.999,9 h 0.002 C 15.553,9 16,9.447 16,9.999 Z M 1,4.976 C 1,4.453 1.208,3.95 1.579,3.579 1.95,3.208 2.453,3 2.976,3 H 11 V 1 l 5,4 H 3.994 C 3.444,5 3,5.446 3,5.994 V 8.001 C 3,8.266 2.894,8.521 2.707,8.708 2.52,8.895 2.266,9 2.001,9 H 1.999 C 1.734,9 1.48,8.895 1.292,8.708 1.105,8.521 1,8.266 1,8.001 Z" />
+<path
+   style="baseline-shift:baseline;clip-rule:nonzero;display:inline;overflow:visible;opacity:1;vector-effect:none;fill-rule:nonzero;stroke-width:0.731124;stroke-linecap:square;stroke-linejoin:miter;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+   d="m 8.9729675,5.96875 c -0.137682,0 -0.2542175,0.2680507 -0.2542175,0.5847417 v 3.9242663 c 0,0.316691 0.1165355,0.584742 0.2542175,0.584742 H 12.245782 C 12.383464,11.0625 12.5,10.794449 12.5,10.477758 V 6.5534917 C 12.5,6.2368007 12.383464,5.96875 12.245782,5.96875 Z"
+   id="rect1"
+   sodipodi:nodetypes="sssssssss" /><path
+   style="baseline-shift:baseline;clip-rule:nonzero;display:inline;overflow:visible;vector-effect:none;fill-rule:nonzero;stroke-width:0.581187;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;enable-background:accumulate;stop-color:#000000"
+   d="M 4.6917175,7.84375 C 4.5540355,7.84375 4.4375,8.0131314 4.4375,8.2132499 V 10.693 c 0,0.200119 0.1165355,0.3695 0.2542175,0.3695 H 7.964532 c 0.137682,0 0.254218,-0.169381 0.254218,-0.3695 V 8.2132499 C 8.21875,8.0131314 8.102214,7.84375 7.964532,7.84375 Z"
+   id="rect1-9"
+   sodipodi:nodetypes="sssssssss" /></svg>

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2211,7 +2211,8 @@ QWidget* PreferencesPopup::createXsheetPage() {
   {
     insertUI(showQuickToolbar, xshToolbarLay);
     insertUI(showXsheetBreadcrumbs, xshToolbarLay);
-    insertUI(expandFunctionHeader, xshToolbarLay);
+// Obsolete. Setting is local to panel
+//    insertUI(expandFunctionHeader, xshToolbarLay);
   }
   insertUI(showColumnNumbers, lay);
   insertUI(showColumnParents, lay);

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -620,6 +620,7 @@
 		<file>icons/dark/actions/16/tool_options.svg</file>
 		<file>icons/dark/actions/16/view_file.svg</file>
 		<file>icons/dark/actions/16/level_strip.svg</file>
+    <file>icons/dark/actions/17/syncheader.svg</file>
     <file>icons/dark/actions/17/syncscale.svg</file>
 		<file>icons/dark/actions/16/new_project.svg</file>
 		<file>icons/dark/actions/16/project_settings.svg</file>

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -1541,6 +1541,8 @@ void FunctionPanel::fitGraphToWindow(bool currentCurveOnly) {
   } else {
     double mx       = (width() - m_valueAxisX - 20) / (f1 - f0);
     double my       = -(height() - m_graphViewportY - 20) / (v1 - v0);
+    // Keep value negative so vertical axis is numbered top down
+    if (my > 0) my *= -1;
     double dx       = m_valueAxisX + 10 - f0 * mx;
     double dy       = m_graphViewportY + 10 - v1 * my;
     m_viewTransform = QTransform(mx, 0, 0, my, dx, dy);

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -196,11 +196,29 @@ public:
 
 FunctionSheetButtonArea::FunctionSheetButtonArea(QWidget *parent)
     : QWidget(parent) {
+  m_syncHeaderBtn = new QPushButton("", this);
+  m_syncHeaderBtn->setCheckable(true);
+  m_syncHeaderBtn->setFixedSize(17, 17);
+  static QPixmap syncHeaderImg = generateIconPixmap("syncheader");
+  QPixmap offPmHeader(16, 16);
+  offPmHeader.fill(Qt::transparent);
+  {
+    QPainter p(&offPmHeader);
+    p.setOpacity(0.7);
+    p.drawPixmap(0, 0, syncHeaderImg);
+  }
+  QIcon iconHeader;
+  iconHeader.addPixmap(offPmHeader);
+  iconHeader.addPixmap(syncHeaderImg, QIcon::Normal, QIcon::On);
+  m_syncHeaderBtn->setIcon(iconHeader);
+
+  m_syncHeaderBtn->setToolTip(tr("Expand Function Editor Header to Match Xsheet Header Height"));
+  
   m_syncSizeBtn = new QPushButton("", this);
   m_syncSizeBtn->setCheckable(true);
-  m_syncSizeBtn->setFixedSize(20, 20);
+  m_syncSizeBtn->setFixedSize(17, 17);
   static QPixmap syncScaleImg = generateIconPixmap("syncscale");
-  QPixmap offPm(17, 17);
+  QPixmap offPm(16, 16);
   offPm.fill(Qt::transparent);
   {
     QPainter p(&offPm);
@@ -216,19 +234,31 @@ FunctionSheetButtonArea::FunctionSheetButtonArea(QWidget *parent)
 
   QVBoxLayout *layout = new QVBoxLayout();
   layout->setContentsMargins(2, 2, 2, 2);
-  layout->setSpacing(0);
+  layout->setSpacing(1);
   {
     layout->addStretch();
+    layout->addWidget(m_syncHeaderBtn, 0, Qt::AlignCenter);
     layout->addWidget(m_syncSizeBtn, 0, Qt::AlignCenter);
   }
   setLayout(layout);
 
+  connect(m_syncHeaderBtn, SIGNAL(clicked(bool)), this,
+          SIGNAL(syncHeaderBtnToggled(bool)));
   connect(m_syncSizeBtn, SIGNAL(clicked(bool)), this,
           SIGNAL(syncSizeBtnToggled(bool)));
+
+  if (Preferences::instance()->getFunctionEditorToggle() ==
+      Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup) {
+    m_syncHeaderBtn->hide();
+  }
 }
 
 void FunctionSheetButtonArea::setSyncSizeBtnState(bool on) {
   m_syncSizeBtn->setChecked(on);
+}
+
+void FunctionSheetButtonArea::setSyncHeaderBtnState(bool on) {
+  m_syncHeaderBtn->setChecked(on);
 }
 
 //********************************************************************************
@@ -1223,6 +1253,8 @@ FunctionSheet::FunctionSheet(QWidget *parent, bool isFloating)
   setButtonAreaWidget(m_buttonArea = new FunctionSheetButtonArea(this));
   connect(m_buttonArea, SIGNAL(syncSizeBtnToggled(bool)), this,
           SLOT(onSyncSizeBtnToggled(bool)));
+  connect(m_buttonArea, SIGNAL(syncHeaderBtnToggled(bool)), this,
+          SIGNAL(syncHeaderBtnToggled(bool)));
 }
 
 //-----------------------------------------------------------------------------
@@ -1421,6 +1453,13 @@ TStageObject *FunctionSheet::getStageObject(int column) {
   if (!stageItem) return nullptr;
 
   return stageItem->getStageObject();
+}
+
+//-----------------------------------------------------------------------------
+
+void FunctionSheet::setSyncHeader(bool on) {
+  m_buttonArea->setSyncHeaderBtnState(on);
+  update();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -126,7 +126,6 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
   QString layout = Preferences::instance()->getLoadedXsheetLayout();
   bool toolBarOnBottom =
       layout == QString("Minimum") &&
-      Preferences::instance()->isExpandFunctionHeaderEnabled() &&
       m_toggleStart !=
           Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup;
 
@@ -137,9 +136,9 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
     if (!toolBarOnBottom) m_leftLayout->addWidget(m_toolbar);
     m_spacing = 35;
     if (layout == QString("Compact"))
-      m_spacing -= 18;
+      m_spacing = 17;
     else if (toolBarOnBottom) {
-      m_spacing = 3;  // m_spacing is used for the height of spacer widget
+      m_spacing = 0;  // m_spacing is used for the height of spacer widget
       m_leftLayout->addSpacing(m_spacing);
     }
 
@@ -212,6 +211,10 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
                 m_numericalColumns,
                 SLOT(onCurrentChannelChanged(FunctionTreeModel::Channel *)));
 
+  ret = ret && connect(m_numericalColumns, SIGNAL(syncHeaderBtnToggled(bool)),
+                       this,
+                       SLOT(onSyncHeaderBtnToggled(bool)));
+
   assert(ret);
   if (m_toggleStart ==
       Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup) {
@@ -219,26 +222,14 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
     if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem())
       spacer->changeSize(0, 0);
   } else {
-    bool toolBarVisible =
-        Preferences::instance()->isShowQuickToolbarEnabled() &&
-        Preferences::instance()->isExpandFunctionHeaderEnabled();
-    bool breadcrumbsVisible =
-        Preferences::instance()->isShowXsheetBreadcrumbsEnabled() &&
-        Preferences::instance()->isExpandFunctionHeaderEnabled();
-    if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
-      spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0) +
-                                ((breadcrumbsVisible) ? 10 : 0),
-                         QSizePolicy::Fixed, QSizePolicy::Fixed);
-      spacer->invalidate();
-    } else
-      m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0) +
-                               ((breadcrumbsVisible) ? 10 : 0));
+    adjustHeader();
     if (m_toggleStart ==
         Preferences::FunctionEditorToggle::ShowGraphEditorInPopup) {
       m_functionGraph->hide();
     }
   }
   m_toggleStatus = FunctionEditorToggleStatus;
+  showToggleMode(m_toggleStatus);
 }
 
 //-----------------------------------------------------------------------------
@@ -515,40 +506,13 @@ void FunctionViewer::toggleMode() {
   } else if (m_toggleStart == Preferences::FunctionEditorToggle::
                                   ToggleBetweenGraphAndSpreadsheet) {
     if (m_functionGraph->isVisible()) {
-      m_functionGraph->hide();
-      m_numericalColumns->show();
-      m_numericalColumns->setFocus();
-      bool toolBarVisible =
-          Preferences::instance()->isShowQuickToolbarEnabled() &&
-          Preferences::instance()->isExpandFunctionHeaderEnabled();
-      bool breadcrumbsVisible =
-          Preferences::instance()->isShowXsheetBreadcrumbsEnabled() &&
-          Preferences::instance()->isExpandFunctionHeaderEnabled();
-      if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
-        spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0) +
-                                  ((breadcrumbsVisible) ? 10 : 0),
-                           QSizePolicy::Fixed, QSizePolicy::Fixed);
-        spacer->invalidate();
-        m_numericalColumns->updateHeaderHeight();
-        m_leftLayout->setSpacing(0);
-      } else
-        m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0) +
-                                 ((breadcrumbsVisible) ? 10 : 0));
-      updateGeometry();
       m_toggleStatus = 0;
     } else {
-      m_functionGraph->show();
-      m_functionGraph->setFocus();
-      m_numericalColumns->hide();
-      m_leftLayout->setSpacing(0);
-      if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
-        spacer->changeSize(0, 0);
-        spacer->invalidate();
-      }
       m_toggleStatus = 1;
     }
+    showToggleMode(m_toggleStatus);
+    FunctionEditorToggleStatus = m_toggleStatus;
   }
-  FunctionEditorToggleStatus = m_toggleStatus;
 }
 
 //-----------------------------------------------------------------------------
@@ -693,7 +657,7 @@ void FunctionViewer::onPreferenceChanged(const QString &prefName) {
   if (prefName != "QuickToolbar" && prefName != "XsheetBreadcrumbs" &&
       !prefName.isEmpty())
     return;
-  if (!Preferences::instance()->isExpandFunctionHeaderEnabled()) return;
+  if (!m_syncHeader) return;
   if (m_toggleStart ==
       Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
     return;
@@ -712,25 +676,9 @@ void FunctionViewer::onPreferenceChanged(const QString &prefName) {
   }
 
   // spreadsheet is shown
-  bool toolBarVisible =
-      Preferences::instance()->isShowQuickToolbarEnabled() &&
-      Preferences::instance()->isExpandFunctionHeaderEnabled();
-  bool breadcrumbsVisible =
-      Preferences::instance()->isShowXsheetBreadcrumbsEnabled() &&
-      Preferences::instance()->isExpandFunctionHeaderEnabled();
   m_functionGraph->hide();
   m_numericalColumns->show();
-  if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
-    spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0) +
-                              ((breadcrumbsVisible) ? 10 : 0),
-                       QSizePolicy::Fixed, QSizePolicy::Fixed);
-    spacer->invalidate();
-    m_numericalColumns->updateHeaderHeight();
-    m_leftLayout->setSpacing(0);
-  } else
-    m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0) +
-                             ((breadcrumbsVisible) ? 30 : 0));
-  updateGeometry();
+  adjustHeader();
 }
 
 //-----------------------------------------------------------------------------
@@ -831,10 +779,11 @@ bool FunctionViewer::isExpressionPageActive() {
 //----------------------------------------------------------------------------
 
 void FunctionViewer::save(QSettings &settings, bool forPopupIni) const {
-  FunctionEditorToggleStatus = m_toggleStatus;
+//  FunctionEditorToggleStatus = m_toggleStatus;
   settings.setValue("toggleStatus", m_toggleStatus);
   settings.setValue("showIbtwnValuesInSheet",
                     m_numericalColumns->isIbtwnValueVisible());
+  settings.setValue("syncHeader", m_syncHeader);
   settings.setValue("syncSize", m_numericalColumns->isSyncSize());
 }
 
@@ -844,13 +793,17 @@ void FunctionViewer::load(QSettings &settings) {
   QVariant toggleStatus = settings.value("toggleStatus");
   if (toggleStatus.canConvert(QVariant::Int)) {
     m_toggleStatus = toggleStatus.toInt();
+    showToggleMode(m_toggleStatus);
   }
-  m_toggleStatus    = FunctionEditorToggleStatus;
+//  m_toggleStatus    = FunctionEditorToggleStatus;
   bool ibtwnVisible = settings
                           .value("showIbtwnValuesInSheet",
                                  m_numericalColumns->isIbtwnValueVisible())
                           .toBool();
   m_numericalColumns->setIbtwnValueVisible(ibtwnVisible);
+
+  m_syncHeader = settings.value("syncHeader").toBool();
+  m_numericalColumns->setSyncHeader(m_syncHeader);
 
   bool syncSize =
       settings.value("syncSize", m_numericalColumns->isSyncSize()).toBool();
@@ -867,4 +820,64 @@ QColor FunctionViewer::getCurrentTextColor() const {
                             (int)currentColumnPixel.g,
                             (int)currentColumnPixel.b, 255);
   return currentColumnColor;
+}
+
+//-----------------------------------------------------------------------------
+
+void FunctionViewer::showToggleMode(int toggleMode) {
+  if (m_toggleStart !=
+      Preferences::FunctionEditorToggle::ToggleBetweenGraphAndSpreadsheet)
+    return;
+
+  if (toggleMode == 0) {
+    m_functionGraph->hide();
+    m_numericalColumns->show();
+    m_numericalColumns->setFocus();
+    adjustHeader();
+  } else {
+    m_functionGraph->show();
+    m_functionGraph->setFocus();
+    m_numericalColumns->hide();
+    m_leftLayout->setSpacing(0);
+    if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
+      spacer->changeSize(0, 0);
+      spacer->invalidate();
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void FunctionViewer::onSyncHeaderBtnToggled(bool on) {
+  // switch the flag
+  m_syncHeader = on;
+  adjustHeader();
+}
+
+//-----------------------------------------------------------------------------
+
+void FunctionViewer::adjustHeader() {
+  if (m_toggleStart ==
+      Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
+    return;
+
+  bool toolBarVisible =
+      Preferences::instance()->isShowQuickToolbarEnabled() && m_syncHeader;
+  bool breadcrumbsVisible =
+      Preferences::instance()->isShowXsheetBreadcrumbsEnabled() && m_syncHeader;
+
+  QString layout = Preferences::instance()->getLoadedXsheetLayout();
+  m_spacing      = (!m_syncHeader || layout == QString("Minimum") ? 0
+                    : layout == QString("Compact")                ? 17
+                                                                  : 35);
+  m_spacing += (toolBarVisible ? 29 : 0) + (breadcrumbsVisible ? 29 : 0);
+
+  if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
+    spacer->changeSize(1, m_spacing, QSizePolicy::Fixed, QSizePolicy::Fixed);
+    spacer->invalidate();
+    m_numericalColumns->updateHeaderHeight();
+    m_leftLayout->setSpacing(0);
+  } else
+    m_leftLayout->setSpacing(m_spacing);
+  updateGeometry();
 }

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -574,14 +574,7 @@ SpreadsheetViewer::SpreadsheetViewer(QWidget *parent)
 
   m_rowScrollArea->setFixedWidth(30);
 
-  if (Preferences::instance()->getLoadedXsheetLayout() == QString("Minimum") &&
-      !Preferences::instance()->isShowQuickToolbarEnabled() &&
-      Preferences::instance()->isExpandFunctionHeaderEnabled() &&
-      Preferences::instance()->getFunctionEditorToggle() !=
-          Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
-    m_columnScrollArea->setFixedHeight(m_rowHeight * 2 - 4);
-  else
-    m_columnScrollArea->setFixedHeight(m_rowHeight * 3 - 4);
+  updateHeaderHeight();
 
   m_frameScroller.setFrameScrollArea(m_cellScrollArea);
   connect(&m_frameScroller, &Spreadsheet::FrameScroller::prepareToScrollOffset,
@@ -1055,12 +1048,12 @@ void SpreadsheetViewer::ensureVisibleCol(int col) {
 }
 
 bool SpreadsheetViewer::isSmallHeader() {
-  return (
-      Preferences::instance()->getLoadedXsheetLayout() == QString("Minimum") &&
-      !Preferences::instance()->isShowQuickToolbarEnabled() &&
-      Preferences::instance()->isExpandFunctionHeaderEnabled() &&
-      Preferences::instance()->getFunctionEditorToggle() !=
-          Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup);
+  if (Preferences::instance()->getLoadedXsheetLayout() != QString("Minimum") ||
+      Preferences::instance()->getFunctionEditorToggle() ==
+          Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
+    return false;
+
+  return true;
 }
 
 void SpreadsheetViewer::updateHeaderHeight() {


### PR DESCRIPTION
This fixes the following Function Editor issues:

- Fixes an issue where the graph's vertical axis is flipped (negative to positive) if you double-click the Stage/FX tree panel before switching to graph for the 1st time.
- Fixes an issue where the toggle switch doesn't initially switch from spreadsheet to graph until you press it a second time.   
- Fixes the loading of the default mode, Graph, on new installs.  Change was made but not quite implemented correctly.
- Fixes the restoration of spreadsheet or graph mode from the prior session on startup.  As the default was always Graph since T2D 1.0 but not restored correctly, you may find your function editors showing as graphs after this change.
- Fixes header expansion to align correctly with the different modes (`Compact`, `Roomy`, `Minimum`) and the visibility of Quick Toolbar and Sub-Scene Navigation bar.
- Preference setting `Expand Function Editor Header to Match Xsheet Header Height` is now obsolete and hidden. A button is available in each editor so that each editor can have different settings.
