### PR TITLE
Fixes/enhancements to Animate tool and pegbar column

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -279,7 +279,7 @@ class ArrowToolOptionsBox final : public ToolOptionsBox {
 
   // Flip buttons
   QPushButton *m_hFlipButton, *m_vFlipButton, *m_leftRotateButton,
-      *m_rightRotateButton, *m_setKeyButton;
+      *m_rightRotateButton, *m_setKeyButton, *m_resetCenterButton;
 
   // enables adjusting value by dragging on the label
   void connectLabelAndField(ClickableLabel *label, MeasuredValueField *field);
@@ -320,6 +320,7 @@ protected slots:
   void onRotateLeft();
   void onRotateRight();
   void onSetKey();
+  void onResetCenter();
 };
 
 //=============================================================================

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -622,6 +622,7 @@ in TXsheetImp.
   void shiftMarkers(int row, int col, int rowCount);
 
   bool isPegbarColumn(int col);
+  TXshColumn *getColumnForPegbarObjectId(TStageObjectId pegbarObjId) const;
 
 protected:
   bool checkCircularReferences(TXsheet *childCandidate);

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -13,6 +13,7 @@
 #include "toonz/tstageobjectspline.h"
 #include "toonz/toonzscene.h"
 #include "toonz/txshcolumn.h"
+#include "toonz/txshpegbarcolumn.h"
 #include "toonz/stage.h"
 #include "toonz/tcamera.h"
 
@@ -956,7 +957,11 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
           id2 = xsh->getStageObjectParent(id2);
           if (!id2.isColumn() && !id2.isPegbar()) break;
         }
-        if (id2.isPegbar()) id = id2;
+        if (id2.isPegbar()) {
+          id                       = id2;
+          TXshColumn *pegbarColumn = xsh->getColumnForPegbarObjectId(id2);
+          if (pegbarColumn) columnIndex = pegbarColumn->getIndex();
+        }
       }
       if (id.isColumn()) {
         if (columnIndex >= 0 && columnIndex != currentColumnIndex) {
@@ -980,8 +985,13 @@ void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
           }
         }
       } else {
-        TTool::getApplication()->getCurrentObject()->setObjectId(id);
-        updateMatrix();
+        TXshColumn *column = xsh->getColumn(columnIndex);
+        if (!column || !column->isLocked()) {
+          TTool::getApplication()->getCurrentObject()->setObjectId(id);
+          TTool::getApplication()->getCurrentColumn()->setColumnIndex(
+              columnIndex);
+          updateMatrix();
+        }
       }
     }
     pos = getMatrix().inv() * pos;
@@ -1703,6 +1713,12 @@ QString EditTool::updateEnabled(int rowIndex, int columnIndex) {
     return (
         enable(false),
         QObject::tr("It is not possible to animate unlinked motion paths."));
+  }
+
+  if (objId.isPegbar()) {
+    TXshColumn *pegbarColumn = xsh->getColumnForPegbarObjectId(objId);
+    if (pegbarColumn)
+      objId = TStageObjectId::ColumnId(pegbarColumn->getIndex());
   }
 
   if (!objId.isColumn()) return (enable(true), QString());

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -861,18 +861,22 @@ void EditTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
   /*-- Soundカラムの場合は何もしない --*/
   if (!doesApply()) return;
 
-  if (m_activeAxis.getValue() == L"Position")
+  if (m_activeAxis.getValue() == L"Position") {
     if (e.isCtrlPressed())
       m_what = ZTranslation;
     else
       m_what = Translation;
-  else if (m_activeAxis.getValue() == L"Scale")
+  } else if (m_activeAxis.getValue() == L"Scale") {
     if (e.isCtrlPressed())
       m_what = ScaleXY;
     else
       m_what = Scale;
-  else if (m_activeAxis.getValue() == L"All")
-    onEditAllLeftButtonDown(pos, e);
+  } else if (m_activeAxis.getValue() == L"All") {
+    int selectedDevice = pick(e.m_pos);
+    m_what             = selectedDevice >= 0 ? selectedDevice : Translation;
+  }
+
+  onLeftButtonPick(pos, e);
 
   int scaleConstraint = 0;
   if (m_scaleConstraint.getValue() == L"A/R")
