### PR TITLE
Animate drawing substitution

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1084,6 +1084,7 @@
   <item>W_ShearH		"Shear H"		</item>
   <item>W_ShearV		"Shear V"		</item>
   <item>W_Scale			"Scale"			</item>
+  <item>W_DrawingNumber			"Drawing #"			</item>
   
 <!------------------------------ Ino FXs ------------------------------------------->
 

--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -479,7 +479,6 @@ void TDoubleParam::copy(TParam *src) {
   if (!p) throw TException("invalid source for copy");
   setName(src->getName());
   m_imp->copy(p->m_imp);
-  
   m_imp->notify(TParamChange(this, 0, 0, true, false, false));
 }
 
@@ -1201,8 +1200,6 @@ is >> m_imp->m_defaultValue;
     }
     if (!is.matchEndTag()) throw TException(tagName + " : missing endtag");
   }
-
-
   if (m_imp->m_keyframes.empty() && !is.eos()) {
     // vecchio sistema (prima 16/1/2003)
     while (!is.eos()) {

--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -663,6 +663,8 @@ double TDoubleParam::getValue(double frame, bool leftmost) const {
     if (convertUnit) value = a->convertFrom(m_imp->m_measure, value);
   }
 
+  if (getName() == "W_DrawingNumber" && value < 0) value = 0;
+
   // if (cropped)
   //  value = tcrop(value, m_imp->m_minValue, m_imp->m_maxValue);
   return value;
@@ -738,6 +740,9 @@ void TDoubleParam::setKeyframe(int index, const TDoubleKeyframe &k) {
   TActualDoubleKeyframe &dst        = keyframes[index];
   TActualDoubleKeyframe oldKeyframe = dst;
 
+  int minFrame = std::min(oldKeyframe.m_frame, k.m_frame);
+  int maxFrame = std::max(oldKeyframe.m_frame, k.m_frame);
+
   (TDoubleKeyframe &)dst = k;
   dst.updateUnit(m_imp->m_measure);
 
@@ -747,7 +752,7 @@ void TDoubleParam::setKeyframe(int index, const TDoubleKeyframe &k) {
   if (dst.m_type == TDoubleKeyframe::File)
     dst.m_fileData.setParams(dst.m_fileParams);
 
-  m_imp->notify(TParamChange(this, k.m_frame, k.m_frame, true, false, false));
+  m_imp->notify(TParamChange(this, minFrame, maxFrame, true, false, false));
 
   assert(0 == index || keyframes[index - 1].m_frame < keyframes[index].m_frame);
   assert(getKeyframeCount() - 1 == index ||
@@ -767,8 +772,8 @@ void TDoubleParam::setKeyframes(const std::map<int, TDoubleKeyframe> &ks) {
   DoubleKeyframeVector &keyframes = m_imp->m_keyframes;
 
   std::map<int, TDoubleKeyframe>::const_iterator it;
-  int minFrame      = 0; 
-  int maxFrame      = INT_MAX; 
+  int minFrame      = INT_MAX; 
+  int maxFrame      = -1; 
   auto updateMinMax = [&](int frame) {
     minFrame = std::min(minFrame, frame);
     maxFrame = std::max(maxFrame, frame);
@@ -780,6 +785,8 @@ void TDoubleParam::setKeyframes(const std::map<int, TDoubleKeyframe> &ks) {
     TActualDoubleKeyframe oldKeyframe = keyframes[index];
     TActualDoubleKeyframe &dst        = keyframes[index];
 
+    updateMinMax(oldKeyframe.m_frame);
+
     (TDoubleKeyframe &)dst = it->second;
     dst.updateUnit(m_imp->m_measure);
 
@@ -788,6 +795,7 @@ void TDoubleParam::setKeyframes(const std::map<int, TDoubleKeyframe> &ks) {
       dst.m_expression.setText(dst.m_expressionText);
     if (dst.m_type == TDoubleKeyframe::File)
       dst.m_fileData.setParams(dst.m_fileParams);
+    updateMinMax(dst.m_frame);
   }
   if (!keyframes.empty()) {
     keyframes[0].m_prevType = TDoubleKeyframe::None;
@@ -1070,8 +1078,8 @@ is >> m_imp->m_defaultValue;
 
   m_imp->m_keyframes.clear();
   int oldType = -1;
-  int minFrame = -1;
-  int maxFrame = INT_MAX; 
+  int minFrame = INT_MAX;
+  int maxFrame = -1; 
 
   auto updateMinMax = [&](int frame) {
     minFrame = std::min(minFrame, frame);

--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -479,7 +479,7 @@ void TDoubleParam::copy(TParam *src) {
   if (!p) throw TException("invalid source for copy");
   setName(src->getName());
   m_imp->copy(p->m_imp);
-
+  
   m_imp->notify(TParamChange(this, 0, 0, true, false, false));
 }
 
@@ -690,7 +690,7 @@ bool TDoubleParam::setValue(double frame, double value) {
 
     it->m_value = value;
 
-    m_imp->notify(TParamChange(this, 0, 0, true, false, false));
+    m_imp->notify(TParamChange(this, frame, frame, true, false, false));
   }
   /*-- It is a segment, so create a new keyframe. --*/
   else {
@@ -720,7 +720,7 @@ bool TDoubleParam::setValue(double frame, double value) {
 
     index = std::distance(keyframes.begin(), it);
 
-    m_imp->notify(TParamChange(this, 0, 0, true, false, false));
+    m_imp->notify(TParamChange(this, frame, frame, true, false, false));
     created = true;
   }
   assert(0 == index || keyframes[index - 1].m_frame < keyframes[index].m_frame);
@@ -748,7 +748,7 @@ void TDoubleParam::setKeyframe(int index, const TDoubleKeyframe &k) {
   if (dst.m_type == TDoubleKeyframe::File)
     dst.m_fileData.setParams(dst.m_fileParams);
 
-  m_imp->notify(TParamChange(this, 0, 0, true, false, false));
+  m_imp->notify(TParamChange(this, k.m_frame, k.m_frame, true, false, false));
 
   assert(0 == index || keyframes[index - 1].m_frame < keyframes[index].m_frame);
   assert(getKeyframeCount() - 1 == index ||
@@ -768,6 +768,12 @@ void TDoubleParam::setKeyframes(const std::map<int, TDoubleKeyframe> &ks) {
   DoubleKeyframeVector &keyframes = m_imp->m_keyframes;
 
   std::map<int, TDoubleKeyframe>::const_iterator it;
+  int minFrame      = 0; 
+  int maxFrame      = INT_MAX; 
+  auto updateMinMax = [&](int frame) {
+    minFrame = std::min(minFrame, frame);
+    maxFrame = std::max(maxFrame, frame);
+  };
   for (it = ks.begin(); it != ks.end(); ++it) {
     int index = it->first;
     assert(0 <= index && index < (int)keyframes.size());
@@ -790,7 +796,7 @@ void TDoubleParam::setKeyframes(const std::map<int, TDoubleKeyframe> &ks) {
       keyframes[i].m_prevType = keyframes[i - 1].m_type;
   }
 
-  m_imp->notify(TParamChange(this, 0, 0, true, false, false));
+  m_imp->notify(TParamChange(this, minFrame, maxFrame, true, false, false));
 
 #ifndef NDEBUG
   for (int i = 0; i + 1 < (int)keyframes.size(); i++) {
@@ -842,7 +848,7 @@ void TDoubleParam::setKeyframe(const TDoubleKeyframe &k) {
 
   if (it + 1 != keyframes.end()) it[1].m_prevType = it->m_type;
 
-  m_imp->notify(TParamChange(this, 0, 0, true, false, false));
+  m_imp->notify(TParamChange(this, k.m_frame, k.m_frame, true, false, false));
 
   assert(it == keyframes.begin() || (it - 1)->m_frame < it->m_frame);
   assert(it + 1 == keyframes.end() || (it + 1)->m_frame > it->m_frame);
@@ -935,7 +941,7 @@ void TDoubleParam::deleteKeyframe(double frame) {
   else if (m_imp->m_keyframes.size())  // end was deleted
     keyframes.rbegin()->m_type = TDoubleKeyframe::Linear;
 
-  m_imp->notify(TParamChange(this, 0, 0, true, false, false));
+  m_imp->notify(TParamChange(this, frame, frame, true, false, false));
 }
 
 //---------------------------------------------------------
@@ -1065,6 +1071,14 @@ is >> m_imp->m_defaultValue;
 
   m_imp->m_keyframes.clear();
   int oldType = -1;
+  int minFrame = -1;
+  int maxFrame = INT_MAX; 
+
+  auto updateMinMax = [&](int frame) {
+    minFrame = std::min(minFrame, frame);
+    maxFrame = std::max(maxFrame, frame);
+  };
+
   while (is.matchTag(tagName)) {
     if (tagName == "type") {
       // (old) format 5.2. Since 6.0 param type is no used anymore
@@ -1087,6 +1101,7 @@ is >> m_imp->m_defaultValue;
       k.m_isKeyframe    = true;
       k.m_linkedHandles = (linkStatus & 1) != 0;
 
+      updateMinMax(k.m_frame); 
       if ((linkStatus & 1) != 0)
         k.m_type = TDoubleKeyframe::SpeedInOut;
       else if ((linkStatus & 2) != 0 || (linkStatus & 4) != 0)
@@ -1099,6 +1114,7 @@ is >> m_imp->m_defaultValue;
                          ? TDoubleKeyframe::None
                          : m_imp->m_keyframes.back().m_type;
       m_imp->m_keyframes.push_back(k);
+      updateMinMax(k.m_frame); 
     } else if (tagName == "expr") {
       // vecchio formato
       if (oldType != 1) continue;
@@ -1127,6 +1143,8 @@ is >> m_imp->m_defaultValue;
                           : m_imp->m_keyframes.back().m_type;
       m_imp->m_keyframes.push_back(k1);
       m_imp->m_keyframes.push_back(k2);
+      updateMinMax(k1.m_frame); 
+      updateMinMax(k2.m_frame); 
       continue;
     } else if (tagName == "file") {
       // vecchio formato
@@ -1155,6 +1173,8 @@ is >> m_imp->m_defaultValue;
                           : m_imp->m_keyframes.back().m_type;
       m_imp->m_keyframes.push_back(k1);
       m_imp->m_keyframes.push_back(k2);
+      updateMinMax(k1.m_frame);
+      updateMinMax(k2.m_frame); 
       continue;
     } else if (tagName == "step") {
       int step = 0;
@@ -1174,18 +1194,22 @@ is >> m_imp->m_defaultValue;
                            ? TDoubleKeyframe::None
                            : m_imp->m_keyframes.back().m_type;
         m_imp->m_keyframes.push_back(k);
+        updateMinMax(k.m_frame); 
       }
     } else {
       throw TException(tagName + " : unexpected tag");
     }
     if (!is.matchEndTag()) throw TException(tagName + " : missing endtag");
   }
+
+
   if (m_imp->m_keyframes.empty() && !is.eos()) {
     // vecchio sistema (prima 16/1/2003)
     while (!is.eos()) {
       double t, v;
       is >> t >> v;
       m_imp->m_keyframes.push_back(TActualDoubleKeyframe(t, v));
+      updateMinMax(t);
     }
     if (!m_imp->m_keyframes.empty()) {
       m_imp->m_keyframes[0].m_prevType = TDoubleKeyframe::None;
@@ -1200,7 +1224,7 @@ is >> m_imp->m_defaultValue;
       m_imp->m_keyframes.rbegin()->m_type = TDoubleKeyframe::Linear;
   }
 
-  m_imp->notify(TParamChange(this, 0, 0, true, false, false));
+  m_imp->notify(TParamChange(this, minFrame, maxFrame, true, false, false));
 }
 
 //---------------------------------------------------------

--- a/toonz/sources/include/tdoubleparam.h
+++ b/toonz/sources/include/tdoubleparam.h
@@ -154,6 +154,7 @@ public:
   std::string getStreamTag() const;
 
   std::string getValueAlias(double frame, int precision) override;
+
 };
 
 DVAPI void splitSpeedInOutSegment(TDoubleKeyframe &k, TDoubleKeyframe &k0,

--- a/toonz/sources/include/tdoubleparam.h
+++ b/toonz/sources/include/tdoubleparam.h
@@ -154,7 +154,6 @@ public:
   std::string getStreamTag() const;
 
   std::string getValueAlias(double frame, int precision) override;
-
 };
 
 DVAPI void splitSpeedInOutSegment(TDoubleKeyframe &k, TDoubleKeyframe &k0,

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -239,7 +239,9 @@ class ArrowToolOptionsBox final : public ToolOptionsBox {
 
   ToolOptionCheckbox *m_lockEWPosCheckbox;
   ToolOptionCheckbox *m_lockNSPosCheckbox;
-
+  // Drawing Number 
+  ClickableLabel *m_drawingNumberLabel;
+  PegbarChannelField *m_drawingNumberField;
   // SO = Stacked Order
   ClickableLabel *m_soLabel;
   PegbarChannelField *m_soField;

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -208,7 +208,15 @@ public:
 class ArrowToolOptionsBox final : public ToolOptionsBox {
   Q_OBJECT
 
-  enum AXIS { Position = 0, Rotation, Scale, Shear, CenterPosition, AllAxis };
+  enum AXIS {
+    Position = 0,
+    Rotation,
+    Scale,
+    Shear,
+    DrawingNumber,
+    CenterPosition,
+    AllAxis
+  };
 
   TPropertyGroup *m_pg;
   bool m_splined;

--- a/toonz/sources/include/toonz/tstageobject.h
+++ b/toonz/sources/include/toonz/tstageobject.h
@@ -340,17 +340,15 @@ object.
   //! global scale channel.
   bool is52FullKeyframe(int frame) const;
 
+  bool hasDrawingNumberKey(int frame) const;
+  bool isChannelInterpolated(TStageObject::Channel channel, int frame);
+
   /*!
 Retrieves from the list of the keyframes a keyframe object
 (TStageObject::Keyframe) associated
 with the frame.
 */
   Keyframe getKeyframe(int frame) const;
-
-  bool setKeyframe(const TDoubleParamP &param, const TDoubleKeyframe &kf, int frame, 
-    const double &easeIn, const double &easeOut);
-
-  void setkey(const TDoubleParamP &param, int frame);
 
   void setKeyframeWithoutUndo(int frame, const Keyframe &);
   void setKeyframeWithoutUndo(int frame);
@@ -526,13 +524,6 @@ the table, camera is in the table for cameraZ = -1000.
   double paramsTime(
       double t) const;  //!< Traduces the xsheet-time into the one suitable
   //!< for param values extraction (dealing with repeat/cycling)
-  struct KeyFrameMarker {
-    int start;
-    int end;
-    KeyFrameMarker(int aStart, int aEnd) : start(aStart), end(aEnd) {}
-  };
-
-  KeyFrameMarker* tryDequeueKeyFrameChangeRangeQueue(); 
 
 private:
   // Lazily updated data
@@ -545,11 +536,6 @@ private:
   };
 
 private:
-  
-  // Key frame range queue is a queue only for updates involving drawing numbers. It is not used for any other types of
-  // of keyframes . 
-  QQueue<KeyFrameMarker> keyFrameChangeRangeQueue;
-  
   tcg::invalidable<LazyData> m_lazyData;
 
   TStageObjectId m_id;

--- a/toonz/sources/include/toonz/tstageobject.h
+++ b/toonz/sources/include/toonz/tstageobject.h
@@ -95,8 +95,6 @@ responsibility of the
   TStageObjectTree class.
 */
 
-
-
 class DVAPI TStageObject final : public TSmartObject, public TParamObserver {
   DECLARE_CLASS_CODE
 
@@ -618,7 +616,6 @@ private:
   void updateKeyframes(LazyData &ld) const;
 
   void onChange(const class TParamChange &c) override;
-
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/toonz/tstageobject.h
+++ b/toonz/sources/include/toonz/tstageobject.h
@@ -14,12 +14,15 @@
 
 // TnzLib includes
 #include "tstageobjectid.h"
+#include "toonz/txshcell.h"
+#include "toonz/txsheet.h"
 
 // tcg includes
 #include "tcg/tcg_controlled_access.h"
 
 // Qt includes
 #include <QStack>
+#include <QQueue>
 
 #undef DVAPI
 #undef DVVAR
@@ -92,6 +95,8 @@ responsibility of the
   TStageObjectTree class.
 */
 
+
+
 class DVAPI TStageObject final : public TSmartObject, public TParamObserver {
   DECLARE_CLASS_CODE
 
@@ -100,6 +105,18 @@ public:
 Used to describe the object status - ie how the object can move.
 The default value is XY.
 */
+  using DrawingNumberCallback = std::function<void(const TParamChange&)>;
+
+  class DrawingNumberObserver final : TParamObserver {
+
+    public:
+    DrawingNumberCallback m_callback;
+    DrawingNumberObserver() {}; 
+    void onChange(const TParamChange &c) override;
+  };
+  DrawingNumberObserver m_drawingNumberObserver; 
+  void setDrawingNumberCallback(DrawingNumberCallback callback);
+
   enum Status {
     XY,            //!< The object can move freely on a plane
     PATH     = 1,  //!< The movement take place on a spline
@@ -131,7 +148,8 @@ The default value is XY.
              //! of the spline
     T_ShearX,  //!< Shear along x-axis
     T_ShearY,  //!< Shear along y-axis
-    T_ChannelCount
+    T_DrawingNumber,
+    T_ChannelCount,
   };
 
   /*!
@@ -331,6 +349,11 @@ with the frame.
 */
   Keyframe getKeyframe(int frame) const;
 
+  bool setKeyframe(const TDoubleParamP &param, const TDoubleKeyframe &kf, int frame, 
+    const double &easeIn, const double &easeOut);
+
+  void setkey(const TDoubleParamP &param, int frame);
+
   void setKeyframeWithoutUndo(int frame, const Keyframe &);
   void setKeyframeWithoutUndo(int frame);
   void removeKeyframeWithoutUndo(int frame);
@@ -371,6 +394,11 @@ Returns the object's depth at specified frame.
 
   //!	Returns the object's stacking order at specified frame.
   double getSO(double frame);
+
+  //!	Returns the object's drawing number at specified frame.
+  double getDrawingNumber(double frame);
+
+  TParamP getDrawingNumberParamP() { return m_drawingnumber;  }
 
   //! Returns the absolute depth with no scale factor.
   double getGlobalNoScaleZ() const;
@@ -500,6 +528,13 @@ the table, camera is in the table for cameraZ = -1000.
   double paramsTime(
       double t) const;  //!< Traduces the xsheet-time into the one suitable
   //!< for param values extraction (dealing with repeat/cycling)
+  struct KeyFrameMarker {
+    int start;
+    int end;
+    KeyFrameMarker(int aStart, int aEnd) : start(aStart), end(aEnd) {}
+  };
+
+  KeyFrameMarker* tryDequeueKeyFrameChangeRangeQueue(); 
 
 private:
   // Lazily updated data
@@ -512,6 +547,11 @@ private:
   };
 
 private:
+  
+  // Key frame range queue is a queue only for updates involving drawing numbers. It is not used for any other types of
+  // of keyframes . 
+  QQueue<KeyFrameMarker> keyFrameChangeRangeQueue;
+  
   tcg::invalidable<LazyData> m_lazyData;
 
   TStageObjectId m_id;
@@ -528,7 +568,7 @@ private:
   Status m_status;
 
   TDoubleParamP m_x, m_y, m_z, m_so, m_rot, m_scalex, m_scaley, m_scale,
-      m_posPath, m_shearx, m_sheary;
+      m_posPath, m_shearx, m_sheary, m_drawingnumber; 
 
   PlasticSkeletonDeformationP
       m_skeletonDeformation;  //!< Deformation curves for a plastic skeleton
@@ -578,6 +618,7 @@ private:
   void updateKeyframes(LazyData &ld) const;
 
   void onChange(const class TParamChange &c) override;
+
 };
 
 //-----------------------------------------------------------------------------
@@ -612,7 +653,7 @@ public:
   std::string m_handle, m_parentHandle;
   TPinnedRangeSet *m_pinnedRangeSet;
   TDoubleParamP m_x, m_y, m_z, m_so, m_rot, m_scalex, m_scaley, m_scale,
-      m_posPath, m_shearx, m_sheary;
+      m_posPath, m_shearx, m_sheary, m_drawingnumber;
   PlasticSkeletonDeformationP
       m_skeletonDeformation;  //!< Deformation curves for a plastic skeleton
   double m_noScaleZ;

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -17,6 +17,7 @@
 #include "tparamchange.h"
 
 #include "cellposition.h"
+#include "tstageobject.h"
 
 // STD includes
 #include <set>
@@ -282,21 +283,23 @@ public:
   */
   int getMaxFrame(int col) const;
 
-  void getUpdateRange(int col, int frame, QPair<int, int> *output, int channel);
+  void getUpdateRanges(int col, int frame, int endFrame,
+                       std::vector<QPair<int, int>> *output, int channel);
 
-  void updateNonZeroDrawingNumberCellsParam(int colNumber, const TParamChange &c);
+  void updateNonZeroDrawingNumberCellsParam(TXshColumn *column,
+                                            const TParamChange &c);
 
-  void updateNonZeroDrawingNumberCellsAfterMoving(int col, int frameAfter,
-                                                  int dt);
+  bool updateNonZeroDrawingNumberCellsBox(int r, int c0, int c1);
 
-  bool updateNonZeroDrawingNumberCellsBox(
-      int r0, int c0, int r1, int c1,
-      std::vector<std::pair<TRect, TXshCell>> &m_undoCells);
-  void updateNonZeroDrawingNumberCellsBox(
-      int r0, int c0, int r1, int c1);
+  void updateNonZeroDrawingNumberCells(int col, int frame = 0, int endFrame = -1);
 
-  void updateNonZeroDrawingNumberCells(int col, int frame = 0,
-                                       int frameEnd = INT_MAX, int keyframeStart = -1, int keyFrameEnd = -1);
+  bool addUndoDrawingNumberChange(int row, TStageObjectId objId);
+  bool addUndoDrawingNumberChange(int row, int col, std::set<double> frames,
+                                  std::vector<TXshCell> cells);
+
+  void restoreDrawings(int col, int from, int to, TXsheet *xsh,
+                       QMap<int, std::vector<TXshCell>> drawings);
+
   /*! Returns true if xsheet column identified by \b \e col is empty, it calls
           \b TXshColumn::isEmpty(), otherwise returns false.
   */
@@ -503,8 +506,9 @@ frame duplication.
   void insertColumn(int index,
                     TXshColumn::ColumnType type = TXshColumn::eLevelType);
   void addDrawingNumberObserversAll();
-  void addDrawingNumberObserver(int col, TXshColumn *column);
-  void removeDrawingNumberObserver(int col, TXshColumn *column);
+  void addDrawingNumberObserver(TXshColumn *column);
+  void removeDrawingNumberObserversAll();
+  void removeDrawingNumberObserver(TXshColumn *column);
   /*! Insert \b \e column in column \b \e index. Insert column in the column
      set, in the
           pegbarTree \b TStageObjectTree contained in TXsheetImp and if column

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -14,6 +14,7 @@
 #include "toonz/txshcolumn.h"
 #include "toonz/txshlevel.h"
 #include "toonz/txsheetcolumnchange.h"
+#include "tparamchange.h"
 
 #include "cellposition.h"
 
@@ -280,6 +281,22 @@ public:
           \sa getFrameCount()
   */
   int getMaxFrame(int col) const;
+
+  void getUpdateRange(int col, int frame, QPair<int, int> *output, int channel);
+
+  void updateNonZeroDrawingNumberCellsParam(int colNumber, const TParamChange &c);
+
+  void updateNonZeroDrawingNumberCellsAfterMoving(int col, int frameAfter,
+                                                  int dt);
+
+  bool updateNonZeroDrawingNumberCellsBox(
+      int r0, int c0, int r1, int c1,
+      std::vector<std::pair<TRect, TXshCell>> &m_undoCells);
+  void updateNonZeroDrawingNumberCellsBox(
+      int r0, int c0, int r1, int c1);
+
+  void updateNonZeroDrawingNumberCells(int col, int frame = 0,
+                                       int frameEnd = INT_MAX, int keyframeStart = -1, int keyFrameEnd = -1);
   /*! Returns true if xsheet column identified by \b \e col is empty, it calls
           \b TXshColumn::isEmpty(), otherwise returns false.
   */
@@ -485,6 +502,9 @@ frame duplication.
    */
   void insertColumn(int index,
                     TXshColumn::ColumnType type = TXshColumn::eLevelType);
+  void addDrawingNumberObserversAll();
+  void addDrawingNumberObserver(int col, TXshColumn *column);
+  void removeDrawingNumberObserver(int col, TXshColumn *column);
   /*! Insert \b \e column in column \b \e index. Insert column in the column
      set, in the
           pegbarTree \b TStageObjectTree contained in TXsheetImp and if column

--- a/toonz/sources/include/toonzqt/functionkeyframenavigator.h
+++ b/toonz/sources/include/toonzqt/functionkeyframenavigator.h
@@ -9,12 +9,14 @@
 #include <QToolBar>
 class FunctionPanel;
 class TFrameHandle;
+class TColumnHandle;
 class FrameNavigator;
 
 class DVAPI FunctionKeyframeNavigator final : public KeyframeNavigator {
   Q_OBJECT
   TDoubleParamP m_curve;
   TXsheetHandle *m_xsheetHandle;
+  TColumnHandle *m_columnHandle;
 
 public:
   FunctionKeyframeNavigator(QWidget *parent);
@@ -23,6 +25,10 @@ public:
 
   void setXsheetHandle(TXsheetHandle *xsheetHandle) {
     m_xsheetHandle = xsheetHandle;
+  }
+
+  void setColumnHandle(TColumnHandle *columnHandle) {
+    m_columnHandle = columnHandle;
   }
 
 protected:

--- a/toonz/sources/include/toonzqt/functionpanel.h
+++ b/toonz/sources/include/toonzqt/functionpanel.h
@@ -27,6 +27,7 @@ class TDoubleParam;
 class TDoubleKeyframe;
 class TFrameHandle;
 class FunctionSelection;
+class FunctionSheet;
 
 //-----------------------------------------------------------------------------
 
@@ -96,6 +97,7 @@ private:
   TFrameHandle *m_frameHandle;
   TXsheetHandle *m_xsheetHandle;
   FunctionTreeModel *m_functionTreeModel;
+  FunctionSheet *m_sheet;
 
   int m_currentFrameStatus;
 
@@ -138,6 +140,9 @@ public:
     m_xsheetHandle = xsheetHandle;
   }
   TXsheetHandle *getXsheetHandle() const { return m_xsheetHandle; }
+
+  void setFunctionSheet(FunctionSheet *sheet) { m_sheet = sheet; }
+  FunctionSheet *getFunctionSheet() const { return m_sheet; }
 
   QTransform getViewTransform() const { return m_viewTransform; }
   void setViewTransform(const QTransform &viewTransform) {

--- a/toonz/sources/include/toonzqt/functionselection.h
+++ b/toonz/sources/include/toonzqt/functionselection.h
@@ -29,6 +29,7 @@
 // forward declaration
 class TDoubleParam;
 class TFrameHandle;
+class FunctionSheet;
 
 //-----------------------------------------------------------------------------
 
@@ -54,6 +55,7 @@ class FunctionSelection final : public QObject, public TSelection {
   TFrameHandle *m_frameHandle;
   TXsheetHandle *m_xsheetHandle;
   ColumnToCurveMapper *m_columnToCurveMapper;
+  FunctionSheet *m_sheet;
 
   int getCurveIndex(TDoubleParam *curve) const;
   // finds i : m_selectedKeyframes[i].first == curve
@@ -71,7 +73,8 @@ public:
   void setXsheetHandle(TXsheetHandle *xsheetHandle) {
     m_xsheetHandle = xsheetHandle;
   }
-
+  void setFunctionSheet(FunctionSheet *sheet) { m_sheet = sheet; }
+ 
   // function graph
   void selectCurve(TDoubleParam *curve);
   void deselectAllKeyframes();

--- a/toonz/sources/include/toonzqt/functiontoolbar.h
+++ b/toonz/sources/include/toonzqt/functiontoolbar.h
@@ -31,6 +31,7 @@
 
 class TDoubleParam;
 class TFrameHandle;
+class TColumnHandle;
 
 namespace DVGui {
 class MeasuredDoubleLineEdit;
@@ -69,6 +70,7 @@ class FunctionToolbar final : public DVGui::ToolBar, public TParamObserver {
   TDoubleParam *m_curve;
   TFrameHandle *m_frameHandle;
   TXsheetHandle *m_xsheetHandle;
+  TColumnHandle *m_columnHandle;
 
   FunctionSelection *m_selection;
 
@@ -85,6 +87,7 @@ public:
   void setSelection(FunctionSelection *);
   void setFrameHandle(TFrameHandle *frameHandle);
   void setXsheetHandle(TXsheetHandle *xsheetHandle);
+  void setColumnHandle(TColumnHandle *columnHandle);
 
   void onChange(const TParamChange &) override;
 

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -173,7 +173,6 @@ public:
       m_before.add(TStageObject::T_X);
       m_before.add(TStageObject::T_Y);
       m_before.add(TStageObject::T_Z);
-      m_before.add(TStageObject::T_DrawingNumber);
       m_before.add(TStageObject::T_SO);
       m_before.add(TStageObject::T_ScaleX);
       m_before.add(TStageObject::T_ScaleY);
@@ -200,7 +199,6 @@ public:
       m_before.add(TStageObject::T_X);
       m_before.add(TStageObject::T_Y);
       m_before.add(TStageObject::T_Z);
-      m_before.add(TStageObject::T_DrawingNumber);
       m_before.add(TStageObject::T_SO);
       m_before.add(TStageObject::T_ScaleX);
       m_before.add(TStageObject::T_ScaleY);
@@ -266,7 +264,7 @@ public:
 // DragPositionTool
 //-----------------------------------------------------------------------------
 
-class DragPositionTool : public DragChannelTool {
+class DragPositionTool final : public DragChannelTool {
   bool m_lockPositionX;
   bool m_lockPositionY;
 
@@ -605,62 +603,85 @@ public:
 // DragZTool
 //-----------------------------------------------------------------------------
 
-
-class DragZTool : public DragChannelTool {
+class DragZTool final : public DragChannelTool {
   TPointD m_lastPos;
   TTool::Viewer *m_viewer;
   double m_dz;
-  double m_dx;
-  double i_x; 
 
 public:
-  int currentDrawingNumber    = 0;
-  bool affectingDrawingNumber = false; 
-
   DragZTool(TTool::Viewer *viewer, bool globalKeyframesEnabled)
-      : DragChannelTool(TStageObject::T_Z, TStageObject::T_DrawingNumber,  globalKeyframesEnabled)
+      : DragChannelTool(TStageObject::T_Z, globalKeyframesEnabled)
       , m_viewer(viewer) {}
  
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override {
     m_lastPos  = e.m_pos;
     m_firstPos = pos;
     m_dz       = 0;
-    m_dx       = 0; 
-    i_x                  = 0; 
-    //currentDrawingNumber = getOldValue(1); 
     start();
-  }
-  void updateDrawingNumber() { 
-    //currentDrawingNumber = getOldValue(1); 
-  }
-  void setCurrentDrawingNumber(double val) {
-    int dn = std::max(0, (int)std::round(val));
-    setValues(getOldValue(0) + m_dx, dn);
-    currentDrawingNumber = dn; 
-    i_x                  = dn; 
-  }
-  void shiftToggle() { 
-    affectingDrawingNumber = !affectingDrawingNumber;
   }
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override {
     double dz = m_viewer->projectToZ(e.m_pos - m_lastPos);
     double dx = (e.m_pos - m_lastPos).x * 0.07;
     // precise control with pressing Alt key
-    if (e.isAltPressed()) {
-      dz *= 0.1;
-      dx *= 0.1;
-    }
+    if (e.isAltPressed()) dz *= 0.1;
     m_lastPos = e.m_pos;
 
-    if (affectingDrawingNumber && dx != 0.0) {
-      m_dx += dx; 
-    } else if (!affectingDrawingNumber && dz != 0.0) {
+    if (dz != 0.0) {
       m_dz += dz;
+      setValue(getOldValue(0) + m_dz);
     }
-    int dn = std::max(0, (int)std::round(i_x + getOldValue(1) + m_dx));
-    setValues(getOldValue(0) + m_dz, dn);
+  }
+};
 
-    currentDrawingNumber = dn; 
+//=============================================================================
+// DragDrawingNumberTool
+//-----------------------------------------------------------------------------
+
+class DragDrawingNumberTool final : public DragChannelTool {
+  bool m_firstMove;
+
+public:
+  DragDrawingNumberTool()
+      : DragChannelTool(TStageObject::T_DrawingNumber, false)
+      , m_firstMove(true) {}
+
+  void leftButtonDown(const TPointD &pos, const TMouseEvent &) override {
+    start();
+    m_firstPos = pos;
+  }
+  void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override {
+    if (m_firstMove) {
+      m_firstMove = false;
+
+      TApplication *app    = TTool::getApplication();
+      TXsheet *xsh         = app->getCurrentXsheet()->getXsheet();
+      int frame            = app->getCurrentFrame()->getFrameIndex();
+      TStageObjectId objId = app->getCurrentObject()->getObjectId();
+
+      TStageObject *stgObj = xsh->getStageObject(objId);
+
+      TStageObject::KeyframeMap keyframes;
+      stgObj->getKeyframes(keyframes);
+      if (!keyframes.size() || frame < keyframes.begin()->first ||
+          frame > keyframes.rbegin()->first) {
+        int col       = objId.getIndex();
+        TXshCell cell = xsh->getCell(frame, col, true, true);
+        if (!cell.isEmpty() && !cell.getFrameId().isStopFrame()) {
+          int frameIdNum = cell.getFrameId().getNumber();
+          m_before.setValue(frameIdNum);
+          m_after.setValue(frameIdNum);
+        }
+        xsh->addUndoDrawingNumberChange(frame, objId);
+      }
+    }
+
+    TPointD delta = pos - m_firstPos;
+
+    double factor = 1.0 / Stage::inch;
+
+    double v0 = getOldValue(0) + delta.x * factor;
+    if (v0 < 0.0) v0 = 0;
+    setValues(v0, getOldValue(1) + delta.y * factor);
   }
 };
 
@@ -702,7 +723,7 @@ EditTool::EditTool()
     , m_lockGlobalScale("Lock Global Scale", false)
     , m_showEWNSposition("X and Y Positions", true)
     , m_showZposition("Z Position", true)
-    , m_showDrawingNumber("Drawing Number", true)
+    , m_showDrawingNumber("Drawing #", true)
     , m_showSOposition("SO", true)
     , m_showRotation("Rotation", true)
     , m_showGlobalScale("Global Scale", true)
@@ -712,8 +733,7 @@ EditTool::EditTool()
     , m_dragTool(0)
     , m_firstTime(true)
     , m_activeAxis("Active Axis")
-    , m_isAltPressed(false)
-    , m_isShiftPressed(false) {
+    , m_isAltPressed(false) {
   bind(TTool::AllTargets);
   m_prop.bind(m_scaleConstraint);
   m_prop.bind(m_autoSelect);
@@ -758,6 +778,7 @@ EditTool::EditTool()
   m_activeAxis.addValue(L"Rotation", "edit_rotation");
   m_activeAxis.addValue(L"Scale", "edit_scale");
   m_activeAxis.addValue(L"Shear", "edit_shear");
+  m_activeAxis.addValue(L"Drawing #", "edit_drawingnumber");
   m_activeAxis.addValue(L"Center", "edit_center");
   m_activeAxis.addValue(L"All", "edit_all");
   m_activeAxis.setValue(L"Position");
@@ -798,7 +819,7 @@ void EditTool::updateTranslation() {
   m_lockGlobalScale.setQStringName(tr("Lock Global Scale"));
   m_showEWNSposition.setQStringName(tr("X and Y Positions"));
   m_showZposition.setQStringName(tr("Z Position"));
-  m_showDrawingNumber.setQStringName(tr("Drawing Number"));
+  m_showDrawingNumber.setQStringName(tr("Drawing #"));
   m_showSOposition.setQStringName(tr("SO"));
   m_showRotation.setQStringName(tr("Rotation"));
   m_showGlobalScale.setQStringName(tr("Global Scale"));
@@ -811,6 +832,7 @@ void EditTool::updateTranslation() {
   m_activeAxis.setItemUIName(L"Rotation", tr("Rotation"));
   m_activeAxis.setItemUIName(L"Scale", tr("Scale"));
   m_activeAxis.setItemUIName(L"Shear", tr("Shear"));
+  m_activeAxis.setItemUIName(L"Drawing #", tr("Drawing #"));
   m_activeAxis.setItemUIName(L"Center", tr("Center"));
   m_activeAxis.setItemUIName(L"All", tr("All"));
 }
@@ -854,13 +876,6 @@ const TStroke *EditTool::getSpline() const {
 //-----------------------------------------------------------------------------
 
 void EditTool::mouseMove(const TPointD &, const TMouseEvent &e) {
-  DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool);
-  if (ztool != nullptr) {
-    if (m_isShiftJustPressed) ztool->shiftToggle();
-    currentDrawingNumberDisplay = ztool->currentDrawingNumber;
-  } 
-  
-  
   /*-- return while left dragging --*/
   if (e.isLeftButtonPressed()) return;
 
@@ -890,23 +905,7 @@ void EditTool::mouseMove(const TPointD &, const TMouseEvent &e) {
   }
 
   // for adding decoration to the cursor while pressing Alt key
-  m_isAltPressed   = e.isAltPressed();
-  m_isShiftPressed = e.isShiftPressed();
-
-  //DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool);
-  if (m_isShiftJustPressed)
-    m_isShiftJustPressed = false;
-  else if (m_isShiftPressed)
-    m_isShiftJustPressed = true;
-
-  if (m_isShiftJustPressed) {
-    if (ztool) {
-      ztool->shiftToggle();
-      isDisplayingDrawingNumber = ztool->affectingDrawingNumber;
-    } else {
-      isDisplayingDrawingNumber = !isDisplayingDrawingNumber;
-    }
-  }
+  m_isAltPressed = e.isAltPressed();
 }
 
 //-----------------------------------------------------------------------------
@@ -986,27 +985,10 @@ void EditTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
       break;
     case ZTranslation:
       m_dragTool = new DragZTool(m_viewer, m_globalKeyframes.getValue());
-      DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool); 
-      if (isDisplayingDrawingNumber) {
-        ztool->shiftToggle(); 
-      }
-      int currentCol =
-          TTool::getApplication()->getCurrentColumn()->getColumnIndex();
-      int currentFrame = TTool::getApplication()->getCurrentFrame()->getFrame();
-      TXshCell cell =
-          TTool::getApplication()->getCurrentXsheet()->getXsheet()->getCell(
-              currentFrame, currentCol);
+      break;
 
-      int cellNum = cell.getFrameId().getNumber(); 
-      if (cellNum == -1) cellNum = 0; 
-      TStageObject* pegbar = TTool::getApplication()
-          ->getCurrentXsheet()
-          ->getXsheet()
-          ->getStageObjectTree()
-          ->getStageObject(currentCol);
-      //if (pegbar && pegbar->getDrawingNumber(currentFrame) == 0) cellNum = 0; 
-      ztool->setCurrentDrawingNumber(cellNum); 
-      currentDrawingNumberDisplay = ztool->currentDrawingNumber;
+    case DrawingNumber:
+      if (getObjectId().isColumn()) m_dragTool = new DragDrawingNumberTool();
       break;
     }
   }
@@ -1418,6 +1400,18 @@ void EditTool::drawMainHandle() {
   tglColor(normalColor);
   tglDrawSegment(p, center);
 
+  // draw drawing number handle
+  p = center + unit * TPointD(0, -delta);
+  tglColor(m_highlightedDevice == DrawingNumber ? highlightedColor
+                                                : normalColor);
+  glPushName(DrawingNumber);
+  drawText(p + TPointD(-unit * 18, 0), unit, "#");
+  glPopName();
+  if (m_highlightedDevice == DrawingNumber && !dragging)
+    drawText(p + TPointD(0, -unit * 10), unit, "Drawing Number");
+  tglColor(normalColor);
+  tglDrawSegment(p + TPointD(0, unit * 11), center);
+
   //
   if (objId.isCamera()) {
     if (xsh->getStageObjectTree()->getCurrentCameraId() != objId) {
@@ -1519,56 +1513,7 @@ void EditTool::draw() {
     tglMultMatrix(camParentAff.inv() *
                   TTranslation(camAff * TPointD(0.0, 0.0)));
     glScaled(unit * 8, unit * 8, 1);
-
-    DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool); 
-    if (!ztool) {
-      int currentCol =
-          TTool::getApplication()->getCurrentColumn()->getColumnIndex();
-      int currentFrame = TTool::getApplication()->getCurrentFrame()->getFrame();
-      TXshCell cell =
-          TTool::getApplication()->getCurrentXsheet()->getXsheet()->getCell(
-              currentFrame, currentCol);
-
-      int cellNum          = cell.getFrameId().getNumber();
-      if (cellNum == -1) cellNum = 0; 
-      TStageObject *pegbar = TTool::getApplication()
-                                 ->getCurrentXsheet()
-                                 ->getXsheet()
-                                 ->getStageObjectTree()
-                                 ->getStageObject(TStageObjectId::ColumnId(currentCol));
-      if (pegbar && pegbar->getDrawingNumber(currentFrame) == 0) cellNum = 0; 
-      //if (pegbar) cellNum = pegbar->getParam(TStageObject::T_DrawingNumber)->getValue(currentFrame);
-      currentDrawingNumberDisplay = cellNum;
-    }
-
-    if (ztool && ztool->affectingDrawingNumber) {
-      currentDrawingNumberDisplay = ztool->currentDrawingNumber;
-    }
-
-
-    if (isDisplayingDrawingNumber)
-    {
-      glPushMatrix();   
-      glScaled(0.5,0.5,0.5);
-      drawDrawingNumberBox();
-      // Inside your draw() or onDraw() method of a tool:
-      double unit = 0.5;  // or something like viewer->getPixelSize()
-      TPointD pos(0, unit * 20);  // Position in world coordinates
-     
-      std::string label;
-      label = "ID: " + std::to_string(currentDrawingNumberDisplay);
-
-      drawText(pos, unit, label);
-      glPopMatrix(); 
-    }
-    else
-    {
-      drawZArrow();
-    }
-   
-
-    
-
+    drawZArrow();
     glPopMatrix();
   }
   /*-- Rotation, Position : Draw vertical and horizontal lines --*/
@@ -1795,6 +1740,8 @@ bool EditTool::onPropertyChanged(std::string propertyName) {
       m_what = Scale;
     else if (activeAxis == L"Shear")
       m_what = Shear;
+    else if (activeAxis == L"Drawing #")
+      m_what = DrawingNumber;
     else if (activeAxis == L"Center")
       m_what = Center;
     else if (activeAxis == L"All")
@@ -1868,6 +1815,10 @@ int EditTool::getCursorId() const {
         ret = ToolCursor::MoveEWCursor;
       else
         ret = ToolCursor::MoveCursor;
+    } else if (activeAxis == L"Drawing #") {
+      if (!getObjectId().isColumn()) 
+        return ToolCursor::DisableCursor;
+      ret = ToolCursor::MoveEWCursor;
     } else
       ret = ToolCursor::StrokeSelectCursor;
   } else

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -619,11 +619,8 @@ public:
 
   DragZTool(TTool::Viewer *viewer, bool globalKeyframesEnabled)
       : DragChannelTool(TStageObject::T_Z, TStageObject::T_DrawingNumber,  globalKeyframesEnabled)
-      , m_viewer(viewer) {
-
-  }
-  
-
+      , m_viewer(viewer) {}
+ 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override {
     m_lastPos  = e.m_pos;
     m_firstPos = pos;
@@ -1054,7 +1051,7 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
             TStageObjectId colId = xsh->getColumnObjectId(columnIndex);
             TStageObjectCmd::setParent(curColId, colId, "", xshHandle);
             m_what = None;
-            xshHandle->notifyXsheetChanged();  
+            xshHandle->notifyXsheetChanged();
           } else {
             TXshColumn *column = xsh->getColumn(columnIndex);
             if (!column || !column->isLocked()) {
@@ -1078,7 +1075,6 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
 void EditTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
   if (!m_dragTool) return;
   m_dragTool->leftButtonDrag(pos, e);
-
   TTool::getApplication()->getCurrentObject()->notifyObjectIdChanged(true);
   invalidate();
 }

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -55,6 +55,7 @@ TEnv::IntVar LockGlobalScale("EditToolLockGlobalScale", 0);
 
 TEnv::IntVar ShowEWNSposition("EditToolShowEWNSposition", 1);
 TEnv::IntVar ShowZposition("EditToolShowZposition", 1);
+TEnv::IntVar ShowDrawingNumber("EditToolShowDrawingNumber", 0);
 TEnv::IntVar ShowSOposition("EditToolShowSOposition", 1);
 TEnv::IntVar ShowRotation("EditToolShowRotation", 1);
 TEnv::IntVar ShowGlobalScale("EditToolShowGlobalScale", 1);
@@ -172,6 +173,7 @@ public:
       m_before.add(TStageObject::T_X);
       m_before.add(TStageObject::T_Y);
       m_before.add(TStageObject::T_Z);
+      m_before.add(TStageObject::T_DrawingNumber);
       m_before.add(TStageObject::T_SO);
       m_before.add(TStageObject::T_ScaleX);
       m_before.add(TStageObject::T_ScaleY);
@@ -198,6 +200,7 @@ public:
       m_before.add(TStageObject::T_X);
       m_before.add(TStageObject::T_Y);
       m_before.add(TStageObject::T_Z);
+      m_before.add(TStageObject::T_DrawingNumber);
       m_before.add(TStageObject::T_SO);
       m_before.add(TStageObject::T_ScaleX);
       m_before.add(TStageObject::T_ScaleY);
@@ -263,7 +266,7 @@ public:
 // DragPositionTool
 //-----------------------------------------------------------------------------
 
-class DragPositionTool final : public DragChannelTool {
+class DragPositionTool : public DragChannelTool {
   bool m_lockPositionX;
   bool m_lockPositionY;
 
@@ -602,31 +605,65 @@ public:
 // DragZTool
 //-----------------------------------------------------------------------------
 
-class DragZTool final : public DragChannelTool {
+
+class DragZTool : public DragChannelTool {
   TPointD m_lastPos;
   TTool::Viewer *m_viewer;
   double m_dz;
+  double m_dx;
+  double i_x; 
 
 public:
+  int currentDrawingNumber    = 0;
+  bool affectingDrawingNumber = false; 
+
   DragZTool(TTool::Viewer *viewer, bool globalKeyframesEnabled)
-      : DragChannelTool(TStageObject::T_Z, globalKeyframesEnabled)
-      , m_viewer(viewer) {}
+      : DragChannelTool(TStageObject::T_Z, TStageObject::T_DrawingNumber,  globalKeyframesEnabled)
+      , m_viewer(viewer) {
+
+  }
+  
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override {
     m_lastPos  = e.m_pos;
     m_firstPos = pos;
     m_dz       = 0;
+    m_dx       = 0; 
+    i_x                  = 0; 
+    //currentDrawingNumber = getOldValue(1); 
     start();
+  }
+  void updateDrawingNumber() { 
+    //currentDrawingNumber = getOldValue(1); 
+  }
+  void setCurrentDrawingNumber(double val) {
+    int dn = std::max(0, (int)std::round(val));
+    setValues(getOldValue(0) + m_dx, dn);
+    currentDrawingNumber = dn; 
+    i_x                  = dn; 
+  }
+  void shiftToggle() { 
+    affectingDrawingNumber = !affectingDrawingNumber;
   }
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override {
     double dz = m_viewer->projectToZ(e.m_pos - m_lastPos);
+    double dx = (e.m_pos - m_lastPos).x * 0.07;
     // precise control with pressing Alt key
-    if (e.isAltPressed()) dz *= 0.1;
-    m_lastPos = e.m_pos;
-    if (dz != 0.0) {
-      m_dz += dz;
-      setValue(getOldValue(0) + m_dz);
+    if (e.isAltPressed()) {
+      dz *= 0.1;
+      dx *= 0.1;
     }
+    m_lastPos = e.m_pos;
+
+    if (affectingDrawingNumber && dx != 0.0) {
+      m_dx += dx; 
+    } else if (!affectingDrawingNumber && dz != 0.0) {
+      m_dz += dz;
+    }
+    int dn = std::max(0, (int)std::round(i_x + getOldValue(1) + m_dx));
+    setValues(getOldValue(0) + m_dz, dn);
+
+    currentDrawingNumber = dn; 
   }
 };
 
@@ -668,6 +705,7 @@ EditTool::EditTool()
     , m_lockGlobalScale("Lock Global Scale", false)
     , m_showEWNSposition("X and Y Positions", true)
     , m_showZposition("Z Position", true)
+    , m_showDrawingNumber("Drawing Number", true)
     , m_showSOposition("SO", true)
     , m_showRotation("Rotation", true)
     , m_showGlobalScale("Global Scale", true)
@@ -677,7 +715,8 @@ EditTool::EditTool()
     , m_dragTool(0)
     , m_firstTime(true)
     , m_activeAxis("Active Axis")
-    , m_isAltPressed(false) {
+    , m_isAltPressed(false)
+    , m_isShiftPressed(false) {
   bind(TTool::AllTargets);
   m_prop.bind(m_scaleConstraint);
   m_prop.bind(m_autoSelect);
@@ -696,6 +735,7 @@ EditTool::EditTool()
 
   m_prop.bind(m_showEWNSposition);
   m_prop.bind(m_showZposition);
+  m_prop.bind(m_showDrawingNumber);
   m_prop.bind(m_showSOposition);
   m_prop.bind(m_showRotation);
   m_prop.bind(m_showGlobalScale);
@@ -761,6 +801,7 @@ void EditTool::updateTranslation() {
   m_lockGlobalScale.setQStringName(tr("Lock Global Scale"));
   m_showEWNSposition.setQStringName(tr("X and Y Positions"));
   m_showZposition.setQStringName(tr("Z Position"));
+  m_showDrawingNumber.setQStringName(tr("Drawing Number"));
   m_showSOposition.setQStringName(tr("SO"));
   m_showRotation.setQStringName(tr("Rotation"));
   m_showGlobalScale.setQStringName(tr("Global Scale"));
@@ -816,6 +857,13 @@ const TStroke *EditTool::getSpline() const {
 //-----------------------------------------------------------------------------
 
 void EditTool::mouseMove(const TPointD &, const TMouseEvent &e) {
+  DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool);
+  if (ztool != nullptr) {
+    if (m_isShiftJustPressed) ztool->shiftToggle();
+    currentDrawingNumberDisplay = ztool->currentDrawingNumber;
+  } 
+  
+  
   /*-- return while left dragging --*/
   if (e.isLeftButtonPressed()) return;
 
@@ -845,7 +893,23 @@ void EditTool::mouseMove(const TPointD &, const TMouseEvent &e) {
   }
 
   // for adding decoration to the cursor while pressing Alt key
-  m_isAltPressed = e.isAltPressed();
+  m_isAltPressed   = e.isAltPressed();
+  m_isShiftPressed = e.isShiftPressed();
+
+  //DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool);
+  if (m_isShiftJustPressed)
+    m_isShiftJustPressed = false;
+  else if (m_isShiftPressed)
+    m_isShiftJustPressed = true;
+
+  if (m_isShiftJustPressed) {
+    if (ztool) {
+      ztool->shiftToggle();
+      isDisplayingDrawingNumber = ztool->affectingDrawingNumber;
+    } else {
+      isDisplayingDrawingNumber = !isDisplayingDrawingNumber;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -925,6 +989,27 @@ void EditTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
       break;
     case ZTranslation:
       m_dragTool = new DragZTool(m_viewer, m_globalKeyframes.getValue());
+      DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool); 
+      if (isDisplayingDrawingNumber) {
+        ztool->shiftToggle(); 
+      }
+      int currentCol =
+          TTool::getApplication()->getCurrentColumn()->getColumnIndex();
+      int currentFrame = TTool::getApplication()->getCurrentFrame()->getFrame();
+      TXshCell cell =
+          TTool::getApplication()->getCurrentXsheet()->getXsheet()->getCell(
+              currentFrame, currentCol);
+
+      int cellNum = cell.getFrameId().getNumber(); 
+      if (cellNum == -1) cellNum = 0; 
+      TStageObject* pegbar = TTool::getApplication()
+          ->getCurrentXsheet()
+          ->getXsheet()
+          ->getStageObjectTree()
+          ->getStageObject(currentCol);
+      //if (pegbar && pegbar->getDrawingNumber(currentFrame) == 0) cellNum = 0; 
+      ztool->setCurrentDrawingNumber(cellNum); 
+      currentDrawingNumberDisplay = ztool->currentDrawingNumber;
       break;
     }
   }
@@ -969,7 +1054,7 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
             TStageObjectId colId = xsh->getColumnObjectId(columnIndex);
             TStageObjectCmd::setParent(curColId, colId, "", xshHandle);
             m_what = None;
-            xshHandle->notifyXsheetChanged();
+            xshHandle->notifyXsheetChanged();  
           } else {
             TXshColumn *column = xsh->getColumn(columnIndex);
             if (!column || !column->isLocked()) {
@@ -993,6 +1078,7 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
 void EditTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
   if (!m_dragTool) return;
   m_dragTool->leftButtonDrag(pos, e);
+
   TTool::getApplication()->getCurrentObject()->notifyObjectIdChanged(true);
   invalidate();
 }
@@ -1085,6 +1171,69 @@ void drawCameraIcon() {
   glVertex2i(5, 6);
   glVertex2i(5, 0);
   glEnd();
+}
+
+void drawSimpleArrowNoBack() { 
+  glBegin(GL_LINE_STRIP);
+  glVertex2f(5, 3);
+  glVertex2f(-3, 3);
+  glVertex2f(-3, 6);
+  glVertex2f(-8, 0);
+  glVertex2f(-3, -6);
+  glVertex2f(-3, -3);
+  glVertex2f(5, -3);
+  //glVertex2f(5, 3);
+  glEnd();
+}
+void drawTwoSidedArrow() {
+  glBegin(GL_LINE_STRIP);
+  glVertex2f(5, 3);
+  glVertex2f(-3, 3);
+  glVertex2f(-3, 6);
+  glVertex2f(-8, 0);
+  glVertex2f(-3, -6);
+  glVertex2f(-3, -3);
+  glVertex2f(5, -3);
+  //glVertex2f(5, 3);
+  glEnd();
+}
+
+
+void drawDrawingNumberBox() {
+  /*
+  glBegin(GL_LINE_LOOP);
+  glVertex2i(-5,-5);
+  glVertex2i(5, -5);
+  glVertex2i(5, 5);
+  glVertex2i(-5, 5);
+  glEnd();
+  */
+  /*
+  glPushMatrix(); 
+  glTranslatef(-10, 0, 0);
+  drawSimpleArrow(); 
+
+  glPopMatrix(); 
+
+  glPushMatrix();
+  glRotatef(180, 0, 0, 1);  
+  glTranslatef(-10, 0, 0);
+  drawSimpleArrow();
+  glPopMatrix(); 
+  */
+
+  int dist = -5; 
+  glPushMatrix();
+  glTranslatef(0, 0, 0);
+  glTranslatef(dist, 0, 0);
+  drawSimpleArrowNoBack(); 
+  glRotatef(180,0,0,1.0);
+  glTranslatef(2 * dist, 0, 0);
+  drawSimpleArrowNoBack(); 
+
+  glPopMatrix();
+
+  
 }
 
 void drawZArrow() {
@@ -1374,7 +1523,56 @@ void EditTool::draw() {
     tglMultMatrix(camParentAff.inv() *
                   TTranslation(camAff * TPointD(0.0, 0.0)));
     glScaled(unit * 8, unit * 8, 1);
-    drawZArrow();
+
+    DragZTool *ztool = dynamic_cast<DragZTool *>(m_dragTool); 
+    if (!ztool) {
+      int currentCol =
+          TTool::getApplication()->getCurrentColumn()->getColumnIndex();
+      int currentFrame = TTool::getApplication()->getCurrentFrame()->getFrame();
+      TXshCell cell =
+          TTool::getApplication()->getCurrentXsheet()->getXsheet()->getCell(
+              currentFrame, currentCol);
+
+      int cellNum          = cell.getFrameId().getNumber();
+      if (cellNum == -1) cellNum = 0; 
+      TStageObject *pegbar = TTool::getApplication()
+                                 ->getCurrentXsheet()
+                                 ->getXsheet()
+                                 ->getStageObjectTree()
+                                 ->getStageObject(TStageObjectId::ColumnId(currentCol));
+      if (pegbar && pegbar->getDrawingNumber(currentFrame) == 0) cellNum = 0; 
+      //if (pegbar) cellNum = pegbar->getParam(TStageObject::T_DrawingNumber)->getValue(currentFrame);
+      currentDrawingNumberDisplay = cellNum;
+    }
+
+    if (ztool && ztool->affectingDrawingNumber) {
+      currentDrawingNumberDisplay = ztool->currentDrawingNumber;
+    }
+
+
+    if (isDisplayingDrawingNumber)
+    {
+      glPushMatrix();   
+      glScaled(0.5,0.5,0.5);
+      drawDrawingNumberBox();
+      // Inside your draw() or onDraw() method of a tool:
+      double unit = 0.5;  // or something like viewer->getPixelSize()
+      TPointD pos(0, unit * 20);  // Position in world coordinates
+     
+      std::string label;
+      label = "ID: " + std::to_string(currentDrawingNumberDisplay);
+
+      drawText(pos, unit, label);
+      glPopMatrix(); 
+    }
+    else
+    {
+      drawZArrow();
+    }
+   
+
+    
+
     glPopMatrix();
   }
   /*-- Rotation, Position : Draw vertical and horizontal lines --*/
@@ -1485,6 +1683,8 @@ void EditTool::onActivate() {
 
     m_showEWNSposition.setValue(ShowEWNSposition ? 1 : 0);
     m_showZposition.setValue(ShowZposition ? 1 : 0);
+    m_showDrawingNumber.setValue(ShowDrawingNumber ? 1 : 0);
+
     m_showSOposition.setValue(ShowSOposition ? 1 : 0);
     m_showRotation.setValue(ShowRotation ? 1 : 0);
     m_showGlobalScale.setValue(ShowGlobalScale ? 1 : 0);
@@ -1567,6 +1767,8 @@ bool EditTool::onPropertyChanged(std::string propertyName) {
 
   else if (propertyName == m_showZposition.getName())
     ShowZposition = (int)m_showZposition.getValue();
+  else if (propertyName == m_showDrawingNumber.getName())
+    ShowDrawingNumber = (int)m_showDrawingNumber.getValue();
 
   else if (propertyName == m_showSOposition.getName())
     ShowSOposition = (int)m_showSOposition.getValue();

--- a/toonz/sources/tnztools/edittool.h
+++ b/toonz/sources/tnztools/edittool.h
@@ -37,6 +37,7 @@ class EditTool final : public QObject, public TTool {
     Center,
     ZTranslation,
     Shear,
+    DrawingNumber,
   };
 
   // DragInfo m_dragInfo;

--- a/toonz/sources/tnztools/edittool.h
+++ b/toonz/sources/tnztools/edittool.h
@@ -20,6 +20,9 @@ class EditTool final : public QObject, public TTool {
   Q_OBJECT
 
   DragTool* m_dragTool;
+  
+  int currentDrawingNumberDisplay = 0; 
+  bool isDisplayingDrawingNumber  = false; 
 
   bool m_firstTime;
 
@@ -54,6 +57,8 @@ class EditTool final : public QObject, public TTool {
   FxGadgetController* m_fxGadgetController;
 
   bool m_isAltPressed;
+  bool m_isShiftPressed; 
+  bool m_isShiftJustPressed; 
 
   TEnumProperty m_scaleConstraint;
   TEnumProperty m_autoSelect;
@@ -78,6 +83,7 @@ class EditTool final : public QObject, public TTool {
   TBoolProperty m_showHVscale;
   TBoolProperty m_showShear;
   TBoolProperty m_showCenterPosition;
+  TBoolProperty m_showDrawingNumber; 
 
   TEnumProperty m_activeAxis;
 

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -494,7 +494,11 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_soLabel = new ClickableLabel(tr("SO:"), this);
   m_soField = new PegbarChannelField(m_tool, TStageObject::T_SO, "field",
                                      frameHandle, objHandle, xshHandle, this);
-
+  /* --- Drawing Number */
+  m_drawingNumberLabel = new ClickableLabel(tr("DN:"), this);
+  m_drawingNumberField =
+      new PegbarChannelField(m_tool, TStageObject::T_DrawingNumber, "field",
+                             frameHandle, objHandle, xshHandle, this);
   /* --- Rotation --- */
   m_rotationLabel = new ClickableLabel(tr("Rotation:"), this);
   m_rotationField =
@@ -597,6 +601,8 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
 
   m_zField->setPrecision(4);
   m_noScaleZField->setPrecision(4);
+
+  m_drawingNumberField->setPrecision(2); 
 
   m_hFlipButton = new QPushButton(this);
   m_vFlipButton = new QPushButton(this);
@@ -721,9 +727,15 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
         posLay->addWidget(m_soField, 10);
 
         posLay->addSpacing(ITEM_SPACING);
+
+        posLay->addWidget(m_drawingNumberLabel, 0);
+        posLay->addWidget(m_drawingNumberField, 10); 
+
         posLay->addWidget(new DVGui::Separator("", this, false));
 
         posLay->addStretch(1);
+
+
       }
       m_axisOptionWidgets[Position] = posFrame;
       mainLay->addWidget(m_axisOptionWidgets[Position], 0);
@@ -890,6 +902,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   connectLabelAndField(m_ewPosLabel, m_ewPosField);
   connectLabelAndField(m_nsPosLabel, m_nsPosField);
   connectLabelAndField(m_zLabel, m_zField);
+  connectLabelAndField(m_drawingNumberLabel, m_drawingNumberField);
   connectLabelAndField(m_soLabel, m_soField);
   connectLabelAndField(m_rotationLabel, m_rotationField);
   connectLabelAndField(m_globalScaleLabel, m_globalScaleField);
@@ -1206,6 +1219,7 @@ void ArrowToolOptionsBox::updateStatus() {
   m_ewPosField->updateStatus();
   m_nsPosField->updateStatus();
   m_zField->updateStatus();
+  m_drawingNumberField->updateStatus(); 
   m_noScaleZField->updateStatus();
   m_lockEWPosCheckbox->updateStatus();
   m_lockNSPosCheckbox->updateStatus();

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -116,7 +116,7 @@ ToolOptionsBox::ToolOptionsBox(QWidget *parent, bool isScrollable)
     toolContainer->setSizePolicy(QSizePolicy::MinimumExpanding,
                                  QSizePolicy::Fixed);
     toolContainer->setFixedHeight(24);
-    toolContainer->setObjectName("toolOptionsPanel");
+//    toolContainer->setObjectName("toolOptionsPanel");
     toolContainer->setLayout(m_layout);
   } else
     setLayout(m_layout);
@@ -495,7 +495,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_soField = new PegbarChannelField(m_tool, TStageObject::T_SO, "field",
                                      frameHandle, objHandle, xshHandle, this);
   /* --- Drawing Number */
-  m_drawingNumberLabel = new ClickableLabel(tr("DN:"), this);
+  m_drawingNumberLabel = new ClickableLabel(tr("Drawing #:"), this);
   m_drawingNumberField =
       new PegbarChannelField(m_tool, TStageObject::T_DrawingNumber, "field",
                              frameHandle, objHandle, xshHandle, this);
@@ -728,9 +728,6 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
 
         posLay->addSpacing(ITEM_SPACING);
 
-        posLay->addWidget(m_drawingNumberLabel, 0);
-        posLay->addWidget(m_drawingNumberField, 10); 
-
         posLay->addWidget(new DVGui::Separator("", this, false));
 
         posLay->addStretch(1);
@@ -838,6 +835,31 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       }
       m_axisOptionWidgets[Shear] = shearFrame;
       mainLay->addWidget(m_axisOptionWidgets[Shear], 0);
+
+      // Drawing Number
+      QFrame *drwaingNumberFrame    = new QFrame(this);
+      QHBoxLayout *drawingNumberLay = new QHBoxLayout();
+      drawingNumberLay->setContentsMargins(0, 0, 0, 0);
+      drawingNumberLay->setSpacing(0);
+      drwaingNumberFrame->setLayout(drawingNumberLay);
+      {
+        drawingNumberLay->addWidget(
+            new SimpleIconViewField("edit_drawingnumber", tr("Drawing #"),
+                                    this),
+            0);
+        drawingNumberLay->addSpacing(LABEL_SPACING * 2);
+
+        drawingNumberLay->addWidget(m_drawingNumberLabel, 0);
+        drawingNumberLay->addSpacing(LABEL_SPACING);
+        drawingNumberLay->addWidget(m_drawingNumberField, 10); 
+
+        drawingNumberLay->addSpacing(ITEM_SPACING);
+        drawingNumberLay->addWidget(new DVGui::Separator("", this, false));
+
+        drawingNumberLay->addStretch(1);
+      }
+      m_axisOptionWidgets[DrawingNumber] = drwaingNumberFrame;
+      mainLay->addWidget(m_axisOptionWidgets[DrawingNumber], 0);
 
       // Center Position
       QFrame *centerPosFrame    = new QFrame(this);
@@ -1042,41 +1064,15 @@ int ArrowToolOptionsBox::getKeysStatus(int axisId, bool allKeys,
     if (keys.m_channels[TStageObject::T_ShearY].m_isKeyframe) keysFound++;
   }
 
+  if (axisId == AXIS::DrawingNumber) {
+    keyCount += 1;
+    if (keys.m_channels[TStageObject::T_DrawingNumber].m_isKeyframe)
+      keysFound++;
+  }
+
   if (keysFound > 0 && keysFound == keyCount) return 2;  // Full
   if (keysFound > 0 && keysFound != keyCount) return 1;  // Partial
   return 0;                                              // None
-}
-
-bool isChannelInterpolated(TStageObject::Channel channel, int frame,
-                           TStageObject::KeyframeMap keyframes) {
-  if (keyframes.empty() || frame < keyframes.begin()->first ||
-      frame > keyframes.rbegin()->first)
-    return false;
-
-  bool upperKeyFound = false, lowerKeyFound = false;
-
-  auto it = keyframes.lower_bound(frame);
-  while (it != keyframes.end()) {
-    TStageObject::Keyframe keys = it->second;
-    if (keys.m_channels[channel].m_isKeyframe) {
-      upperKeyFound = true;
-      break;
-    }
-    it++;
-  }
-
-  it = keyframes.lower_bound(frame);
-  std::map<int, TStageObject::Keyframe>::reverse_iterator rit(it);
-  while (rit != keyframes.rend()) {
-    TStageObject::Keyframe keys = rit->second;
-    if (keys.m_channels[channel].m_isKeyframe) {
-      lowerKeyFound = true;
-      break;
-    }
-    rit++;
-  }
-
-  return upperKeyFound && lowerKeyFound;
 }
 
 bool ArrowToolOptionsBox::canSetInterpolation(int axisId, bool allKeys,
@@ -1102,22 +1098,22 @@ bool ArrowToolOptionsBox::canSetInterpolation(int axisId, bool allKeys,
         if (m_splined || m_globalKey->isChecked()) {
           keyCount += 1;
           if ((isKey && keys.m_channels[TStageObject::T_Path].m_isKeyframe) ||
-              isChannelInterpolated(TStageObject::T_Path, frame, keyframes))
+              stageObj->isChannelInterpolated(TStageObject::T_Path, frame))
             keysFound++;
         }
         if (!m_splined || m_globalKey->isChecked()) {
           keyCount += 4;
           if ((isKey && keys.m_channels[TStageObject::T_X].m_isKeyframe) ||
-              isChannelInterpolated(TStageObject::T_X, frame, keyframes))
+              stageObj->isChannelInterpolated(TStageObject::T_X, frame))
             keysFound++;
           if ((isKey && keys.m_channels[TStageObject::T_Y].m_isKeyframe) ||
-              isChannelInterpolated(TStageObject::T_Y, frame, keyframes))
+              stageObj->isChannelInterpolated(TStageObject::T_Y, frame))
             keysFound++;
           if ((isKey && keys.m_channels[TStageObject::T_Z].m_isKeyframe) ||
-              isChannelInterpolated(TStageObject::T_Z, frame, keyframes))
+              stageObj->isChannelInterpolated(TStageObject::T_Z, frame))
             keysFound++;
           if ((isKey && keys.m_channels[TStageObject::T_SO].m_isKeyframe) ||
-              isChannelInterpolated(TStageObject::T_SO, frame, keyframes))
+              stageObj->isChannelInterpolated(TStageObject::T_SO, frame))
             keysFound++;
         }
       }
@@ -1125,30 +1121,39 @@ bool ArrowToolOptionsBox::canSetInterpolation(int axisId, bool allKeys,
       if (axisId == AXIS::Rotation || allKeys) {
         keyCount += 1;
         if ((isKey && keys.m_channels[TStageObject::T_Angle].m_isKeyframe) ||
-            isChannelInterpolated(TStageObject::T_Angle, frame, keyframes))
+            stageObj->isChannelInterpolated(TStageObject::T_Angle, frame))
           keysFound++;
       }
 
       if (axisId == AXIS::Scale || allKeys) {
         keyCount += 3;
         if ((isKey && keys.m_channels[TStageObject::T_Scale].m_isKeyframe) ||
-            isChannelInterpolated(TStageObject::T_Scale, frame, keyframes))
+            stageObj->isChannelInterpolated(TStageObject::T_Scale, frame))
           keysFound++;
         if ((isKey && keys.m_channels[TStageObject::T_ScaleX].m_isKeyframe) ||
-            isChannelInterpolated(TStageObject::T_ScaleX, frame, keyframes))
+            stageObj->isChannelInterpolated(TStageObject::T_ScaleX, frame))
           keysFound++;
         if ((isKey && keys.m_channels[TStageObject::T_ScaleY].m_isKeyframe) ||
-            isChannelInterpolated(TStageObject::T_ScaleY, frame, keyframes))
+            stageObj->isChannelInterpolated(TStageObject::T_ScaleY, frame))
           keysFound++;
       }
 
       if (axisId == AXIS::Shear || allKeys) {
         keyCount += 2;
         if ((isKey && keys.m_channels[TStageObject::T_ShearX].m_isKeyframe) ||
-            isChannelInterpolated(TStageObject::T_ShearX, frame, keyframes))
+            stageObj->isChannelInterpolated(TStageObject::T_ShearX, frame))
           keysFound++;
         if ((isKey && keys.m_channels[TStageObject::T_ShearY].m_isKeyframe) ||
-            isChannelInterpolated(TStageObject::T_ShearY, frame, keyframes))
+            stageObj->isChannelInterpolated(TStageObject::T_ShearY, frame))
+          keysFound++;
+      }
+
+      if (axisId == AXIS::DrawingNumber) {
+        keyCount += 1;
+        if ((isKey &&
+             keys.m_channels[TStageObject::T_DrawingNumber].m_isKeyframe) ||
+            stageObj->isChannelInterpolated(TStageObject::T_DrawingNumber,
+                                            frame))
           keysFound++;
       }
 
@@ -1186,38 +1191,37 @@ void ArrowToolOptionsBox::updateStatus() {
   m_motionPathPosField->setStyleSheet(
       keys.m_channels[TStageObject::T_Path].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_Path, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_Path, frame)
                  ? highlightInbetween
                  : ""));
   m_ewPosField->setStyleSheet(
       keys.m_channels[TStageObject::T_X].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_X, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_X, frame)
                  ? highlightInbetween
                  : ""));
   m_nsPosField->setStyleSheet(
       keys.m_channels[TStageObject::T_Y].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_Y, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_Y, frame)
                  ? highlightInbetween
                  : ""));
   m_zField->setStyleSheet(
       keys.m_channels[TStageObject::T_Z].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_Z, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_Z, frame)
                  ? highlightInbetween
                  : ""));
   m_soField->setStyleSheet(
       keys.m_channels[TStageObject::T_SO].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_SO, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_SO, frame)
                  ? highlightInbetween
                  : ""));
   m_motionPathPosField->updateStatus();
   m_ewPosField->updateStatus();
   m_nsPosField->updateStatus();
   m_zField->updateStatus();
-  m_drawingNumberField->updateStatus(); 
   m_noScaleZField->updateStatus();
   m_lockEWPosCheckbox->updateStatus();
   m_lockNSPosCheckbox->updateStatus();
@@ -1227,7 +1231,7 @@ void ArrowToolOptionsBox::updateStatus() {
   m_rotationField->setStyleSheet(
       keys.m_channels[TStageObject::T_Angle].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_Angle, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_Angle, frame)
                  ? highlightInbetween
                  : ""));
   m_rotationField->updateStatus();
@@ -1236,19 +1240,19 @@ void ArrowToolOptionsBox::updateStatus() {
   m_globalScaleField->setStyleSheet(
       keys.m_channels[TStageObject::T_Scale].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_Scale, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_Scale, frame)
                  ? highlightInbetween
                  : ""));
   m_scaleHField->setStyleSheet(
       keys.m_channels[TStageObject::T_ScaleX].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_ScaleX, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_ScaleX, frame)
                  ? highlightInbetween
                  : ""));
   m_scaleVField->setStyleSheet(
       keys.m_channels[TStageObject::T_ScaleY].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_ScaleY, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_ScaleY, frame)
                  ? highlightInbetween
                  : ""));
   m_globalScaleField->updateStatus();
@@ -1262,19 +1266,29 @@ void ArrowToolOptionsBox::updateStatus() {
   m_shearHField->setStyleSheet(
       keys.m_channels[TStageObject::T_ShearX].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_ShearX, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_ShearX, frame)
                  ? highlightInbetween
                  : ""));
   m_shearVField->setStyleSheet(
       keys.m_channels[TStageObject::T_ShearY].m_isKeyframe
           ? highlightKey
-          : (isChannelInterpolated(TStageObject::T_ShearY, frame, keyframes)
+          : (stageObj->isChannelInterpolated(TStageObject::T_ShearY, frame)
                  ? highlightInbetween
                  : ""));
   m_shearHField->updateStatus();
   m_shearVField->updateStatus();
   m_lockShearHCheckbox->updateStatus();
   m_lockShearVCheckbox->updateStatus();
+
+  // Drawing Number
+  m_drawingNumberField->setStyleSheet(
+      keys.m_channels[TStageObject::T_DrawingNumber].m_isKeyframe
+          ? highlightKey
+          : (stageObj->isChannelInterpolated(TStageObject::T_DrawingNumber,
+                                             frame)
+                 ? highlightInbetween
+                 : ""));
+  m_drawingNumberField->updateStatus();
 
   // Center Position
   m_ewCenterField->updateStatus();
@@ -1287,18 +1301,24 @@ void ArrowToolOptionsBox::updateStatus() {
   bool splined = isCurrentObjectSplined();
   if (splined != m_splined) setSplined(splined);
 
-  m_interpolationCombo->setVisible(false);
+  int axisId   = m_chooseActiveAxisCombo->currentIndex();
+  bool allKeys = axisId == AXIS::AllAxis || m_globalKey->isChecked();
 
-  int axisId = m_chooseActiveAxisCombo->currentIndex();
+  m_drawingNumberLabel->setEnabled(objId.isColumn());
+  m_drawingNumberField->setEnabled(objId.isColumn());
+
+  m_setKeyButton->setEnabled(
+      (axisId != AXIS::DrawingNumber || objId.isColumn()));
+
+  m_interpolationCombo->setVisible(false);
 
   m_setKeyButton->setVisible(axisId != AXIS::CenterPosition);
 
   if (axisId == AXIS::CenterPosition) return;
 
-  bool allKeys = axisId == AXIS::AllAxis || m_globalKey->isChecked();
-
   m_interpolationCombo->setVisible(true);
   bool enableInterpolation =
+      (axisId != AXIS::DrawingNumber || objId.isColumn()) &&
       canSetInterpolation(axisId, allKeys, frame, stageObj);
   if (!isPlaying) m_interpolationCombo->setEnabled(enableInterpolation);
 
@@ -1536,6 +1556,19 @@ void ArrowToolOptionsBox::onSetKey() {
       if (!keys.m_channels[TStageObject::T_ShearY].m_isKeyframe)
         emit m_shearVField->measuredValueChanged(
             m_shearVField->getMeasuredValue());
+    }
+  }
+
+  if (axisId == AXIS::DrawingNumber) {
+    if (removeAllKeys) {
+      emit m_drawingNumberField->measuredValueDeleted();
+    } else {
+      if (!keys.m_channels[TStageObject::T_DrawingNumber].m_isKeyframe) {
+        m_xshHandle->getXsheet()->addUndoDrawingNumberChange(frame, objId);
+
+        emit m_drawingNumberField->measuredValueChanged(
+            m_drawingNumberField->getMeasuredValue());
+      }
     }
   }
   TUndoManager::manager()->endBlock();

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -734,8 +734,6 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
         posLay->addWidget(new DVGui::Separator("", this, false));
 
         posLay->addStretch(1);
-
-
       }
       m_axisOptionWidgets[Position] = posFrame;
       mainLay->addWidget(m_axisOptionWidgets[Position], 0);

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1262,8 +1262,31 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
       fld->setValue(TMeasuredValue::MainUnit, 0.0001);
     }
   }
