### PR TITLE
Fix non-Ubuntu linux build errors

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -240,7 +240,6 @@ add_definitions(
     -DQT_NETWORK_LIB
     -DQT_CORE_LIB
     -DQT_SHARED
-    -DQT_DISABLE_DEPRECATED_BEFORE=0x050F02
 )
 
 # Find includes in corresponding build directories
@@ -300,6 +299,7 @@ if(BUILD_ENV_MSVC)
     )
     add_definitions(
         -DGLUT_NO_LIB_PRAGMA
+        -DQT_DISABLE_DEPRECATED_BEFORE=0x050F02
     )
 
     if(WITH_GPHOTO2)

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -513,10 +513,15 @@ elseif(BUILD_ENV_UNIXLIKE)
     pkg_check_modules(LZMA liblzma)
     set(TIFF_LIB ${TIFF_LIBRARY} ${LZMA_LIBRARIES})
 
-    if(GLEW-NOTFOUND)
+    if(TARGET GLEW::GLEW)
+        set(GLEW_LIB GLEW::GLEW)
+    elseif(GLEW_FOUND)
+        set(GLEW_LIB ${GLEW_LIBRARIES})
+    else()
+        find_package(PkgConfig REQUIRED)
         pkg_check_modules(GLEW REQUIRED glew)
+        set(GLEW_LIB ${GLEW_LIBRARIES})
     endif()
-    set(GLEW_LIB ${GLEW_LIBRARIES})
 
     pkg_check_modules(LZ4_LIB REQUIRED liblz4)
 

--- a/toonz/sources/image/tzp/avl.h
+++ b/toonz/sources/image/tzp/avl.h
@@ -72,7 +72,7 @@ extern double Avl_Dummy[];
 #define AVL_DUP_USH (AVL_NODUP_USH | 1)
 #define AVL_DUP_CHR (AVL_NODUP_CHR | 1)
 
-#define AVL_AVLCMP (int (*)())0
+#define AVL_AVLCMP (int (*)(void *, void *))0
 
 #define avl_tree_nodup(usrcmp) avl__tree(AVL_NODUP_MBR, (unsigned)0, (usrcmp))
 #define avl_tree_nodup_mbr(structure, member, usrcmp)                          \
@@ -163,7 +163,7 @@ struct avl_path {
 typedef struct avl_tree {
   unsigned short keyinfo;
   unsigned short keyoffs;
-  int (*usrcmp)();
+  int (*usrcmp)(void *, void *);
   long nodes;
   struct avl_node *root;
   struct avl_path *path;
@@ -223,7 +223,7 @@ TNZAPI int avl_porting_problems();
 
 #else
 
-TNZAPI TREE *avl__tree(int treetype, unsigned keyoffs, int (*usrcmp)());
+TNZAPI TREE *avl__tree(int treetype, unsigned keyoffs, int (*usrcmp)(void *, void *));
 TNZAPI TREE *avl_copy(TREE *tree);
 
 TNZAPI int avl_insert(TREE *tree, void *data);
@@ -236,7 +236,7 @@ TNZAPI void *avl_locate_first(TREE *tree);
 TNZAPI void *avl_locate_last(TREE *tree);
 TNZAPI void *avl__remove(TREE *tree, long keyval);
 
-TNZAPI void avl__scan(TREE *tree, void (*usrfun)(), int back);
+TNZAPI void avl__scan(TREE *tree, void (*usrfun)(void *), int back);
 
 TNZAPI void *avl_first(TREE *tree);
 TNZAPI void *avl_last(TREE *tree);
@@ -247,7 +247,7 @@ TNZAPI void avl_stop(TREE *tree);
 
 TNZAPI void *avl__link(TREE *tree, unsigned ptroffs, int back);
 
-TNZAPI void avl_release(TREE *tree, void (*usrfun)());
+TNZAPI void avl_release(TREE *tree, void (*usrfun)(void *));
 TNZAPI void avl_reset(TREE *tree);
 TNZAPI void avl_close(TREE *tree);
 


### PR DESCRIPTION
This addresses some build errors that Linux users (Fedora/Arch, so far) are getting when building from source. (Fixes #2118)  These errors are not occurring in T2D's Ubuntu builds.

- Removed `-DQT_DISABLE_DEPRECATED_BEFORE=0x050F02` from Linux/macOS builds.
   - Resolves  error: `‘Recursive’ is not a member of ‘QMutex’`
   - Kept for Windows build to catch use of deprecated Qt classes/functions.
 
- Ported opentoonz/opentoonz/#6422 - Fix   build on gcc 15.1: prototypes must match  by @hfiguiere
   - Resolves error: `conflicting types for ‘avl__tree’; have ‘TREE *(int,  uint,  int (*)(void *, void *))’ {aka ‘struct avl_tree *(int,  unsigned int,  int (*)(void *, void *))’}`

- Ported opentoonz/opentoonz/#6836 - Fix GLEW   detection issues on newer systems  by @andeon 
