### PR TITLE
Fix standard raster brush with grid option enabled

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -985,7 +985,7 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
     TDimension size   = m_workRaster->getSize();
     TPointD rasCenter = TPointD(size.lx * 0.5, size.ly * 0.5);
     TThickPoint thickPoint(
-        pos + rasCenter, thickness,
+        point, thickness,
         (m_brushTip.getBrushTip() && m_brushTip.isAutoRotate() ? m_tiltAngle
                                                                : 0));
     std::vector<TThickPoint> pts;


### PR DESCRIPTION
Fixes an issue where the standard raster brush doesn't work correctly when the `Grid` option is enabled