### PR TITLE
Fix looped frame logic crash

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1598,6 +1598,7 @@ public:
   void undo() const override {
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_c);
+    if (!column) return;
 
     column->removeLoop(m_r0, m_r1);
 
@@ -1607,7 +1608,7 @@ public:
   void redo() const override {
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_c);
-
+    if (!column) return;
     column->addLoop(m_r0, m_r1);
 
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -1636,7 +1637,7 @@ public:
   void undo() const override {
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_c);
-
+    if (!column) return;
     column->addLoop(m_r0, m_r1);
 
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -1645,6 +1646,7 @@ public:
   void redo() const override {
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_c);
+    if (!column) return;
 
     column->removeLoop(m_r0, m_r1);
 
@@ -3549,7 +3551,7 @@ void TCellSelection::duplicateFrame(int row, int col, bool multiple) {
   TXshCell prevCell   = xsh->getCell(row - 1, col);
 
   // check if we use the current cell to duplicate or the previous cell
-  if (!column->isLoopedFrame(row) && !targetCell.isEmpty() &&
+  if (column && !column->isLoopedFrame(row) && !targetCell.isEmpty() &&
       targetCell != prevCell) {
     // Current cell has a drawing to duplicate and it's not a hold shift focus
     // to next cell as if they selected that one to duplicate into
@@ -4752,7 +4754,7 @@ void TCellSelection::loopFrameRange(int col, int r0, int r1) {
   TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
   TXshColumn *column = xsh->getColumn(col);
 
-  if (column->isEmpty() || column->getSoundColumn() ||
+  if (!column || column->isEmpty() || column->getSoundColumn() ||
       column->getSoundTextColumn() || column->getFolderColumn())
     return;
 
@@ -4785,7 +4787,7 @@ void TCellSelection::removeFrameLoopRange(int col, int r0, int r1) {
   TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
   TXshColumn *column = xsh->getColumn(col);
 
-  if (!column->hasLoops()) return;
+  if (!column || !column->hasLoops()) return;
 
   if (column->isInLoopRange(r0)) {
     std::pair<int, int> loop = column->getLoopWithRow(r0);

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -747,6 +747,7 @@ ReframeUndo::ReframeUndo(int r0, int r1, std::vector<int> columnIndeces,
   for (auto colIndex : m_columnIndeces) {
     int rTo                = m_r1;
     TXshCellColumn *column = xsh->getColumn(colIndex)->getCellColumn();
+    if (!column) continue;
     int colLen0, colLen1;
     column->getRange(colLen0, colLen1);
     TXshCell tmpCell = column->getCell(m_r1, true, false);

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -1912,6 +1912,7 @@ void LoopColumnsUndo::redo() const {
 
   for (auto c : m_indices) {
     TXshColumn *column = xsh->getColumn(c);
+    if (!column) continue;
 
     int r0, r1;
     column->getRange(r0, r1);
@@ -1933,6 +1934,7 @@ void LoopColumnsUndo::undo() const {
 
   for (auto c : m_indices) {
     TXshColumn *column = xsh->getColumn(c);
+    if (!column) continue;
 
     QList<std::pair<int, int>> loops = column->getLoops();
 
@@ -2012,6 +2014,7 @@ void RemoveColumnLoopsUndo::initialize(const std::set<int> &indices) {
 
   for (auto c : indices) {
     TXshColumn *column = xsh->getColumn(c);
+    if (!column) continue;
 
     QList<std::pair<int, int>> loops = column->getLoops();
 
@@ -2029,6 +2032,7 @@ void RemoveColumnLoopsUndo::redo() const {
 
   for (auto c : m_columnLoops.keys()) {
     TXshColumn *column = xsh->getColumn(c);
+    if (!column) continue;
     for (auto loop : m_columnLoops[c]) {
       column->removeLoop(loop);
     }
@@ -2048,6 +2052,7 @@ void RemoveColumnLoopsUndo::undo() const {
 
   for (auto c : m_columnLoops.keys()) {
     TXshColumn *column = xsh->getColumn(c);
+    if (!column) continue;
     for (auto loop : m_columnLoops[c]) {
       column->addLoop(loop);
     }

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -75,13 +75,16 @@ public:
     const TXshCell &cell = xsh->getCell(row, col);
 
     int frameCount = xsh->getFrameCount();
-    if (row >= frameCount - 1) {
-      if (xsh->getColumn(col)->isLoopedFrame(row)) {
-        std::pair<int, int> loop = xsh->getColumn(col)->getLoopForRow(row);
-        frameCount = row + (loop.second - loop.first + 1);
-      } else if (xsh->getColumn(col)->isInLoopRange(row)) {
-        std::pair<int, int> loop = xsh->getColumn(col)->getLoopWithRow(row);
-        frameCount = row + (loop.second - loop.first + 1);
+    if (frameCount && row >= frameCount - 1) {
+      TXshColumn *column = xsh->getColumn(col);
+      if (column) {
+        if (column->isLoopedFrame(row)) {
+          std::pair<int, int> loop = column->getLoopForRow(row);
+          frameCount               = row + (loop.second - loop.first + 1);
+        } else if (column->isInLoopRange(row)) {
+          std::pair<int, int> loop = column->getLoopWithRow(row);
+          frameCount               = row + (loop.second - loop.first + 1);
+        }
       }
     }
 

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2051,7 +2051,7 @@ void CellArea::drawCellMarker(QPainter &p, int markId, QRect rect,
 void CellArea::drawLoopFrameMarker(QPainter &p, int row, int col) {
   TXshColumn *column = m_viewer->getXsheet()->getColumn(col);
 
-  if (!column->hasLoops()) return;
+  if (!column || !column->hasLoops()) return;
 
   QList<std::pair<int, int>> loops = column->getLoops();
 
@@ -2123,9 +2123,12 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
   bool isSimpleView = m_viewer->getFrameZoomFactor() <=
                       o->dimension(PredefinedDimension::SCALE_THRESHOLD);
 
-  bool isLoopedCell = cellColumn->isLoopedFrame(row);
-  std::pair<int, int> loopRange = cellColumn->getLoopForRow(row);
-  int loopR0 = loopRange.first, loopR1 = loopRange.second;
+  int loopR1        = -1;
+  bool isLoopedCell = cellColumn && cellColumn->isLoopedFrame(row);
+  if (isLoopedCell) {
+    std::pair<int, int> loopRange = cellColumn->getLoopForRow(row);
+    loopR1                        = loopRange.second;
+  }
 
   TXshCell cell = xsh->getCell(row, col);
 
@@ -2142,7 +2145,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
   if (row > 0) {
     prevCell       = xsh->getCell(prevFrame, col);  // cell in previous frame
     prevIsImplicit = xsh->isImplicitCell(prevFrame, col);
-    prevIsLooped   = cellColumn->isLoopedFrame(prevFrame);
+    prevIsLooped   = cellColumn && cellColumn->isLoopedFrame(prevFrame);
   }
 
   bool sameLevel = prevCell.m_level.getPointer() == cell.m_level.getPointer();

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -561,7 +561,7 @@ public:
           xsh->setCell(r, col, TXshCell());
         else {
           xsh->setCell(r, col, m_cells[k]);
-          if (column->isLoopStart(r + 1)) {
+          if (column && column->isLoopStart(r + 1)) {
             column->shiftStartLoop(r + 1, r0 - (r + 1));
           } 
         }
@@ -909,7 +909,7 @@ public:
         bool isSountTextColumn = (column && column->getSoundTextColumn());
         if (m_insert) {
           xsh->insertCells(m_r1 + 1, m_c0 + c, dr);
-          if (column->isLoopEnd(m_r1)) {
+          if (column && column->isLoopEnd(m_r1)) {
             xsh->shiftLoopMarkers(m_r1, m_c0 + c, dr);
             xsh->shiftCellMarks(m_r1 + 1, m_c0 + c, dr);
           } else
@@ -991,7 +991,7 @@ public:
             xsh->setCell(r, m_c0 + c, TXshCell());
           else {
             xsh->setCell(r, m_c0 + c, m_columns[c].generate(r));
-            if (column->isLoopStart(r + 1)) {
+            if (column && column->isLoopStart(r + 1)) {
               if (m_origStartLoop == -1) m_origStartLoop = r + 1;
               column->shiftStartLoop(r + 1, -1);
             }
@@ -2787,7 +2787,7 @@ public:
   void undo() const override {
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_col);
-
+    if (!column) return;
     column->removeLoop(m_newLoop);
     column->addLoop(m_oldLoop);
 
@@ -2797,7 +2797,7 @@ public:
   void redo() const override {
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_col);
-
+    if (!column) return;
     column->removeLoop(m_oldLoop);
     column->addLoop(m_newLoop);
 
@@ -2832,6 +2832,7 @@ public:
     m_markerRow        = row;
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_targetCol);
+    if (!column) return;
     m_newLoop          = column->getLoopWithRow(m_markerRow);
     m_oldLoop          = m_newLoop;
     refreshCellsArea();
@@ -2854,6 +2855,7 @@ public:
 
     TXsheet *xsh       = TApp::instance()->getCurrentXsheet()->getXsheet();
     TXshColumn *column = xsh->getColumn(m_targetCol);
+    if (!column) return;
 
     QList<std::pair<int, int>> loops = column->getLoops();
 


### PR DESCRIPTION
This fixes crashes related to looped frame logic being used on non-existent columns.

There was some logic missing to check for a valid column before attempting to get loop information.