+
+  // Do now allow drawing number to be < 0
+  if (m_actionId == TStageObject::T_DrawingNumber &&
+      fld->getValue(TMeasuredValue::MainUnit) < 0) {
+    updateStatus();
+    return;
+  }
+
   bool modifyConnectedActionId = false;
-  if (addToUndo) TUndoManager::manager()->beginBlock();
+
+  TXsheet *xsh         = m_xshHandle->getXsheet();
+  TStageObjectId objId = m_objHandle->getObjectId();
+  int frame            = m_frameHandle->getFrameIndex();
+
+  bool setDrawingKey   = false;
+  if (m_actionId == TStageObject::T_DrawingNumber) {
+    TStageObject *stgObj = xsh->getStageObject(objId);
+    TStageObject::KeyframeMap keyframes;
+    stgObj->getKeyframes(keyframes);
+    if (!keyframes.size() || frame < keyframes.begin()->first ||
+        frame > keyframes.rbegin()->first)
+      setDrawingKey = true;
+  }
+
+  if (addToUndo || setDrawingKey) TUndoManager::manager()->beginBlock();
   // m_firstMouseDrag is set to true only if addToUndo is false
   // and only for the first drag
   // This should always fire if addToUndo is true
@@ -1288,7 +1311,6 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
       m_before.add(TStageObject::T_Y);
       m_before.add(TStageObject::T_Z);
       m_before.add(TStageObject::T_SO);
