### PR TITLE
Fix reading xml tags with special characters

### DIFF
--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -676,7 +676,12 @@ bool TIStream::Imp::matchIdent(string &ident) {
   char c;
   is.get(c);
   ident.append(1, c);
-  while (c = is.peek(), isalnum(c) || c == '_' || c == '.' || c == '-') {
+  // Modified to allow for multi-byte characters on translated strings that
+  // might wind up in tags
+  // 
+  //while (c = is.peek(), isalnum(c) || c == '_' || c == '.' || c == '-') {
+  while (c = is.peek()) {
+    if (c == '>' || c == ' ' || c == '=' || (int)c == EOF) break;
     is.get(c);
     ident.append(1, c);
   }


### PR DESCRIPTION
This fixes an issue that was introduced with translation support changes for fx.  It currently impacts Spanish and Russian translation users who create new macroFx with the latest release.

When macro fx are created, the fx id is stored as part of an xml tag for the names of the input ports.  Fx ids are based on the original name of the fx which is now translatable.  Tags created with translated text can fail to be read properly when the translated text has multi-byte characters.

Changed the logic for reading tags to allow for multi-byte characters. Rather than ending the tag reading when it encounters a non-Alphanumeric character or certain allowed characters, it now looks for ">", " " (space), "=" or EOF (corrupted file?) to denote the end of the tag.

This change impacts reading of any xml-type file that T2D generates and reads like `tnz`, `tpl`, `macroFx` files.  If there is an issue detecting the end of a tag, I would expect an "invalid tag" error which will need to be researched further.