### PR TITLE
Additional fixes for timeline/xsheet ease handles and interpolation

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3406,39 +3406,36 @@ void CellArea::drawKeyframe(QPainter &p, const QRect toBeUpdated) {
                                   ease1)) {
         drawKeyframeLine(p, col, NumberRange(segmentRow0, segmentRow1));
 
-        if (segmentRow1 - segmentRow0 >
-            3) {  // only show if distance more than 4 frames
-          int handleRow0, handleRow1;
-          if (getEaseHandles(segmentRow0, segmentRow1, ease0, ease1, handleRow0,
-                             handleRow1)) {
-            QRect easeRect = tmpKeyRect;
-            if (!Preferences::instance()->isShowDragBarsEnabled() &&
-                !o->isVerticalTimeline()) {
-              int adjust = col < 0 ? -1 : -1;
-              easeRect.adjust(0, adjust, 0, adjust);
-            }
-
-            if (o->isVerticalTimeline()) easeRect.adjust(-2, 0, -2, 0);
-            QPoint topLeft =
-                m_viewer->positionToXY(CellPosition(handleRow0, col));
-            PredefinedPath easePath =
-                (m_keyHighlight == QPoint(handleRow0, col))
-                    ? PredefinedPath::BEGIN_EASE_TRIANGLE_LARGE
-                    : PredefinedPath::BEGIN_EASE_TRIANGLE;
-
-            m_viewer->drawPredefinedPath(p, easePath,
-                                         easeRect.translated(topLeft).center(),
-                                         keyFrameColor, outline);
-
-            topLeft  = m_viewer->positionToXY(CellPosition(handleRow1, col));
-            easePath = (m_keyHighlight == QPoint(handleRow1, col))
-                           ? PredefinedPath::END_EASE_TRIANGLE_LARGE
-                           : PredefinedPath::END_EASE_TRIANGLE;
-
-            m_viewer->drawPredefinedPath(p, easePath,
-                                         easeRect.translated(topLeft).center(),
-                                         keyFrameColor, outline);
+        int handleRow0, handleRow1;
+        if (getEaseHandles(segmentRow0, segmentRow1, ease0, ease1, handleRow0,
+                           handleRow1)) {
+          QRect easeRect = tmpKeyRect;
+          if (!Preferences::instance()->isShowDragBarsEnabled() &&
+              !o->isVerticalTimeline()) {
+            int adjust = col < 0 ? -1 : -1;
+            easeRect.adjust(0, adjust, 0, adjust);
           }
+
+          if (o->isVerticalTimeline()) easeRect.adjust(-2, 0, -2, 0);
+          QPoint topLeft =
+              m_viewer->positionToXY(CellPosition(handleRow0, col));
+          PredefinedPath easePath =
+              (m_keyHighlight == QPoint(handleRow0, col))
+                  ? PredefinedPath::BEGIN_EASE_TRIANGLE_LARGE
+                  : PredefinedPath::BEGIN_EASE_TRIANGLE;
+
+          m_viewer->drawPredefinedPath(p, easePath,
+                                       easeRect.translated(topLeft).center(),
+                                       keyFrameColor, outline);
+
+          topLeft  = m_viewer->positionToXY(CellPosition(handleRow1, col));
+          easePath = (m_keyHighlight == QPoint(handleRow1, col))
+                         ? PredefinedPath::END_EASE_TRIANGLE_LARGE
+                         : PredefinedPath::END_EASE_TRIANGLE;
+
+          m_viewer->drawPredefinedPath(p, easePath,
+                                       easeRect.translated(topLeft).center(),
+                                       keyFrameColor, outline);
         }
         // skip to next segment
         row = segmentRow1 - 1;
@@ -3612,7 +3609,7 @@ void CellArea::drawNotes(QPainter &p, const QRect toBeUpdated) {
 
 bool CellArea::getEaseHandles(int r0, int r1, double e0, double e1, int &rh0,
                               int &rh1) {
-  if (r1 <= r0 + 3) {  // ... what?
+  if (r1 - r0 <= 2) {  // Don't show if there is only 1 frame between keys
     rh0 = r0;
     rh1 = r1;
     return false;
@@ -3649,6 +3646,7 @@ bool CellArea::getEaseHandles(int r0, int r1, double e0, double e1, int &rh0,
     assert(a <= b);
     rh1 = tcrop((int)(r1 - e1 + 0.5), a, b);
   }
+  if (rh0 == rh1) rh1++; // Make sure handles dont overlap
   return true;
 }
 
@@ -3772,15 +3770,11 @@ bool CellArea::isKeyFrameArea(int col, int row, QPoint mouseInCell,
   int r0, r1;
   double e0, e1;
   if (pegbar->getKeyframeSpan(row, r0, e0, r1, e1)) {
-    if (r1 - r0 > 2) {
-      int rh0, rh1;
-      if (getEaseHandles(r0, r1, e0, e1, rh0, rh1)) {
-        if (row == rh0 && easeRect.contains(mouseInCell))
-          return true;
+    int rh0, rh1;
+    if (getEaseHandles(r0, r1, e0, e1, rh0, rh1)) {
+      if (row == rh0 && easeRect.contains(mouseInCell)) return true;
 
-        if (row == rh1 && easeRect.contains(mouseInCell))
-          return true;
-      }
+      if (row == rh1 && easeRect.contains(mouseInCell)) return true;
     }
   }
 

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2266,9 +2266,26 @@ public:
     TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
     TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
 
+    double segmentWidth = r1 - r0;
+    switch (m_type) {
+    case TDoubleKeyframe::SpeedInOut:
+    case TDoubleKeyframe::EaseInOut:
+    case TDoubleKeyframe::EaseInOutPercentage:
+      if (ease0 == -1 && ease1 == -1) {
+        ease0 = segmentWidth / 3.0;
+        ease1 = -ease0;
+      }
+      break;
+    default:
+      ease0 = ease1 = 0;
+      break;
+    }
+
     for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
       k0.m_channels[i].m_type     = m_type;
+      k0.m_channels[i].m_speedOut  = TPointD(ease0, 0);
       k1.m_channels[i].m_prevType = m_type;
+      k1.m_channels[i].m_speedIn  = TPointD(ease1, 0);
     }
 
     std::map<QString, SkVD::Keyframe> &vdfs0 =
@@ -2284,13 +2301,16 @@ public:
       for (int p = 0; p < SkVD::PARAMS_COUNT; ++p) {
         TDoubleKeyframe &vkf0 = vdft0->second.m_keyframes[p];
         TDoubleKeyframe &vkf1 = vdft1->second.m_keyframes[p];
-        vkf0.m_type = m_type;
-        vkf1.m_prevType = m_type;
+        vkf0.m_type           = m_type;
+        vkf0.m_speedOut       = TPointD(ease0, 0);
+        vkf1.m_prevType       = m_type;
+        vkf1.m_speedIn        = TPointD(ease1, 0);
       }
     }
 
     pegbar->setKeyframeWithoutUndo(r0, k0);
     pegbar->setKeyframeWithoutUndo(r1, k1);
+    pegbar->updateKeyframes();
 
     TUndoManager::manager()->add(undo);
 


### PR DESCRIPTION
A follow-up to #2104, a few more fixes to timeline/xsheet ease handles.

- When setting interpolation from timeline/xsheet, the default easing values are set similar to changing interpolation from Function Editor
   - In case of multiple ease handles existing values will be used.
- Now shows ease handles even when there are only 2 frames between keys.