-      m_before.add(TStageObject::T_DrawingNumber);
       m_before.add(TStageObject::T_ScaleX);
       m_before.add(TStageObject::T_ScaleY);
       m_before.add(TStageObject::T_Scale);
@@ -1312,6 +1334,19 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
     after.setValues(v, newV);
   } else
     after.setValue(v);
+  if (setDrawingKey) {
+    int col       = objId.getIndex();
+    TXshCell cell = xsh->getCell(frame, col, true, true);
+    if (!cell.isEmpty() && !cell.getFrameId().isStopFrame() &&
+        !cell.getFrameId().isNoFrame()) {
+      int frameIdNum = cell.getFrameId().getNumber();
+      m_before.setValue(frameIdNum);
+      after.setValue(frameIdNum);
+    }
+    xsh->addUndoDrawingNumberChange(frame, objId);
+    after.applyValues();
+    after.setValue(v);
+  }
   after.applyValues();
 
   TTool::Viewer *viewer = m_tool->getViewer();
@@ -1323,9 +1358,9 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
     undo->setXsheetHandle(m_xshHandle);
     undo->setObjectHandle(m_objHandle);
     TUndoManager::manager()->add(undo);
-    TUndoManager::manager()->endBlock();
     m_firstMouseDrag = false;
   }
+  if (addToUndo || setDrawingKey) TUndoManager::manager()->endBlock();
   if (!addToUndo && !m_firstMouseDrag) m_firstMouseDrag = true;
   m_objHandle->notifyObjectIdChanged(false);
 
