### PR TITLE
Fixes for ease handles and interpolation management from timeline/xsheet 

### DIFF
--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -1195,6 +1195,12 @@ is >> m_imp->m_defaultValue;
     }
   }
 
+  if (!m_imp->m_keyframes.empty()) {
+    // For loader scenes, ensure the last keyframe's type is set to Linear
+    if (m_imp->m_keyframes.rbegin()->m_type != TDoubleKeyframe::Linear)
+      m_imp->m_keyframes.rbegin()->m_type = TDoubleKeyframe::Linear;
+  }
+
   m_imp->notify(TParamChange(this, 0, 0, true, false, false));
 }
 

--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -804,6 +804,7 @@ void TDoubleParam::setKeyframes(const std::map<int, TDoubleKeyframe> &ks) {
 void TDoubleParam::setKeyframe(const TDoubleKeyframe &k) {
   DoubleKeyframeVector &keyframes = m_imp->m_keyframes;
   DoubleKeyframeVector::iterator it;
+  bool atEnd = false;
   it = std::lower_bound(keyframes.begin(), keyframes.end(), k);
   if (it != keyframes.end() && it->m_frame == k.m_frame) {
     // int index = std::distance(keyframes.begin(), it);
@@ -811,6 +812,13 @@ void TDoubleParam::setKeyframe(const TDoubleKeyframe &k) {
     (TDoubleKeyframe &)dst     = k;
     dst.updateUnit(m_imp->m_measure);
   } else {
+    if (keyframes.size()) {
+      if (it == keyframes.end()) {  // Adding after the last one
+        keyframes.rbegin()->m_type = k.m_prevType;
+        atEnd                      = true;
+      } else if (it != keyframes.begin() && it[-1].m_type != k.m_prevType)
+        it[-1].m_type = k.m_prevType;
+    }
     it = keyframes.insert(it, TActualDoubleKeyframe(k));
     // int index = std::distance(keyframes.begin(), it);
     // TDoubleKeyframe oldKeyframe = *it;
@@ -819,6 +827,8 @@ void TDoubleParam::setKeyframe(const TDoubleKeyframe &k) {
     it->updateUnit(m_imp->m_measure);
   }
   it->m_isKeyframe = true;
+
+  if (atEnd) it->m_type = TDoubleKeyframe::Linear;
 
   if (it->m_type == TDoubleKeyframe::Expression)
     it->m_expression.setText(it->m_expressionText);
@@ -921,7 +931,10 @@ void TDoubleParam::deleteKeyframe(double frame) {
 
   TDoubleKeyframe::Type type = it->m_prevType;
   it                         = m_imp->m_keyframes.erase(it);
-  if (it != keyframes.end()) it->m_prevType = type;
+  if (it != keyframes.end())
+    it->m_prevType = type;
+  else if (m_imp->m_keyframes.size())  // end was deleted
+    keyframes.rbegin()->m_type = TDoubleKeyframe::Linear;
 
   m_imp->notify(TParamChange(this, 0, 0, true, false, false));
 }

--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -816,8 +816,7 @@ void TDoubleParam::setKeyframe(const TDoubleKeyframe &k) {
       if (it == keyframes.end()) {  // Adding after the last one
         keyframes.rbegin()->m_type = k.m_prevType;
         atEnd                      = true;
-      } else if (it != keyframes.begin() && it[-1].m_type != k.m_prevType)
-        it[-1].m_type = k.m_prevType;
+      }
     }
     it = keyframes.insert(it, TActualDoubleKeyframe(k));
     // int index = std::distance(keyframes.begin(), it);

--- a/toonz/sources/tnztools/plastictool_build.cpp
+++ b/toonz/sources/tnztools/plastictool_build.cpp
@@ -395,14 +395,15 @@ public:
       // Put a keyframe at the previous cell to preserve values before current
       // frame
       TDoubleKeyframe kf(frame - 1.0, skelIdsParam->getDefaultValue());
-      kf.m_type = TDoubleKeyframe::Constant;
+      kf.m_type     = TDoubleKeyframe::Constant;
+      kf.m_prevType = TDoubleKeyframe::None;
 
       skelIdsParam->setKeyframe(kf);
       m_added1stKeyframe = true;
     }
 
     TDoubleKeyframe kf(frame, m_skelId);
-    kf.m_type = TDoubleKeyframe::Constant;
+    kf.m_type = kf.m_prevType = TDoubleKeyframe::Constant;
 
     skelIdsParam->setKeyframe(kf);
 

--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -131,21 +131,7 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
     TStageObject::Keyframe newKey = pegbar->getKeyframe(row);
     // Process 1st key added in column
     if (itF != firstRowCol.end() && itF->second == row) {
-      if (row > kL) {
-        // If new key was added after the existing last one, create new
-        // interpolation between them using preference setting
-        TStageObject::Keyframe prevKey = pegbar->getKeyframe(kL);
-        for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-          if (newKey.m_channels[i].m_isKeyframe &&
-              prevKey.m_channels[i].m_isKeyframe) {
-            prevKey.m_channels[i].m_type = TDoubleKeyframe::Type(
-                Preferences::instance()->getKeyframeType());
-            newKey.m_channels[i].m_prevType = prevKey.m_channels[i].m_type;
-          }
-        }
-        pegbar->setKeyframeWithoutUndo(kL, prevKey);
-        pegbar->setKeyframeWithoutUndo(row, newKey);
-      } else if (row > kF) {
+      if (row > kF) {
         // If new key was added between existing keys, sync new key's previous
         // interpolation to key just before it
         if (!pegbar->getKeyframeSpan(row - 1, kP, e0, kN, e1)) kP = row - 1;
@@ -160,21 +146,7 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
     }
     // Process last key added in column
     if (itL != lastRowCol.end() && itL->second == row) {
-      if (row < kF) {
-        // If new key was added before the existing 1st one, create new
-        // interpolation between them using preference setting
-        TStageObject::Keyframe nextKey = pegbar->getKeyframe(kF);
-        for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-          if (newKey.m_channels[i].m_isKeyframe &&
-              nextKey.m_channels[i].m_isKeyframe) {
-            newKey.m_channels[i].m_type = TDoubleKeyframe::Type(
-                Preferences::instance()->getKeyframeType());
-            nextKey.m_channels[i].m_prevType = newKey.m_channels[i].m_type;
-          }
-        }
-        pegbar->setKeyframeWithoutUndo(row, newKey);
-        pegbar->setKeyframeWithoutUndo(kF, nextKey);
-      } else if (row < kL) {
+      if (row < kL) {
         // If new key was added between existing keys, sync new key to the next
         // key's previous interpolation
         if (!pegbar->getKeyframeSpan(row + 1, kP, e0, kN, e1)) kN = row + 1;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -5102,21 +5102,12 @@ void CellArea::createKeyLineMenu(QMenu &menu, int row, int col) {
     }
   }
 
-  TDoubleKeyframe::Type rType =
-      pegbar->getParam(TStageObject::T_X)->getKeyframeAt(r0).m_type;
-
-  if (rType != TDoubleKeyframe::Constant)
-    menu.addAction(cmdManager->getAction(MI_UseConstantInterpolation));
-  if (rType != TDoubleKeyframe::Linear)
-    menu.addAction(cmdManager->getAction(MI_UseLinearInterpolation));
-  if (rType != TDoubleKeyframe::SpeedInOut)
-    menu.addAction(cmdManager->getAction(MI_UseSpeedInOutInterpolation));
-  if (rType != TDoubleKeyframe::EaseInOut)
-    menu.addAction(cmdManager->getAction(MI_UseEaseInOutInterpolation));
-  if (rType != TDoubleKeyframe::EaseInOutPercentage)
-    menu.addAction(cmdManager->getAction(MI_UseEaseInOutPctInterpolation));
-  if (rType != TDoubleKeyframe::Exponential)
-    menu.addAction(cmdManager->getAction(MI_UseExponentialInterpolation));
+  menu.addAction(cmdManager->getAction(MI_UseConstantInterpolation));
+  menu.addAction(cmdManager->getAction(MI_UseLinearInterpolation));
+  menu.addAction(cmdManager->getAction(MI_UseSpeedInOutInterpolation));
+  menu.addAction(cmdManager->getAction(MI_UseEaseInOutInterpolation));
+  menu.addAction(cmdManager->getAction(MI_UseEaseInOutPctInterpolation));
+  menu.addAction(cmdManager->getAction(MI_UseExponentialInterpolation));
 
   if (col < 0) {
     menu.addSeparator();

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2258,6 +2258,8 @@ public:
 
     pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
 
+    if (r0 > r1) return;
+
     KeyFrameHandleCommandUndo *undo =
         new KeyFrameHandleCommandUndo(objectId, r0, r1);
 
@@ -2268,6 +2270,25 @@ public:
       k0.m_channels[i].m_type     = m_type;
       k1.m_channels[i].m_prevType = m_type;
     }
+
+    std::map<QString, SkVD::Keyframe> &vdfs0 =
+        k0.m_skeletonKeyframe.m_vertexKeyframes;
+    std::map<QString, SkVD::Keyframe> &vdfs1 =
+        k1.m_skeletonKeyframe.m_vertexKeyframes;
+
+    std::map<QString, SkVD::Keyframe>::iterator vdft0 = vdfs0.begin(),
+                                                vdfEnd0(vdfs0.end());
+    std::map<QString, SkVD::Keyframe>::iterator vdft1 = vdfs1.begin(),
+                                                vdfEnd1(vdfs1.end());
+    for (; vdft0 != vdfEnd0; ++vdft0, ++vdft1) {
+      for (int p = 0; p < SkVD::PARAMS_COUNT; ++p) {
+        TDoubleKeyframe &vkf0 = vdft0->second.m_keyframes[p];
+        TDoubleKeyframe &vkf1 = vdft1->second.m_keyframes[p];
+        vkf0.m_type = m_type;
+        vkf1.m_prevType = m_type;
+      }
+    }
+
     pegbar->setKeyframeWithoutUndo(r0, k0);
     pegbar->setKeyframeWithoutUndo(r1, k1);
 

--- a/toonz/sources/toonzlib/doubleparamcmd.cpp
+++ b/toonz/sources/toonzlib/doubleparamcmd.cpp
@@ -462,6 +462,7 @@ void KeyframeSetter::setType(int kIndex, TDoubleKeyframe::Type type) {
   std::map<int, TDoubleKeyframe> keyframes;
   switch (type) {
   case TDoubleKeyframe::SpeedInOut:
+    m_undo->addKeyframe(kIndex + 1);
     keyframe.m_speedOut    = TPointD(segmentWidth / 3, 0);
     nextKeyframe.m_speedIn = TPointD(-segmentWidth / 3, 0);
     if (nextKeyframe.m_linkedHandles && nextKeyframe.m_speedOut.x > 0.01)
@@ -476,6 +477,7 @@ void KeyframeSetter::setType(int kIndex, TDoubleKeyframe::Type type) {
 
   case TDoubleKeyframe::EaseInOut:
   case TDoubleKeyframe::EaseInOutPercentage:
+    m_undo->addKeyframe(kIndex + 1);
     if (keyframe.m_type == TDoubleKeyframe::EaseInOut) {
       // absolute -> percentage
       ease0 = keyframe.m_speedOut.x * 100.0 / segmentWidth;

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -319,7 +319,6 @@ bool touchEaseAndCompare(const TDoubleKeyframe &kf,
   } else if ((kf.m_type == TDoubleKeyframe::SpeedInOut ||
               kf.m_type == TDoubleKeyframe::EaseInOut) &&
              kf.m_type != type) {
-    stageKf.m_easeIn  = -1.0;
     stageKf.m_easeOut = -1.0;
     return false;
   }
@@ -330,8 +329,7 @@ bool touchEaseAndCompare(const TDoubleKeyframe &kf,
     if (stageKf.m_easeIn == -1)
       stageKf.m_easeIn = easeIn;
     else if (!areAlmostEqual(stageKf.m_easeIn, easeIn, 0.1)) {
-      stageKf.m_easeIn  = -1.0;
-      stageKf.m_easeOut = -1.0;
+      stageKf.m_easeIn = -1.0;
       return false;
     }
   }
@@ -342,7 +340,6 @@ bool touchEaseAndCompare(const TDoubleKeyframe &kf,
     if (stageKf.m_easeOut == -1)
       stageKf.m_easeOut = easeOut;
     else if (!areAlmostEqual(stageKf.m_easeOut, easeOut, 0.1)) {
-      stageKf.m_easeIn  = -1.0;
       stageKf.m_easeOut = -1.0;
       return false;
     }

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -26,6 +26,7 @@
 #include "tconvert.h"
 #include "tundo.h"
 #include "tconst.h"
+#include "tutil.h"
 
 // Qt includes
 #include <QMetaObject>
@@ -310,33 +311,42 @@ TPointD updateDagPosition(const TPointD &pos, const VersionNumber &tnzVersion) {
 bool touchEaseAndCompare(const TDoubleKeyframe &kf,
                          TStageObject::Keyframe &stageKf,
                          TDoubleKeyframe::Type &type) {
-  bool initialization = (type == TDoubleKeyframe::None);
 
-  if (initialization) type = kf.m_type;
-
-  if (kf.m_prevType != TDoubleKeyframe::SpeedInOut &&
-      kf.m_prevType != TDoubleKeyframe::EaseInOut) {
-    stageKf.m_easeIn = -1.0;
-  } else {
-    double easeIn = -kf.m_speedIn.x;
-    if (initialization)
-      stageKf.m_easeIn = easeIn;
-    else if (stageKf.m_easeIn != easeIn)
-      stageKf.m_easeIn = -1.0;
-  }
-
-  if (kf.m_type != TDoubleKeyframe::SpeedInOut &&
-      kf.m_type != TDoubleKeyframe::EaseInOut) {
+  if (type == TDoubleKeyframe::None) {
+    if (kf.m_type == TDoubleKeyframe::SpeedInOut ||
+        kf.m_type == TDoubleKeyframe::EaseInOut)
+      type = kf.m_type;
+  } else if ((kf.m_type == TDoubleKeyframe::SpeedInOut ||
+              kf.m_type == TDoubleKeyframe::EaseInOut) &&
+             kf.m_type != type) {
+    stageKf.m_easeIn  = -1.0;
     stageKf.m_easeOut = -1.0;
-  } else {
-    double easeOut = kf.m_speedOut.x;
-    if (initialization)
-      stageKf.m_easeOut = easeOut;
-    else if (stageKf.m_easeOut != easeOut)
-      stageKf.m_easeOut = -1.0;
+    return false;
   }
 
-  if (stageKf.m_easeIn == -1.0 && stageKf.m_easeOut == -1.0) return false;
+  if (kf.m_prevType == TDoubleKeyframe::SpeedInOut ||
+      kf.m_prevType == TDoubleKeyframe::EaseInOut) {
+    double easeIn = -kf.m_speedIn.x;
+    if (stageKf.m_easeIn == -1)
+      stageKf.m_easeIn = easeIn;
+    else if (!areAlmostEqual(stageKf.m_easeIn, easeIn, 0.1)) {
+      stageKf.m_easeIn  = -1.0;
+      stageKf.m_easeOut = -1.0;
+      return false;
+    }
+  }
+
+  if (kf.m_type == TDoubleKeyframe::SpeedInOut ||
+      kf.m_type == TDoubleKeyframe::EaseInOut) {
+    double easeOut = kf.m_speedOut.x;
+    if (stageKf.m_easeOut == -1)
+      stageKf.m_easeOut = easeOut;
+    else if (!areAlmostEqual(stageKf.m_easeOut, easeOut, 0.1)) {
+      stageKf.m_easeIn  = -1.0;
+      stageKf.m_easeOut = -1.0;
+      return false;
+    }
+  }
 
   return true;
 }
@@ -1598,7 +1608,7 @@ void TStageObject::updateKeyframes(LazyData &ld) const {
 
     std::map<QString, SkVD::Keyframe>::const_iterator vdft, vdfEnd(vdfs.end());
     for (vdft = vdfs.begin(); easeOk && vdft != vdfEnd; ++vdft) {
-      for (int p = 0; p < SkVD::PARAMS_COUNT; ++p) {
+      for (int p = 0; easeOk && p < SkVD::PARAMS_COUNT; ++p) {
         const TDoubleKeyframe &kf = vdft->second.m_keyframes[p];
         if (!kf.m_isKeyframe) continue;
 

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -328,9 +328,13 @@ bool touchEaseAndCompare(const TDoubleKeyframe &kf,
     double easeIn = -kf.m_speedIn.x;
     if (stageKf.m_easeIn == -1)
       stageKf.m_easeIn = easeIn;
-    else if (!areAlmostEqual(stageKf.m_easeIn, easeIn, 0.1)) {
-      stageKf.m_easeIn = -1.0;
-      return false;
+    else {
+      double easeInR      = tround(easeIn * 10) / 10.0;
+      double stageEaseInR = tround(stageKf.m_easeIn * 10) / 10.0;
+      if (stageEaseInR != easeInR) {
+        stageKf.m_easeIn = -1.0;
+        return false;
+      }
     }
   }
 
@@ -339,9 +343,13 @@ bool touchEaseAndCompare(const TDoubleKeyframe &kf,
     double easeOut = kf.m_speedOut.x;
     if (stageKf.m_easeOut == -1)
       stageKf.m_easeOut = easeOut;
-    else if (!areAlmostEqual(stageKf.m_easeOut, easeOut, 0.1)) {
-      stageKf.m_easeOut = -1.0;
-      return false;
+    else {
+      double easeOutInR    = tround(easeOut * 10) / 10.0;
+      double stageEaseOutR = tround(stageKf.m_easeOut * 10) / 10.0;
+      if (stageEaseOutR != easeOutInR) {
+        stageKf.m_easeOut = -1.0;
+        return false;
+      }
     }
   }
 

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -314,28 +314,29 @@ bool touchEaseAndCompare(const TDoubleKeyframe &kf,
 
   if (initialization) type = kf.m_type;
 
-  if (kf.m_type != type || (kf.m_type != TDoubleKeyframe::SpeedInOut &&
-                            kf.m_type != TDoubleKeyframe::EaseInOut &&
-                            (kf.m_prevType != TDoubleKeyframe::None &&
-                             kf.m_prevType != TDoubleKeyframe::SpeedInOut &&
-                             kf.m_prevType != TDoubleKeyframe::EaseInOut))) {
-    stageKf.m_easeIn  = -1.0;
-    stageKf.m_easeOut = -1.0;
-
-    return false;
+  if (kf.m_prevType != TDoubleKeyframe::SpeedInOut &&
+      kf.m_prevType != TDoubleKeyframe::EaseInOut) {
+    stageKf.m_easeIn = -1.0;
+  } else {
+    double easeIn = -kf.m_speedIn.x;
+    if (initialization)
+      stageKf.m_easeIn = easeIn;
+    else if (stageKf.m_easeIn != easeIn)
+      stageKf.m_easeIn = -1.0;
   }
 
-  double easeIn = -kf.m_speedIn.x;
-  if (initialization)
-    stageKf.m_easeIn = easeIn;
-  else if (stageKf.m_easeIn != easeIn)
-    stageKf.m_easeIn = -1.0;
-
-  double easeOut = kf.m_speedOut.x;
-  if (initialization)
-    stageKf.m_easeOut = easeOut;
-  else if (stageKf.m_easeOut != easeOut)
+  if (kf.m_type != TDoubleKeyframe::SpeedInOut &&
+      kf.m_type != TDoubleKeyframe::EaseInOut) {
     stageKf.m_easeOut = -1.0;
+  } else {
+    double easeOut = kf.m_speedOut.x;
+    if (initialization)
+      stageKf.m_easeOut = easeOut;
+    else if (stageKf.m_easeOut != easeOut)
+      stageKf.m_easeOut = -1.0;
+  }
+
+  if (stageKf.m_easeIn == -1.0 && stageKf.m_easeOut == -1.0) return false;
 
   return true;
 }

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -135,7 +135,7 @@ class KeyframesDeleteUndo final : public TUndo {
 public:
   struct ColumnKeyframes {
     TDoubleParam *m_param;
-    std::vector<TDoubleKeyframe> m_keyframes;
+    std::map<int, TDoubleKeyframe> m_keyframes;
   };
   struct Column {
     TDoubleParam *m_param;
@@ -151,7 +151,7 @@ public:
       const QSet<int> &keyframes = columns[col].m_keyframes;
       for (QSet<int>::const_iterator it = keyframes.begin();
            it != keyframes.end(); ++it)
-        m_columns[col].m_keyframes.push_back(param->getKeyframe(*it));
+        m_columns[col].m_keyframes[*it] = param->getKeyframe(*it);
     }
   }
   ~KeyframesDeleteUndo() {
@@ -164,16 +164,21 @@ public:
   }
 
   void undo() const override {
-    for (int col = 0; col < (int)m_columns.size(); col++)
-      for (int i = 0; i < (int)m_columns[col].m_keyframes.size(); i++)
-        m_columns[col].m_param->setKeyframe(m_columns[col].m_keyframes[i]);
+    for (int col = 0; col < (int)m_columns.size(); col++) {
+      std::map<int, TDoubleKeyframe>::const_iterator it,
+          itEnd(m_columns[col].m_keyframes.cend());
+      for (it = m_columns[col].m_keyframes.cbegin(); it != itEnd; ++it)
+        m_columns[col].m_param->setKeyframe(it->second);
+    }
     if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
   }
   void redo() const override {
-    for (int col = 0; col < (int)m_columns.size(); col++)
-      for (int i = 0; i < (int)m_columns[col].m_keyframes.size(); i++)
-        m_columns[col].m_param->deleteKeyframe(
-            m_columns[col].m_keyframes[i].m_frame);
+    for (int col = 0; col < (int)m_columns.size(); col++) {
+      std::map<int, TDoubleKeyframe>::const_iterator it,
+          itEnd(m_columns[col].m_keyframes.cend());
+      for (it = m_columns[col].m_keyframes.cbegin(); it != itEnd; ++it)
+        m_columns[col].m_param->deleteKeyframe(it->second.m_frame);
+    }
     if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
   }
   int getSize() const override {


### PR DESCRIPTION
This addresses the following issues as it relates to timeline/xsheet ease handles and interpolation:
- Fixed issue where handles were hidden or shown when it shouldn't due to incorrect storage of ease handle information.
- Fixed issue where handles were hidden due to multiple animated channels with mixed interpolation types
- Fixed issue where some ease values were not restored on undo of an interpolation change
- Allow changing interpolation type from timeline/xsheet for mesh keys
- Show all interpolation options in the timeline/xsheet context menu instead of hiding the "active" interpolation.
- Fixes setting the correct interpolation type information at end of channel keys
- Autocorrects the last channel key on loading to have the correct internal default interpolation type (Linear)

NOTE: There are valid reasons why ease handles may not show. Here are the conditions for displaying:
- Shows only for `Speed In/Out` and `Ease In/Out` interpolation types.
- For keys with multiple animated channels
  - 1 or more `Speed In/Out` or 1 or more `Ease In/Out` will show ease handles. A mix of both will not.  Other interpolation types are ignored.
  - The `Speed Out` (First Speed Handle)  or `Ease Out` values must all match on the left key
  - The `Speed In` (Last Speed Handle) or `Ease In` values must all match on the right key