@@ -939,63 +943,59 @@ void EditTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
 
 //-----------------------------------------------------------------------------
 
-void EditTool::onEditAllLeftButtonDown(TPointD &pos, const TMouseEvent &e) {
-  int selectedDevice = pick(e.m_pos);
-  m_what             = selectedDevice >= 0 ? selectedDevice : Translation;
+void EditTool::onLeftButtonPick(TPointD &pos, const TMouseEvent &e) {
+  if (m_autoSelect.getValue() == L"None") return;
 
-  if (selectedDevice < 0 && m_autoSelect.getValue() != L"None") {
-    pos = getMatrix() * pos;
-    int columnIndex = getViewer()->posToColumnIndex(e.m_pos, 5.0, false);
-    if (columnIndex >= 0) {
-      int currentColumnIndex = getColumnIndex();
-      TXsheet *xsh           = getXsheet();
-      TStageObjectId id      = xsh->getColumnObjectId(columnIndex);
+  pos             = getMatrix() * pos;
+  int columnIndex = getViewer()->posToColumnIndex(e.m_pos, 5.0, false);
+  if (columnIndex >= 0) {
+    int currentColumnIndex = getColumnIndex();
+    TXsheet *xsh           = getXsheet();
+    TStageObjectId id      = xsh->getColumnObjectId(columnIndex);
 
-      if (m_autoSelect.getValue() == L"Pegbar") {
-        TStageObjectId id2 = id;
-        while (!id2.isPegbar()) {
-          id2 = xsh->getStageObjectParent(id2);
-          if (!id2.isColumn() && !id2.isPegbar()) break;
-        }
-        if (id2.isPegbar()) {
-          id                       = id2;
-          TXshColumn *pegbarColumn = xsh->getColumnForPegbarObjectId(id2);
-          if (pegbarColumn) columnIndex = pegbarColumn->getIndex();
-        }
+    if (m_autoSelect.getValue() == L"Pegbar") {
+      TStageObjectId id2 = id;
+      while (!id2.isPegbar()) {
+        id2 = xsh->getStageObjectParent(id2);
+        if (!id2.isColumn() && !id2.isPegbar()) break;
       }
-      if (id.isColumn()) {
-        if (columnIndex >= 0 && columnIndex != currentColumnIndex) {
-          if (e.isShiftPressed()) {
-            TXsheetHandle *xshHandle =
-                TTool::getApplication()->getCurrentXsheet();
-            TXsheet *xsh = xshHandle->getXsheet();
-            TStageObjectId curColId =
-                xsh->getColumnObjectId(currentColumnIndex);
-            TStageObjectId colId = xsh->getColumnObjectId(columnIndex);
-            TStageObjectCmd::setParent(curColId, colId, "", xshHandle);
-            m_what = None;
-            xshHandle->notifyXsheetChanged();
-          } else {
-            TXshColumn *column = xsh->getColumn(columnIndex);
-            if (!column || !column->isLocked()) {
-              TTool::getApplication()->getCurrentColumn()->setColumnIndex(
-                  columnIndex);
-              updateMatrix();
-            }
-          }
-        }
-      } else {
-        TXshColumn *column = xsh->getColumn(columnIndex);
-        if (!column || !column->isLocked()) {
-          TTool::getApplication()->getCurrentObject()->setObjectId(id);
-          TTool::getApplication()->getCurrentColumn()->setColumnIndex(
-              columnIndex);
-          updateMatrix();
-        }
+      if (id2.isPegbar()) {
+        id                       = id2;
+        TXshColumn *pegbarColumn = xsh->getColumnForPegbarObjectId(id2);
+        if (pegbarColumn) columnIndex = pegbarColumn->getIndex();
       }
     }
-    pos = getMatrix().inv() * pos;
+    if (id.isColumn()) {
+      if (columnIndex >= 0 && columnIndex != currentColumnIndex) {
+        if (e.isShiftPressed()) {
+          TXsheetHandle *xshHandle =
+              TTool::getApplication()->getCurrentXsheet();
+          TXsheet *xsh            = xshHandle->getXsheet();
+          TStageObjectId curColId = xsh->getColumnObjectId(currentColumnIndex);
+          TStageObjectId colId    = xsh->getColumnObjectId(columnIndex);
+          TStageObjectCmd::setParent(curColId, colId, "", xshHandle);
+          m_what = None;
+          xshHandle->notifyXsheetChanged();
+        } else {
+          TXshColumn *column = xsh->getColumn(columnIndex);
+          if (!column || !column->isLocked()) {
+            TTool::getApplication()->getCurrentColumn()->setColumnIndex(
+                columnIndex);
+            updateMatrix();
+          }
+        }
+      }
+    } else {
+      TXshColumn *column = xsh->getColumn(columnIndex);
+      if (!column || !column->isLocked()) {
+        TTool::getApplication()->getCurrentObject()->setObjectId(id);
+        TTool::getApplication()->getCurrentColumn()->setColumnIndex(
+            columnIndex);
+        updateMatrix();
+      }
+    }
   }
+  pos = getMatrix().inv() * pos;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -861,6 +861,8 @@ void EditTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
   /*-- Soundカラムの場合は何もしない --*/
   if (!doesApply()) return;
 
+  int origWhat = m_what;
+
   if (m_activeAxis.getValue() == L"Position") {
     if (e.isCtrlPressed())
       m_what = ZTranslation;
@@ -933,6 +935,10 @@ void EditTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
       break;
     }
   }
+
+  // Restore mode in case it was changed when setting parent
+  if (m_what == None) m_what = origWhat;
+
   if (m_dragTool) {
     m_dragTool->enableGlobalKeyframes(m_globalKeyframes.getValue());
     TUndoManager::manager()->beginBlock();
@@ -953,8 +959,8 @@ void EditTool::onLeftButtonPick(TPointD &pos, const TMouseEvent &e) {
     TXsheet *xsh           = getXsheet();
     TStageObjectId id      = xsh->getColumnObjectId(columnIndex);
 
+    TStageObjectId id2 = id;
     if (m_autoSelect.getValue() == L"Pegbar") {
-      TStageObjectId id2 = id;
       while (!id2.isPegbar()) {
         id2 = xsh->getStageObjectParent(id2);
         if (!id2.isColumn() && !id2.isPegbar()) break;
@@ -965,18 +971,31 @@ void EditTool::onLeftButtonPick(TPointD &pos, const TMouseEvent &e) {
         if (pegbarColumn) columnIndex = pegbarColumn->getIndex();
       }
     }
-    if (id.isColumn()) {
+
+    if (e.isShiftPressed()) {
+      TXsheetHandle *xshHandle = TTool::getApplication()->getCurrentXsheet();
+      TXsheet *xsh             = xshHandle->getXsheet();
+      TStageObjectId curColId  = xsh->getColumnObjectId(currentColumnIndex);
+
+      if (id2.isPegbar()) {
+        for (int i = 0; i < xsh->getColumnCount(); i++) {
+          if (!xsh->getColumn(i) || !xsh->getColumn(i)->getPegbarColumn() ||
+              xsh->getColumn(i)->getPegbarColumn()->getPegbarObjectId() != id2)
+            continue;
+          columnIndex = i;
+          break;
+        }
+      }
       if (columnIndex >= 0 && columnIndex != currentColumnIndex) {
-        if (e.isShiftPressed()) {
-          TXsheetHandle *xshHandle =
-              TTool::getApplication()->getCurrentXsheet();
-          TXsheet *xsh            = xshHandle->getXsheet();
-          TStageObjectId curColId = xsh->getColumnObjectId(currentColumnIndex);
-          TStageObjectId colId    = xsh->getColumnObjectId(columnIndex);
-          TStageObjectCmd::setParent(curColId, colId, "", xshHandle);
-          m_what = None;
-          xshHandle->notifyXsheetChanged();
-        } else {
+        TStageObjectId colId = xsh->getColumnObjectId(columnIndex);
+
+        TStageObjectCmd::setParent(curColId, colId, "", xshHandle);
+        m_what = None;
+        xshHandle->notifyXsheetChanged();
+      }
+    } else {
+      if (id.isColumn()) {
+        if (columnIndex >= 0 && columnIndex != currentColumnIndex) {
           TXshColumn *column = xsh->getColumn(columnIndex);
           if (!column || !column->isLocked()) {
             TTool::getApplication()->getCurrentColumn()->setColumnIndex(
@@ -984,14 +1003,14 @@ void EditTool::onLeftButtonPick(TPointD &pos, const TMouseEvent &e) {
             updateMatrix();
           }
         }
-      }
-    } else {
-      TXshColumn *column = xsh->getColumn(columnIndex);
-      if (!column || !column->isLocked()) {
-        TTool::getApplication()->getCurrentObject()->setObjectId(id);
-        TTool::getApplication()->getCurrentColumn()->setColumnIndex(
-            columnIndex);
-        updateMatrix();
+      } else {
+        TXshColumn *column = xsh->getColumn(columnIndex);
+        if (!column || !column->isLocked()) {
+          TTool::getApplication()->getCurrentObject()->setObjectId(id);
+          TTool::getApplication()->getCurrentColumn()->setColumnIndex(
+              columnIndex);
+          updateMatrix();
+        }
       }
     }
   }

--- a/toonz/sources/tnztools/edittool.h
+++ b/toonz/sources/tnztools/edittool.h
@@ -84,7 +84,7 @@ class EditTool final : public QObject, public TTool {
   TPropertyGroup m_prop;
 
   void drawMainHandle();
-  void onEditAllLeftButtonDown(TPointD& pos, const TMouseEvent& e);
+  void onLeftButtonPick(TPointD& pos, const TMouseEvent& e);
 
 public:
   EditTool();

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -43,6 +43,7 @@
 #include "toonz/tstageobjecttree.h"
 #include "toonz/mypaintbrushstyle.h"
 #include "toonz/tonionskinmaskhandle.h"
+#include "toonz/tstageobjectcmd.h"
 
 // TnzCore includes
 #include "tproperty.h"
@@ -643,6 +644,11 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_interpolationCombo->addItem(tr("Expression "), 7);
   m_interpolationCombo->addItem(tr("File"), 8);
 
+  m_resetCenterButton = new QPushButton(this);
+  m_resetCenterButton->setIcon(createQIcon("center_reset"));
+  m_resetCenterButton->setIconSize(QSize(20, 20));
+  m_resetCenterButton->setToolTip(tr("Reset Center"));
+
   int interpolationType = Preferences::instance()->getKeyframeType();
   for (int i = 0; i < m_interpolationCombo->count(); ++i)
     if (m_interpolationCombo->itemData(i) == interpolationType) {
@@ -673,8 +679,6 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
     }
     m_pickWidget->setLayout(pickLay);
     mainLay->addWidget(m_pickWidget, 0);
-
-    addSeparator();
 
     mainLay->addWidget(m_interpolationCombo, 0);
     mainLay->addWidget(m_setKeyButton, 0);
@@ -856,6 +860,9 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
         centerPosLay->addWidget(m_lockNSCenterCheckbox, 0);
 
         centerPosLay->addSpacing(ITEM_SPACING);
+        centerPosLay->addWidget(m_resetCenterButton, 0);
+
+        centerPosLay->addSpacing(ITEM_SPACING);
         centerPosLay->addWidget(new DVGui::Separator("", this, false));
 
         centerPosLay->addStretch(1);
@@ -913,6 +920,8 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
 
   connect(m_interpolationCombo, SIGNAL(activated(int)), this,
           SLOT(onInterpolationComboActivated(int)));
+
+  connect(m_resetCenterButton, SIGNAL(clicked()), SLOT(onResetCenter()));
 
   connect(editTool, SIGNAL(clickFlipHorizontal()), SLOT(onFlipHorizontal()));
   connect(editTool, SIGNAL(clickFlipVertical()), SLOT(onFlipVertical()));
@@ -1529,6 +1538,13 @@ void ArrowToolOptionsBox::onSetKey() {
   TUndoManager::manager()->endBlock();
 
   m_xshHandle->notifyXsheetChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+void ArrowToolOptionsBox::onResetCenter() {
+  TStageObjectId id = m_objHandle->getObjectId();
+  TStageObjectCmd::resetCenterAndOffset(id, m_xshHandle);
 }
 
 //------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -674,6 +674,8 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
     m_pickWidget->setLayout(pickLay);
     mainLay->addWidget(m_pickWidget, 0);
 
+    addSeparator();
+
     mainLay->addWidget(m_interpolationCombo, 0);
     mainLay->addWidget(m_setKeyButton, 0);
 
@@ -1406,8 +1408,6 @@ void ArrowToolOptionsBox::onCurrentAxisChanged(int axisId) {
   // Show the specified axis options, hide all the others
   for (int a = 0; a != AllAxis; ++a)
     m_axisOptionWidgets[a]->setVisible(a == axisId || axisId == AllAxis);
-
-  m_pickWidget->setVisible(axisId == AllAxis);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -34,6 +34,7 @@
 #include "toonz/tframehandle.h"
 #include "toonz/tcolumnhandle.h"
 #include "toonz/tstageobjectcmd.h"
+#include "toonz/txshpegbarcolumn.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -1644,14 +1645,17 @@ void TCellSelection::setKeyframes() {
 
   int row = m_range.m_r0, col = m_range.m_c0;
 
-  if (xsh->getColumn(col) && xsh->getColumn(col)->getFolderColumn()) return;
+  TXshColumn *column = xsh->getColumn(col);
+  if (column && (column->isLocked() || column->getFolderColumn() ||
+                 column->getSoundColumn() || column->getSoundTextColumn()))
+    return;
 
-  const TXshCell &cell = xsh->getCell(row, col);
-  if (cell.getSoundLevel() || cell.getSoundTextLevel()) return;
-
-  const TStageObjectId &id =
+  TStageObjectId id =
       col >= 0 ? TStageObjectId::ColumnId(col)
                : TStageObjectId::CameraId(xsh->getCameraColumnIndex());
+
+  if (column && column->getPegbarColumn())
+    id = column->getPegbarColumn()->getPegbarObjectId();
 
   TStageObject *obj = xsh->getStageObject(id);
   if (!obj) return;

--- a/toonz/sources/toonz/icons/dark/actions/16/center_reset.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/center_reset.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="svg2"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   sodipodi:docname="center_reset.svg"
+   x="0px"
+   y="0px"
+   viewBox="0 0 16 16"
+   xml:space="preserve"
+   width="16"
+   height="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata
+     id="metadata3385"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs3383">
+        
+    
+            
+            
+            
+            
+        </defs><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1141"
+     id="namedview3381"
+     showgrid="true"
+     inkscape:zoom="38.474928"
+     inkscape:cx="10.643295"
+     inkscape:cy="6.9785706"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"><inkscape:grid
+       type="xygrid"
+       id="grid3387"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" /></sodipodi:namedview><style
+     type="text/css"
+     id="style3355">
+	.st0{fill:#FFFFFF;stroke:#000000;stroke-width:2;stroke-miterlimit:10;}
+	.st1{fill:#FFFFFF;}
+</style><g
+     id="bg"
+     transform="matrix(0.110345,0,0,0.121212,-16.220405,-18.90907)"
+     style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+                <rect
+   x="147"
+   y="156"
+   width="145"
+   height="132"
+   style="fill:#878787;fill-opacity:0"
+   id="rect1" />
+            </g><path
+     d="m 0.370895,9.59093 h 0.787 c 0.722,3.111 3.514,5.432 6.842,5.432 3.876,0 7.023,-3.147 7.023,-7.023 0,-3.876 -3.147,-7.023 -7.023,-7.023 -2.866,0 -5.334,1.721 -6.425,4.185 v 0.001 c -0.011,0.024 -0.041,0.036 -0.076,0.049 -0.14,0.049 -0.362,0.041 -0.534,-0.006 -0.071,-0.02 -0.135,-0.047 -0.174,-0.083 -0.014,-0.013 -0.024,-0.028 -0.016,-0.046 1.157,-2.854 3.957,-4.869 7.225,-4.869 4.3,0 7.792,3.492 7.792,7.792 0,4.3 -3.492,7.792 -7.792,7.792 -3.756,0 -6.893,-2.663 -7.629,-6.201 z"
+     id="path1"
+     style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2" /><g
+     transform="rotate(-135,4.560896,125.80398)"
+     id="g2"
+     style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+                <path
+   d="m 92.5,207.293 3.182,3.182 h -6.364 z"
+   id="path2" />
+            </g><path
+     class="st0"
+     d="m 9.7062004,8.0000016 c 0,-0.8603686 -0.7799897,-1.5848893 -1.7061654,-1.5848893 -0.9261757,0 -1.7061654,0.7245207 -1.7061654,1.5848893 0,0.8603682 0.7799897,1.5848898 1.7061654,1.5848898 0.9261757,0 1.7061654,-0.7245216 1.7061654,-1.5848898 z m 0.4875346,0 c 0,1.1320632 -0.9749868,2.0377144 -2.1937,2.0377144 -1.2187132,0 -2.1937004,-0.9056512 -2.1937004,-2.0377144 0,-1.1320639 0.9749872,-2.0377149 2.1937004,-2.0377149 1.2187132,0 2.1937,0.905651 2.1937,2.0377149 z"
+     id="path3357"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke:#000000;stroke-width:0.939667;stroke-miterlimit:10" /><path
+     class="st0"
+     d="m 10.294135,8.0000017 v 0 c 0,-0.176471 0.1177,-0.294118 0.2941,-0.294118 h 1.5294 c 0.1765,0 0.2942,0.117647 0.2942,0.294118 v 0 c 0,0.1764703 -0.1177,0.2941174 -0.2942,0.2941174 h -1.5294 c -0.1764,0 -0.2941,-0.1176471 -0.2941,-0.2941174 z"
+     id="path3361"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke:#000000;stroke-width:1.17647;stroke-miterlimit:10" /><path
+     class="st0"
+     d="m 3.588235,8.0000017 v 0 c 0,-0.176471 0.1177,-0.294118 0.2942,-0.294118 h 1.5294 c 0.1764,0 0.2941,0.117647 0.2941,0.294118 v 0 c 0,0.1764703 -0.1177,0.2941174 -0.2941,0.2941174 h -1.5294 c -0.1765,0 -0.2942,-0.1176471 -0.2942,-0.2941174 z"
+     id="path3363"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke:#000000;stroke-width:1.17647;stroke-miterlimit:10" /><path
+     class="st0"
+     d="m 8.000035,5.7058829 v 0 c -0.1765,0 -0.2941,-0.1176471 -0.2941,-0.2941178 V 3.8823527 c 0,-0.1764705 0.1176,-0.2941177 0.2941,-0.2941177 v 0 c 0.1765,0 0.2941,0.1176472 0.2941,0.2941177 v 1.5294124 c 0,0.1764707 -0.1176,0.2941178 -0.2941,0.2941178 z"
+     id="path3365"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke:#000000;stroke-width:1.17647;stroke-miterlimit:10" /><path
+     class="st0"
+     d="m 8.000035,12.411768 v 0 c -0.1765,0 -0.2941,-0.117649 -0.2941,-0.294118 v -1.529412 c 0,-0.17647 0.1176,-0.294118 0.2941,-0.294118 v 0 c 0.1765,0 0.2941,0.117648 0.2941,0.294118 v 1.529412 c 0,0.176469 -0.1176,0.294118 -0.2941,0.294118 z"
+     id="path3367"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke:#000000;stroke-width:1.17647;stroke-miterlimit:10" /></svg>

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -57,7 +57,9 @@
 
     <file>icons/dark/actions/16/config.svg</file>
 
-    <!-- File / Common -->
+		<file>icons/dark/actions/16/center_reset.svg</file>
+
+		<!-- File / Common -->
 		<file>icons/dark/actions/16/menu.svg</file>
 		<file>icons/dark/actions/16/export.svg</file>
 		<file>icons/dark/actions/16/import.svg</file>

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -506,17 +506,16 @@ void GlobalKeyframeUndo::doInsertGlobalKeyframes(
     TStageObjectId objectId;
 
     TXshColumn *column = xsh->getColumn(c);
-    if (column && (column->getSoundColumn() || column->getFolderColumn())) continue;
+    if (!column || column->isLocked() || column->getSoundColumn() ||
+        column->getFolderColumn())
+      continue;
 
     if (c == -1)
       objectId = TStageObjectId::CameraId(xsh->getCameraColumnIndex());
-    else
+    else {
       objectId = xsh->getColumnObjectId(c);
-
-    TXshColumn *xshColumn = xsh->getColumn(c);
-    if (!xshColumn || xshColumn->isLocked() ||
-        (xshColumn->isCellEmpty(frame) && !objectId.isCamera()))
-      continue;
+      if (!objectId.isPegbar() && column->isCellEmpty(frame)) continue;
+    }
 
     TStageObject *obj = xsh->getStageObject(objectId);
     obj->setKeyframeWithoutUndo(frame);
@@ -533,14 +532,14 @@ void GlobalKeyframeUndo::doRemoveGlobalKeyframes(
     TStageObjectId objectId;
 
     TXshColumn *column = xsh->getColumn(c);
-    if (column && (column->getSoundColumn() || column->getFolderColumn())) continue;
+    if (column && (column->isLocked() || column->getSoundColumn() ||
+                   column->getFolderColumn()))
+      continue;
 
     if (c == -1)
       objectId = TStageObjectId::CameraId(xsh->getCameraColumnIndex());
     else
       objectId = xsh->getColumnObjectId(c);
-
-    if (xsh->getColumn(c) && xsh->getColumn(c)->isLocked()) continue;
 
     TStageObject *obj = xsh->getStageObject(objectId);
     obj->removeKeyframeWithoutUndo(frame);

--- a/toonz/sources/toonzlib/stageobjectutil.cpp
+++ b/toonz/sources/toonzlib/stageobjectutil.cpp
@@ -349,7 +349,10 @@ void UndoStageObjectMove::undo() const {
 
   // Delay recalculating last scene frame, which might be due to a key, since
   // the actual removal of the key happens immediately after this.
-  QTimer::singleShot(50, [=]() { m_xsheetHandle->notifyXsheetChanged(); });
+  QTimer::singleShot(50, [=]() {
+    m_xsheetHandle->notifyXsheetChanged();
+    m_objectHandle->notifyObjectIdChanged(true);
+  });
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/tstageobjecttree.cpp
+++ b/toonz/sources/toonzlib/tstageobjecttree.cpp
@@ -438,15 +438,10 @@ void TStageObjectTree::loadData(TIStream &is, TXsheet *xsh) {
       // If there isn't a pegbar column for this pegbar, create it now
       // Assume columns have already been loaded
       if (id.isPegbar()) {
-        bool found = false;
-        int cols   = xsh->getColumnCount();
-        for (int i = 0; i < cols; i++) {
-          if (!xsh->getColumn(i) || !xsh->getColumn(i)->getPegbarColumn() ||
-              xsh->getColumn(i)->getPegbarColumn()->getPegbarObjectId() != id)
-            continue;
-          found = true;
-        }
+        TXshColumn *pegbarColumn = xsh->getColumnForPegbarObjectId(id);
+        bool found               = pegbarColumn;
         if (!found) {
+          int cols                    = xsh->getColumnCount();
           TXshPegbarColumn *pegbarCol = new TXshPegbarColumn();
           pegbarCol->setXsheet(xsh);
           pegbarCol->setPegbarObjectId(id);

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -2304,6 +2304,21 @@ bool TXsheet::isPegbarColumn(int col) {
 
 //---------------------------------------------------------
 
+TXshColumn *TXsheet::getColumnForPegbarObjectId(TStageObjectId pegbarObjId) const {
+  for (int i = 0; i < getColumnCount(); i++) {
+    TXshColumn *column = getColumn(i);
+    if (!column || !column->getPegbarColumn() ||
+        column->getPegbarColumn()->getPegbarObjectId() !=
+            pegbarObjId)
+      continue;
+    return column;
+  }
+
+  return nullptr;
+}
+
+//---------------------------------------------------------
+
 void TXsheet::openCloseFolder(int folderCol, bool openFolder) {
   if (folderCol < 0) return;
 

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -640,13 +640,8 @@ void FunctionViewer::doSwitchCurrentObject(TStageObject *obj) {
     m_columnHandle->setColumnIndex(id.getIndex());
   else if (id.isPegbar()) {
     TXsheet *xsh = m_xshHandle->getXsheet();
-    for (int i = 0; i < xsh->getColumnCount(); i++) {
-      if (!xsh->getColumn(i) || !xsh->getColumn(i)->getPegbarColumn() ||
-          xsh->getColumn(i)->getPegbarColumn()->getPegbarObjectId() != id)
-        continue;
-      m_columnHandle->setColumnIndex(i);
-      break;
-    }
+    TXshColumn *pegbarColumn = xsh->getColumnForPegbarObjectId(id);
+    if (pegbarColumn) m_columnHandle->setColumnIndex(pegbarColumn->getIndex());
   } else
     m_objectHandle->setObjectId(id);
 }

--- a/toonz/sources/toonzqt/keyframenavigator.cpp
+++ b/toonz/sources/toonzqt/keyframenavigator.cpp
@@ -243,6 +243,10 @@ void ViewerKeyframeNavigator::toggle() {
   if (!pegbar) return;
   int frame = getCurrentFrame();
 
+  TXshColumn *pegbarColumn =
+      m_xsheetHandle->getXsheet()->getColumnForPegbarObjectId(pegbar->getId());
+  if (pegbarColumn && pegbarColumn->isLocked()) return;
+
   if (pegbar->isFullKeyframe(frame)) {
     TStageObject::Keyframe key = pegbar->getKeyframe(frame);
     pegbar->removeKeyframeWithoutUndo(frame);

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1505,13 +1505,8 @@ void StageSchematicNode::onClicked() {
     StageSchematicScene *stageScene =
         dynamic_cast<StageSchematicScene *>(scene());
     TXsheet *xsh = stageScene->getXsheet();
-    for (int i = 0; i < xsh->getColumnCount(); i++) {
-      if (!xsh->getColumn(i) || !xsh->getColumn(i)->getPegbarColumn() ||
-          xsh->getColumn(i)->getPegbarColumn()->getPegbarObjectId() != id)
-        continue;
-      emit currentColumnChanged(i);
-      break;
-    }
+    TXshColumn *pegbarColumn = xsh->getColumnForPegbarObjectId(id);
+    if (pegbarColumn) emit currentColumnChanged(pegbarColumn->getIndex());
     emit editObject();
   } else if (id.isCamera() || id.isTable())
     emit editObject();


### PR DESCRIPTION
The following fixes and enhancements included in this PR are as follows:

#### Animate Tool
- Fixed an issue where the key'd fields color indicator in tool options was not being removed on undo of key creation (related to #2061)
- Enabled `Pick` option for all Animate modes (request from #2098)
- Extended the ability to change a column's parent using `Shift`+click parent image to work with with any mode (not just `All`) and to select a pegbar, via an image connected to pegbar, as a parent (not just `Column`)
- Add `Reset Center` to toolbar

#### Pegbar Columns (related to #2038)
- Fixed an issue in Animate Tool where the current column was not changed to the pegbar's column when `Pick` mode was `Pegbar`
   - This refactored the logic impacting the same behavior in the Stage Schematic and Function Editor,  
- Fixed an issue where keys were created on locked pegbar columns (Animate Tool, `Set Key` viewer button)
- Fixed an issue where keys were not created on pegbar columns (`Insert Multiple Keys`, `Set Key` timeline/xsheet context menu, `Set Key` shortcut)