@@ -1406,7 +1441,20 @@ void PegbarChannelField::updateStatus() {
   if (m_actionId == TStageObject::T_Z)
     setMeasure(objId.isCamera() ? "zdepth.cam" : "zdepth");
 
-  double v = xsh->getStageObject(objId)->getParam(m_actionId, frame);
+  TStageObject *stgObj = xsh->getStageObject(objId);
+  double v             = stgObj->getParam(m_actionId, frame);
+
+  if (m_actionId == TStageObject::T_DrawingNumber) {
+    TStageObject::KeyframeMap keyframes;
+    stgObj->getKeyframes(keyframes);
+    if (!keyframes.size() || frame < keyframes.begin()->first ||
+        frame > keyframes.rbegin()->first) {
+      int col       = m_tool->getColumnIndex();
+      TXshCell cell = xsh->getCell(frame, col);
+      if (!cell.isEmpty() && !cell.getFrameId().isStopFrame())
+        v = cell.getFrameId().getNumber();
+    }
+  }
 
   if (getValue() == v) return;
   setValue(v);

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1330,7 +1330,6 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
   m_objHandle->notifyObjectIdChanged(false);
 
   if (m_actionId == TStageObject::T_DrawingNumber) {
-    
     m_tool->getXsheet()->updateNonZeroDrawingNumberCells(
         m_tool->getColumnIndex(), m_tool->getFrame());
   }
@@ -1403,7 +1402,6 @@ void PegbarChannelField::onDelete(bool addToUndo) {
 void PegbarChannelField::updateStatus() {
   TXsheet *xsh         = m_tool->getXsheet();
   int frame            = m_tool->getFrame();
-  int col              = m_tool->getColumnIndex(); 
   TStageObjectId objId = m_tool->getObjectId();
   if (m_actionId == TStageObject::T_Z)
     setMeasure(objId.isCamera() ? "zdepth.cam" : "zdepth");
@@ -1411,8 +1409,8 @@ void PegbarChannelField::updateStatus() {
   double v = xsh->getStageObject(objId)->getParam(m_actionId, frame);
 
   if (getValue() == v) return;
-    setValue(v);
-    setCursorPosition(0);
+  setValue(v);
+  setCursorPosition(0);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1288,6 +1288,7 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
       m_before.add(TStageObject::T_Y);
       m_before.add(TStageObject::T_Z);
       m_before.add(TStageObject::T_SO);
+      m_before.add(TStageObject::T_DrawingNumber);
       m_before.add(TStageObject::T_ScaleX);
       m_before.add(TStageObject::T_ScaleY);
       m_before.add(TStageObject::T_Scale);
@@ -1327,6 +1328,12 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
   }
   if (!addToUndo && !m_firstMouseDrag) m_firstMouseDrag = true;
   m_objHandle->notifyObjectIdChanged(false);
+
+  if (m_actionId == TStageObject::T_DrawingNumber) {
+    
+    m_tool->getXsheet()->updateNonZeroDrawingNumberCells(
+        m_tool->getColumnIndex(), m_tool->getFrame());
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1396,6 +1403,7 @@ void PegbarChannelField::onDelete(bool addToUndo) {
 void PegbarChannelField::updateStatus() {
   TXsheet *xsh         = m_tool->getXsheet();
   int frame            = m_tool->getFrame();
+  int col              = m_tool->getColumnIndex(); 
   TStageObjectId objId = m_tool->getObjectId();
   if (m_actionId == TStageObject::T_Z)
     setMeasure(objId.isCamera() ? "zdepth.cam" : "zdepth");
@@ -1403,8 +1411,8 @@ void PegbarChannelField::updateStatus() {
   double v = xsh->getStageObject(objId)->getParam(m_actionId, frame);
 
   if (getValue() == v) return;
-  setValue(v);
-  setCursorPosition(0);
+    setValue(v);
+    setCursorPosition(0);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -80,7 +80,6 @@ public:
   // commands
   void reverseCells();
   void swingCells();
-  void updateNonZeroDrawingNumberCellsBox();
   void incrementCells();
   void randomCells();
   void stepCells(int count);

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -80,6 +80,7 @@ public:
   // commands
   void reverseCells();
   void swingCells();
+  void updateNonZeroDrawingNumberCellsBox();
   void incrementCells();
   void randomCells();
   void stepCells(int count);

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -232,8 +232,10 @@ void DrawingNumberUpdateUndo::redo() const {
   TCG_ASSERT(m_r1 >= m_r0 && m_c1 >= m_c0, return);
 
   m_undoCells.clear();
-  m_ok = TApp::instance()->getCurrentXsheet()->getXsheet()->updateNonZeroDrawingNumberCellsBox(
-      m_r0, m_c0, m_r1, m_c1, m_undoCells);
+  m_ok = TApp::instance()
+             ->getCurrentXsheet()
+             ->getXsheet()
+             ->updateNonZeroDrawingNumberCellsBox(m_r0, m_c0, m_c1);
 
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
@@ -269,9 +271,7 @@ void DrawingNumberUpdateUndo::undo() const {
 
 }  // namespace
 
-void TCellSelection::updateNonZeroDrawingNumberCellsBox() {
-}
-  //*********************************************************************************
+//*********************************************************************************
 //    Increment Cells  command
 //*********************************************************************************
 

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -201,6 +201,77 @@ void TCellSelection::swingCells() {
 }
 
 //*********************************************************************************
+//    Drawing Number Undo 
+//*********************************************************************************
+
+namespace {
+
+class DrawingNumberUpdateUndo final : public TUndo {
+  int m_r0, m_c0, m_r1, m_c1;
+  mutable std::vector<std::pair<TRect, TXshCell>> m_undoCells;
+
+public:
+  mutable bool m_ok;
+
+public:
+  DrawingNumberUpdateUndo(int r0, int c0, int r1, int c1)
+      : m_r0(r0), m_c0(c0), m_r1(r1), m_c1(c1), m_ok(true) {}
+
+  void redo() const override;
+  void undo() const override;
+
+  int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override { return QObject::tr("Autoexpose"); }
+  int getHistoryType() override { return HistoryType::Xsheet; }
+};
+
+//-----------------------------------------------------------------------------
+
+void DrawingNumberUpdateUndo::redo() const {
+  TCG_ASSERT(m_r1 >= m_r0 && m_c1 >= m_c0, return);
+
+  m_undoCells.clear();
+  m_ok = TApp::instance()->getCurrentXsheet()->getXsheet()->updateNonZeroDrawingNumberCellsBox(
+      m_r0, m_c0, m_r1, m_c1, m_undoCells);
+
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+}
+
+//-----------------------------------------------------------------------------
+
+void DrawingNumberUpdateUndo::undo() const {
+  TCG_ASSERT(m_r1 >= m_r0 && m_c1 >= m_c0 && m_ok, return);
+
+  TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+
+  for (int i = m_undoCells.size() - 1; i >= 0; --i) {
+    const TRect &r = m_undoCells[i].first;
+    int size       = r.x1 - r.x0 + 1;
+
+    if (m_undoCells[i].second.getFrameId().isNoFrame())
+      xsh->removeCells(r.x0, r.y0, size);
+    else {
+      xsh->insertCells(r.x0, r.y0, size);
+      for (int j = 0; j < size; ++j) {
+        if (j > 0 && Preferences::instance()->isImplicitHoldEnabled())
+          xsh->setCell(r.x0 + j, r.y0, TXshCell(0, TFrameId::EMPTY_FRAME));
+        else
+          xsh->setCell(r.x0 + j, r.y0, m_undoCells[i].second);
+      }
+    }
+  }
+
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+}
+
+}  // namespace
+
+void TCellSelection::updateNonZeroDrawingNumberCellsBox() {
+}
+  //*********************************************************************************
 //    Increment Cells  command
 //*********************************************************************************
 

--- a/toonz/sources/toonz/icons/dark/tools/18/edit_drawingnumber.svg
+++ b/toonz/sources/toonz/icons/dark/tools/18/edit_drawingnumber.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="18px"
+   height="18px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:square;stroke-miterlimit:3;"
+   id="svg3"
+   sodipodi:docname="edit_drawingnumber.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs3">
+        
+    </defs><sodipodi:namedview
+   id="namedview3"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="49.833333"
+   inkscape:cx="9"
+   inkscape:cy="9"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg3" />
+    
+    
+    
+    
+    
+<g
+   id="rect6_1_"
+   transform="matrix(1.3379587,0,0,1.2617845,-4.4053531,0.7161834)"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:square;stroke-miterlimit:3">
+        <path
+   style="baseline-shift:baseline;clip-rule:nonzero;display:inline;overflow:visible;vector-effect:none;fill-rule:nonzero;stroke-linecap:butt;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+   d="M 4.0390625,1.0390625 V 12.960938 H 15.960938 V 1.0390625 Z m 0.921875,0.921875 H 15.039063 V 12.039063 H 4.9609375 Z"
+   id="rect2" />
+    </g><text
+   xml:space="preserve"
+   style="font-style:italic;font-weight:900;font-size:13.3333px;line-height:1.25;font-family:'Segoe UI';-inkscape-font-specification:'Segoe UI Heavy Italic'"
+   x="5.0167217"
+   y="14.568561"
+   id="text3"><tspan
+     sodipodi:role="line"
+     id="tspan3"
+     x="5.0167217"
+     y="14.568561">#</tspan></text></svg>

--- a/toonz/sources/toonz/keyframemover.cpp
+++ b/toonz/sources/toonz/keyframemover.cpp
@@ -57,6 +57,7 @@ void KeyframeMover::setKeyframes() {
     for (auto const &frame : keyframes) {
       stObj->removeKeyframeWithoutUndo(frame.first);
     }
+    xsh->updateNonZeroDrawingNumberCells(c, key.first);
   }
   m_lastKeyframeData->getKeyframes(m_lastKeyframes, xsh);
 }
@@ -150,8 +151,11 @@ bool KeyframeMover::moveKeyframes(
         if (m_qualifiers & eCopyKeyframes) {
           firstTime = true;
           stObj->setKeyframeWithoutUndo(r + dr, stObj->getKeyframe(r));
+          xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
         } else
           stObj->moveKeyframe(r + dr, r);
+        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
+        
         newPositions.insert(TKeyframeSelection::Position(r + dr, c));
       }
     } else {  // ... and vice versa
@@ -165,8 +169,10 @@ bool KeyframeMover::moveKeyframes(
         if (m_qualifiers & eCopyKeyframes) {
           firstTime = true;
           stObj->setKeyframeWithoutUndo(r + dr, stObj->getKeyframe(r));
+          xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
         } else
           stObj->moveKeyframe(r + dr, r);
+        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
         newPositions.insert(TKeyframeSelection::Position(r + dr, c));
       }
     }
@@ -205,15 +211,20 @@ bool KeyframeMover::moveKeyframes(
 
     if (m_qualifiers & eOverwriteKeyframes) {
       stObj->removeKeyframeWithoutUndo(r + dr);
-      if (m_qualifiers & eCopyKeyframes)
+      if (m_qualifiers & eCopyKeyframes) {
         stObj->setKeyframeWithoutUndo(r + dr, stObj->getKeyframe(r));
-      else
+        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr);
+      } else {
         stObj->moveKeyframe(r + dr, r);
+        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr);
+      }
       newPositions.insert(TKeyframeSelection::Position(r + dr, c));
     } else if (m_qualifiers & eInsertKeyframes) {
       int s                           = r;
       TStageObject::Keyframe keyframe = stObj->getKeyframe(r);
-      if (!(m_qualifiers & eCopyKeyframes)) stObj->removeKeyframeWithoutUndo(r);
+      if (!(m_qualifiers & eCopyKeyframes)) {
+        stObj->removeKeyframeWithoutUndo(r);
+      }
       std::set<int> keyframeToShift;
       while (stObj->isKeyframe(s + dr) && s + dr != r) {
         keyframeToShift.insert(s + dr);
@@ -221,6 +232,7 @@ bool KeyframeMover::moveKeyframes(
       }
       stObj->moveKeyframes(keyframeToShift, 1);
       stObj->setKeyframeWithoutUndo(r + dr, keyframe);
+      xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr);
       newPositions.insert(TKeyframeSelection::Position(r + dr, c));
     }
   }
@@ -453,6 +465,7 @@ void KeyframeMoverTool::onClick(const QMouseEvent *event) {
   if (!getCellSelection()->isEmpty()) {
     cellsSelected = true;
     getCellSelection()->getSelectedCells(r0, c0, r1, c1);
+    xsheet->updateNonZeroDrawingNumberCellsBox(r0, c0, r1, c1); 
   }
 
   if (!m_startSelection.isEmpty()) {

--- a/toonz/sources/toonz/keyframemover.cpp
+++ b/toonz/sources/toonz/keyframemover.cpp
@@ -14,6 +14,7 @@
 #include "toonz/tscenehandle.h"
 #include "toonz/txsheet.h"
 #include "toonz/preferences.h"
+#include "toonz/txshcell.h"
 
 // TnzCore includes
 #include "tundo.h"
@@ -46,6 +47,7 @@ TXsheet *KeyframeMover::getXsheet() const {
 void KeyframeMover::setKeyframes() {
   TXsheet *xsh = getXsheet();
   std::set<KeyframePosition>::iterator posIt;
+  std::map<int, std::pair<int, int>> oldRanges;
   for (auto const &key : m_lastKeyframes) {
     int c = key.second;
     TStageObjectId objId =
@@ -54,12 +56,55 @@ void KeyframeMover::setKeyframes() {
     TStageObject *stObj = xsh->getStageObject(objId);
     TStageObject::KeyframeMap keyframes;
     stObj->getKeyframes(keyframes);
+    if (!keyframes.size()) continue;
+
+    if (oldRanges.find(c) == oldRanges.end())
+      oldRanges[c] = std::pair(INT_MAX, -1);
+
     for (auto const &frame : keyframes) {
+      oldRanges[c].first  = std::min(oldRanges[c].first, frame.first);
+      oldRanges[c].second = std::max(oldRanges[c].second, frame.first);
       stObj->removeKeyframeWithoutUndo(frame.first);
     }
-    xsh->updateNonZeroDrawingNumberCells(c, key.first);
   }
   m_lastKeyframeData->getKeyframes(m_lastKeyframes, xsh);
+
+  std::map<int, std::pair<int, int>> newRanges;
+  for (auto const &key : m_lastKeyframes) {
+    int c = key.second;
+    if (newRanges.find(c) == newRanges.end()) {
+      newRanges[c] = std::pair(INT_MAX, -1);
+
+      TStageObjectId objId =
+          c >= 0 ? xsh->getColumnObjectId(c)
+                 : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
+      TStageObject *stObj = xsh->getStageObject(objId);
+      TStageObject::KeyframeMap keyframes;
+      stObj->getKeyframes(keyframes);
+      if (!keyframes.size()) continue;
+
+      for (auto const &frame : keyframes) {
+        newRanges[c].first  = std::min(newRanges[c].first, frame.first);
+        newRanges[c].second = std::max(newRanges[c].second, frame.first);
+      }
+      int first = newRanges[c].first;
+      int last  = newRanges[c].second;
+      if (oldRanges.find(c) != oldRanges.end()) {
+        first = std::min(first, oldRanges[c].first);
+        last  = std::max(last, oldRanges[c].second);
+      }
+      xsh->updateNonZeroDrawingNumberCells(c, first, last);
+
+      if (m_undoDrawings.find(c) != m_undoDrawings.end()) {
+        if (oldRanges[c].first < newRanges[c].first)
+          xsh->restoreDrawings(c, oldRanges[c].first, newRanges[c].first - 1,
+                               xsh, m_undoDrawings);
+        if (oldRanges[c].second > newRanges[c].second)
+          xsh->restoreDrawings(c, newRanges[c].second + 1, oldRanges[c].second,
+                               xsh, m_undoDrawings);
+      }
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -73,10 +118,31 @@ void KeyframeMover::getKeyframes() {
                : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
     TStageObject *stObj = xsh->getStageObject(objId);
     assert(stObj->isKeyframe(pos.first));
+
+    bool hasDrawingKey = false;
+
     TStageObject::KeyframeMap keyframes;
     stObj->getKeyframes(keyframes);
     for (auto const &frame : keyframes) {
+      if (pos.first == frame.first && stObj->hasDrawingNumberKey(frame.first))
+        hasDrawingKey = true;
+
       m_lastKeyframes.insert(KeyframePosition(frame.first, c));
+    }
+
+    if (hasDrawingKey) {
+      int r0, r1;
+      xsh->getCellRange(c, r0, r1);
+      int n = r1 + 1;
+      std::vector<TXshCell> cells(n);
+      xsh->getCells(0, c, n, &cells[0], false, false);
+      for (int i = 0; i < n; i++) {
+        if (cells[i].isEmpty()) continue;
+        if (stObj->hasDrawingNumberKey(i) ||
+            stObj->isChannelInterpolated(TStageObject::T_DrawingNumber, i))
+          cells[i] = TXshCell();
+      }
+      m_undoDrawings.insert(c, cells);
     }
   }
 
@@ -139,9 +205,11 @@ bool KeyframeMover::moveKeyframes(
 
     // move keys from the end of the selection on dragging forward
     if (dr > 0) {
+      std::set<TKeyframeSelection::Position>::reverse_iterator startRevIt =
+          m_startSelectedKeyframes.rbegin();
       for (std::set<TKeyframeSelection::Position>::reverse_iterator revIt =
                positions.rbegin();
-           revIt != positions.rend(); ++revIt) {
+           revIt != positions.rend(); ++revIt, ++startRevIt) {
         int c = revIt->second;
         int r = revIt->first;
         TStageObjectId objId =
@@ -151,15 +219,20 @@ bool KeyframeMover::moveKeyframes(
         if (m_qualifiers & eCopyKeyframes) {
           firstTime = true;
           stObj->setKeyframeWithoutUndo(r + dr, stObj->getKeyframe(r));
-          xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
         } else
           stObj->moveKeyframe(r + dr, r);
-        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
-        
+
+        if (r < startRevIt->first &&
+            m_undoDrawings.find(c) != m_undoDrawings.end())
+          xsh->restoreDrawings(c, r, (r + dr - 1), xsh, m_undoDrawings);
+
         newPositions.insert(TKeyframeSelection::Position(r + dr, c));
       }
     } else {  // ... and vice versa
-      for (posIt = positions.begin(); posIt != positions.end(); ++posIt) {
+      std::set<TKeyframeSelection::Position>::iterator startIt =
+          m_startSelectedKeyframes.begin();
+      for (posIt = positions.begin(); posIt != positions.end();
+           ++posIt, ++startIt) {
         int c = posIt->second;
         int r = posIt->first;
         TStageObjectId objId =
@@ -169,10 +242,13 @@ bool KeyframeMover::moveKeyframes(
         if (m_qualifiers & eCopyKeyframes) {
           firstTime = true;
           stObj->setKeyframeWithoutUndo(r + dr, stObj->getKeyframe(r));
-          xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
         } else
           stObj->moveKeyframe(r + dr, r);
-        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr); 
+
+        if (r > startIt->first &&
+            m_undoDrawings.find(c) != m_undoDrawings.end())
+          xsh->restoreDrawings(c, (r + dr + 1), r, xsh, m_undoDrawings);
+
         newPositions.insert(TKeyframeSelection::Position(r + dr, c));
       }
     }
@@ -200,8 +276,11 @@ bool KeyframeMover::moveKeyframes(
   if (notChange) return true;
 
   newPositions.clear();
+  std::set<TKeyframeSelection::Position>::iterator origIt =
+      positions.begin();
   for (posIt = m_startSelectedKeyframes.begin();
-       posIt != m_startSelectedKeyframes.end(); ++posIt) {
+       posIt != m_startSelectedKeyframes.end(); ++posIt, ++origIt) {
+    int sr = origIt->first;
     int c = posIt->second;
     int r = posIt->first;
     TStageObjectId objId =
@@ -213,11 +292,16 @@ bool KeyframeMover::moveKeyframes(
       stObj->removeKeyframeWithoutUndo(r + dr);
       if (m_qualifiers & eCopyKeyframes) {
         stObj->setKeyframeWithoutUndo(r + dr, stObj->getKeyframe(r));
-        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr);
       } else {
         stObj->moveKeyframe(r + dr, r);
-        xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr);
       }
+
+      if (sr != (r + dr) && m_undoDrawings.find(c) != m_undoDrawings.end()) {
+        int startFrame = std::min(sr, (r + dr));
+        int endFrame   = std::max(sr, (r + dr));
+        xsh->restoreDrawings(c, startFrame, endFrame, xsh, m_undoDrawings);
+      }
+
       newPositions.insert(TKeyframeSelection::Position(r + dr, c));
     } else if (m_qualifiers & eInsertKeyframes) {
       int s                           = r;
@@ -232,7 +316,13 @@ bool KeyframeMover::moveKeyframes(
       }
       stObj->moveKeyframes(keyframeToShift, 1);
       stObj->setKeyframeWithoutUndo(r + dr, keyframe);
-      xsh->updateNonZeroDrawingNumberCellsAfterMoving(c, r + dr, dr);
+
+      if (sr != (r + dr) && m_undoDrawings.find(c) != m_undoDrawings.end()) {
+        int startFrame = std::min(sr, (r + dr));
+        int endFrame   = std::max(sr, (r + dr));
+        xsh->restoreDrawings(c, startFrame, endFrame, xsh, m_undoDrawings);
+      }
+
       newPositions.insert(TKeyframeSelection::Position(r + dr, c));
     }
   }
@@ -465,7 +555,7 @@ void KeyframeMoverTool::onClick(const QMouseEvent *event) {
   if (!getCellSelection()->isEmpty()) {
     cellsSelected = true;
     getCellSelection()->getSelectedCells(r0, c0, r1, c1);
-    xsheet->updateNonZeroDrawingNumberCellsBox(r0, c0, r1, c1); 
+    xsheet->updateNonZeroDrawingNumberCellsBox(r0, c0, c1); 
   }
 
   if (!m_startSelection.isEmpty()) {

--- a/toonz/sources/toonz/keyframemover.h
+++ b/toonz/sources/toonz/keyframemover.h
@@ -10,6 +10,7 @@
 #include "toonz/txshcell.h"
 
 class TXsheet;
+class TXshCell;
 
 //=============================================================================
 // KeyframeMover
@@ -28,6 +29,8 @@ class KeyframeMover {
   std::set<KeyframePosition> m_lastKeyframes;
   //! Store all keyframes in selected stageObject.
   TKeyframeData *m_lastKeyframeData;
+
+  QMap<int, std::vector<TXshCell>> m_undoDrawings;
 
   //! Helper method: returns the current xsheet
   TXsheet *getXsheet() const;

--- a/toonz/sources/toonz/keyframeselection.cpp
+++ b/toonz/sources/toonz/keyframeselection.cpp
@@ -65,6 +65,7 @@ bool shiftKeyframesWithoutUndo(int r0, int r1, int c0, int c1, bool cut,
     }
     isShifted = stObj->moveKeyframes(keyToShift, delta);
   }
+  xsh->updateNonZeroDrawingNumberCellsBox(r0,c0,r1,c1);
   return isShifted;
 }
 
@@ -112,6 +113,7 @@ bool deleteKeyframesWithoutUndo(
     areAllColumnLocked = false;
     assert(pegbar);
     pegbar->removeKeyframeWithoutUndo(row);
+    ///xsh->updateNonZeroDrawingNumberCells(col,row);
   }
   if (areAllColumnLocked) return false;
 

--- a/toonz/sources/toonz/keyframeselection.cpp
+++ b/toonz/sources/toonz/keyframeselection.cpp
@@ -113,7 +113,6 @@ bool deleteKeyframesWithoutUndo(
     areAllColumnLocked = false;
     assert(pegbar);
     pegbar->removeKeyframeWithoutUndo(row);
-    ///xsh->updateNonZeroDrawingNumberCells(col,row);
   }
   if (areAllColumnLocked) return false;
 

--- a/toonz/sources/toonz/keyframeselection.cpp
+++ b/toonz/sources/toonz/keyframeselection.cpp
@@ -65,7 +65,7 @@ bool shiftKeyframesWithoutUndo(int r0, int r1, int c0, int c1, bool cut,
     }
     isShifted = stObj->moveKeyframes(keyToShift, delta);
   }
-  xsh->updateNonZeroDrawingNumberCellsBox(r0,c0,r1,c1);
+  xsh->updateNonZeroDrawingNumberCellsBox(r0, c0, c1);
   return isShifted;
 }
 
@@ -449,6 +449,33 @@ void TKeyframeSelection::pasteKeyframesWithShift(int r0, int r1, int c0,
   TXsheet *xsh           = TApp::instance()->getCurrentXsheet()->getXsheet();
   oldData->setKeyframes(positions, xsh);
 
+  bool hasDrawingKeys = false;
+  std::map<int, std::set<double>> oldKeyRange;
+  std::map<int, std::vector<TXshCell>> undoFrames;
+
+  foreach (auto keyData, data->m_keyData) {
+    int r = keyData.second.m_channels->m_frame;
+    int c = keyData.first.second;
+    if (c < 0 || oldKeyRange.find(c) != oldKeyRange.end()) continue;
+    TStageObject *stObj = xsh->getStageObject(xsh->getColumnObjectId(c));
+    if (!stObj->hasDrawingNumberKey(r)) continue;
+    hasDrawingKeys = true;
+
+    TStageObject::KeyframeMap keyframes;
+    stObj->getKeyframes(keyframes);
+    std::set<double> range;
+    range.insert(keyframes.begin()->first);
+    range.insert(keyframes.rbegin()->first);
+    oldKeyRange[c] = range;
+
+    int cr0, cr1;
+    xsh->getCellRange(c, cr0, cr1);
+    int n = cr1 + 1;
+    std::vector<TXshCell> cells(n);
+    xsh->getCells(0, c, n, &cells[0], false, false);
+    undoFrames[c] = cells;
+  }
+
   bool isShift = shiftKeyframesWithoutUndo(r0, r1, c0, c1, false, true);
   bool isPaste = pasteKeyframesWithoutUndo(data, &m_positions);
   if (!isPaste && !isShift) {
@@ -459,8 +486,28 @@ void TKeyframeSelection::pasteKeyframesWithShift(int r0, int r1, int c0,
   TKeyframeData *newData = new TKeyframeData();
   newData->setKeyframes(m_positions, xsh);
   TKeyframeSelection *selection = new TKeyframeSelection(m_positions);
+
+  if (hasDrawingKeys) {
+    TUndoManager::manager()->beginBlock();
+
+    std::map<int, std::set<double>>::iterator it(oldKeyRange.begin()),
+        itEnd(oldKeyRange.end());
+    std::map<int, std::vector<TXshCell>>::iterator cit(undoFrames.begin());
+    for (; it != itEnd; it++, cit++) {
+      int c               = cit->first;
+      TStageObject *stObj = xsh->getStageObject(xsh->getColumnObjectId(c));
+      TStageObject::KeyframeMap keyframes;
+      stObj->getKeyframes(keyframes);
+      foreach (auto key, keyframes) {
+        int r = key.first;
+        xsh->addUndoDrawingNumberChange(r, c, it->second, cit->second);
+      }
+    }
+  }
   TUndoManager::manager()->add(
       new PasteKeyframesUndo(selection, newData, oldData, r0, r1, c0, c1));
+  if (hasDrawingKeys) TUndoManager::manager()->endBlock();
+
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
 }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2905,6 +2905,8 @@ void MainWindow::defineActions() {
                ToolCommandType, "edit_shear");
   createAction(MI_EditCenter, QT_TR_NOOP("Animate Tool - Center"), "", "",
                ToolCommandType, "edit_center");
+  createAction(MI_EditDrawingNumber, QT_TR_NOOP("Animate Tool - Drawing #"), "", "",
+               ToolCommandType, "edit_drawingnumber");
   createAction(MI_EditAll, QT_TR_NOOP("Animate Tool - All"), "", "",
                ToolCommandType, "edit_all");
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -366,6 +366,7 @@
 #define MI_EditRotation "MI_EditRotation"
 #define MI_EditScale "MI_EditScale"
 #define MI_EditShear "MI_EditShear"
+#define MI_EditDrawingNumber "MI_EditDrawingNumber"
 #define MI_EditCenter "MI_EditCenter"
 #define MI_EditAll "MI_EditAll"
 

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -40,6 +40,7 @@
 		<file>icons/dark/tools/18/edit_rotation.svg</file>
 		<file>icons/dark/tools/18/edit_scale.svg</file>
 		<file>icons/dark/tools/18/edit_shear.svg</file>
+		<file>icons/dark/tools/18/edit_drawingnumber.svg</file>
 
 		<file>icons/dark/actions/16/round_join.svg</file>
 		<file>icons/dark/actions/16/projecting_cap.svg</file>

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -394,7 +394,10 @@ bool isGlobalKeyFrameWithSameTypeDiffFromLinear(TStageObject *stageObject,
       type !=
           stageObject->getParam(TStageObject::T_ShearY)
               ->getKeyframeAt(frame)
-              .m_type)
+              .m_type ||
+      type != stageObject->getParam(TStageObject::T_DrawingNumber)
+                  ->getKeyframeAt(frame)
+                  .m_type)
     return false;
   return true;
 }
@@ -455,6 +458,10 @@ bool isGlobalKeyFrameWithSamePrevTypeDiffFromLinear(TStageObject *stageObject,
               .m_prevType ||
       type !=
           stageObject->getParam(TStageObject::T_ShearY)
+              ->getKeyframeAt(frame)
+              .m_prevType ||
+      type !=
+          stageObject->getParam(TStageObject::T_DrawingNumber)
               ->getKeyframeAt(frame)
               .m_prevType)
     return false;
@@ -3568,10 +3575,25 @@ void CellArea::drawKeyframeLine(QPainter &p, int col,
     end.setY(end.y() + adjust);
   }
 
+  // draw drawing keyframe informaiton
+  
   p.setPen(m_viewer->getKeyframeLineColor());
   p.drawLine(QLine(begin, end));
-}
+  /*
+  if (drawingNumberDouble > 0) {
+    // create green tint
+    QPen pen(Qt::white);        
+    pen.setStyle(Qt::DashLine);  
+    p.setPen(pen);              
 
+    p.drawLine(QLine(begin, end));
+  }
+  else {
+     p.setPen(m_viewer->getKeyframeLineColor());
+     p.drawLine(QLine(begin, end));
+  }
+  */
+}
 //-----------------------------------------------------------------------------
 
 void CellArea::drawNotes(QPainter &p, const QRect toBeUpdated) {
@@ -3653,7 +3675,6 @@ bool CellArea::getEaseHandles(int r0, int r1, double e0, double e1, int &rh0,
 }
 
 //-----------------------------------------------------------------------------
-
 void CellArea::paintEvent(QPaintEvent *event) {
   QRect toBeUpdated = event->rect();
 
@@ -3701,6 +3722,14 @@ public:
     m_area->update();
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);
     TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    TStageObjectId id = m_pegbar->getId();
+    if (id.isColumn()) {
+      xsh->updateNonZeroDrawingNumberCells(id.getIndex(), INT_MAX); 
+    }
+    
   }
   void redo() const override { undo(); }
   int getSize() const override { return sizeof *this; }
@@ -5239,6 +5268,11 @@ void CellArea::onStepChanged(QAction *act) {
   if (keyFrameIndex >= 0) {
     setParamStep(keyFrameIndex, step,
                  stageObject->getParam(TStageObject::T_ShearY));
+  }
+  keyFrameIndex = param->getClosestKeyframe(frame);
+  if (keyFrameIndex >= 0) {
+    setParamStep(keyFrameIndex, step,
+                 stageObject->getParam(TStageObject::T_DrawingNumber));
   }
 
   TUndoManager::manager()->endBlock();

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3579,21 +3579,8 @@ void CellArea::drawKeyframeLine(QPainter &p, int col,
   
   p.setPen(m_viewer->getKeyframeLineColor());
   p.drawLine(QLine(begin, end));
-  /*
-  if (drawingNumberDouble > 0) {
-    // create green tint
-    QPen pen(Qt::white);        
-    pen.setStyle(Qt::DashLine);  
-    p.setPen(pen);              
-
-    p.drawLine(QLine(begin, end));
-  }
-  else {
-     p.setPen(m_viewer->getKeyframeLineColor());
-     p.drawLine(QLine(begin, end));
-  }
-  */
 }
+
 //-----------------------------------------------------------------------------
 
 void CellArea::drawNotes(QPainter &p, const QRect toBeUpdated) {

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1300,7 +1300,6 @@ void ColumnArea::DrawHeader::drawConfig() const {
   if (zColumn || column->getPaletteColumn() || column->getSoundTextColumn() ||
       column->getPegbarColumn())
     return;
-    
 
   QPixmap icon = svgToPixmap(svgFilePath, configImgRect.size(),
                              Qt::KeepAspectRatio, bgColor);
@@ -1535,7 +1534,6 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
   if (o->flag(PredefinedFlag::THUMBNAIL_AREA_BORDER)) p.drawRect(thumbnailRect);
 
   // sound thumbnail
-  /*
   if (column->getSoundColumn()) {
     TXshSoundColumn *sc =
         xsh->getColumn(col) ? xsh->getColumn(col)->getSoundColumn() : 0;
@@ -1547,11 +1545,9 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
       drawVolumeControl(sc->getVolume());
     return;
   }
-  */
 
   // Folder thumbnail
   if (column->getFolderColumn()) {
-
     TXshFolderColumn *lfc =
         xsh->getColumn(col) ? xsh->getColumn(col)->getFolderColumn() : 0;
 
@@ -2552,7 +2548,6 @@ void ColumnArea::paintEvent(QPaintEvent *event) {  // AREA
       drawFoldedColumnHead(p, col);
     } else {
       TXshColumn *column = m_viewer->getXsheet()->getColumn(col);
-     
       int colType = (column && !column->isEmpty()) ? column->getColumnType()
                                                    : TXshColumn::eLevelType;
 

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1300,6 +1300,7 @@ void ColumnArea::DrawHeader::drawConfig() const {
   if (zColumn || column->getPaletteColumn() || column->getSoundTextColumn() ||
       column->getPegbarColumn())
     return;
+    
 
   QPixmap icon = svgToPixmap(svgFilePath, configImgRect.size(),
                              Qt::KeepAspectRatio, bgColor);
@@ -1534,6 +1535,7 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
   if (o->flag(PredefinedFlag::THUMBNAIL_AREA_BORDER)) p.drawRect(thumbnailRect);
 
   // sound thumbnail
+  /*
   if (column->getSoundColumn()) {
     TXshSoundColumn *sc =
         xsh->getColumn(col) ? xsh->getColumn(col)->getSoundColumn() : 0;
@@ -1545,9 +1547,11 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
       drawVolumeControl(sc->getVolume());
     return;
   }
+  */
 
   // Folder thumbnail
   if (column->getFolderColumn()) {
+
     TXshFolderColumn *lfc =
         xsh->getColumn(col) ? xsh->getColumn(col)->getFolderColumn() : 0;
 
@@ -2548,7 +2552,7 @@ void ColumnArea::paintEvent(QPaintEvent *event) {  // AREA
       drawFoldedColumnHead(p, col);
     } else {
       TXshColumn *column = m_viewer->getXsheet()->getColumn(col);
-
+     
       int colType = (column && !column->isEmpty()) ? column->getColumnType()
                                                    : TXshColumn::eLevelType;
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1210,7 +1210,10 @@ void XsheetViewer::showEvent(QShowEvent *) {
                        SLOT(onXsheetChanged()));
   ret = ret && connect(xsheetHandle, SIGNAL(xsheetChanged()), this,
                        SLOT(changeWindowTitle()));
-
+  ret = ret && connect(xsheetHandle, SIGNAL(xsheetChanged()), this,
+                       SLOT(changeWindowTitle()));
+  ret = ret && connect(xsheetHandle, SIGNAL(xsheetSwitched()), this,
+                       SLOT(updateDrawingNumberObservers()));
   ret = ret &&
         connect(app->getCurrentSelection(),
                 SIGNAL(selectionSwitched(TSelection *, TSelection *)), this,
@@ -1264,6 +1267,8 @@ void XsheetViewer::hideEvent(QHideEvent *) {
   TXsheetHandle *xsheetHandle = app->getCurrentXsheet();
   disconnect(xsheetHandle, SIGNAL(xsheetSwitched()), this,
              SLOT(updateAllAree()));
+  disconnect(xsheetHandle, SIGNAL(xsheetSwitched()), this,
+             SLOT(updateDrawingNumberObservers()));
   disconnect(xsheetHandle, SIGNAL(xsheetChanged()), this,
              SLOT(onXsheetChanged()));
   disconnect(xsheetHandle, SIGNAL(xsheetChanged()), this,
@@ -1571,6 +1576,39 @@ void XsheetViewer::onSceneSwitched() {
 //-----------------------------------------------------------------------------
 
 void XsheetViewer::onXsheetChanged() {
+  /*
+  TApp *app                   = TApp::instance();
+  TXsheetHandle *xsheetHandle = app->getCurrentXsheet();
+  TXsheetP txsheet            = xsheetHandle->getXsheet(); 
+
+  XsheetViewer *xv = TApp::instance()->getCurrentXsheetViewer();
+  if (xv != nullptr)
+  {
+    TKeyframeSelection *keyframeSelection = xv->getKeyframeSelection();
+    std::set<TKeyframeSelection::Position> selection =
+        keyframeSelection->getSelection();
+
+    // qDebug() << selection.size() << "\n";
+
+    int last  = -1;
+    int first = -1;
+
+    for (TKeyframeSelection::Position pos : selection) {
+      int row = pos.first;
+      int col = pos.second;
+      last    = std::max(row, last);
+      first   = std::min(col, first);
+    }
+
+    // qDebug() << "first : " << first << " last :" << last << " count : " <<
+    // selectedFrames.size() << "\n";
+    for (int i = 1; i <= txsheet->getColumnCount(); i++) {
+      txsheet->updateNonZeroDrawingNumberCells(i, last, INT_MAX, first, last);
+    }
+
+    // QPair<TDoubleParamP, int>  x = m_selection->getSelectedKeyframe(); 
+  }
+  */
   refreshContentSize(0, 0);
   updateAllAree();
 
@@ -1778,7 +1816,19 @@ void XsheetViewer::updateAllAree(bool isDragging) {
   m_toolbar->update(m_toolbar->visibleRegion());
 }
 
-//-----------------------------------------------------------------------------
+
+void XsheetViewer::updateDrawingNumberObservers() {
+  TApp *app = TApp::instance();
+  TXsheetHandle *xsheetHandle = app->getCurrentXsheet();
+  if (xsheetHandle && xsheetHandle->getXsheet()) {
+    xsheetHandle->getXsheet()->addDrawingNumberObserversAll(); 
+    xsheetHandle->getXsheet()->updateNonZeroDrawingNumberCellsBox(
+        app->getCurrentFrame()->getFrame(), 0,
+        app->getCurrentFrame()->getFrame(),
+        xsheetHandle->getXsheet()->getColumnCount() - 1);
+  }
+}
+    //-----------------------------------------------------------------------------
 
 void XsheetViewer::updateColumnArea() {
   m_columnArea->update(m_columnArea->visibleRegion());
@@ -2205,7 +2255,7 @@ bool XsheetViewer::event(QEvent *e) {
   return QFrame::event(e);
 }
 
-//=============================================================================
+    //=============================================================================
 // XSheetViewerCommand
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1790,7 +1790,6 @@ void XsheetViewer::updateDrawingNumberObservers() {
     xsheetHandle->getXsheet()->addDrawingNumberObserversAll();
     xsheetHandle->getXsheet()->updateNonZeroDrawingNumberCellsBox(
         app->getCurrentFrame()->getFrame(), 0,
-        app->getCurrentFrame()->getFrame(),
         xsheetHandle->getXsheet()->getColumnCount() - 1);
   }
 }

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1210,8 +1210,6 @@ void XsheetViewer::showEvent(QShowEvent *) {
                        SLOT(onXsheetChanged()));
   ret = ret && connect(xsheetHandle, SIGNAL(xsheetChanged()), this,
                        SLOT(changeWindowTitle()));
-  ret = ret && connect(xsheetHandle, SIGNAL(xsheetChanged()), this,
-                       SLOT(changeWindowTitle()));
   ret = ret && connect(xsheetHandle, SIGNAL(xsheetSwitched()), this,
                        SLOT(updateDrawingNumberObservers()));
   ret = ret &&
@@ -1576,39 +1574,6 @@ void XsheetViewer::onSceneSwitched() {
 //-----------------------------------------------------------------------------
 
 void XsheetViewer::onXsheetChanged() {
-  /*
-  TApp *app                   = TApp::instance();
-  TXsheetHandle *xsheetHandle = app->getCurrentXsheet();
-  TXsheetP txsheet            = xsheetHandle->getXsheet(); 
-
-  XsheetViewer *xv = TApp::instance()->getCurrentXsheetViewer();
-  if (xv != nullptr)
-  {
-    TKeyframeSelection *keyframeSelection = xv->getKeyframeSelection();
-    std::set<TKeyframeSelection::Position> selection =
-        keyframeSelection->getSelection();
-
-    // qDebug() << selection.size() << "\n";
-
-    int last  = -1;
-    int first = -1;
-
-    for (TKeyframeSelection::Position pos : selection) {
-      int row = pos.first;
-      int col = pos.second;
-      last    = std::max(row, last);
-      first   = std::min(col, first);
-    }
-
-    // qDebug() << "first : " << first << " last :" << last << " count : " <<
-    // selectedFrames.size() << "\n";
-    for (int i = 1; i <= txsheet->getColumnCount(); i++) {
-      txsheet->updateNonZeroDrawingNumberCells(i, last, INT_MAX, first, last);
-    }
-
-    // QPair<TDoubleParamP, int>  x = m_selection->getSelectedKeyframe(); 
-  }
-  */
   refreshContentSize(0, 0);
   updateAllAree();
 
@@ -1816,19 +1781,21 @@ void XsheetViewer::updateAllAree(bool isDragging) {
   m_toolbar->update(m_toolbar->visibleRegion());
 }
 
+//-----------------------------------------------------------------------------
 
 void XsheetViewer::updateDrawingNumberObservers() {
-  TApp *app = TApp::instance();
+  TApp *app                   = TApp::instance();
   TXsheetHandle *xsheetHandle = app->getCurrentXsheet();
   if (xsheetHandle && xsheetHandle->getXsheet()) {
-    xsheetHandle->getXsheet()->addDrawingNumberObserversAll(); 
+    xsheetHandle->getXsheet()->addDrawingNumberObserversAll();
     xsheetHandle->getXsheet()->updateNonZeroDrawingNumberCellsBox(
         app->getCurrentFrame()->getFrame(), 0,
         app->getCurrentFrame()->getFrame(),
         xsheetHandle->getXsheet()->getColumnCount() - 1);
   }
 }
-    //-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
 
 void XsheetViewer::updateColumnArea() {
   m_columnArea->update(m_columnArea->visibleRegion());
@@ -2255,7 +2222,7 @@ bool XsheetViewer::event(QEvent *e) {
   return QFrame::event(e);
 }
 
-    //=============================================================================
+//=============================================================================
 // XSheetViewerCommand
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -1482,6 +1482,7 @@ public slots:
   void updateColumnArea();
   void updateCellColumnAree();
   void updateCellRowAree();
+  void updateDrawingNumberObservers(); 
 
   void onScrubStopped();
   void onPreferenceChanged(const QString &prefName);

--- a/toonz/sources/toonzlib/doubleparamcmd.cpp
+++ b/toonz/sources/toonzlib/doubleparamcmd.cpp
@@ -567,11 +567,14 @@ void KeyframeSetter::setUnitName(std::string unitName) {
   m_param->setKeyframe(m_kIndex, m_keyframe);
 }
 
+#include <QDebug>
+
 void KeyframeSetter::setValue(double value) {
   assert(m_kIndex >= 0 && m_indices.size() == 1);
   if (m_keyframe.m_value == value) return;
   m_changed          = true;
   m_keyframe.m_value = value;
+  
   m_param->setKeyframe(m_kIndex, m_keyframe);
 }
 

--- a/toonz/sources/toonzlib/doubleparamcmd.cpp
+++ b/toonz/sources/toonzlib/doubleparamcmd.cpp
@@ -567,14 +567,11 @@ void KeyframeSetter::setUnitName(std::string unitName) {
   m_param->setKeyframe(m_kIndex, m_keyframe);
 }
 
-#include <QDebug>
-
 void KeyframeSetter::setValue(double value) {
   assert(m_kIndex >= 0 && m_indices.size() == 1);
   if (m_keyframe.m_value == value) return;
   m_changed          = true;
   m_keyframe.m_value = value;
-  
   m_param->setKeyframe(m_kIndex, m_keyframe);
 }
 

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -50,6 +50,8 @@
 
 #include "toonz/stage.h"
 
+#include <QDebug>
+
 // #define  NUOVO_ONION
 
 //=============================================================================
@@ -728,8 +730,8 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
                             int row, int level, bool includeUnvisible,
                             bool checkPreviewVisibility, int subSheetColIndex) {
   int columnCount        = xsh->getColumnCount();
-  unsigned int maskCount = m_masks.size();
-
+  unsigned int maskCount = m_masks.size(); 
+  
   std::vector<std::pair<double, int>> shuffle;
   for (int c = 0; c < columnCount; c++) {
     TXshColumnP column = xsh->getColumn(c);
@@ -737,6 +739,12 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     TStageObject *pegbar = xsh->getStageObject(TStageObjectId::ColumnId(c));
     double columnSO      = pegbar->getSO(row);
     shuffle.push_back(std::make_pair(columnSO, c));
+
+    /*
+    This is the code to handle drawing numbers;
+    */
+    //xsh->updateNonZeroDrawingNumberCells(c, row);
+    //
   }
   std::stable_sort(shuffle.begin(), shuffle.end(), StackingOrder());
 

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -50,8 +50,6 @@
 
 #include "toonz/stage.h"
 
-#include <QDebug>
-
 // #define  NUOVO_ONION
 
 //=============================================================================
@@ -739,12 +737,6 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     TStageObject *pegbar = xsh->getStageObject(TStageObjectId::ColumnId(c));
     double columnSO      = pegbar->getSO(row);
     shuffle.push_back(std::make_pair(columnSO, c));
-
-    /*
-    This is the code to handle drawing numbers;
-    */
-    //xsh->updateNonZeroDrawingNumberCells(c, row);
-    //
   }
   std::stable_sort(shuffle.begin(), shuffle.end(), StackingOrder());
 

--- a/toonz/sources/toonzlib/stageobjectutil.cpp
+++ b/toonz/sources/toonzlib/stageobjectutil.cpp
@@ -101,6 +101,9 @@ void TStageObjectValues::applyValues(bool undoEnabled) const {
       KeyframeSetter setter(param, -1,
                             undoEnabled);  // Deve essere registrato l'undo
       setter.createKeyframe(m_frame);
+      if ((TStageObject::Channel)it->m_actionId ==
+          TStageObject::T_DrawingNumber)
+        setter.setValue(it->getValue());
     }
     int indexKeyframe = param->getClosestKeyframe(m_frame);
     KeyframeSetter setter(param, indexKeyframe,
@@ -197,7 +200,7 @@ QString TStageObjectValues::getStringForHistory() {
       channelStr = QObject::tr("Edit Shear Y");
       break;
     case TStageObject::T_DrawingNumber:
-      channelStr = QObject::tr("Edit Drawing Number");
+      channelStr = QObject::tr("Edit Drawing #");
       break;
     default:
       channelStr = QObject::tr("Move");

--- a/toonz/sources/toonzlib/stageobjectutil.cpp
+++ b/toonz/sources/toonzlib/stageobjectutil.cpp
@@ -196,6 +196,9 @@ QString TStageObjectValues::getStringForHistory() {
     case TStageObject::T_ShearY:
       channelStr = QObject::tr("Edit Shear Y");
       break;
+    case TStageObject::T_DrawingNumber:
+      channelStr = QObject::tr("Edit Drawing Number");
+      break;
     default:
       channelStr = QObject::tr("Move");
       break;

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -30,7 +30,6 @@
 
 // Qt includes
 #include <QMetaObject>
-#include <QDebug>
 
 // STD includes
 #include <fstream>
@@ -42,7 +41,6 @@ using namespace std;
 // Per un problema su alcune macchine, solo Release.
 // il problema si verifica ruotando gli oggetti sul camera stand
 //
-
 
 #ifdef _MSC_VER
 #pragma optimize("", off)
@@ -275,8 +273,7 @@ bool setKeyframe(const TDoubleParamP &param, const TDoubleKeyframe &kf,
 void setkey(const TDoubleParamP &param, int frame) {
   KeyframeSetter setter(param.getPointer(), -1, false);
   setter.createKeyframe(frame);
-
- }
+}
 
 //-----------------------------------------------------------------------------
 
@@ -405,8 +402,7 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
     , m_noScaleZ(0)
     , m_pinnedRangeSet(0)
     , m_ikflag(0)
-    , m_groupSelector(-1)
-    {
+    , m_groupSelector(-1) {
   // NOTA: per le unita' di misura controlla anche tooloptions.cpp
   m_x->setName("W_X");
   m_x->setMeasureName("length.x");
@@ -446,7 +442,7 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
   m_sheary->setName("W_ShearV");
   m_sheary->setMeasureName("shear");
   m_sheary->addObserver(this);
-  
+
   m_posPath->setName("posPath");
   m_posPath->setMeasureName("percentage2");
   m_posPath->addObserver(this);
@@ -476,17 +472,21 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
   m_pinnedRangeSet = new TPinnedRangeSet();
 }
 
-    //-----------------------------------------------------------------------------
-void TStageObject::DrawingNumberObserver::onChange(
-    const TParamChange &c) {
+//-----------------------------------------------------------------------------
+
+void TStageObject::DrawingNumberObserver::onChange(const TParamChange &c) {
   if (m_callback != nullptr) {
     m_callback(c);
   }
 };
 
+//-----------------------------------------------------------------------------
+
 void TStageObject::setDrawingNumberCallback(DrawingNumberCallback callback) {
   m_drawingNumberObserver.m_callback = callback;
 }
+
+//-----------------------------------------------------------------------------
 
 TStageObject::~TStageObject() {
   if (m_spline) {
@@ -505,11 +505,10 @@ TStageObject::~TStageObject() {
   if (m_shearx) m_shearx->removeObserver(this);
   if (m_sheary) m_sheary->removeObserver(this);
   if (m_posPath) m_posPath->removeObserver(this);
-  if (m_drawingnumber)
-  {
+  if (m_drawingnumber) {
     m_drawingnumber->removeObserver(this);
-    m_drawingnumber->removeObserver((TParamObserver *)(&
-                                    m_drawingNumberObserver));
+    m_drawingnumber->removeObserver(
+        (TParamObserver *)(&m_drawingNumberObserver));
   }
 
   if (m_skeletonDeformation) {
@@ -908,7 +907,8 @@ TStageObject::Keyframe TStageObject::getKeyframe(int frame) const {
     k.m_channels[TStageObject::T_Path]   = m_posPath->getValue(frame);
     k.m_channels[TStageObject::T_ShearX] = m_shearx->getValue(frame);
     k.m_channels[TStageObject::T_ShearY] = m_sheary->getValue(frame);
-    k.m_channels[TStageObject::T_DrawingNumber] = m_drawingnumber->getValue(frame); 
+    k.m_channels[TStageObject::T_DrawingNumber] =
+        m_drawingnumber->getValue(frame); 
 
     if (m_skeletonDeformation)
       m_skeletonDeformation->getKeyframeAt(frame, k.m_skeletonKeyframe);
@@ -943,6 +943,8 @@ TStageObject::KeyFrameMarker* TStageObject::tryDequeueKeyFrameChangeRangeQueue()
   if (keyFrameChangeRangeQueue.isEmpty()) return nullptr;
   return &keyFrameChangeRangeQueue.dequeue();
 }
+
+//-----------------------------------------------------------------------------
 
 void TStageObject::setKeyframeWithoutUndo(int frame,
                                           const TStageObject::Keyframe &k) {
@@ -1222,7 +1224,7 @@ TDoubleParam *TStageObject::getParam(Channel channel) const {
   case T_ShearX:
     return m_shearx.getPointer();
   case T_ShearY:
-    return m_sheary.getPointer();   
+    return m_sheary.getPointer();
   case T_DrawingNumber:
     return m_drawingnumber.getPointer(); 
   default:
@@ -1345,9 +1347,7 @@ bool TStageObject::isCycleEnabled() const { return m_cycleEnabled; }
 
 //-----------------------------------------------------------------------------
 
-void TStageObject::enableCycle(bool on) { 
-  m_cycleEnabled = on; 
-}
+void TStageObject::enableCycle(bool on) { m_cycleEnabled = on; }
 
 //-----------------------------------------------------------------------------
 
@@ -1534,7 +1534,9 @@ double TStageObject::getSO(double t) {
   else
     return m_so->getValue(tt);
 }
-// 
+
+//-----------------------------------------------------------------------------
+
 double TStageObject::getDrawingNumber(double t) {
   double tt = paramsTime(t);
   if (m_parent)

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -101,6 +101,7 @@ TStageObjectParams::TStageObjectParams(TStageObjectParams *data)
     , m_posPath(data->m_posPath)
     , m_shearx(data->m_shearx)
     , m_sheary(data->m_sheary)
+    , m_drawingnumber(data->m_drawingnumber)
     , m_skeletonDeformation(data->m_skeletonDeformation)
     , m_noScaleZ(data->m_noScaleZ)
     , m_center(data->m_center)
@@ -447,10 +448,11 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
   m_posPath->setMeasureName("percentage2");
   m_posPath->addObserver(this);
 
-  m_drawingnumber->setName("W_Drawing_Number");
-  //m_drawingnumber->setMeasureName("dummy"); 
+  m_drawingnumber->setName("W_DrawingNumber");
+//   m_drawingnumber->setMeasureName("dummy");
   m_drawingnumber->addObserver(this);
-
+  m_drawingnumber->addObserver((TParamObserver *)(&m_drawingNumberObserver)); 
+  
   m_tree->setGrammar(m_x);
   m_tree->setGrammar(m_y);
   m_tree->setGrammar(m_z);
@@ -464,11 +466,8 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
   m_tree->setGrammar(m_posPath);
   m_tree->setGrammar(m_drawingnumber); 
  
-
   if (id.isCamera()) m_camera = new TCamera();
 
-  m_drawingnumber->addObserver((TParamObserver*)(&m_drawingNumberObserver)); 
-  
   m_pinnedRangeSet = new TPinnedRangeSet();
 }
 
@@ -884,7 +883,49 @@ bool TStageObject::isFullKeyframe(int frame) const {
          m_so->isKeyframe(frame) && m_posPath->isKeyframe(frame) &&
          m_scalex->isKeyframe(frame) && m_scaley->isKeyframe(frame) &&
          m_scale->isKeyframe(frame) && m_shearx->isKeyframe(frame) &&
-         m_sheary->isKeyframe(frame) && m_drawingnumber->isKeyframe(frame);
+         m_sheary->isKeyframe(frame);
+}
+
+//-----------------------------------------------------------------------------
+
+bool TStageObject::hasDrawingNumberKey(int frame) const {
+  return m_drawingnumber->isKeyframe(frame);
+}
+
+//-----------------------------------------------------------------------------
+
+bool TStageObject::isChannelInterpolated(TStageObject::Channel channel,
+                                         int frame) {
+  KeyframeMap keyframes = lazyData().m_keyframes;
+
+  if (keyframes.empty() || frame < keyframes.begin()->first ||
+      frame > keyframes.rbegin()->first)
+    return false;
+
+  bool upperKeyFound = false, lowerKeyFound = false;
+
+  auto it = keyframes.lower_bound(frame);
+  while (it != keyframes.end()) {
+    TStageObject::Keyframe keys = it->second;
+    if (keys.m_channels[channel].m_isKeyframe) {
+      upperKeyFound = true;
+      break;
+    }
+    it++;
+  }
+
+  it = keyframes.lower_bound(frame);
+  std::map<int, TStageObject::Keyframe>::reverse_iterator rit(it);
+  while (rit != keyframes.rend()) {
+    TStageObject::Keyframe keys = rit->second;
+    if (keys.m_channels[channel].m_isKeyframe) {
+      lowerKeyFound = true;
+      break;
+    }
+    rit++;
+  }
+
+  return upperKeyFound && lowerKeyFound;
 }
 
 //-----------------------------------------------------------------------------
@@ -920,73 +961,49 @@ TStageObject::Keyframe TStageObject::getKeyframe(int frame) const {
 }
 
 //-----------------------------------------------------------------------------
-bool TStageObject::setKeyframe(const TDoubleParamP &param,
-                               const TDoubleKeyframe &kf, int frame,
-                               const double &easeIn, const double &easeOut) {
-  bool output = ::setKeyframe(param, kf, frame, easeIn, easeOut); 
-
-  if (param == m_drawingnumber) {
-    //int previousKeyFrame = m_drawingnumber->getNextKeyframe(); 
-    //keyFrameChangeRangeQueue.enqueue(TStageObject::KeyFrameMarker(frame, 1)); 
-  }
-  return output; 
-}
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-void TStageObject::setkey(const TDoubleParamP &param, int frame) { 
-  ::setkey(param, frame);
-
-}
-//-----------------------------------------------------------------------------
-
-TStageObject::KeyFrameMarker* TStageObject::tryDequeueKeyFrameChangeRangeQueue() {
-  if (keyFrameChangeRangeQueue.isEmpty()) return nullptr;
-  return &keyFrameChangeRangeQueue.dequeue();
-}
-
-//-----------------------------------------------------------------------------
 
 void TStageObject::setKeyframeWithoutUndo(int frame,
                                           const TStageObject::Keyframe &k) {
   KeyframeMap &keyframes = lazyData().m_keyframes;
 
   bool keyWasSet = false;
-  keyWasSet = setKeyframe(m_rot, k.m_channels[TStageObject::T_Angle], frame,
+  keyWasSet = ::setKeyframe(m_rot, k.m_channels[TStageObject::T_Angle], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_x, k.m_channels[TStageObject::T_X], frame,
+  keyWasSet = ::setKeyframe(m_x, k.m_channels[TStageObject::T_X], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_y, k.m_channels[TStageObject::T_Y], frame,
+  keyWasSet = ::setKeyframe(m_y, k.m_channels[TStageObject::T_Y], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_z, k.m_channels[TStageObject::T_Z], frame,
+  keyWasSet = ::setKeyframe(m_z, k.m_channels[TStageObject::T_Z], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_so, k.m_channels[TStageObject::T_SO], frame,
+  keyWasSet = ::setKeyframe(m_so, k.m_channels[TStageObject::T_SO], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_posPath, k.m_channels[TStageObject::T_Path],
+  keyWasSet = ::setKeyframe(m_posPath, k.m_channels[TStageObject::T_Path],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_scalex, k.m_channels[TStageObject::T_ScaleX],
+  keyWasSet = ::setKeyframe(m_scalex, k.m_channels[TStageObject::T_ScaleX],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_scaley, k.m_channels[TStageObject::T_ScaleY],
+  keyWasSet = ::setKeyframe(m_scaley, k.m_channels[TStageObject::T_ScaleY],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_scale, k.m_channels[TStageObject::T_Scale], frame,
+  keyWasSet = ::setKeyframe(m_scale, k.m_channels[TStageObject::T_Scale], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_shearx, k.m_channels[TStageObject::T_ShearX],
+  keyWasSet = ::setKeyframe(m_shearx, k.m_channels[TStageObject::T_ShearX],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_sheary, k.m_channels[TStageObject::T_ShearY],
+  keyWasSet = ::setKeyframe(m_sheary, k.m_channels[TStageObject::T_ShearY],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = setKeyframe(m_drawingnumber, k.m_channels[TStageObject::T_DrawingNumber],
-                            frame, k.m_easeIn, k.m_easeOut) ||
-              keyWasSet; 
+  keyWasSet = ::setKeyframe(m_drawingnumber,
+                            k.m_channels[TStageObject::T_DrawingNumber], frame,
+                            k.m_easeIn, k.m_easeOut) ||
+              keyWasSet;
 
   if (m_skeletonDeformation)
     keyWasSet = m_skeletonDeformation->setKeyframe(k.m_skeletonKeyframe, frame,
@@ -1014,7 +1031,6 @@ void TStageObject::setKeyframeWithoutUndo(int frame) {
   setkey(m_scale, frame);
   setkey(m_shearx, frame);
   setkey(m_sheary, frame);
-  setkey(m_drawingnumber, frame);
 
   // Plastic keys are currently not *created* by xsheet commands.
 
@@ -2032,6 +2048,7 @@ void TStageObject::assignParams(const TStageObjectParams *src,
     m_sheary->addObserver(this);
     m_drawingnumber = src->m_drawingnumber.getPointer();
     m_drawingnumber->addObserver(this);
+    m_drawingnumber->addObserver((TParamObserver *)(&m_drawingNumberObserver));
 
     m_skeletonDeformation = src->m_skeletonDeformation;
     if (m_skeletonDeformation) m_skeletonDeformation->addObserver(this);

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -30,6 +30,7 @@
 
 // Qt includes
 #include <QMetaObject>
+#include <QDebug>
 
 // STD includes
 #include <fstream>
@@ -41,6 +42,7 @@ using namespace std;
 // Per un problema su alcune macchine, solo Release.
 // il problema si verifica ruotando gli oggetti sul camera stand
 //
+
 
 #ifdef _MSC_VER
 #pragma optimize("", off)
@@ -273,7 +275,8 @@ bool setKeyframe(const TDoubleParamP &param, const TDoubleKeyframe &kf,
 void setkey(const TDoubleParamP &param, int frame) {
   KeyframeSetter setter(param.getPointer(), -1, false);
   setter.createKeyframe(frame);
-}
+
+ }
 
 //-----------------------------------------------------------------------------
 
@@ -389,6 +392,7 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
     , m_posPath(new TDoubleParam())
     , m_shearx(new TDoubleParam())
     , m_sheary(new TDoubleParam())
+    , m_drawingnumber(new TDoubleParam())
     , m_center()
     , m_frameCenter()
     , m_offset()
@@ -401,7 +405,8 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
     , m_noScaleZ(0)
     , m_pinnedRangeSet(0)
     , m_ikflag(0)
-    , m_groupSelector(-1) {
+    , m_groupSelector(-1)
+    {
   // NOTA: per le unita' di misura controlla anche tooloptions.cpp
   m_x->setName("W_X");
   m_x->setMeasureName("length.x");
@@ -441,10 +446,14 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
   m_sheary->setName("W_ShearV");
   m_sheary->setMeasureName("shear");
   m_sheary->addObserver(this);
-
+  
   m_posPath->setName("posPath");
   m_posPath->setMeasureName("percentage2");
   m_posPath->addObserver(this);
+
+  m_drawingnumber->setName("W_Drawing_Number");
+  //m_drawingnumber->setMeasureName("dummy"); 
+  m_drawingnumber->addObserver(this);
 
   m_tree->setGrammar(m_x);
   m_tree->setGrammar(m_y);
@@ -457,13 +466,27 @@ TStageObject::TStageObject(TStageObjectTree *tree, TStageObjectId id)
   m_tree->setGrammar(m_shearx);
   m_tree->setGrammar(m_sheary);
   m_tree->setGrammar(m_posPath);
+  m_tree->setGrammar(m_drawingnumber); 
+ 
 
   if (id.isCamera()) m_camera = new TCamera();
 
+  m_drawingnumber->addObserver((TParamObserver*)(&m_drawingNumberObserver)); 
+  
   m_pinnedRangeSet = new TPinnedRangeSet();
 }
 
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+void TStageObject::DrawingNumberObserver::onChange(
+    const TParamChange &c) {
+  if (m_callback != nullptr) {
+    m_callback(c);
+  }
+};
+
+void TStageObject::setDrawingNumberCallback(DrawingNumberCallback callback) {
+  m_drawingNumberObserver.m_callback = callback;
+}
 
 TStageObject::~TStageObject() {
   if (m_spline) {
@@ -482,6 +505,12 @@ TStageObject::~TStageObject() {
   if (m_shearx) m_shearx->removeObserver(this);
   if (m_sheary) m_sheary->removeObserver(this);
   if (m_posPath) m_posPath->removeObserver(this);
+  if (m_drawingnumber)
+  {
+    m_drawingnumber->removeObserver(this);
+    m_drawingnumber->removeObserver((TParamObserver *)(&
+                                    m_drawingNumberObserver));
+  }
 
   if (m_skeletonDeformation) {
     PlasticDeformerStorage::instance()->releaseDeformationData(
@@ -856,7 +885,7 @@ bool TStageObject::isFullKeyframe(int frame) const {
          m_so->isKeyframe(frame) && m_posPath->isKeyframe(frame) &&
          m_scalex->isKeyframe(frame) && m_scaley->isKeyframe(frame) &&
          m_scale->isKeyframe(frame) && m_shearx->isKeyframe(frame) &&
-         m_sheary->isKeyframe(frame);
+         m_sheary->isKeyframe(frame) && m_drawingnumber->isKeyframe(frame);
 }
 
 //-----------------------------------------------------------------------------
@@ -879,6 +908,7 @@ TStageObject::Keyframe TStageObject::getKeyframe(int frame) const {
     k.m_channels[TStageObject::T_Path]   = m_posPath->getValue(frame);
     k.m_channels[TStageObject::T_ShearX] = m_shearx->getValue(frame);
     k.m_channels[TStageObject::T_ShearY] = m_sheary->getValue(frame);
+    k.m_channels[TStageObject::T_DrawingNumber] = m_drawingnumber->getValue(frame); 
 
     if (m_skeletonDeformation)
       m_skeletonDeformation->getKeyframeAt(frame, k.m_skeletonKeyframe);
@@ -890,45 +920,71 @@ TStageObject::Keyframe TStageObject::getKeyframe(int frame) const {
 }
 
 //-----------------------------------------------------------------------------
+bool TStageObject::setKeyframe(const TDoubleParamP &param,
+                               const TDoubleKeyframe &kf, int frame,
+                               const double &easeIn, const double &easeOut) {
+  bool output = ::setKeyframe(param, kf, frame, easeIn, easeOut); 
+
+  if (param == m_drawingnumber) {
+    //int previousKeyFrame = m_drawingnumber->getNextKeyframe(); 
+    //keyFrameChangeRangeQueue.enqueue(TStageObject::KeyFrameMarker(frame, 1)); 
+  }
+  return output; 
+}
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+void TStageObject::setkey(const TDoubleParamP &param, int frame) { 
+  ::setkey(param, frame);
+
+}
+//-----------------------------------------------------------------------------
+
+TStageObject::KeyFrameMarker* TStageObject::tryDequeueKeyFrameChangeRangeQueue() {
+  if (keyFrameChangeRangeQueue.isEmpty()) return nullptr;
+  return &keyFrameChangeRangeQueue.dequeue();
+}
 
 void TStageObject::setKeyframeWithoutUndo(int frame,
                                           const TStageObject::Keyframe &k) {
   KeyframeMap &keyframes = lazyData().m_keyframes;
 
   bool keyWasSet = false;
-  keyWasSet = ::setKeyframe(m_rot, k.m_channels[TStageObject::T_Angle], frame,
+  keyWasSet = setKeyframe(m_rot, k.m_channels[TStageObject::T_Angle], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_x, k.m_channels[TStageObject::T_X], frame,
+  keyWasSet = setKeyframe(m_x, k.m_channels[TStageObject::T_X], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_y, k.m_channels[TStageObject::T_Y], frame,
+  keyWasSet = setKeyframe(m_y, k.m_channels[TStageObject::T_Y], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_z, k.m_channels[TStageObject::T_Z], frame,
+  keyWasSet = setKeyframe(m_z, k.m_channels[TStageObject::T_Z], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_so, k.m_channels[TStageObject::T_SO], frame,
+  keyWasSet = setKeyframe(m_so, k.m_channels[TStageObject::T_SO], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_posPath, k.m_channels[TStageObject::T_Path],
+  keyWasSet = setKeyframe(m_posPath, k.m_channels[TStageObject::T_Path],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_scalex, k.m_channels[TStageObject::T_ScaleX],
+  keyWasSet = setKeyframe(m_scalex, k.m_channels[TStageObject::T_ScaleX],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_scaley, k.m_channels[TStageObject::T_ScaleY],
+  keyWasSet = setKeyframe(m_scaley, k.m_channels[TStageObject::T_ScaleY],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_scale, k.m_channels[TStageObject::T_Scale], frame,
+  keyWasSet = setKeyframe(m_scale, k.m_channels[TStageObject::T_Scale], frame,
                             k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_shearx, k.m_channels[TStageObject::T_ShearX],
+  keyWasSet = setKeyframe(m_shearx, k.m_channels[TStageObject::T_ShearX],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
-  keyWasSet = ::setKeyframe(m_sheary, k.m_channels[TStageObject::T_ShearY],
+  keyWasSet = setKeyframe(m_sheary, k.m_channels[TStageObject::T_ShearY],
                             frame, k.m_easeIn, k.m_easeOut) ||
               keyWasSet;
+  keyWasSet = setKeyframe(m_drawingnumber, k.m_channels[TStageObject::T_DrawingNumber],
+                            frame, k.m_easeIn, k.m_easeOut) ||
+              keyWasSet; 
 
   if (m_skeletonDeformation)
     keyWasSet = m_skeletonDeformation->setKeyframe(k.m_skeletonKeyframe, frame,
@@ -956,6 +1012,7 @@ void TStageObject::setKeyframeWithoutUndo(int frame) {
   setkey(m_scale, frame);
   setkey(m_shearx, frame);
   setkey(m_sheary, frame);
+  setkey(m_drawingnumber, frame);
 
   // Plastic keys are currently not *created* by xsheet commands.
 
@@ -997,6 +1054,7 @@ void TStageObject::removeKeyframeWithoutUndo(int frame) {
   m_posPath->deleteKeyframe(frame);
   m_shearx->deleteKeyframe(frame);
   m_sheary->deleteKeyframe(frame);
+  m_drawingnumber->deleteKeyframe(frame);
 
   if (m_skeletonDeformation) m_skeletonDeformation->deleteKeyframe(frame);
 
@@ -1130,6 +1188,8 @@ double TStageObject::getParam(Channel type, double frame) const {
     return m_shearx->getValue(frame);
   case T_ShearY:
     return m_sheary->getValue(frame);
+  case T_DrawingNumber:
+    return m_drawingnumber->getValue(frame); 
 
   default:
     assert(false);
@@ -1162,7 +1222,9 @@ TDoubleParam *TStageObject::getParam(Channel channel) const {
   case T_ShearX:
     return m_shearx.getPointer();
   case T_ShearY:
-    return m_sheary.getPointer();
+    return m_sheary.getPointer();   
+  case T_DrawingNumber:
+    return m_drawingnumber.getPointer(); 
   default:
     return 0;
   }
@@ -1261,6 +1323,7 @@ TStageObject *TStageObject::clone() {
   cloned->m_posPath = static_cast<TDoubleParam *>(m_posPath->clone());
   cloned->m_shearx  = static_cast<TDoubleParam *>(m_shearx->clone());
   cloned->m_sheary  = static_cast<TDoubleParam *>(m_sheary->clone());
+  cloned->m_drawingnumber  = static_cast<TDoubleParam *>(m_drawingnumber->clone());
 
   if (m_skeletonDeformation)
     cloned->m_skeletonDeformation =
@@ -1282,7 +1345,9 @@ bool TStageObject::isCycleEnabled() const { return m_cycleEnabled; }
 
 //-----------------------------------------------------------------------------
 
-void TStageObject::enableCycle(bool on) { m_cycleEnabled = on; }
+void TStageObject::enableCycle(bool on) { 
+  m_cycleEnabled = on; 
+}
 
 //-----------------------------------------------------------------------------
 
@@ -1469,6 +1534,14 @@ double TStageObject::getSO(double t) {
   else
     return m_so->getValue(tt);
 }
+// 
+double TStageObject::getDrawingNumber(double t) {
+  double tt = paramsTime(t);
+  if (m_parent)
+    return /* m_parent->getDrawingNumber(t)*/ m_drawingnumber->getValue(tt);
+  else
+    return m_drawingnumber->getValue(tt);
+}
 
 //-----------------------------------------------------------------------------
 
@@ -1537,6 +1610,7 @@ void TStageObject::updateKeyframes(LazyData &ld) const {
   params.push_back(m_scale.getPointer());
   params.push_back(m_shearx.getPointer());
   params.push_back(m_sheary.getPointer());
+  params.push_back(m_drawingnumber.getPointer());
 
   if (m_skeletonDeformation) {
     params.push_back(m_skeletonDeformation->skeletonIdsParam().getPointer());
@@ -1586,6 +1660,7 @@ void TStageObject::updateKeyframes(LazyData &ld) const {
     stageKf.m_channels[TStageObject::T_Path]   = m_posPath->getKeyframeAt(f);
     stageKf.m_channels[TStageObject::T_ShearX] = m_shearx->getKeyframeAt(f);
     stageKf.m_channels[TStageObject::T_ShearY] = m_sheary->getKeyframeAt(f);
+    stageKf.m_channels[TStageObject::T_DrawingNumber] = m_drawingnumber->getKeyframeAt(f);
 
     if (m_skeletonDeformation)
       m_skeletonDeformation->getKeyframeAt(f, stageKf.m_skeletonKeyframe);
@@ -1672,6 +1747,7 @@ void TStageObject::saveData(TOStream &os) {
   if (!m_posPath->isDefault()) os.child("pos") << *m_posPath;
   if (!m_shearx->isDefault()) os.child("shx") << *m_shearx;
   if (!m_sheary->isDefault()) os.child("shy") << *m_sheary;
+  if (!m_drawingnumber->isDefault()) os.child("drawingnumber") << *m_drawingnumber;
   if (m_cycleEnabled) os.child("cycle") << 1;
 
   if (m_skeletonDeformation) os.child("plasticSD") << *m_skeletonDeformation;
@@ -1750,6 +1826,8 @@ void TStageObject::loadData(TIStream &is) {
       is >> *m_shearx;
     else if (tagName == "shy")
       is >> *m_sheary;
+    else if (tagName == "drawingnumber")
+      is >> *m_drawingnumber; 
     else if (tagName == "pos")
       is >> *m_posPath;
     else if (tagName == "posCP") {
@@ -1883,7 +1961,7 @@ TStageObjectParams *TStageObject::getParams() const {
   data->m_posPath = m_posPath;
   data->m_shearx  = m_shearx;
   data->m_sheary  = m_sheary;
-
+  data->m_drawingnumber = m_drawingnumber;
   data->m_skeletonDeformation = m_skeletonDeformation;
 
   data->m_cycleEnabled = m_cycleEnabled;
@@ -1922,6 +2000,7 @@ void TStageObject::assignParams(const TStageObjectParams *src,
     m_posPath->copy(src->m_posPath.getPointer());
     m_shearx->copy(src->m_shearx.getPointer());
     m_sheary->copy(src->m_sheary.getPointer());
+    m_drawingnumber->copy(src->m_drawingnumber.getPointer());
 
     if (src->m_skeletonDeformation)
       setPlasticSkeletonDeformation(
@@ -1949,6 +2028,8 @@ void TStageObject::assignParams(const TStageObjectParams *src,
     m_shearx->addObserver(this);
     m_sheary = src->m_sheary.getPointer();
     m_sheary->addObserver(this);
+    m_drawingnumber = src->m_drawingnumber.getPointer();
+    m_drawingnumber->addObserver(this);
 
     m_skeletonDeformation = src->m_skeletonDeformation;
     if (m_skeletonDeformation) m_skeletonDeformation->addObserver(this);

--- a/toonz/sources/toonzlib/tstageobjecttree.cpp
+++ b/toonz/sources/toonzlib/tstageobjecttree.cpp
@@ -170,7 +170,7 @@ void TStageObjectTree::checkIntegrity() {
 //-----------------------------------------------------------------------------
 
 TStageObject *TStageObjectTree::getStageObject(const TStageObjectId &id,
-    bool create) {
+                                               bool create) {
   std::map<TStageObjectId, TStageObject *> &pegbars     = m_imp->m_pegbarTable;
   std::map<TStageObjectId, TStageObject *>::iterator it = pegbars.find(id);
   if (it != pegbars.end()) {

--- a/toonz/sources/toonzlib/tstageobjecttree.cpp
+++ b/toonz/sources/toonzlib/tstageobjecttree.cpp
@@ -170,7 +170,7 @@ void TStageObjectTree::checkIntegrity() {
 //-----------------------------------------------------------------------------
 
 TStageObject *TStageObjectTree::getStageObject(const TStageObjectId &id,
-                                               bool create) {
+    bool create) {
   std::map<TStageObjectId, TStageObject *> &pegbars     = m_imp->m_pegbarTable;
   std::map<TStageObjectId, TStageObject *>::iterator it = pegbars.find(id);
   if (it != pegbars.end()) {

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -40,8 +40,11 @@
 #include "toonz/txsheet.h"
 #include "toonz/preferences.h"
 
+
+
 // STD includes
 #include <set>
+#include <QDebug>
 
 using namespace std;
 
@@ -558,6 +561,180 @@ int TXsheet::getMaxFrame(int col) const {
   TXshColumnP column = m_imp->m_columnSet.getColumn(col);
   if (!column) return 0;
   return column->getMaxFrame();
+}
+/*
+QPair<int, int> chooseBounds(, int frame, int frameEnd,
+                             int keyframeStart,
+                             int keyframeEnd) {
+
+}*/
+//-----------------------------------------------------------------------------
+void TXsheet::getUpdateRange(
+    int col, int frame, QPair<int, int> *output,
+                             int channel
+                                 = TStageObject::T_DrawingNumber) {
+  TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
+  if (pegbar == nullptr) return; 
+  TDoubleParamP drawingNumberParamP = pegbar->getParam((TStageObject::Channel)channel);
+  TXshColumn *column          = getColumn(col); 
+  if (column == nullptr) return; 
+  int keyframeAmount = drawingNumberParamP->getKeyframeCount(); 
+  if (drawingNumberParamP->getKeyframeCount() == 0) return; 
+  int closestIndex = drawingNumberParamP->getClosestKeyframe(frame);
+
+  int prevKeyFrameIndex = std :: max(closestIndex-1, 0); 
+  int nextKeyFrameIndex = std :: min(closestIndex+1, keyframeAmount-1); 
+
+  // set variabels 
+  int maximumFrame = column->getMaxFrame(); 
+  // get surrounding keyframes, 
+  output->first  = drawingNumberParamP->keyframeIndexToFrame(prevKeyFrameIndex); 
+  output->second = drawingNumberParamP->keyframeIndexToFrame(nextKeyFrameIndex);
+  int trueOrNot  = drawingNumberParamP->isCycleEnabled(); 
+
+  if (pegbar->isCycleEnabled() && nextKeyFrameIndex == keyframeAmount - 1) {
+    for (int c = 0; c < getColumnCount(); c++) {
+      output->second = std::max(getMaxFrame(c), output->second); 
+    }
+  }
+
+  qDebug() << "hello:" << output->first << "," << output->second << "," << frame << prevKeyFrameIndex << "," << nextKeyFrameIndex << "\n";
+  if (frame < output->first) {
+    output->first = frame; 
+  } else if (frame > output->second) {
+    output->second = frame;   
+  }
+
+}
+void TXsheet::updateNonZeroDrawingNumberCellsParam(int col,
+                                              const TParamChange &c) {
+  updateNonZeroDrawingNumberCells(col, c.m_firstAffectedFrame,c.m_lastAffectedFrame); 
+}
+
+void TXsheet::updateNonZeroDrawingNumberCellsAfterMoving(int col, int frameAfter, int dt) {
+  TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
+  if (pegbar == nullptr) return;
+  TDoubleParamP drawingNumberParamP = pegbar->getDrawingNumberParamP();
+  if (drawingNumberParamP->getKeyframeCount() <= 1) return; 
+  int firstkeyframeindex = drawingNumberParamP->keyframeIndexToFrame(0);
+  int lastkeyframeindex  = drawingNumberParamP->keyframeIndexToFrame(drawingNumberParamP->getKeyframeCount()-1); 
+  
+  if (frameAfter <= firstkeyframeindex)
+  {
+    updateNonZeroDrawingNumberCells(col, std::min(frameAfter - dt, frameAfter )); 
+  } else if (frameAfter >= lastkeyframeindex) {
+    updateNonZeroDrawingNumberCells(col, std::max(frameAfter - dt, frameAfter)); 
+  } else {
+    updateNonZeroDrawingNumberCells(col, frameAfter); 
+  }
+
+  //updateNonZeroDrawingNumberCells(col, frameAfter - dt);
+}
+void TXsheet::updateNonZeroDrawingNumberCellsBox(int r0, int c0, int r1, int c1) {
+  
+  for (int c = c0; c <= c1; c++) {
+    updateNonZeroDrawingNumberCells(c, r0, r1); 
+  }
+  
+}
+bool TXsheet::updateNonZeroDrawingNumberCellsBox(int r0, int c0, int r1, int c1,
+    std::vector<std::pair<TRect, TXshCell>> &undoCells) {
+  for (int c = c0; c <= c1; c++) {
+    updateNonZeroDrawingNumberCells(c, r0, r1);
+  }
+  return true; 
+}
+
+
+void TXsheet::updateNonZeroDrawingNumberCells(int col, int frame,
+                                              int frameEnd, int keyframeStart,
+                                              int keyframeEnd) {
+
+  // check whether column and stage object are valid
+  int overrideOutside  = true; 
+  TStageObject *pegbar        = getStageObject(TStageObjectId::ColumnId(col)); 
+  if (pegbar == nullptr) return; 
+  TDoubleParamP drawingNumberParamP = pegbar->getDrawingNumberParamP();
+  TXshColumn* column = getColumn(col); 
+  qDebug() << frame << "\n"; 
+  if (column == nullptr || column->getColumnType() != TXshColumn::eLevelType) return; 
+  // do not alter locked columns
+  if (column->isLocked() || column->getParentFolder() != nullptr && column->isParentFolderLocked()) return; 
+  // only alter if it has keyframes for drawingnumber
+  if (!drawingNumberParamP->hasKeyframes()) return; 
+  // get keyframe indexes
+  if (frame == INT_MAX) frame = column->getMaxFrame(); 
+  QPair<int, int> updateRange{-1, -1};
+  getUpdateRange(col, frame, &updateRange); 
+  qDebug() << updateRange.first << "," << updateRange.second << "\n";
+  if (updateRange.first == -1 || updateRange.second == -1) return; 
+  TXshCell zeroCell = TXshCell(0, 0);
+
+  TXshCell cell; 
+  // ensure first cell is not empty
+  TXshCell firstcell = getCell(updateRange.first, col); 
+  int firstcellindex              = updateRange.first; 
+  while (firstcell.isEmpty()) {
+    if (firstcellindex >= updateRange.second - 1) return; 
+    firstcellindex++;
+    firstcell = getCell(firstcellindex, col);  
+  }
+  int behindCellDrawingNumber = -1; 
+
+  int firstkeyframeindex = drawingNumberParamP->keyframeIndexToFrame(0);
+  int lastkeyframeindex  = pegbar->isCycleEnabled() ? INT_MAX : drawingNumberParamP->keyframeIndexToFrame(
+      drawingNumberParamP->getKeyframeCount() - 1); 
+  
+  // loop through cells and set their id 
+  for (int r = updateRange.first; r <= updateRange.second; r++) {
+    double drawingNumberDouble = pegbar->getDrawingNumber(r);
+    int drawingNumber = drawingNumberDouble;
+    if (overrideOutside && (r < firstkeyframeindex || r > lastkeyframeindex)) {
+      if (drawingNumber) {
+        setCell(r, col, zeroCell);
+      }
+      continue;
+    }
+    if (behindCellDrawingNumber &&
+        behindCellDrawingNumber >= drawingNumberDouble) {
+      drawingNumber = std::ceil(drawingNumberDouble);
+    }
+    else
+    {
+      drawingNumber = std::floor(drawingNumberDouble);
+    }
+    behindCellDrawingNumber = drawingNumber; 
+    if (!drawingNumber) continue; // check for non zero drawing number
+    cell                       = getCell(r, col);
+    if (cell.isEmpty()) cell.m_level = firstcell.m_level; 
+    cell.m_frameId = drawingNumber; 
+    setCell(r, col, cell);
+  }
+  // trigger implicit holds
+  if (Preferences::instance()->isImplicitHoldEnabled()) {
+    TXshCell behindcell = zeroCell;
+    behindCellDrawingNumber =
+        updateRange.first >= 1 ? pegbar->getDrawingNumber(updateRange.first - 1)
+                               : -1;
+
+    for (int r = updateRange.first; r <= updateRange.second; r++) {
+      qDebug() << r << "lol";
+      if (r < firstkeyframeindex || r > lastkeyframeindex) {
+        if (overrideOutside) setCell(r, col, zeroCell);
+        continue;
+      }
+      double drawingNumberDouble = pegbar->getDrawingNumber(r);
+
+      cell              = getCell(r, col);
+      int drawingNumber = cell.getFrameId().getNumber();
+      if (!behindcell.isEmpty() && behindCellDrawingNumber == drawingNumber) {
+        setCell(r, col, zeroCell);
+      } else {
+        behindcell              = getCell(r, col);
+        behindCellDrawingNumber = drawingNumber;
+      }
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1436,6 +1613,7 @@ void TXsheet::loadData(TIStream &is) {
         if (!column) throw TException("expected xsheet column");
         m_imp->m_columnSet.insertColumn(col++, column);
         column->setXsheet(this);
+        addDrawingNumberObserver(col, column); 
         if (TXshZeraryFxColumn *zc =
                 dynamic_cast<TXshZeraryFxColumn *>(column)) {
           TFx *fx         = zc->getZeraryColumnFx()->getZeraryFx();
@@ -1586,8 +1764,26 @@ PERSIST_IDENTIFIER(TXsheet, "xsheet")
 void TXsheet::insertColumn(int col, TXshColumn::ColumnType type) {
   insertColumn(col, TXshColumn::createEmpty(type));
 }
+void TXsheet ::addDrawingNumberObserversAll() {
+  for (int c = 0; c < getColumnCount(); c++) {
+    TXshColumn *column = getColumn(c);
+    addDrawingNumberObserver(c, column);
+  }
+}
+  void TXsheet::addDrawingNumberObserver(int col, TXshColumn *column) {
+  if (column->getColumnType() != TXshColumn::ColumnType::eLevelType) return; 
+  TStageObject *pegbar =
+      getStageObjectTree()->getStageObject(TStageObjectId::ColumnId(col));
 
-//-----------------------------------------------------------------------------
+  pegbar->setDrawingNumberCallback(
+      std::bind(&TXsheet::updateNonZeroDrawingNumberCellsParam,
+                this, col,
+                std::placeholders::_1)
+  );
+}
+
+//class TXsheet::addDrawingNumberObserver : 
+      //-----------------------------------------------------------------------------
 
 void TXsheet::insertColumn(int col, TXshColumn *column) {
   if (col < 0) col = 0;
@@ -1598,6 +1794,8 @@ void TXsheet::insertColumn(int col, TXshColumn *column) {
   }
   m_imp->m_columnSet.insertColumn(col, column);
   m_imp->m_pegTree->insertColumn(col);
+  addDrawingNumberObserver(col, column); 
+  
   if (column->getPaletteColumn() ==
       0)  // palette column are not connected to the xsheet fx node
   {

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -40,11 +40,8 @@
 #include "toonz/txsheet.h"
 #include "toonz/preferences.h"
 
-
-
 // STD includes
 #include <set>
-#include <QDebug>
 
 using namespace std;
 
@@ -562,133 +559,146 @@ int TXsheet::getMaxFrame(int col) const {
   if (!column) return 0;
   return column->getMaxFrame();
 }
-/*
-QPair<int, int> chooseBounds(, int frame, int frameEnd,
-                             int keyframeStart,
-                             int keyframeEnd) {
 
-}*/
 //-----------------------------------------------------------------------------
-void TXsheet::getUpdateRange(
-    int col, int frame, QPair<int, int> *output,
-                             int channel
-                                 = TStageObject::T_DrawingNumber) {
+
+void TXsheet::getUpdateRange(int col, int frame, QPair<int, int> *output,
+                             int channel = TStageObject::T_DrawingNumber) {
   TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
-  if (pegbar == nullptr) return; 
-  TDoubleParamP drawingNumberParamP = pegbar->getParam((TStageObject::Channel)channel);
-  TXshColumn *column          = getColumn(col); 
-  if (column == nullptr) return; 
-  int keyframeAmount = drawingNumberParamP->getKeyframeCount(); 
-  if (drawingNumberParamP->getKeyframeCount() == 0) return; 
+  if (pegbar == nullptr) return;
+  TDoubleParamP drawingNumberParamP =
+      pegbar->getParam((TStageObject::Channel)channel);
+  TXshColumn *column = getColumn(col);
+  if (column == nullptr) return;
+  int keyframeAmount = drawingNumberParamP->getKeyframeCount();
+  if (drawingNumberParamP->getKeyframeCount() == 0) return;
   int closestIndex = drawingNumberParamP->getClosestKeyframe(frame);
 
-  int prevKeyFrameIndex = std :: max(closestIndex-1, 0); 
-  int nextKeyFrameIndex = std :: min(closestIndex+1, keyframeAmount-1); 
+  int prevKeyFrameIndex = std ::max(closestIndex - 1, 0);
+  int nextKeyFrameIndex = std ::min(closestIndex + 1, keyframeAmount - 1);
 
-  // set variabels 
-  int maximumFrame = column->getMaxFrame(); 
-  // get surrounding keyframes, 
-  output->first  = drawingNumberParamP->keyframeIndexToFrame(prevKeyFrameIndex); 
+  // set variabels
+  int maximumFrame = column->getMaxFrame();
+  // get surrounding keyframes,
+  output->first  = drawingNumberParamP->keyframeIndexToFrame(prevKeyFrameIndex);
   output->second = drawingNumberParamP->keyframeIndexToFrame(nextKeyFrameIndex);
-  int trueOrNot  = drawingNumberParamP->isCycleEnabled(); 
+  int trueOrNot  = drawingNumberParamP->isCycleEnabled();
 
   if (pegbar->isCycleEnabled() && nextKeyFrameIndex == keyframeAmount - 1) {
     for (int c = 0; c < getColumnCount(); c++) {
-      output->second = std::max(getMaxFrame(c), output->second); 
+      output->second = std::max(getMaxFrame(c), output->second);
     }
   }
 
-  qDebug() << "hello:" << output->first << "," << output->second << "," << frame << prevKeyFrameIndex << "," << nextKeyFrameIndex << "\n";
   if (frame < output->first) {
-    output->first = frame; 
+    output->first = frame;
   } else if (frame > output->second) {
-    output->second = frame;   
+    output->second = frame;
   }
-
 }
+
+//-----------------------------------------------------------------------------
+
 void TXsheet::updateNonZeroDrawingNumberCellsParam(int col,
-                                              const TParamChange &c) {
-  updateNonZeroDrawingNumberCells(col, c.m_firstAffectedFrame,c.m_lastAffectedFrame); 
+                                                   const TParamChange &c) {
+  updateNonZeroDrawingNumberCells(col, c.m_firstAffectedFrame,
+                                  c.m_lastAffectedFrame);
 }
 
-void TXsheet::updateNonZeroDrawingNumberCellsAfterMoving(int col, int frameAfter, int dt) {
+//-----------------------------------------------------------------------------
+
+void TXsheet::updateNonZeroDrawingNumberCellsAfterMoving(int col,
+                                                         int frameAfter,
+                                                         int dt) {
   TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
   if (pegbar == nullptr) return;
   TDoubleParamP drawingNumberParamP = pegbar->getDrawingNumberParamP();
-  if (drawingNumberParamP->getKeyframeCount() <= 1) return; 
+  if (drawingNumberParamP->getKeyframeCount() <= 1) return;
   int firstkeyframeindex = drawingNumberParamP->keyframeIndexToFrame(0);
-  int lastkeyframeindex  = drawingNumberParamP->keyframeIndexToFrame(drawingNumberParamP->getKeyframeCount()-1); 
-  
-  if (frameAfter <= firstkeyframeindex)
-  {
-    updateNonZeroDrawingNumberCells(col, std::min(frameAfter - dt, frameAfter )); 
+  int lastkeyframeindex  = drawingNumberParamP->keyframeIndexToFrame(
+      drawingNumberParamP->getKeyframeCount() - 1);
+
+  if (frameAfter <= firstkeyframeindex) {
+    updateNonZeroDrawingNumberCells(col, std::min(frameAfter - dt, frameAfter));
   } else if (frameAfter >= lastkeyframeindex) {
-    updateNonZeroDrawingNumberCells(col, std::max(frameAfter - dt, frameAfter)); 
+    updateNonZeroDrawingNumberCells(col, std::max(frameAfter - dt, frameAfter));
   } else {
-    updateNonZeroDrawingNumberCells(col, frameAfter); 
+    updateNonZeroDrawingNumberCells(col, frameAfter);
   }
 
-  //updateNonZeroDrawingNumberCells(col, frameAfter - dt);
+  // updateNonZeroDrawingNumberCells(col, frameAfter - dt);
 }
-void TXsheet::updateNonZeroDrawingNumberCellsBox(int r0, int c0, int r1, int c1) {
-  
+
+//-----------------------------------------------------------------------------
+
+void TXsheet::updateNonZeroDrawingNumberCellsBox(int r0, int c0, int r1,
+                                                 int c1) {
   for (int c = c0; c <= c1; c++) {
-    updateNonZeroDrawingNumberCells(c, r0, r1); 
+    updateNonZeroDrawingNumberCells(c, r0, r1);
   }
-  
 }
-bool TXsheet::updateNonZeroDrawingNumberCellsBox(int r0, int c0, int r1, int c1,
+
+//-----------------------------------------------------------------------------
+
+bool TXsheet::updateNonZeroDrawingNumberCellsBox(
+    int r0, int c0, int r1, int c1,
     std::vector<std::pair<TRect, TXshCell>> &undoCells) {
   for (int c = c0; c <= c1; c++) {
     updateNonZeroDrawingNumberCells(c, r0, r1);
   }
-  return true; 
+  return true;
 }
 
+//-----------------------------------------------------------------------------
 
-void TXsheet::updateNonZeroDrawingNumberCells(int col, int frame,
-                                              int frameEnd, int keyframeStart,
+void TXsheet::updateNonZeroDrawingNumberCells(int col, int frame, int frameEnd,
+                                              int keyframeStart,
                                               int keyframeEnd) {
-
   // check whether column and stage object are valid
-  int overrideOutside  = true; 
-  TStageObject *pegbar        = getStageObject(TStageObjectId::ColumnId(col)); 
-  if (pegbar == nullptr) return; 
+  int overrideOutside  = true;
+  TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
+  if (pegbar == nullptr) return;
   TDoubleParamP drawingNumberParamP = pegbar->getDrawingNumberParamP();
-  TXshColumn* column = getColumn(col); 
-  qDebug() << frame << "\n"; 
-  if (column == nullptr || column->getColumnType() != TXshColumn::eLevelType) return; 
+  TXshColumn *column                = getColumn(col);
+
+  if (column == nullptr || column->getColumnType() != TXshColumn::eLevelType)
+    return;
   // do not alter locked columns
-  if (column->isLocked() || column->getParentFolder() != nullptr && column->isParentFolderLocked()) return; 
+  if (column->isLocked() ||
+      column->getParentFolder() != nullptr && column->isParentFolderLocked())
+    return;
   // only alter if it has keyframes for drawingnumber
-  if (!drawingNumberParamP->hasKeyframes()) return; 
+  if (!drawingNumberParamP->hasKeyframes()) return;
   // get keyframe indexes
-  if (frame == INT_MAX) frame = column->getMaxFrame(); 
+  if (frame == INT_MAX) frame = column->getMaxFrame();
   QPair<int, int> updateRange{-1, -1};
-  getUpdateRange(col, frame, &updateRange); 
-  qDebug() << updateRange.first << "," << updateRange.second << "\n";
-  if (updateRange.first == -1 || updateRange.second == -1) return; 
+  getUpdateRange(col, frame, &updateRange);
+
+  if (updateRange.first == -1 || updateRange.second == -1) return;
   TXshCell zeroCell = TXshCell(0, 0);
 
-  TXshCell cell; 
+  TXshCell cell;
   // ensure first cell is not empty
-  TXshCell firstcell = getCell(updateRange.first, col); 
-  int firstcellindex              = updateRange.first; 
+  TXshCell firstcell = getCell(updateRange.first, col);
+  int firstcellindex = updateRange.first;
   while (firstcell.isEmpty()) {
-    if (firstcellindex >= updateRange.second - 1) return; 
+    if (firstcellindex >= updateRange.second - 1) return;
     firstcellindex++;
-    firstcell = getCell(firstcellindex, col);  
+    firstcell = getCell(firstcellindex, col);
   }
-  int behindCellDrawingNumber = -1; 
+  int behindCellDrawingNumber = -1;
 
   int firstkeyframeindex = drawingNumberParamP->keyframeIndexToFrame(0);
-  int lastkeyframeindex  = pegbar->isCycleEnabled() ? INT_MAX : drawingNumberParamP->keyframeIndexToFrame(
-      drawingNumberParamP->getKeyframeCount() - 1); 
-  
-  // loop through cells and set their id 
+  int lastkeyframeindex =
+      pegbar->isCycleEnabled()
+          ? INT_MAX
+          : drawingNumberParamP->keyframeIndexToFrame(
+                drawingNumberParamP->getKeyframeCount() - 1);
+
+  // loop through cells and set their id
   for (int r = updateRange.first; r <= updateRange.second; r++) {
     double drawingNumberDouble = pegbar->getDrawingNumber(r);
-    int drawingNumber = drawingNumberDouble;
+    int drawingNumber          = drawingNumberDouble;
     if (overrideOutside && (r < firstkeyframeindex || r > lastkeyframeindex)) {
       if (drawingNumber) {
         setCell(r, col, zeroCell);
@@ -698,16 +708,14 @@ void TXsheet::updateNonZeroDrawingNumberCells(int col, int frame,
     if (behindCellDrawingNumber &&
         behindCellDrawingNumber >= drawingNumberDouble) {
       drawingNumber = std::ceil(drawingNumberDouble);
-    }
-    else
-    {
+    } else {
       drawingNumber = std::floor(drawingNumberDouble);
     }
-    behindCellDrawingNumber = drawingNumber; 
-    if (!drawingNumber) continue; // check for non zero drawing number
-    cell                       = getCell(r, col);
-    if (cell.isEmpty()) cell.m_level = firstcell.m_level; 
-    cell.m_frameId = drawingNumber; 
+    behindCellDrawingNumber = drawingNumber;
+    if (!drawingNumber) continue;  // check for non zero drawing number
+    cell = getCell(r, col);
+    if (cell.isEmpty()) cell.m_level = firstcell.m_level;
+    cell.m_frameId = drawingNumber;
     setCell(r, col, cell);
   }
   // trigger implicit holds
@@ -718,7 +726,6 @@ void TXsheet::updateNonZeroDrawingNumberCells(int col, int frame,
                                : -1;
 
     for (int r = updateRange.first; r <= updateRange.second; r++) {
-      qDebug() << r << "lol";
       if (r < firstkeyframeindex || r > lastkeyframeindex) {
         if (overrideOutside) setCell(r, col, zeroCell);
         continue;
@@ -1764,26 +1771,26 @@ PERSIST_IDENTIFIER(TXsheet, "xsheet")
 void TXsheet::insertColumn(int col, TXshColumn::ColumnType type) {
   insertColumn(col, TXshColumn::createEmpty(type));
 }
+
+//-----------------------------------------------------------------------------
+
 void TXsheet ::addDrawingNumberObserversAll() {
   for (int c = 0; c < getColumnCount(); c++) {
     TXshColumn *column = getColumn(c);
     addDrawingNumberObserver(c, column);
   }
 }
-  void TXsheet::addDrawingNumberObserver(int col, TXshColumn *column) {
-  if (column->getColumnType() != TXshColumn::ColumnType::eLevelType) return; 
+void TXsheet::addDrawingNumberObserver(int col, TXshColumn *column) {
+  if (column->getColumnType() != TXshColumn::ColumnType::eLevelType) return;
   TStageObject *pegbar =
       getStageObjectTree()->getStageObject(TStageObjectId::ColumnId(col));
 
   pegbar->setDrawingNumberCallback(
-      std::bind(&TXsheet::updateNonZeroDrawingNumberCellsParam,
-                this, col,
-                std::placeholders::_1)
-  );
+      std::bind(&TXsheet::updateNonZeroDrawingNumberCellsParam, this, col,
+                std::placeholders::_1));
 }
 
-//class TXsheet::addDrawingNumberObserver : 
-      //-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 void TXsheet::insertColumn(int col, TXshColumn *column) {
   if (col < 0) col = 0;

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -9,6 +9,7 @@
 #include "tparamcontainer.h"
 #include "tparamset.h"
 #include "tfxattributes.h"
+#include "historytypes.h"
 
 // TnzLib includes
 #include "toonz/fxdag.h"
@@ -562,8 +563,9 @@ int TXsheet::getMaxFrame(int col) const {
 
 //-----------------------------------------------------------------------------
 
-void TXsheet::getUpdateRange(int col, int frame, QPair<int, int> *output,
-                             int channel = TStageObject::T_DrawingNumber) {
+void TXsheet::getUpdateRanges(int col, int frame, int endFrame,
+                              std::vector<QPair<int, int>> *output,
+                              int channel = TStageObject::T_DrawingNumber) {
   TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
   if (pegbar == nullptr) return;
   TDoubleParamP drawingNumberParamP =
@@ -571,176 +573,225 @@ void TXsheet::getUpdateRange(int col, int frame, QPair<int, int> *output,
   TXshColumn *column = getColumn(col);
   if (column == nullptr) return;
   int keyframeAmount = drawingNumberParamP->getKeyframeCount();
-  if (drawingNumberParamP->getKeyframeCount() == 0) return;
-  int closestIndex = drawingNumberParamP->getClosestKeyframe(frame);
+  if (keyframeAmount == 0) return;
+  int firstFrame = drawingNumberParamP->getKeyframe(0).m_frame;
+  int lastFrame  = drawingNumberParamP->getKeyframe(keyframeAmount - 1).m_frame;
+  if ((frame < firstFrame || frame > lastFrame) && endFrame < 0) return;
 
-  int prevKeyFrameIndex = std ::max(closestIndex - 1, 0);
-  int nextKeyFrameIndex = std ::min(closestIndex + 1, keyframeAmount - 1);
-
-  // set variabels
-  int maximumFrame = column->getMaxFrame();
-  // get surrounding keyframes,
-  output->first  = drawingNumberParamP->keyframeIndexToFrame(prevKeyFrameIndex);
-  output->second = drawingNumberParamP->keyframeIndexToFrame(nextKeyFrameIndex);
-  int trueOrNot  = drawingNumberParamP->isCycleEnabled();
-
-  if (pegbar->isCycleEnabled() && nextKeyFrameIndex == keyframeAmount - 1) {
-    for (int c = 0; c < getColumnCount(); c++) {
-      output->second = std::max(getMaxFrame(c), output->second);
-    }
+  if (frame > lastFrame) {
+    output->push_back(QPair<int, int>(lastFrame, frame));
+    return;
   }
 
-  if (frame < output->first) {
-    output->first = frame;
-  } else if (frame > output->second) {
-    output->second = frame;
+  int f = frame;
+  for (int i = 0; i < keyframeAmount; i++) {
+    int nf = drawingNumberParamP->getKeyframe(i).m_frame;
+    if (nf < f) continue;
+    if (f > nf) break;
+    int pf = i == 0 ? frame : drawingNumberParamP->getKeyframe(i - 1).m_frame;
+    QPair<int, int> range(pf, nf);
+    output->push_back(range);
+    f = nf;
   }
+  if (f < endFrame) output->push_back(QPair<int, int>(f, endFrame));
 }
 
 //-----------------------------------------------------------------------------
 
-void TXsheet::updateNonZeroDrawingNumberCellsParam(int col,
+void TXsheet::updateNonZeroDrawingNumberCellsParam(TXshColumn *column,
                                                    const TParamChange &c) {
-  updateNonZeroDrawingNumberCells(col, c.m_firstAffectedFrame,
+  if (!column) return;
+  updateNonZeroDrawingNumberCells(column->getIndex(), c.m_firstAffectedFrame,
                                   c.m_lastAffectedFrame);
 }
 
 //-----------------------------------------------------------------------------
 
-void TXsheet::updateNonZeroDrawingNumberCellsAfterMoving(int col,
-                                                         int frameAfter,
-                                                         int dt) {
-  TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
-  if (pegbar == nullptr) return;
-  TDoubleParamP drawingNumberParamP = pegbar->getDrawingNumberParamP();
-  if (drawingNumberParamP->getKeyframeCount() <= 1) return;
-  int firstkeyframeindex = drawingNumberParamP->keyframeIndexToFrame(0);
-  int lastkeyframeindex  = drawingNumberParamP->keyframeIndexToFrame(
-      drawingNumberParamP->getKeyframeCount() - 1);
-
-  if (frameAfter <= firstkeyframeindex) {
-    updateNonZeroDrawingNumberCells(col, std::min(frameAfter - dt, frameAfter));
-  } else if (frameAfter >= lastkeyframeindex) {
-    updateNonZeroDrawingNumberCells(col, std::max(frameAfter - dt, frameAfter));
-  } else {
-    updateNonZeroDrawingNumberCells(col, frameAfter);
-  }
-
-  // updateNonZeroDrawingNumberCells(col, frameAfter - dt);
-}
-
-//-----------------------------------------------------------------------------
-
-void TXsheet::updateNonZeroDrawingNumberCellsBox(int r0, int c0, int r1,
-                                                 int c1) {
+bool TXsheet::updateNonZeroDrawingNumberCellsBox(int r, int c0, int c1) {
   for (int c = c0; c <= c1; c++) {
-    updateNonZeroDrawingNumberCells(c, r0, r1);
+    updateNonZeroDrawingNumberCells(c, r);
   }
-}
 
-//-----------------------------------------------------------------------------
-
-bool TXsheet::updateNonZeroDrawingNumberCellsBox(
-    int r0, int c0, int r1, int c1,
-    std::vector<std::pair<TRect, TXshCell>> &undoCells) {
-  for (int c = c0; c <= c1; c++) {
-    updateNonZeroDrawingNumberCells(c, r0, r1);
-  }
   return true;
 }
 
 //-----------------------------------------------------------------------------
 
-void TXsheet::updateNonZeroDrawingNumberCells(int col, int frame, int frameEnd,
-                                              int keyframeStart,
-                                              int keyframeEnd) {
-  // check whether column and stage object are valid
-  int overrideOutside  = true;
-  TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
-  if (pegbar == nullptr) return;
-  TDoubleParamP drawingNumberParamP = pegbar->getDrawingNumberParamP();
-  TXshColumn *column                = getColumn(col);
+void TXsheet::updateNonZeroDrawingNumberCells(int col, int frame,
+                                              int endFrame) {
+  if (col < 0 || frame < 0) return;
 
-  if (column == nullptr || column->getColumnType() != TXshColumn::eLevelType)
+  TXshColumn *column = getColumn(col);
+  if (column == nullptr || column->isEmpty() ||
+      column->getColumnType() != TXshColumn::eLevelType)
     return;
+
   // do not alter locked columns
   if (column->isLocked() ||
       column->getParentFolder() != nullptr && column->isParentFolderLocked())
     return;
+
+  TStageObject *pegbar = getStageObject(TStageObjectId::ColumnId(col));
+  if (pegbar == nullptr) return;
+
   // only alter if it has keyframes for drawingnumber
+  TDoubleParamP drawingNumberParamP = pegbar->getDrawingNumberParamP();
   if (!drawingNumberParamP->hasKeyframes()) return;
+
+  int overrideOutside = true;
+
   // get keyframe indexes
   if (frame == INT_MAX) frame = column->getMaxFrame();
-  QPair<int, int> updateRange{-1, -1};
-  getUpdateRange(col, frame, &updateRange);
+  std::vector<QPair<int, int>> updateRanges;
+  getUpdateRanges(col, frame, endFrame, &updateRanges);
+  if (!updateRanges.size()) return;
 
-  if (updateRange.first == -1 || updateRange.second == -1) return;
-  TXshCell zeroCell = TXshCell(0, 0);
+  int r0, r1;
+  column->getLevelColumn()->getRange(r0, r1);
 
   TXshCell cell;
-  // ensure first cell is not empty
-  TXshCell firstcell = getCell(updateRange.first, col);
-  int firstcellindex = updateRange.first;
-  while (firstcell.isEmpty()) {
-    if (firstcellindex >= updateRange.second - 1) return;
-    firstcellindex++;
-    firstcell = getCell(firstcellindex, col);
-  }
-  int behindCellDrawingNumber = -1;
+  TXshCell zeroCell  = TXshCell(0, 0);
+  TXshCell firstcell = getCell(r0, col);
+
+  int prevDrawingNumber = -1;
 
   int firstkeyframeindex = drawingNumberParamP->keyframeIndexToFrame(0);
   int lastkeyframeindex =
-      pegbar->isCycleEnabled()
+      /* pegbar->isCycleEnabled()
           ? INT_MAX
-          : drawingNumberParamP->keyframeIndexToFrame(
+          : */drawingNumberParamP->keyframeIndexToFrame(
                 drawingNumberParamP->getKeyframeCount() - 1);
 
-  // loop through cells and set their id
-  for (int r = updateRange.first; r <= updateRange.second; r++) {
-    double drawingNumberDouble = pegbar->getDrawingNumber(r);
-    int drawingNumber          = drawingNumberDouble;
-    if (overrideOutside && (r < firstkeyframeindex || r > lastkeyframeindex)) {
-      if (drawingNumber) {
-        setCell(r, col, zeroCell);
-      }
-      continue;
-    }
-    if (behindCellDrawingNumber &&
-        behindCellDrawingNumber >= drawingNumberDouble) {
-      drawingNumber = std::ceil(drawingNumberDouble);
-    } else {
-      drawingNumber = std::floor(drawingNumberDouble);
-    }
-    behindCellDrawingNumber = drawingNumber;
-    if (!drawingNumber) continue;  // check for non zero drawing number
-    cell = getCell(r, col);
-    if (cell.isEmpty()) cell.m_level = firstcell.m_level;
-    cell.m_frameId = drawingNumber;
-    setCell(r, col, cell);
-  }
-  // trigger implicit holds
-  if (Preferences::instance()->isImplicitHoldEnabled()) {
-    TXshCell behindcell = zeroCell;
-    behindCellDrawingNumber =
-        updateRange.first >= 1 ? pegbar->getDrawingNumber(updateRange.first - 1)
-                               : -1;
+  bool implicitMode = Preferences::instance()->isImplicitHoldEnabled();
 
+  foreach (auto updateRange, updateRanges) {
     for (int r = updateRange.first; r <= updateRange.second; r++) {
-      if (r < firstkeyframeindex || r > lastkeyframeindex) {
-        if (overrideOutside) setCell(r, col, zeroCell);
+      double drawingNumberDouble = pegbar->getDrawingNumber(r);
+      int drawingNumber          = drawingNumberDouble;
+      if (overrideOutside &&
+          (r < firstkeyframeindex || r > lastkeyframeindex)) {
+        if (drawingNumber >= 0) {
+          setCell(r, col, zeroCell);
+        }
         continue;
       }
-      double drawingNumberDouble = pegbar->getDrawingNumber(r);
 
-      cell              = getCell(r, col);
-      int drawingNumber = cell.getFrameId().getNumber();
-      if (!behindcell.isEmpty() && behindCellDrawingNumber == drawingNumber) {
-        setCell(r, col, zeroCell);
-      } else {
-        behindcell              = getCell(r, col);
-        behindCellDrawingNumber = drawingNumber;
+      if (r != updateRange.first && r != updateRange.second) {
+        if (prevDrawingNumber && prevDrawingNumber >= drawingNumberDouble)
+          drawingNumber = std::ceil(drawingNumberDouble);
+        else
+          drawingNumber = std::floor(drawingNumberDouble);
       }
+      if (!implicitMode || prevDrawingNumber != drawingNumber ||
+          r == updateRange.first || r == updateRange.second) {
+        cell = getCell(r, col);
+        if (cell.isEmpty()) cell.m_level = firstcell.m_level;
+        cell.m_frameId = drawingNumber;
+        setCell(r, col, cell);
+      } else
+        setCell(r, col, zeroCell);
+
+      prevDrawingNumber = drawingNumber;
     }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+class UndoDrawingNumberChange final : public TUndo {
+  TXsheet *m_xsh;
+  int m_col;
+  std::vector<std::pair<int, TXshCell>> m_frameCells;
+
+public:
+  UndoDrawingNumberChange(TXsheet *xsh, int col,
+                          std::vector<std::pair<int, TXshCell>> frameCells)
+      : m_xsh(xsh), m_col(col), m_frameCells(frameCells) {
+  }
+
+  void undo() const override {
+    if (m_xsh) {
+      foreach (auto frameCell , m_frameCells)
+        m_xsh->setCell(frameCell.first, m_col, frameCell.second);
+    }
+  };
+  void redo() const override {};
+  int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override { return ""; }
+  int getHistoryType() override { return HistoryType::EditTool_Move; }
+};
+
+bool TXsheet::addUndoDrawingNumberChange(int row, TStageObjectId objId) {
+  if (!objId.isColumn()) return false;
+
+  TStageObject *stgObj = getStageObject(objId);
+
+  TStageObject::KeyframeMap keyframes;
+  stgObj->getKeyframes(keyframes);
+  int col = objId.getIndex();
+  int r0, r1;
+
+  std::set<double> frames;
+
+  foreach (auto keys, keyframes) frames.insert(keys.first);
+
+  getCellRange(col, r0, r1);
+  int n = r1 + 1;
+  std::vector<TXshCell> cells(n);
+  getCells(0, col, n, &cells[0], false, false);
+
+  return addUndoDrawingNumberChange(row, col, frames, cells);
+}
+
+bool TXsheet::addUndoDrawingNumberChange(int row, int col,
+                                         std::set<double> frames,
+                                         std::vector<TXshCell> cells) {
+  int firstKeyframe = row;
+  int lastKeyframe  = row;
+  if (frames.size()) {
+    firstKeyframe = *frames.begin();
+    lastKeyframe  = *frames.rbegin();
+    if (row >= firstKeyframe && row <= lastKeyframe) return false;
+  }
+
+  std::vector<std::pair<int, TXshCell>> frameCells;
+  int r0, r1;
+  if (row < firstKeyframe) {
+    r0 = row;
+    r1 = firstKeyframe;
+  } else if (row > lastKeyframe) {
+    r0 = lastKeyframe + 1;
+    r1 = row + 1;
+  } else {
+    r0 = row;
+    r1 = row + 1;
+  }
+  if (r0 < 0) r0 = 0;
+  if (r1 >= cells.size()) r1 = cells.size();
+
+  for (int r = r0; r < r1; r++) {
+    if (cells[r].isEmpty()) continue;
+    frameCells.push_back(std::pair(r, cells[r]));
+  }
+
+  if (frameCells.empty())
+    frameCells.push_back(std::pair(r0, TXshCell(0, TFrameId::EMPTY_FRAME)));
+
+  UndoDrawingNumberChange *undo =
+      new UndoDrawingNumberChange(this, col, frameCells);
+  TUndoManager::manager()->add(undo);
+
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXsheet::restoreDrawings(int col, int from, int to, TXsheet *xsh,
+                              QMap<int, std::vector<TXshCell>> drawings) {
+  for (int f = from; f <= to; f++) {
+    if (f >= drawings[col].size()) continue;
+    xsh->setCell(f, col, drawings[col][f]);
   }
 }
 
@@ -1620,7 +1671,7 @@ void TXsheet::loadData(TIStream &is) {
         if (!column) throw TException("expected xsheet column");
         m_imp->m_columnSet.insertColumn(col++, column);
         column->setXsheet(this);
-        addDrawingNumberObserver(col, column); 
+        addDrawingNumberObserver(column); 
         if (TXshZeraryFxColumn *zc =
                 dynamic_cast<TXshZeraryFxColumn *>(column)) {
           TFx *fx         = zc->getZeraryColumnFx()->getZeraryFx();
@@ -1777,17 +1828,42 @@ void TXsheet::insertColumn(int col, TXshColumn::ColumnType type) {
 void TXsheet ::addDrawingNumberObserversAll() {
   for (int c = 0; c < getColumnCount(); c++) {
     TXshColumn *column = getColumn(c);
-    addDrawingNumberObserver(c, column);
+    if (!column) continue;
+    addDrawingNumberObserver(column);
   }
 }
-void TXsheet::addDrawingNumberObserver(int col, TXshColumn *column) {
-  if (column->getColumnType() != TXshColumn::ColumnType::eLevelType) return;
-  TStageObject *pegbar =
-      getStageObjectTree()->getStageObject(TStageObjectId::ColumnId(col));
+
+//-----------------------------------------------------------------------------
+
+void TXsheet::addDrawingNumberObserver(TXshColumn *column) {
+  if (!column) return;
+  TStageObject *pegbar = getStageObjectTree()->getStageObject(
+      TStageObjectId::ColumnId(column->getIndex()));
 
   pegbar->setDrawingNumberCallback(
-      std::bind(&TXsheet::updateNonZeroDrawingNumberCellsParam, this, col,
+      std::bind(&TXsheet::updateNonZeroDrawingNumberCellsParam, this, column,
                 std::placeholders::_1));
+}
+
+//-----------------------------------------------------------------------------
+
+void TXsheet ::removeDrawingNumberObserversAll() {
+  for (int c = 0; c < getColumnCount(); c++) {
+    TXshColumn *column = getColumn(c);
+    if (!column) continue;
+    removeDrawingNumberObserver(column);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void TXsheet::removeDrawingNumberObserver(TXshColumn *column) {
+  if (!column) return;
+
+  TStageObject *pegbar = getStageObjectTree()->getStageObject(
+      TStageObjectId::ColumnId(column->getIndex()));
+
+  pegbar->setDrawingNumberCallback(nullptr);
 }
 
 //-----------------------------------------------------------------------------
@@ -1801,7 +1877,7 @@ void TXsheet::insertColumn(int col, TXshColumn *column) {
   }
   m_imp->m_columnSet.insertColumn(col, column);
   m_imp->m_pegTree->insertColumn(col);
-  addDrawingNumberObserver(col, column); 
+  addDrawingNumberObserver(column); 
   
   if (column->getPaletteColumn() ==
       0)  // palette column are not connected to the xsheet fx node
@@ -1919,8 +1995,14 @@ int TXsheet::getFirstFreeColumnIndex() const {
 //-----------------------------------------------------------------------------
 
 TXshColumn *TXsheet::touchColumn(int index, TXshColumn::ColumnType type) {
-  TXshColumn *column = m_imp->m_columnSet.touchColumn(index, type).getPointer();
-  if (index < 0 || !column) return 0;
+  if (index < 0) return 0;
+
+  TXshColumn *column = m_imp->m_columnSet.getColumn(index).getPointer();
+  if (!column) {
+    column = m_imp->m_columnSet.touchColumn(index, type).getPointer();
+    if (!column) return 0;
+    addDrawingNumberObserver(column);
+  }
 
   // NOTE (Daniele): The following && should be a bug... but I fear I'd break
   // something changing it.

--- a/toonz/sources/toonzlib/txsheetexpr.cpp
+++ b/toonz/sources/toonzlib/txsheetexpr.cpp
@@ -305,6 +305,8 @@ public:
       return TStageObject::T_ShearX;
     else if (s == "sheary" || s == "shy" || s == "shearv" || s == "shv")
       return TStageObject::T_ShearY;
+    else if (s == "W_Drawing_Number" || s == "drawingnumber")
+      return TStageObject::T_DrawingNumber; 
     else
       return TStageObject::T_ChannelCount;
   }

--- a/toonz/sources/toonzlib/txsheetexpr.cpp
+++ b/toonz/sources/toonzlib/txsheetexpr.cpp
@@ -305,7 +305,7 @@ public:
       return TStageObject::T_ShearX;
     else if (s == "sheary" || s == "shy" || s == "shearv" || s == "shv")
       return TStageObject::T_ShearY;
-    else if (s == "W_Drawing_Number" || s == "drawingnumber")
+    else if (s == "drawingnumber")
       return TStageObject::T_DrawingNumber; 
     else
       return TStageObject::T_ChannelCount;

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -569,7 +569,7 @@ TFrameId TXshSimpleLevel::index2fid(int index) const {
 TImageP TXshSimpleLevel::getFrame(const TFrameId &fid, UCHAR imFlags,
                                   int subsampling) const {
   assert(m_type != UNKNOWN_XSHLEVEL);
- 
+
   // If the required frame is not in range, quit
   if (m_frames.count(fid) == 0) return TImageP();
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -16,6 +16,7 @@
 #include "toonz/levelset.h"
 #include "toonz/tcamera.h"
 #include "toonz/txshcell.h"
+#include "toonz/txsheet.h"
 
 // TnzBase includes
 #include "tenv.h"
@@ -568,7 +569,7 @@ TFrameId TXshSimpleLevel::index2fid(int index) const {
 TImageP TXshSimpleLevel::getFrame(const TFrameId &fid, UCHAR imFlags,
                                   int subsampling) const {
   assert(m_type != UNKNOWN_XSHLEVEL);
-
+ 
   // If the required frame is not in range, quit
   if (m_frames.count(fid) == 0) return TImageP();
 

--- a/toonz/sources/toonzqt/functionkeyframenavigator.cpp
+++ b/toonz/sources/toonzqt/functionkeyframenavigator.cpp
@@ -7,6 +7,7 @@
 
 // TnzLib includes
 #include "toonz/tframehandle.h"
+#include "toonz/tcolumnhandle.h"
 #include "toonz/doubleparamcmd.h"
 
 // TnzBase includes
@@ -21,7 +22,7 @@
 #include <QIntValidator>
 
 FunctionKeyframeNavigator::FunctionKeyframeNavigator(QWidget *parent)
-    : KeyframeNavigator(parent), m_xsheetHandle(0) {}
+    : KeyframeNavigator(parent), m_xsheetHandle(0), m_columnHandle(0) {}
 
 void FunctionKeyframeNavigator::setCurve(TDoubleParam *curve) {
   if (m_curve.getPointer() == curve) return;
@@ -53,8 +54,24 @@ void FunctionKeyframeNavigator::toggle() {
     KeyframeSetter::removeKeyframeAt(m_curve.getPointer(), frame,
                                      m_xsheetHandle);
   else {
+    bool isDrawingNumber = m_curve->getName() == "W_DrawingNumber";
+    int frameId          = -1;
+    if (isDrawingNumber) {
+      TUndoManager::manager()->beginBlock();
+      int col  = m_columnHandle->getColumnIndex();
+      int xcol = TStageObjectId::ColumnId(col).getIndex();
+      m_xsheetHandle->getXsheet()->addUndoDrawingNumberChange(
+          frame, TStageObjectId::ColumnId(col));
+      TXshCell cell = m_xsheetHandle->getXsheet()->getCell(frame, xcol);
+      frameId       = cell.getFrameId().getNumber();
+    }
     KeyframeSetter setter(m_curve.getPointer(), m_xsheetHandle);
     setter.createKeyframe(frame);
+    if (isDrawingNumber) {
+      if (frameId >= 0) setter.setValue(frameId);
+      setter.addUndo();
+      TUndoManager::manager()->endBlock();
+    }
   }
 }
 

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -1817,6 +1817,8 @@ QColor FunctionPanel::getChannelColor(QString name, bool active) {
     color = QColor("darkorange");
   else if (name == "Shear V")
     color = QColor("darkorange");
+  else if (name == "Drawing Number")
+    color = QColor("lightgreen"); 
   else if (name == "posPath")
     color = QColor("darksalmon");
   else

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -8,12 +8,15 @@
 #include "toonzqt/imageutils.h"
 #include "functionpaneltools.h"
 #include "toonzqt/gutil.h"
+#include "toonzqt/functionsheet.h"
 
 // TnzLib includes
 #include "toonz/tframehandle.h"
 #include "toonz/doubleparamcmd.h"
 #include "toonz/toonzfolders.h"
 #include "toonz/preferences.h"
+#include "toonz/txsheet.h"
+
 // TnzBase includes
 #include "tdoubleparam.h"
 #include "tdoublekeyframe.h"
@@ -1704,7 +1707,26 @@ void FunctionPanel::openContextMenu(QMouseEvent *e) {
   } else if (action == &deleteKeyframeAction) {
     KeyframeSetter::removeKeyframeAt(curve, kf.m_frame, m_xsheetHandle);
   } else if (action == &insertKeyframeAction) {
-    KeyframeSetter(curve, m_xsheetHandle).createKeyframe(tround(frame));
+
+    bool hasDrawingKeys = curve->getName() == "W_DrawingNumber";
+    int frameId         = -1;
+    if (hasDrawingKeys) {
+      TUndoManager::manager()->beginBlock();
+      int col      = m_sheet->getColumnIndexByCurve(curve);
+      int xcol     = m_sheet->getStageObject(col)->getId().getIndex();
+      TXsheet *xsh = m_xsheetHandle->getXsheet();
+      xsh->addUndoDrawingNumberChange(tround(frame),
+                                      m_sheet->getStageObject(col)->getId());
+      TXshCell cell = xsh->getCell(tround(frame), xcol);
+      frameId       = cell.getFrameId().getNumber();
+    }
+    KeyframeSetter setter(curve, m_xsheetHandle);
+    setter.createKeyframe(tround(frame));
+    if (hasDrawingKeys) {
+      if (frameId >= 0) setter.setValue(frameId);
+      setter.addUndo();
+      TUndoManager::manager()->endBlock();
+    }
   } else if (action == &activateCycleAction) {
     KeyframeSetter::enableCycle(curve, true);
   } else if (action == &deactivateCycleAction) {
@@ -1817,7 +1839,7 @@ QColor FunctionPanel::getChannelColor(QString name, bool active) {
     color = QColor("darkorange");
   else if (name == "Shear V")
     color = QColor("darkorange");
-  else if (name == "Drawing Number")
+  else if (name == "Drawing #")
     color = QColor("lightgreen"); 
   else if (name == "posPath")
     color = QColor("darksalmon");

--- a/toonz/sources/toonzqt/functionpaneltools.cpp
+++ b/toonz/sources/toonzqt/functionpaneltools.cpp
@@ -4,9 +4,12 @@
 
 // TnzQt includes
 #include "toonzqt/functionselection.h"
+#include "toonzqt/functionsheet.h"
 
 // TnzLib includes
 #include "toonz/tframehandle.h"
+#include "toonz/tstageobject.h"
+#include "toonz/txshcell.h"
 
 // TnzCore includes
 #include "tundo.h"
@@ -133,6 +136,7 @@ MovePointDragTool::MovePointDragTool(FunctionPanel *panel, TDoubleParam *curve)
 MovePointDragTool::~MovePointDragTool() {
   for (int i = 0; i < (int)m_setters.size(); i++) delete m_setters[i];
   m_setters.clear();
+  m_startFrames.clear();
   TUndoManager::manager()->endBlock();
 }
 
@@ -196,6 +200,33 @@ void MovePointDragTool::click(QMouseEvent *e) {
   for (int i = 0; i < (int)m_setters.size(); i++) {
     KeyframeSetter *setter = m_setters[i];
     TDoubleParam *curve    = setter->getCurve();
+
+    FunctionSheet *sheet = m_panel->getFunctionSheet();
+    int col              = sheet->getColumnIndexByCurve(curve);
+    int xcol = sheet->getStageObject(col)->getId().getIndex();
+
+    std::set<double> frames;
+    if (curve->getName() == "W_DrawingNumber" &&
+        m_undoDrawings.find(xcol) == m_undoDrawings.end()) {
+      setter->getCurve()->getKeyframes(frames);
+
+      int r0, r1;
+      TXsheet *xsh        = m_panel->getXsheetHandle()->getXsheet();
+      TStageObject *stObj = sheet->getStageObject(col);
+      xsh->getCellRange(xcol, r0, r1);
+      int n = r1 + 1;
+      std::vector<TXshCell> cells(n);
+      xsh->getCells(0, xcol, n, &cells[0], false, false);
+      for (int i = 0; i < n; i++) {
+        if (cells[i].isEmpty()) continue;
+        if (stObj->hasDrawingNumberKey(i) ||
+            stObj->isChannelInterpolated(TStageObject::T_DrawingNumber, i))
+          cells[i] = TXshCell();
+      }
+      m_undoDrawings.insert(xcol, cells);
+    }
+    m_startFrames.push_back(frames);
+
     setter->setPixelRatio(m_panel->getPixelRatio(curve));
     if (!m_groupEnabled) {
       int kIndex = curve->getClosestKeyframe(frame);
@@ -228,10 +259,13 @@ void MovePointDragTool::drag(QMouseEvent *e) {
   m_oldPos      = pos;
 
   // compute frame increment. it must be an integer
-  double totalDFrame =
-      tround(m_panel->xToFrame(pos.x()) - m_panel->xToFrame(m_startPos.x()));
-  double dFrame = totalDFrame - m_deltaFrame;
-  m_deltaFrame  = totalDFrame;
+  int startRow       = m_panel->xToFrame(m_startPos.x());
+  int endRow         = m_panel->xToFrame(pos.x());
+  double totalDFrame = endRow - startRow;
+  double dFrame      = totalDFrame - m_deltaFrame;
+
+  FunctionSheet *sheet = m_panel->getFunctionSheet();
+  TXsheet *xsh         = sheet->getXsheetHandle()->getXsheet();
 
   for (int i = 0; i < (int)m_setters.size(); i++) {
     KeyframeSetter *setter = m_setters[i];
@@ -241,8 +275,55 @@ void MovePointDragTool::drag(QMouseEvent *e) {
     double dValue = m_panel->yToValue(curve, pos.y()) -
                     m_panel->yToValue(curve, oldPos.y());
 
+    if (curve->getName() == "W_DrawingNumber") {
+      // For Drawing nubers, don't let anything go below 0. Find closest
+      // selected frames to 0, that will be the max vertical drop allowed
+      if (dValue < 0) {
+        double v = INT_MAX;
+        for (int i = 0; i < curve->getKeyframeCount(); i++) {
+          if (setter->isSelected(i)) {
+            v = std::min(v, curve->getKeyframe(i).m_value);
+          }
+        }
+        if (v + dValue < 0) dValue = -v;
+      }
+      if (dFrame < 0) {
+        double h = INT_MAX;
+        for (int i = 0; i < curve->getKeyframeCount(); i++) {
+          if (setter->isSelected(i)) {
+            h = std::min(h, curve->getKeyframe(i).m_frame);
+          }
+        }
+        if (h + dFrame < 0) {
+          dFrame = -h;
+          totalDFrame = dFrame + m_deltaFrame;
+        }
+      }
+    }
+
     setter->moveKeyframes(dFrame, dValue);
+
+    int c     = sheet->getColumnIndexByCurve(setter->getCurve());
+    int colId = sheet->getStageObject(c)->getId().getIndex();
+    if (dFrame && m_undoDrawings.find(colId) != m_undoDrawings.end()) {
+      int kCount   = setter->getCurve()->getKeyframeCount();
+      std::set<double>::iterator sit(m_startFrames[i].begin());
+      for (int j = 0; j < kCount; j++, sit++) {
+        if (!setter->isSelected(j)) continue;
+        int r = setter->getCurve()->getKeyframe(j).m_frame;
+        if (dFrame > 0 && (r - dFrame) < *sit) {
+          xsh->restoreDrawings(colId, (r - dFrame), (r - 1), xsh,
+                               m_undoDrawings);
+        } else if (dFrame < 0 && (r - dFrame) > *sit) {
+          xsh->restoreDrawings(colId, (r + 1), (r - dFrame), xsh,
+                               m_undoDrawings);
+        }
+      }
+    }
   }
+
+  m_deltaFrame = totalDFrame;
+
   if (m_selection != 0 && m_setters.size() == 1) {
     KeyframeSetter *setter = m_setters[0];
 
@@ -257,6 +338,24 @@ void MovePointDragTool::drag(QMouseEvent *e) {
 //-----------------------------------------------------------------------------
 
 void MovePointDragTool::release(QMouseEvent *e) {
+  FunctionSheet *sheet = m_panel->getFunctionSheet();
+  TXsheet *xsh         = m_panel->getXsheetHandle()->getXsheet();
+  for (int i = 0; i < (int)m_setters.size(); i++) {
+    KeyframeSetter *setter = m_setters[i];
+    TDoubleParam *curve    = setter->getCurve();
+
+    if (curve->getName() != "W_DrawingNumber") continue;
+    int c    = sheet->getColumnIndexByCurve(curve);
+    int xcol = sheet->getStageObject(c)->getId().getIndex();
+
+    int kCount = curve->getKeyframeCount();
+    for (int j = 0; j < kCount; j++) {
+      int frame = curve->getKeyframe(j).m_frame;
+      xsh->addUndoDrawingNumberChange(frame, xcol, m_startFrames[i],
+                                      m_undoDrawings[xcol]);
+    }
+  }
+
   if (m_panel->getXsheetHandle())
     m_panel->getXsheetHandle()->notifyXsheetChanged();
 }

--- a/toonz/sources/toonzqt/functionpaneltools.h
+++ b/toonz/sources/toonzqt/functionpaneltools.h
@@ -11,6 +11,7 @@
 // class QMouseEvent;
 class KeyframeSetter;
 class TDoubleParam;
+class TXshCell;
 
 class FunctionPanel::DragTool {
 public:
@@ -79,6 +80,7 @@ class MovePointDragTool final : public FunctionPanel::DragTool {
   FunctionPanel *m_panel;
   QPoint m_startPos, m_oldPos;
   double m_deltaFrame;
+  int m_startFrame;
   // length and kIndex of speedinout handles which can change because of point
   // moving
   double m_speed0Length;
@@ -86,8 +88,11 @@ class MovePointDragTool final : public FunctionPanel::DragTool {
   double m_speed1Length;
   int m_speed1Index;
   std::vector<KeyframeSetter *> m_setters;
+  std::vector<std::set<double>> m_startFrames;
   bool m_groupEnabled;
   FunctionSelection *m_selection;
+
+  QMap<int, std::vector<TXshCell>> m_undoDrawings;
 
 public:
   MovePointDragTool(FunctionPanel *panel, TDoubleParam *curve);

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -3,11 +3,13 @@
 #include "toonzqt/functionselection.h"
 
 #include "toonzqt/dvdialog.h"
+#include "toonzqt/functionsheet.h"
 
 // TnzLib includes
 #include "toonz/doubleparamcmd.h"
 #include "toonz/tframehandle.h"
 #include "toonz/txsheetexpr.h"
+#include "toonz/txsheet.h"
 
 // TnzBase includes
 #include "tdoubleparam.h"
@@ -259,7 +261,8 @@ FunctionSelection::FunctionSelection()
     , m_selectedKeyframes()
     , m_selectedSegment(-1)
     , m_frameHandle(0)
-    , m_columnToCurveMapper(0) {}
+    , m_columnToCurveMapper(0)
+    , m_sheet(0) {}
 
 FunctionSelection::~FunctionSelection() {
   for (int i = 0; i < m_selectedKeyframes.size(); i++)
@@ -499,13 +502,17 @@ void FunctionSelection::doPaste() {
   int columnCount = data->getColumnCount();
   double frame    = 0;
   int col         = 0;
+  bool hasDrawingKeys = false;
   std::vector<TDoubleParam *> params;
   if (!m_selectedCells.isEmpty()) {
     col = m_selectedCells.left();
     // numeric columns
     for (int c = 0; c < columnCount; c++) {
       TDoubleParam *curve = getCurveFromColumn(col + c);
-      if (curve) params.push_back(curve);
+      if (curve) {
+        params.push_back(curve);
+        if (curve->getName() == "W_DrawingNumber") hasDrawingKeys = true;
+      }
     }
     columnCount = (int)params.size();
     if (columnCount <= 0) return;
@@ -522,6 +529,7 @@ void FunctionSelection::doPaste() {
     int kIndex = *(m_selectedKeyframes[0].second.begin());
     frame      = curve->keyframeIndexToFrame(kIndex);
     params.push_back(curve);
+    if (curve->getName() == "W_DrawingNumber") hasDrawingKeys = true;
   }
 
   /*--- カーブの貼り付け時に循環参照をチェックして、駄目ならアラートを返す ---*/
@@ -534,9 +542,19 @@ void FunctionSelection::doPaste() {
     }
   }
 
+  if (hasDrawingKeys) {
+    TUndoManager::manager()->beginBlock();
+    foreach (auto param, params) {
+      int c = m_sheet->getColumnIndexByCurve(param);
+      m_xsheetHandle->getXsheet()->addUndoDrawingNumberChange(
+          frame, m_sheet->getStageObject(c)->getId());
+    }
+  }
   KeyframesPasteUndo *undo = new KeyframesPasteUndo(params, data, frame);
   undo->setXsheetHandle(m_xsheetHandle);
   TUndoManager::manager()->add(undo);
+  if (hasDrawingKeys) TUndoManager::manager()->endBlock();
+
   for (int c = 0; c < columnCount; c++) data->setData(c, params[c], frame);
   if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
 }
@@ -547,6 +565,7 @@ void FunctionSelection::doCut() {
 
   bool cellsSelection = !m_selectedCells.isEmpty();
   int bottomRow       = m_selectedCells.bottom();
+  int topRow          = bottomRow - m_selectedCells.height() + 1;
 
   KeyframesMoveUndo *moveUndo = new KeyframesMoveUndo();
   moveUndo->setXsheetHandle(m_xsheetHandle);
@@ -557,6 +576,13 @@ void FunctionSelection::doCut() {
     if (cellsSelection) delta = -m_selectedCells.height();
     int n = curve ? curve->getKeyframeCount() : 0;
     int j = 0;
+    if (curve->getName() == "W_DrawingNumber" &&
+        topRow < curve->getKeyframe(0).m_frame) {
+      int c = m_sheet->getColumnIndexByCurve(curve);
+      m_xsheetHandle->getXsheet()->addUndoDrawingNumberChange(
+          topRow, m_sheet->getStageObject(c)->getId());
+    }
+
     for (int i = 0; i < n; i++) {
       if (kk.contains(i)) {
         if (i + 1 < n && kk.contains(i + 1) && !cellsSelection)
@@ -608,6 +634,7 @@ void FunctionSelection::insertCells() {
   QRect selectedCells     = getSelectedCells();
   int frameDelta          = selectedCells.height();
   int row                 = selectedCells.top();
+  bool undoBlockOpen      = false;
   KeyframesMoveUndo *undo = new KeyframesMoveUndo();
   undo->setXsheetHandle(m_xsheetHandle);
   for (int c = selectedCells.left(); c <= selectedCells.right(); c++) {
@@ -616,12 +643,22 @@ void FunctionSelection::insertCells() {
       // Move keyframes in reverse, so their ordering remains consistent at each
       // step
       int k = param->getKeyframeCount() - 1;
+      if (param->getName() == "W_DrawingNumber") {
+        if (!undoBlockOpen) {
+          undoBlockOpen = true;
+          TUndoManager::manager()->beginBlock();
+        }
+        int newLastFrame = param->keyframeIndexToFrame(k) + frameDelta;
+        m_xsheetHandle->getXsheet()->addUndoDrawingNumberChange(
+            newLastFrame, m_sheet->getStageObject(c)->getId());
+      }
       for (; k >= 0 && param->keyframeIndexToFrame(k) >= row; --k)
         undo->addMovement(param, k, frameDelta);
     }
   }
   undo->redo();
   TUndoManager::manager()->add(undo);
+  if (undoBlockOpen) TUndoManager::manager()->endBlock();
   if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
 }
 

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -15,6 +15,8 @@
 #include "toonz/txsheethandle.h"
 #include "toonz/txsheet.h"
 
+#include "tundo.h"
+
 // TnzBase includes
 #include "tunit.h"
 
@@ -54,9 +56,11 @@ const int cColHeadersEndY = 87;  //!< End of column headers y pos
 class MoveChannelsDragTool final : public Spreadsheet::DragTool {
   FunctionSheet *m_sheet;
   std::vector<KeyframeSetter *> m_setters;
+  std::vector<std::set<double>> m_startFrames;
   int m_oldRow;
   QRect m_selectedCells;
   int m_firstKeyframeRow;
+  QMap<int, std::vector<TXshCell>> m_undoDrawings;
 
 public:
   MoveChannelsDragTool(FunctionSheet *sheet)
@@ -89,12 +93,16 @@ public:
 
     TXsheetHandle *xsheetHandle = m_sheet->getXsheetHandle();
 
+    TUndoManager::manager()->beginBlock();
+
     /*---
-シンプルに左のバーをクリックした場合はcolは1つだけ。
-すでに複数Columnが選択されている上でその選択範囲内のセルの左バーをクリックした場合は
-横（Column）幅は選択範囲に順ずるようになる。高さ(row)はクリックしたセグメントと同じになる。
----*/
-    /*--- セグメントごとドラッグに備えてKeyFrameを格納する ---*/
+    If the left bar is simply clicked, only a single column is selected.
+    If multiple columns are already selected, and the left bar of a cell
+    *within* that selection range is clicked: The horizontal (column) width will
+    match that of the current selection range. The vertical (row) height will
+    match that of the specific segment clicked.
+    ---*/
+    /*--- Store KeyFrames in preparation for segment-based dragging ---*/
     for (int col = m_selectedCells.left(); col <= m_selectedCells.right();
          ++col) {
       TDoubleParam *curve = m_sheet->getCurve(col);
@@ -109,24 +117,86 @@ public:
         }
       }
       m_setters.push_back(setter);
+
+      int xcol = m_sheet->getStageObject(col)->getId().getIndex();
+      std::set<double> frames;
+      if (curve->getName() == "W_DrawingNumber" &&
+          m_undoDrawings.find(xcol) == m_undoDrawings.end()) {
+        setter->getCurve()->getKeyframes(frames);
+
+        int r0, r1;
+        TXsheet *xsh        = xsheetHandle->getXsheet();
+        TStageObject *stObj = m_sheet->getStageObject(col);
+        xsh->getCellRange(xcol, r0, r1);
+        int n = r1 + 1;
+        std::vector<TXshCell> cells(n);
+        xsh->getCells(0, xcol, n, &cells[0], false, false);
+        for (int i = 0; i < n; i++) {
+          if (cells[i].isEmpty()) continue;
+          if (stObj->hasDrawingNumberKey(i) ||
+              stObj->isChannelInterpolated(TStageObject::T_DrawingNumber, i))
+            cells[i] = TXshCell();
+        }
+        m_undoDrawings.insert(xcol, cells);
+      }
+      m_startFrames.push_back(frames);
     }
     m_oldRow = row;
   }
 
   void drag(int row, int col, QMouseEvent *e) override {
-    int d    = row - m_oldRow;
-    m_oldRow = row;
+    int d = row - m_oldRow;
     if (d + m_firstKeyframeRow < 0) d = -m_firstKeyframeRow;
     m_firstKeyframeRow += d;
-    for (int i = 0; i < (int)m_setters.size(); i++)
+    for (int i = 0; i < (int)m_setters.size(); i++) {
       m_setters[i]->moveKeyframes(d, 0.0);
+
+      int c     = m_sheet->getColumnIndexByCurve(m_setters[i]->getCurve());
+      int colId = m_sheet->getStageObject(c)->getId().getIndex();
+      if (d && m_undoDrawings.find(colId) != m_undoDrawings.end()) {
+        TXsheet *xsh = m_sheet->getXsheetHandle()->getXsheet();
+        int kCount   = m_setters[i]->getCurve()->getKeyframeCount();
+        std::set<double>::iterator sit(m_startFrames[i].begin());
+        for (int j = 0; j < kCount; j++, sit++) {
+          if (!m_setters[i]->isSelected(j)) continue;
+          int r = m_setters[i]->getCurve()->getKeyframe(j).m_frame;
+          if (d > 0 && (r - d) < *sit) {
+            xsh->restoreDrawings(colId, (r - d), (r - 1), xsh, m_undoDrawings);
+          } else if (d < 0 && (r - d) > *sit) {
+            xsh->restoreDrawings(colId, (r + 1), (r - d), xsh, m_undoDrawings);
+          }
+        }
+      }
+    }
     m_selectedCells.translate(0, d);
     m_sheet->selectCells(m_selectedCells);
+
+    m_oldRow = std::max(row, 0);
   }
 
   void release(int row, int col, QMouseEvent *e) override {
-    for (int i = 0; i < (int)m_setters.size(); i++) delete m_setters[i];
+    TXsheet *xsh = m_sheet->getXsheetHandle()->getXsheet();
+    for (int i = 0; i < (int)m_setters.size(); i++) {
+      KeyframeSetter *setter = m_setters[i];
+      TDoubleParam *curve    = setter->getCurve();
+
+      if (curve->getName() == "W_DrawingNumber") {
+        int c    = m_sheet->getColumnIndexByCurve(curve);
+        int xcol = m_sheet->getStageObject(c)->getId().getIndex();
+
+        int kCount = curve->getKeyframeCount();
+        for (int j = 0; j < kCount; j++) {
+          int frame = curve->getKeyframe(j).m_frame;
+          xsh->addUndoDrawingNumberChange(frame, xcol, m_startFrames[i],
+                                          m_undoDrawings[xcol]);
+        }
+      }
+
+      delete m_setters[i];
+    }
+    TUndoManager::manager()->endBlock();
     m_setters.clear();
+    m_startFrames.clear();
     m_sheet->getViewer()->getXsheetHandle()->notifyXsheetChanged();
   }
 };
@@ -778,6 +848,8 @@ void FunctionSheetCellViewer::drawCells(QPainter &painter, int r0, int c0,
 
     // draw each cell
     for (int row = r0; row <= r1; row++) {
+      bool drawXsheetFrameId = false;
+
       int ya = m_sheet->rowToY(row);
       int yb = m_sheet->rowToY(row + 1) - 1;
 
@@ -867,9 +939,20 @@ void FunctionSheetCellViewer::drawCells(QPainter &painter, int r0, int c0,
           painter.setPen(Qt::NoPen);
           painter.fillRect(cellRect, cellColor);
         }
+        if (curve->getName() == "W_DrawingNumber") {
+          TXsheet *xsh  = m_sheet->getViewer()->getXsheetHandle()->getXsheet();
+          int col       = m_sheet->getColumnIndexByCurve(curve);
+          int xcol      = m_sheet->getStageObject(col)->getId().getIndex();
+          TXshCell cell = xsh->getCell(row, xcol, true, true);
+          if (!cell.isEmpty() && !cell.getFrameId().isStopFrame() &&
+              !cell.getFrameId().isNoFrame()) {
+            drawXsheetFrameId = true;
+            value             = cell.getFrameId().getNumber();
+          }
+        }
       }
 
-      if (drawValue != None) {
+      if (drawValue != None || drawXsheetFrameId) {
         // draw cell value
         if (drawValue == Key || drawValue == Inbetween)
           painter.setPen(getViewer()->getTextColor());
@@ -993,11 +1076,18 @@ void FunctionSheetCellViewer::onCellEditorEditingFinished() {
       (m_lineEdit->isReturnPressed() || m_lineEdit->getMouseDragEditing())) {
     double value        = text.toDouble();
     TDoubleParam *curve = m_sheet->getCurve(m_editCol);
-    if (curve) {
+    if (curve && (curve->getName() != "W_DrawingNumber" || value >= 0)) {
+      if (curve->getName() == "W_DrawingNumber") {
+        TUndoManager::manager()->beginBlock();
+        m_sheet->getXsheetHandle()->getXsheet()->addUndoDrawingNumberChange(
+            m_editRow, m_sheet->getStageObject(m_editCol)->getId());
+      }
       TMeasure *measure = curve->getMeasure();
       const TUnit *unit = measure ? measure->getCurrentUnit() : 0;
       if (unit) value = unit->convertFrom(value);
       KeyframeSetter::setValue(curve, m_editRow, value);
+      if (curve->getName() == "W_DrawingNumber")
+        TUndoManager::manager()->endBlock();
     }
   }
   m_lineEdit->hide();
@@ -1188,7 +1278,26 @@ void FunctionSheetCellViewer::openContextMenu(QMouseEvent *e) {
     KeyframeSetter::removeKeyframeAt(curve, row);
     m_sheet->getViewer()->getXsheetHandle()->notifyXsheetChanged();
   } else if (action == &insertKeyframeAction) {
-    KeyframeSetter(curve).createKeyframe(row);
+    bool hasDrawingKeys = curve->getName() == "W_DrawingNumber";
+    int frameId        = -1;
+    if (hasDrawingKeys) {
+      TUndoManager::manager()->beginBlock();
+      int col = m_sheet->getColumnIndexByCurve(curve);
+      int xcol = m_sheet->getStageObject(col)->getId().getIndex();
+      TXsheet *xsh = m_sheet->getViewer()->getXsheetHandle()->getXsheet();
+      xsh->addUndoDrawingNumberChange(row,
+                                      m_sheet->getStageObject(col)->getId());
+      TXshCell cell = xsh->getCell(row, xcol);
+      frameId       = cell.getFrameId().getNumber();
+    }
+    KeyframeSetter setter(curve);
+    int kindex = setter.createKeyframe(row);
+    if (hasDrawingKeys) {
+      if (frameId >= 0)
+        setter.setValue(frameId);
+      setter.addUndo();
+      TUndoManager::manager()->endBlock();
+    }
     m_sheet->getViewer()->getXsheetHandle()->notifyXsheetChanged();
   } else if (interpActions.contains(action)) {
     selection->setSegmentType((TDoubleKeyframe::Type)action->data().toInt());

--- a/toonz/sources/toonzqt/functiontoolbar.cpp
+++ b/toonz/sources/toonzqt/functiontoolbar.cpp
@@ -45,6 +45,7 @@ FunctionToolbar::FunctionToolbar(QWidget *parent)
     : DVGui::ToolBar(parent)
     , m_frameHandle(0)
     , m_xsheetHandle(0)
+    , m_columnHandle(0)
     , m_curve(0)
     , m_selection(0) {
   setFixedHeight(28);
@@ -230,6 +231,13 @@ void FunctionToolbar::setFrameHandle(TFrameHandle *frameHandle) {
 void FunctionToolbar::setXsheetHandle(TXsheetHandle *xsheetHandle) {
   m_xsheetHandle = xsheetHandle;
   if (m_keyframeNavigator) m_keyframeNavigator->setXsheetHandle(xsheetHandle);
+}
+
+//-------------------------------------------------------------------
+
+void FunctionToolbar::setColumnHandle(TColumnHandle *columnHandle) {
+  m_columnHandle = columnHandle;
+  if (m_keyframeNavigator) m_keyframeNavigator->setColumnHandle(columnHandle);
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -593,6 +593,8 @@ QVariant FunctionTreeModel::Channel::data(int role) const {
       color = QColor("darkorange");
     else if (name == "Shear V")
       color = QColor("darkorange");
+    else if (name == "Drawing Number")
+      color = QColor("lightgreen"); 
     else if (name == "posPath")
       color = QColor("darksalmon");
     else
@@ -703,6 +705,8 @@ QString FunctionTreeModel::Channel::getExprRefName() const {
       tmpName = "shx";
     else if (tmpName == "Shear V")
       tmpName = "shy";
+    else if (tmpName == "W_Drawing_Number")
+      tmpName = "drawingnumber";
     else if (tmpName == "posPath")
       tmpName = "path";
     else if (tmpName == "Scale")
@@ -884,7 +888,7 @@ void FunctionTreeModel::refreshStageObjects(TXsheet *xsh) {
       TStageObject::T_X,      TStageObject::T_Y,      TStageObject::T_Z,
       TStageObject::T_SO,     TStageObject::T_Path,   TStageObject::T_Angle,
       TStageObject::T_ScaleX, TStageObject::T_ScaleY, TStageObject::T_Scale,
-      TStageObject::T_ShearX, TStageObject::T_ShearY};  // Explicitly ordered
+      TStageObject::T_ShearX, TStageObject::T_ShearY, TStageObject::T_DrawingNumber};  // Explicitly ordered
                                                         // channels
 
   // Retrieve all (not-empty) root stage objects, and add them in the tree model

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -593,7 +593,7 @@ QVariant FunctionTreeModel::Channel::data(int role) const {
       color = QColor("darkorange");
     else if (name == "Shear V")
       color = QColor("darkorange");
-    else if (name == "Drawing Number")
+    else if (name == "Drawing #")
       color = QColor("lightgreen"); 
     else if (name == "posPath")
       color = QColor("darksalmon");
@@ -705,7 +705,7 @@ QString FunctionTreeModel::Channel::getExprRefName() const {
       tmpName = "shx";
     else if (tmpName == "Shear V")
       tmpName = "shy";
-    else if (tmpName == "W_Drawing_Number")
+    else if (tmpName == "Drawing #")
       tmpName = "drawingnumber";
     else if (tmpName == "posPath")
       tmpName = "path";
@@ -919,6 +919,7 @@ void FunctionTreeModel::refreshStageObjects(TXsheet *xsh) {
         dynamic_cast<StageObjectChannelGroup *>(newItems[i]);
 
     TStageObject *stageObject = pegbarItem->getStageObject();
+    TStageObjectId stageObjId = stageObject->getId();
 
     // Add the standard stage object channels
     int j, jCount = TStageObject::T_ChannelCount;
@@ -926,6 +927,9 @@ void FunctionTreeModel::refreshStageObjects(TXsheet *xsh) {
     for (j = 0; j < jCount; ++j) {
       TDoubleParam *param =
           stageObject->getParam((TStageObject::Channel)channelIds[j]);
+      if (channelIds[j] == TStageObject::T_DrawingNumber &&
+          !stageObjId.isColumn())
+        continue;
       Channel *channel = new Channel(this, param);
 
       pegbarItem->appendChild(channel);

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -110,6 +110,9 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
 
   m_numericalColumns->setViewer(this);
 
+  m_selection->setFunctionSheet(m_numericalColumns);
+  m_functionGraph->setFunctionSheet(m_numericalColumns);
+
   m_toolbar->setSelection(m_selection);
   m_toolbar->setFocusPolicy(Qt::NoFocus);
 
@@ -238,6 +241,7 @@ FunctionViewer::~FunctionViewer() {
   delete m_selection;
   m_toolbar->setFrameHandle(0);
   m_toolbar->setXsheetHandle(0);
+  m_toolbar->setColumnHandle(0);
 }
 
 //-----------------------------------------------------------------------------
@@ -472,6 +476,8 @@ void FunctionViewer::setColumnHandle(TColumnHandle *columnHandle) {
   if (columnHandle == m_columnHandle) return;
 
   m_columnHandle = columnHandle;
+
+  m_toolbar->setColumnHandle(m_columnHandle);
 
   if (isVisible()) m_treeView->updateAll();
 }

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -47,6 +47,8 @@
 #include <QToolBar>
 #include <QAction>
 
+#include <QDebug>
+
 using namespace DVGui;
 
 TEnv::IntVar FunctionEditorToggleStatus("FunctionEditorToggleStatus", 1);
@@ -518,10 +520,44 @@ void FunctionViewer::toggleMode() {
 //-----------------------------------------------------------------------------
 
 void FunctionViewer::onCurveChanged(bool isDragging) {
+  /*
+  TXsheetP txsheet = m_xshHandle->getXsheet(); 
+  
+  txsheet->updateNonZeroDrawingNumberCells(
+      m_columnHandle->getColumnIndex(), 
+      m_frameHandle->getFrame()
+    ); 
+  */
+  /*
   if (m_objectHandle) m_objectHandle->notifyObjectIdChanged(isDragging);
-
+  TXsheetP txsheet = m_xshHandle->getXsheet(); 
+  /*
+  XsheetViewer *xv = TApp::instance()->getCurrentXsheetViewer();
+  TKeyframeSelection* keyframeSelection = xv->getKeyframeSelection(); 
+  std::set<TKeyframeSelection::Position> selection          = keyframeSelection->getSelection(); 
+  
+  qDebug() << selection.size() << "\n"; 
+  
+ 
+  QList <int> selectedFrames = keyframeSelection->get m_selection->getSelectedKeyIndices(m_curve);
+  */
+  int last  = -1;  // selectedFrames.back(); 
+  int first = -1;   // selectedFrames.front(); 
+  /*
+  if (selectedFrames.count() == 0) {
+    last = -1; 
+    first = -1; 
+  }
+  */
+  
+  //qDebug() << "first : " << first << " last :" << last << " count : " << selectedFrames.size() << "\n"; 
+  //txsheet->updateNonZeroDrawingNumberCells(m_columnHandle->getColumnIndex(),last, INT_MAX, first, last); 
+  
+  //QPair<TDoubleParamP, int>  x = m_selection->getSelectedKeyframe(); 
   // emit signal if the current channel belongs to Fx in order to update the
   // preview fx
+  if (m_objectHandle) m_objectHandle->notifyObjectIdChanged(isDragging);
+
   if (m_fxHandle) {
     FunctionTreeModel *ftModel =
         dynamic_cast<FunctionTreeModel *>(m_treeView->model());

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -47,8 +47,6 @@
 #include <QToolBar>
 #include <QAction>
 
-#include <QDebug>
-
 using namespace DVGui;
 
 TEnv::IntVar FunctionEditorToggleStatus("FunctionEditorToggleStatus", 1);
@@ -520,40 +518,9 @@ void FunctionViewer::toggleMode() {
 //-----------------------------------------------------------------------------
 
 void FunctionViewer::onCurveChanged(bool isDragging) {
-  /*
-  TXsheetP txsheet = m_xshHandle->getXsheet(); 
-  
-  txsheet->updateNonZeroDrawingNumberCells(
-      m_columnHandle->getColumnIndex(), 
-      m_frameHandle->getFrame()
-    ); 
-  */
-  /*
-  if (m_objectHandle) m_objectHandle->notifyObjectIdChanged(isDragging);
-  TXsheetP txsheet = m_xshHandle->getXsheet(); 
-  /*
-  XsheetViewer *xv = TApp::instance()->getCurrentXsheetViewer();
-  TKeyframeSelection* keyframeSelection = xv->getKeyframeSelection(); 
-  std::set<TKeyframeSelection::Position> selection          = keyframeSelection->getSelection(); 
-  
-  qDebug() << selection.size() << "\n"; 
-  
- 
-  QList <int> selectedFrames = keyframeSelection->get m_selection->getSelectedKeyIndices(m_curve);
-  */
   int last  = -1;  // selectedFrames.back(); 
   int first = -1;   // selectedFrames.front(); 
-  /*
-  if (selectedFrames.count() == 0) {
-    last = -1; 
-    first = -1; 
-  }
-  */
-  
-  //qDebug() << "first : " << first << " last :" << last << " count : " << selectedFrames.size() << "\n"; 
-  //txsheet->updateNonZeroDrawingNumberCells(m_columnHandle->getColumnIndex(),last, INT_MAX, first, last); 
-  
-  //QPair<TDoubleParamP, int>  x = m_selection->getSelectedKeyframe(); 
+
   // emit signal if the current channel belongs to Fx in order to update the
   // preview fx
   if (m_objectHandle) m_objectHandle->notifyObjectIdChanged(isDragging);


### PR DESCRIPTION
This PR adds a new feature that allows you to animate drawing substitution between animation keys based on interpolation type. It was originally started by @conicsectionn but I took over after they stopped development to focus on other non-T2D things.

The Animate tool now has a new `Drawing #` option which allows you to set a key for which Drawing # to show at the current frame location.  Click-drag left and right on the canvas to change the drawing that is to be shown at that key. 
<img width="1164" height="146" alt="image" src="https://github.com/user-attachments/assets/e9b79f19-247d-4e5e-b0c0-a5b7df966ec7" />

Additionally, in `All` mode, an option was added to the Animate widget for Drawing #.  Select it and click-drag left and right to change the drawing number. 
<img width="159.2" height="108" alt="image" src="https://github.com/user-attachments/assets/876fbbef-ec46-434a-8980-40210eb5fd4e" />

When there are 2 Drawing # keys placed on the timeline, drawings between the 2 keys are automatically placed between them based on the interpolation used and the number of drawings that exist for that level.

Notes:
- To use this feature you need a drawing level with multiple sequentially numbered drawings.
- Enabling `Global Key` or using the general `Set Key` will never set a channel key for Drawing #.  Drawing # channel keys can only be created by copy/pasting existing Drawing # keys, by using the Animate Tool's Drawing # mode, or by editing the Drawing # channel in Function Editor.
- Setting Drawing # keys around already exposed frames will cause those frames to be removed due to the automatic drawing substitution logic.  Undo should restore them if done in error.
- Use of this feature will prevent the scene from opening in prior versions of T2D

https://github.com/user-attachments/assets/3cd9cb13-8961-408d-ad52-61eb18da3550

