### PR TITLE
Fix erratic ping pong playback behavior

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -386,7 +386,7 @@ private:
 
   std::vector<int> m_gadgetsMask;
   int m_from, m_to, m_step;
-  int m_currentFrame, m_framesCount;
+  int m_currentFrame, m_framesCount, m_playFrame;
   int m_stopAt = -1;
   int m_startAt =
       -1;  // used in the "play selection" mode of the viewer preview

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -871,33 +871,34 @@ void FlipConsole::playNextFrame(QElapsedTimer *timer, qint64 targetInstant) {
   }
 
   if (m_framesCount == 0 || ((m_isLoop || m_isPingPong) && from == to) ||
-      (m_isPlay && m_currentFrame == (m_reverse ? from : to))) {
+      (m_isPlay && m_playFrame == (m_reverse ? from : to))) {
     doButtonPressed(ePause);
     setChecked(m_isPlay ? ePlay : eLoop, false);
     setChecked(ePause, true);
+    m_playFrame = m_currentFrame;
     if (Preferences::instance()->rewindAfterPlaybackEnabled())
-      m_currentFrame = (m_reverse ? to : from);
+      m_playFrame = (m_reverse ? to : from);
     emit playStateChanged(false);
   } else {
     if (drawBlanks(from, to, timer, targetInstant)) return;
 
     if (m_reverse)
-      m_currentFrame =
-          ((m_currentFrame - m_step < from) ? to : m_currentFrame - m_step);
+      m_playFrame = ((m_playFrame - m_step < from) ? (m_isPingPong ? from : to)
+                                                   : m_playFrame - m_step);
     else
-      m_currentFrame =
-          ((m_currentFrame + m_step > to) ? from : m_currentFrame + m_step);
+      m_playFrame = ((m_playFrame + m_step > to) ? (m_isPingPong ? to : from)
+                                                 : m_playFrame + m_step);
+
+    if (m_isPingPong && (m_playFrame <= from || m_playFrame >= to))
+      m_reverse = !m_reverse;
   }
 
-  m_currFrameSlider->setValue(m_currentFrame);
-  m_editCurrFrame->setText(QString::number(m_currentFrame));
+  m_currFrameSlider->setValue(m_playFrame);
+  m_editCurrFrame->setText(QString::number(m_playFrame));
   updateCurrentTime();
   m_settings.m_blankColor        = TPixel::Transparent;
   m_settings.m_recomputeIfNeeded = true;
-  m_consoleOwner->onDrawFrame(m_currentFrame, m_settings, timer, targetInstant);
-
-  if (m_isPingPong && (m_currentFrame <= from || m_currentFrame >= to))
-    m_reverse = !m_reverse;
+  m_consoleOwner->onDrawFrame(m_playFrame, m_settings, timer, targetInstant);
 }
 
 //-----------------------------------------------------------------------------
@@ -1700,9 +1701,6 @@ void FlipConsole::doButtonPressed(UINT button) {
 
   bool linked = m_areLinked && m_isLinkable;
 
-  m_isLoop     = false;
-  m_isPingPong = false;
-
   switch (button) {
   case eFirst:
     m_currentFrame = from;
@@ -1749,6 +1747,8 @@ void FlipConsole::doButtonPressed(UINT button) {
       if (m_fpsField) m_fpsField->setLineEditBackgroundColor(Qt::red);
     }
 
+    m_playFrame = m_currentFrame;
+
     m_playbackExecutor.resetFps(m_isInbetweenFlip
                                     ? ((float)m_inbetweenFlipDrawings /
                                        ((float)m_inbetweenFlipSpeed / 1000.0))
@@ -1762,12 +1762,12 @@ void FlipConsole::doButtonPressed(UINT button) {
       // if the play button pressed at the end frame, then go back to the
       // start frame and play
       if (!m_isInbetweenFlip &&
-          (m_currentFrame <= from ||
-           m_currentFrame >=
+          (m_playFrame <= from ||
+           m_playFrame >=
                to))  // the first frame of the playback is drawn right now
-        m_currentFrame               = m_reverse ? to : from;
+        m_playFrame = m_reverse ? to : from;
       m_settings.m_recomputeIfNeeded = true;
-      m_consoleOwner->onDrawFrame(m_currentFrame, m_settings);
+      m_consoleOwner->onDrawFrame(m_playFrame, m_settings);
     }
 
     emit playStateChanged(true);
@@ -1800,7 +1800,10 @@ void FlipConsole::doButtonPressed(UINT button) {
     m_stopAt       = -1;
     m_startAt      = -1;
     m_isPlay       = false;
+    m_isLoop       = false;
+    m_isPingPong   = false;
     m_blanksToDraw = 0;
+    m_playFrame    = 0;
 
     m_consoleOwner->swapBuffers();
     m_consoleOwner->changeSwapBehavior(true);


### PR DESCRIPTION
This fixes #1500 

When buttons were pressed some internal variables were reset causing Ping Pong to behave like Loop.  Modified the code to not reset with every button push.

Additionally this corrects an issue where certain actions, like Next/Previous Frame/Key etc, caused Ping Pong to flip quickly between the first and last frames.  This was due to the current frame position jumping outside the playback range and incorrectly calculating the next frame.  Modified playback, in general, to use a separate variable instead of the current frame variable used by other actions.