### PR TITLE
Fix permanent layer offset after key delete

### DIFF
--- a/toonz/sources/include/toonz/doubleparamcmd.h
+++ b/toonz/sources/include/toonz/doubleparamcmd.h
@@ -20,6 +20,8 @@
 class KeyframesUndo;
 class TSceneHandle;
 class TXsheetHandle;
+class TObjectHandle;
+class TStageObject;
 
 class DVAPI KeyframeSetter {
   TDoubleParamP m_param;
@@ -104,7 +106,11 @@ public:
     setter.setValue(value);
   }
   static void removeKeyframeAt(TDoubleParam *curve, double frame,
-                              TXsheetHandle *xsheetHandle = nullptr);
+                               TObjectHandle *objectHandle,
+                               TXsheetHandle *xsheetHandle = nullptr);
+  static void removeKeyframeAt(TDoubleParam *curve, double frame,
+                               TStageObject *stageObj,
+                               TXsheetHandle *xsheetHandle = nullptr);
 
   static void enableCycle(TDoubleParam *curve, bool enabled,
                           TSceneHandle *sceneHandle = nullptr);

--- a/toonz/sources/include/toonz/stageobjectutil.h
+++ b/toonz/sources/include/toonz/stageobjectutil.h
@@ -288,9 +288,12 @@ class DVAPI UndoChannelDelete final : public TUndo {
   TObjectHandle
       *m_objectHandle;  // OK: viene usato per notificare i cambiamenti!
 
+  TPointD m_center, m_offset;
+
 public:
   UndoChannelDelete(TStageObject::Channel actionId,
-                    const TStageObjectValues &before);
+                    const TStageObjectValues &before, TPointD center,
+                    TPointD offset);
 
   void setXsheetHandle(TXsheetHandle *xsheetHandle) {
     m_xsheetHandle = xsheetHandle;

--- a/toonz/sources/include/toonz/stageobjectutil.h
+++ b/toonz/sources/include/toonz/stageobjectutil.h
@@ -156,10 +156,12 @@ class DVAPI UndoRemoveKeyFrame final : public TUndo {
       *m_objectHandle;  // OK: viene usato per notificare i cambiamenti!
 
   TStageObject::Keyframe m_key;
+  TPointD m_center, m_offset;
 
 public:
   UndoRemoveKeyFrame(TStageObjectId objectId, int frame,
-                     TStageObject::Keyframe key, TXsheetHandle *xsheetHandle);
+                     TStageObject::Keyframe key, TPointD center, TPointD offset,
+                     TXsheetHandle *xsheetHandle);
 
   void setXsheetHandle(TXsheetHandle *xsheetHandle) {
     m_xsheetHandle = xsheetHandle;

--- a/toonz/sources/include/toonz/tstageobject.h
+++ b/toonz/sources/include/toonz/tstageobject.h
@@ -311,9 +311,10 @@ object.
 
   //! Sets the center of the \e frame to \e center.
   void setCenter(double frame, const TPointD &centerPoint,
-                 const TPointD &frameCenter);
-  void setCenter(double frame, const TPointD &center) {
-    setCenter(frame, center, center);
+                 const TPointD &frameCenter, bool resetOrigin = false);
+  void setCenter(double frame, const TPointD &center,
+                 bool resetOrigin = false) {
+    setCenter(frame, center, center, resetOrigin);
   }
 
   //! Returns the center of the \e frame.

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -360,9 +360,11 @@ public:
           \sa getCenter()
   */
   void setCenter(const TStageObjectId &id, int frame,
-                 const TPointD &centerPoint, const TPointD &frameCenter);
-  void setCenter(const TStageObjectId &id, int frame, const TPointD &center) {
-    setCenter(id, frame, center, center);
+                 const TPointD &centerPoint, const TPointD &frameCenter,
+                 bool resetOrigin = false);
+  void setCenter(const TStageObjectId &id, int frame, const TPointD &center,
+                 bool resetOrigin = false) {
+    setCenter(id, frame, center, center, resetOrigin);
   }
   /*! Returns parent related to pegbar \b TStageObject with \b \e id
      TStageObjectId specialization;

--- a/toonz/sources/include/toonzqt/functionkeyframenavigator.h
+++ b/toonz/sources/include/toonzqt/functionkeyframenavigator.h
@@ -17,6 +17,7 @@ class DVAPI FunctionKeyframeNavigator final : public KeyframeNavigator {
   TDoubleParamP m_curve;
   TXsheetHandle *m_xsheetHandle;
   TColumnHandle *m_columnHandle;
+  TObjectHandle *m_objectHandle;
 
 public:
   FunctionKeyframeNavigator(QWidget *parent);
@@ -29,6 +30,10 @@ public:
 
   void setColumnHandle(TColumnHandle *columnHandle) {
     m_columnHandle = columnHandle;
+  }
+
+  void setObjectHandle(TObjectHandle *objectHandle) {
+    m_objectHandle = objectHandle;
   }
 
 protected:

--- a/toonz/sources/include/toonzqt/functionpanel.h
+++ b/toonz/sources/include/toonzqt/functionpanel.h
@@ -26,6 +26,7 @@
 class TDoubleParam;
 class TDoubleKeyframe;
 class TFrameHandle;
+class TObjectHandle;
 class FunctionSelection;
 class FunctionSheet;
 
@@ -96,6 +97,7 @@ private:
   FunctionSelection *m_selection;
   TFrameHandle *m_frameHandle;
   TXsheetHandle *m_xsheetHandle;
+  TObjectHandle *m_objectHandle;
   FunctionTreeModel *m_functionTreeModel;
   FunctionSheet *m_sheet;
 
@@ -140,6 +142,10 @@ public:
     m_xsheetHandle = xsheetHandle;
   }
   TXsheetHandle *getXsheetHandle() const { return m_xsheetHandle; }
+  void setObjectHandle(TObjectHandle* objectHandle) {
+    m_objectHandle = objectHandle;
+  }
+  TObjectHandle *getObjectHandle() const { return m_objectHandle; }
 
   void setFunctionSheet(FunctionSheet *sheet) { m_sheet = sheet; }
   FunctionSheet *getFunctionSheet() const { return m_sheet; }

--- a/toonz/sources/include/toonzqt/functionselection.h
+++ b/toonz/sources/include/toonzqt/functionselection.h
@@ -74,7 +74,7 @@ public:
     m_xsheetHandle = xsheetHandle;
   }
   void setFunctionSheet(FunctionSheet *sheet) { m_sheet = sheet; }
- 
+
   // function graph
   void selectCurve(TDoubleParam *curve);
   void deselectAllKeyframes();

--- a/toonz/sources/include/toonzqt/functiontoolbar.h
+++ b/toonz/sources/include/toonzqt/functiontoolbar.h
@@ -32,6 +32,7 @@
 class TDoubleParam;
 class TFrameHandle;
 class TColumnHandle;
+class TObjectHandle;
 
 namespace DVGui {
 class MeasuredDoubleLineEdit;
@@ -71,6 +72,7 @@ class FunctionToolbar final : public DVGui::ToolBar, public TParamObserver {
   TFrameHandle *m_frameHandle;
   TXsheetHandle *m_xsheetHandle;
   TColumnHandle *m_columnHandle;
+  TObjectHandle *m_objectHandle;
 
   FunctionSelection *m_selection;
 
@@ -88,6 +90,7 @@ public:
   void setFrameHandle(TFrameHandle *frameHandle);
   void setXsheetHandle(TXsheetHandle *xsheetHandle);
   void setColumnHandle(TColumnHandle *columnHandle);
+  void setObjectHandle(TObjectHandle *objectHandle);
 
   void onChange(const TParamChange &) override;
 

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1419,10 +1419,16 @@ void PegbarChannelField::onDelete(bool addToUndo) {
   TStageObject *stageObj = m_xshHandle->getXsheet()->getStageObject(objId);
   int frame              = m_frameHandle->getFrameIndex();
 
+  TPointD center, offset;
+  stageObj->getCenterAndOffset(center, offset);
+
   stageObj->getParam(m_actionId)->deleteKeyframe(frame);
+  if (center != TPointD() && !stageObj->isKeyframe(frame))
+    stageObj->setCenter(frame, center, true);
 
   if (addToUndo) {
-    UndoChannelDelete *undo = new UndoChannelDelete(m_actionId, m_before);
+    UndoChannelDelete *undo =
+        new UndoChannelDelete(m_actionId, m_before, center, offset);
     undo->setXsheetHandle(m_xshHandle);
     undo->setObjectHandle(m_objHandle);
     undo->setFrameHandle(m_frameHandle);

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1731,10 +1731,11 @@ void TCellSelection::setKeyframes() {
   // Command body
   if (obj->isFullKeyframe(row)) {
     const TStageObject::Keyframe &key = obj->getKeyframe(row);
-
-    UndoRemoveKeyFrame *undo = new UndoRemoveKeyFrame(id, row, key, xshHandle);
+    TPointD center, offset;
+    obj->getCenterAndOffset(center, offset);
+    UndoRemoveKeyFrame *undo =
+        new UndoRemoveKeyFrame(id, row, key, center, offset, xshHandle);
     undo->setObjectHandle(app->getCurrentObject());
-
     TUndoManager::manager()->add(undo);
     undo->redo();
   } else {

--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -72,7 +72,10 @@ void TKeyframeData::setKeyframes(std::set<Position> positions, TXsheet *xsh,
     if (pegbar->isKeyframe(row)) {
       Position p(row - r0, col - c0);
       TStageObject::Keyframe k = pegbar->getKeyframe(row);
-      m_keyData[p]             = k;
+      TPointD center, offset;
+      pegbar->getCenterAndOffset(center, offset);
+      m_keyData[p]    = k;
+      m_centerData[p] = CenterInfo(center, offset);
     }
   }
 }
@@ -107,8 +110,9 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
   TStageObjectId cameraId =
       TStageObjectId::CameraId(xsh->getCameraColumnIndex());
   Iterator it;
+  Iterator2 it3 = m_centerData.begin();
   bool keyFrameChanged = false;
-  for (it = m_keyData.begin(); it != m_keyData.end(); ++it) {
+  for (it = m_keyData.begin(); it != m_keyData.end(); ++it, ++it3) {
     Position pos = it->first;
     int row      = r0 + pos.first;
     int col      = c0 + pos.second;
@@ -125,6 +129,8 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
     double e0, e1;
     pegbar->getKeyframeRange(kF, kL);
     pegbar->setKeyframeWithoutUndo(row, it->second);
+    CenterInfo centerInfo = it3->second ;
+    pegbar->setCenterAndOffset(centerInfo.first, centerInfo.second);
 
     std::map<int, int>::iterator itF = firstRowCol.find(col);
     std::map<int, int>::iterator itL = lastRowCol.find(col);

--- a/toonz/sources/toonz/keyframedata.h
+++ b/toonz/sources/toonz/keyframedata.h
@@ -20,8 +20,12 @@ public:
   typedef TKeyframeSelection::Position Position;
   typedef std::map<Position, TStageObject::Keyframe> KeyData;
   typedef std::map<Position, TStageObject::Keyframe>::const_iterator Iterator;
+  typedef std::pair<TPointD, TPointD> CenterInfo;
+  typedef std::map<Position, CenterInfo> CenterData;
+  typedef std::map<Position, CenterInfo>::const_iterator Iterator2;
 
   KeyData m_keyData;
+  CenterData m_centerData;
   int m_columnSpanCount;
   int m_rowSpanCount;
 

--- a/toonz/sources/toonz/keyframeselection.cpp
+++ b/toonz/sources/toonz/keyframeselection.cpp
@@ -113,6 +113,9 @@ bool deleteKeyframesWithoutUndo(
     areAllColumnLocked = false;
     assert(pegbar);
     pegbar->removeKeyframeWithoutUndo(row);
+    // Move frame center back to origin
+    TPointD center = pegbar->getCenter(row);
+    if (center != TPointD()) pegbar->setCenter(row, center, true);
   }
   if (areAllColumnLocked) return false;
 
@@ -346,9 +349,16 @@ void TKeyframeSelection::setKeyframes() {
   if (!pegbar) return;
   if (pegbar->isKeyframe(row)) {
     TStageObject::Keyframe key = pegbar->getKeyframe(row);
+
     pegbar->removeKeyframeWithoutUndo(row);
+
+    // Move frame center back to origin
+    TPointD center, offset;
+    pegbar->getCenterAndOffset(center, offset);
+    if (center != TPointD()) pegbar->setCenter(row, center, true);
+
     UndoRemoveKeyFrame *undo =
-        new UndoRemoveKeyFrame(id, row, key, xsheetHandle);
+        new UndoRemoveKeyFrame(id, row, key, center, offset, xsheetHandle);
     undo->setObjectHandle(app->getCurrentObject());
     TUndoManager::manager()->add(undo);
   } else {

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -544,6 +544,9 @@ void GlobalKeyframeUndo::doRemoveGlobalKeyframes(
 
     TStageObject *obj = xsh->getStageObject(objectId);
     obj->removeKeyframeWithoutUndo(frame);
+    // Move frame center back to origin
+    TPointD center = obj->getCenter(frame);
+    if (center != TPointD()) obj->setCenter(frame, center, true);
   }
 }
 
@@ -611,6 +614,7 @@ public:
 
 class RemoveGlobalKeyframeUndo final : public GlobalKeyframeUndo {
   std::vector<TStageObject::Keyframe> m_keyframes;
+  std::vector<std::pair<TPointD, TPointD>> m_centerData;
 
 public:
   RemoveGlobalKeyframeUndo(int frame, const std::vector<int> &columns)
@@ -628,6 +632,19 @@ public:
 
         return object->getKeyframe(r);
       }
+      static std::pair<TPointD, TPointD> getCenterData(int r, int c) {
+        TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+
+        TStageObjectId objectId =
+            (c == -1) ? TStageObjectId::CameraId(xsh->getCameraColumnIndex())
+                      : xsh->getColumnObjectId(c);
+
+        TStageObject *object = xsh->getStageObject(objectId);
+        assert(object);
+        TPointD center, offset;
+        object->getCenterAndOffset(center, offset);
+        return std::pair<TPointD, TPointD>(center, offset);
+      }
     };  // locals
 
     tcg::substitute(m_columns,
@@ -635,6 +652,10 @@ public:
 
     tcg::substitute(m_keyframes,
                     m_columns | ba::transformed([frame](int c){ return locals::getKeyframe(frame, c); }));
+
+    tcg::substitute(m_centerData, m_columns | ba::transformed([frame](int c) {
+                                    return locals::getCenterData(frame, c);
+                                 }));
   }
 
   void redo() const override {
@@ -657,6 +678,7 @@ public:
 
       TStageObject *object = xsh->getStageObject(objectId);
       object->setKeyframeWithoutUndo(m_frame, m_keyframes[c]);
+      object->setCenterAndOffset(m_centerData[c].first,m_centerData[c].second);
     }
 
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);

--- a/toonz/sources/toonzlib/doubleparamcmd.cpp
+++ b/toonz/sources/toonzlib/doubleparamcmd.cpp
@@ -4,6 +4,9 @@
 #include "toonz/preferences.h"
 #include "toonz/tscenehandle.h"
 #include "toonz/txsheethandle.h"
+#include "toonz/tobjecthandle.h"
+#include "toonz/txsheet.h"
+#include "toonz/tstageobject.h"
 #include "tdoubleparam.h"
 #include "tdoublekeyframe.h"
 #include "tundo.h"
@@ -824,21 +827,29 @@ class RemoveKeyframeUndo final : public TUndo {
   TDoubleParam *m_param;
   TDoubleKeyframe m_keyframe;
   TXsheetHandle *m_xsheetHandle;
+  TStageObject *m_stageObj;
+  TPointD m_center, m_offset;
 
 public:
-  RemoveKeyframeUndo(TDoubleParam *param, int kIndex,
+  RemoveKeyframeUndo(TDoubleParam *param, int kIndex, TStageObject *stageObj,
                      TXsheetHandle *xsheetHandle)
-      : m_param(param), m_xsheetHandle(xsheetHandle) {
+      : m_param(param), m_stageObj(stageObj), m_xsheetHandle(xsheetHandle) {
     m_param->addRef();
     m_keyframe = m_param->getKeyframe(kIndex);
+    if (stageObj) stageObj->getCenterAndOffset(m_center, m_offset);
   }
   ~RemoveKeyframeUndo() { m_param->release(); }
   void undo() const override {
     m_param->setKeyframe(m_keyframe);
+    if (m_stageObj && m_center != TPointD())
+      m_stageObj->setCenterAndOffset(m_center, m_offset);
     if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
   }
   void redo() const override {
     m_param->deleteKeyframe(m_keyframe.m_frame);
+    if (m_stageObj && m_center != TPointD() &&
+        !m_stageObj->isKeyframe(m_keyframe.m_frame))
+      m_stageObj->setCenter(m_keyframe.m_frame, m_center, true);
     if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
   }
   int getSize() const override { return sizeof(*this); }
@@ -849,14 +860,33 @@ public:
 //=============================================================================
 
 void KeyframeSetter::removeKeyframeAt(TDoubleParam *curve, double frame,
+                                      TObjectHandle *objectHandle,
+                                      TXsheetHandle *xsheetHandle) {
+  TStageObject *stageObj = nullptr;
+  if (objectHandle) {
+    TStageObjectId objId = objectHandle->getObjectId();
+    stageObj             = xsheetHandle->getXsheet()->getStageObject(objId);
+  }
+  removeKeyframeAt(curve, frame, stageObj, xsheetHandle);
+}
+
+void KeyframeSetter::removeKeyframeAt(TDoubleParam *curve, double frame,
+                                      TStageObject *stageObj,
                                       TXsheetHandle *xsheetHandle) {
   int kIndex = curve->getClosestKeyframe(frame);
   if (kIndex < 0 || kIndex >= curve->getKeyframeCount() ||
       curve->keyframeIndexToFrame(kIndex) != frame)
     return;
   TUndoManager::manager()->add(
-      new RemoveKeyframeUndo(curve, kIndex, xsheetHandle));
+      new RemoveKeyframeUndo(curve, kIndex, stageObj, xsheetHandle));
   curve->deleteKeyframe(frame);
+  if (stageObj) {
+    TPointD center, offset;
+    stageObj->getCenterAndOffset(center, offset);
+    if (center != TPointD() && !stageObj->isKeyframe(frame))
+      stageObj->setCenter(frame, center, true);
+  }
+
   if (xsheetHandle) xsheetHandle->notifyXsheetChanged();
 }
 

--- a/toonz/sources/toonzlib/stageobjectutil.cpp
+++ b/toonz/sources/toonzlib/stageobjectutil.cpp
@@ -271,11 +271,14 @@ int UndoSetKeyFrame::getSize() const {
 
 UndoRemoveKeyFrame::UndoRemoveKeyFrame(TStageObjectId objectId, int frame,
                                        TStageObject::Keyframe key,
+                                       TPointD center, TPointD offset,
                                        TXsheetHandle *xsheetHandle)
     : m_objId(objectId)
     , m_frame(frame)
     , m_xsheetHandle(xsheetHandle)
-    , m_key(key) {}
+    , m_key(key)
+    , m_center(center)
+    , m_offset(offset) {}
 
 //-----------------------------------------------------------------------------
 
@@ -287,6 +290,7 @@ void UndoRemoveKeyFrame::undo() const {
   if (TStageObject *obj = xsh->getStageObject(m_objId)) {
     obj->setKeyframeWithoutUndo(m_frame);
     obj->setKeyframeWithoutUndo(m_frame, m_key);
+    if (m_center != TPointD()) obj->setCenterAndOffset(m_center, m_offset);
   }
 
   m_xsheetHandle->notifyXsheetChanged();
@@ -300,8 +304,11 @@ void UndoRemoveKeyFrame::redo() const {
 
   assert(xsh->getStageObject(m_objId));
 
-  if (TStageObject *obj = xsh->getStageObject(m_objId))
+  if (TStageObject *obj = xsh->getStageObject(m_objId)) {
     obj->removeKeyframeWithoutUndo(m_frame);
+    // Move frame center back to origin
+    if (m_center != TPointD()) obj->setCenter(m_frame, m_center, true);
+  }
 
   m_xsheetHandle->notifyXsheetChanged();
   m_objectHandle->notifyObjectIdChanged(false);

--- a/toonz/sources/toonzlib/stageobjectutil.cpp
+++ b/toonz/sources/toonzlib/stageobjectutil.cpp
@@ -407,13 +407,25 @@ void UndoStageObjectPinned::redo() const {
 //-----------------------------------------------------------------------------
 
 UndoChannelDelete::UndoChannelDelete(TStageObject::Channel actionId,
-                                     const TStageObjectValues &before)
-    : m_actionId(actionId), m_before(before) {}
+                                     const TStageObjectValues &before,
+                                     TPointD center, TPointD offset)
+    : m_actionId(actionId)
+    , m_before(before)
+    , m_center(center)
+    , m_offset(offset) {}
 
 //-----------------------------------------------------------------------------
 
 void UndoChannelDelete::undo() const {
   m_before.applyValues(false);
+
+  if (m_center != TPointD()) {
+    TStageObjectId objId   = m_objectHandle->getObjectId();
+    TStageObject *stageObj = m_xsheetHandle->getXsheet()->getStageObject(objId);
+    int frame              = m_frameHandle->getFrameIndex();
+    stageObj->setCenterAndOffset(m_center, m_offset);
+  }
+
   m_objectHandle->notifyObjectIdChanged(false);
 
   // Delay recalculating last scene frame, which might be due to a key, since
@@ -429,6 +441,8 @@ void UndoChannelDelete::redo() const {
   int frame              = m_frameHandle->getFrameIndex();
 
   stageObj->getParam(m_actionId)->deleteKeyframe(frame);
+  if (m_center != TPointD() && !stageObj->isKeyframe(frame))
+    stageObj->setCenter(frame, m_center, true);
 
   m_xsheetHandle->notifyXsheetChanged();
   m_objectHandle->notifyObjectIdChanged(false);

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -780,7 +780,8 @@ void TStageObject::enableUppk(bool enabled) {
 //-----------------------------------------------------------------------------
 
 void TStageObject::setCenter(double frame, const TPointD &centerPoint,
-                             const TPointD &frameCenter) {
+                             const TPointD &frameCenter, bool resetOrigin) {
+  if (resetOrigin) m_center = m_offset = TPointD();
   TPointD c = centerPoint - getHandlePos(m_handle, (int)frame);
 
   TAffine aff   = computeLocalPlacement(frame);

--- a/toonz/sources/toonzlib/tstageobjectcmd.cpp
+++ b/toonz/sources/toonzlib/tstageobjectcmd.cpp
@@ -1059,12 +1059,26 @@ public:
 //-------------------------------------------------------------------
 
 class ResetCenterAndOffsetUndo final : public SetAttributeUndo<TPointD> {
+  TPointD m_center, m_offset;
+  TXsheetHandle *m_xshHandle;
+
 public:
   ResetCenterAndOffsetUndo(const TStageObjectId &id, TXsheetHandle *xshHandle,
-                           const TPointD &oldOffset)
-      : SetAttributeUndo<TPointD>(id, xshHandle, oldOffset, TPointD()) {}
-  void setAttribute(TStageObject *pegbar, TPointD offset) const override {
-    pegbar->setCenterAndOffset(offset, offset);
+                           const TPointD &oldCenter, const TPointD &oldOffset)
+      : SetAttributeUndo<TPointD>(id, xshHandle, oldOffset, TPointD())
+      , m_xshHandle(xshHandle)
+      , m_center(oldCenter)
+      , m_offset(oldOffset) {}
+  void setAttribute(TStageObject *pegbar, TPointD offset) const override {}
+  void redo() const override {
+    TStageObject *pegbar = getStageObject();
+    if (pegbar) pegbar->setCenterAndOffset(TPointD(), TPointD());
+    m_xshHandle->notifyXsheetChanged();
+  }
+  void undo() const override {
+    TStageObject *pegbar = getStageObject();
+    if (pegbar) pegbar->setCenterAndOffset(m_center, m_offset);
+    m_xshHandle->notifyXsheetChanged();
   }
   QString getActionName() override { return QString("Reset Center"); }
   QString getStringFromValue(TPointD value) override {
@@ -1259,10 +1273,11 @@ void TStageObjectCmd::resetCenterAndOffset(const TStageObjectId &id,
                                            TXsheetHandle *xshHandle) {
   TStageObject *peg = xshHandle->getXsheet()->getStageObject(id);
   if (!peg) return;
-  TPointD oldOffset = peg->getOffset();
-  peg->setCenterAndOffset(TPointD(), TPointD());
+  TPointD oldCenter, oldOffset;
+  peg->getCenterAndOffset(oldCenter, oldOffset);
   TUndoManager::manager()->add(
-      new ResetCenterAndOffsetUndo(id, xshHandle, oldOffset));
+      new ResetCenterAndOffsetUndo(id, xshHandle, oldCenter, oldOffset));
+  peg->setCenterAndOffset(TPointD(), TPointD());
   xshHandle->notifyXsheetChanged();
 }
 

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -906,11 +906,11 @@ TPointD TXsheet::getCenter(const TStageObjectId &id, int frame) const {
 //-----------------------------------------------------------------------------
 
 void TXsheet::setCenter(const TStageObjectId &id, int frame,
-                        const TPointD &centerPoint,
-                        const TPointD &frameCenter) {
+                        const TPointD &centerPoint, const TPointD &frameCenter,
+                        bool resetOrigin) {
   assert(id != TStageObjectId::NoneId);
   m_imp->m_pegTree->getStageObject(id)->setCenter(frame, centerPoint,
-                                                  frameCenter);
+                                                  frameCenter, resetOrigin);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/functionkeyframenavigator.cpp
+++ b/toonz/sources/toonzqt/functionkeyframenavigator.cpp
@@ -51,7 +51,7 @@ void FunctionKeyframeNavigator::toggle() {
   int frame    = getCurrentFrame();
   double value = m_curve->getValue(frame);
   if (m_curve->isKeyframe(frame))
-    KeyframeSetter::removeKeyframeAt(m_curve.getPointer(), frame,
+    KeyframeSetter::removeKeyframeAt(m_curve.getPointer(), frame, m_objectHandle,
                                      m_xsheetHandle);
   else {
     bool isDrawingNumber = m_curve->getName() == "W_DrawingNumber";

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -1705,7 +1705,7 @@ void FunctionPanel::openContextMenu(QMouseEvent *e) {
     kf.m_speedOut = -kf.m_speedIn;
     curve->setKeyframe(kf);
   } else if (action == &deleteKeyframeAction) {
-    KeyframeSetter::removeKeyframeAt(curve, kf.m_frame, m_xsheetHandle);
+    KeyframeSetter::removeKeyframeAt(curve, kf.m_frame, m_objectHandle, m_xsheetHandle);
   } else if (action == &insertKeyframeAction) {
 
     bool hasDrawingKeys = curve->getName() == "W_DrawingNumber";

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -10,6 +10,7 @@
 #include "toonz/tframehandle.h"
 #include "toonz/txsheetexpr.h"
 #include "toonz/txsheet.h"
+#include "toonz/tstageobject.h"
 
 // TnzBase includes
 #include "tdoubleparam.h"
@@ -138,12 +139,14 @@ public:
   struct ColumnKeyframes {
     TDoubleParam *m_param;
     std::map<int, TDoubleKeyframe> m_keyframes;
+    TPointD m_center, m_offset;
   };
   struct Column {
     TDoubleParam *m_param;
     QSet<int> m_keyframes;
   };
-  KeyframesDeleteUndo(const std::vector<Column> &columns) {
+  KeyframesDeleteUndo(const std::vector<Column> &columns, FunctionSheet *sheet)
+      : m_sheet(sheet) {
     m_columns.resize(columns.size());
     for (int col = 0; col < (int)m_columns.size(); col++) {
       TDoubleParam *param    = columns[col].m_param;
@@ -152,8 +155,12 @@ public:
       param->addRef();
       const QSet<int> &keyframes = columns[col].m_keyframes;
       for (QSet<int>::const_iterator it = keyframes.begin();
-           it != keyframes.end(); ++it)
+           it != keyframes.end(); ++it) {
         m_columns[col].m_keyframes[*it] = param->getKeyframe(*it);
+        TStageObject *stgObj            = m_sheet->getStageObject(col);
+        stgObj->getCenterAndOffset(m_columns[col].m_center,
+                                   m_columns[col].m_offset);
+      }
     }
   }
   ~KeyframesDeleteUndo() {
@@ -169,8 +176,14 @@ public:
     for (int col = 0; col < (int)m_columns.size(); col++) {
       std::map<int, TDoubleKeyframe>::const_iterator it,
           itEnd(m_columns[col].m_keyframes.cend());
-      for (it = m_columns[col].m_keyframes.cbegin(); it != itEnd; ++it)
+      for (it = m_columns[col].m_keyframes.cbegin(); it != itEnd; ++it) {
         m_columns[col].m_param->setKeyframe(it->second);
+        double frame = it->second.m_frame;
+        TStageObject *stgObj = m_sheet->getStageObject(col);
+        if (m_columns[col].m_center != TPointD())
+          stgObj->setCenterAndOffset(m_columns[col].m_center,
+                                     m_columns[col].m_offset);
+      }
     }
     if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
   }
@@ -178,8 +191,13 @@ public:
     for (int col = 0; col < (int)m_columns.size(); col++) {
       std::map<int, TDoubleKeyframe>::const_iterator it,
           itEnd(m_columns[col].m_keyframes.cend());
-      for (it = m_columns[col].m_keyframes.cbegin(); it != itEnd; ++it)
-        m_columns[col].m_param->deleteKeyframe(it->second.m_frame);
+      for (it = m_columns[col].m_keyframes.cbegin(); it != itEnd; ++it) {
+        double frame = it->second.m_frame;
+        m_columns[col].m_param->deleteKeyframe(frame);
+        TStageObject *stgObj = m_sheet->getStageObject(col);
+        if (m_columns[col].m_center != TPointD() && !stgObj->isKeyframe(frame))
+          stgObj->setCenter(frame, m_columns[col].m_center, true);
+      }
     }
     if (m_xsheetHandle) m_xsheetHandle->notifyXsheetChanged();
   }
@@ -192,6 +210,7 @@ public:
 private:
   std::vector<ColumnKeyframes> m_columns;
   TXsheetHandle *m_xsheetHandle;
+  FunctionSheet *m_sheet;
 };
 
 //-----------------------------------------------------------------------------
@@ -621,7 +640,7 @@ void FunctionSelection::doDelete() {
     columns.push_back(column);
   }
   if (columns.empty()) return;
-  KeyframesDeleteUndo *undo = new KeyframesDeleteUndo(columns);
+  KeyframesDeleteUndo *undo = new KeyframesDeleteUndo(columns, m_sheet);
   undo->setXsheetHandle(m_xsheetHandle);
   undo->redo();
   TUndoManager::manager()->add(undo);

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -1118,7 +1118,8 @@ void FunctionSheetCellViewer::mousePressEvent(QMouseEvent *e) {
     int col                   = cellPosition.layer();
     TDoubleParam *curve       = m_sheet->getCurve(col);
     if (curve) {
-      KeyframeSetter::removeKeyframeAt(curve, row);
+      KeyframeSetter::removeKeyframeAt(curve, row,
+                                       m_sheet->getStageObject(col));
     }
   } else if (e->button() == Qt::LeftButton || e->button() == Qt::MiddleButton)
     Spreadsheet::CellPanel::mousePressEvent(e);
@@ -1275,7 +1276,7 @@ void FunctionSheetCellViewer::openContextMenu(QMouseEvent *e) {
   // execute menu
   QAction *action = menu.exec(e->globalPos());  // QCursor::pos());
   if (action == &deleteKeyframeAction) {
-    KeyframeSetter::removeKeyframeAt(curve, row);
+    KeyframeSetter::removeKeyframeAt(curve, row, m_sheet->getStageObject(col));
     m_sheet->getViewer()->getXsheetHandle()->notifyXsheetChanged();
   } else if (action == &insertKeyframeAction) {
     bool hasDrawingKeys = curve->getName() == "W_DrawingNumber";

--- a/toonz/sources/toonzqt/functiontoolbar.cpp
+++ b/toonz/sources/toonzqt/functiontoolbar.cpp
@@ -242,6 +242,13 @@ void FunctionToolbar::setColumnHandle(TColumnHandle *columnHandle) {
 
 //-------------------------------------------------------------------
 
+void FunctionToolbar::setObjectHandle(TObjectHandle* objectHandle) {
+  m_objectHandle = objectHandle;
+  if (m_keyframeNavigator) m_keyframeNavigator->setObjectHandle(objectHandle);
+}
+
+//-------------------------------------------------------------------
+
 void FunctionToolbar::setSelection(FunctionSelection *selection) {
   if (m_selection != selection) {
     if (m_selection)

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -447,7 +447,11 @@ void FunctionViewer::setObjectHandle(TObjectHandle *objectHandle) {
   FunctionTreeModel *ftModel =
       static_cast<FunctionTreeModel *>(m_treeView->model());
   if (ftModel) ftModel->setObjectHandle(objectHandle);
+
+  m_toolbar->setObjectHandle(objectHandle);
+  m_functionGraph->setObjectHandle(objectHandle);
 }
+
 //-----------------------------------------------------------------------------
 
 void FunctionViewer::setFxHandle(TFxHandle *fxHandle) {

--- a/toonz/sources/toonzqt/keyframenavigator.cpp
+++ b/toonz/sources/toonzqt/keyframenavigator.cpp
@@ -246,8 +246,14 @@ void ViewerKeyframeNavigator::toggle() {
   if (pegbar->isFullKeyframe(frame)) {
     TStageObject::Keyframe key = pegbar->getKeyframe(frame);
     pegbar->removeKeyframeWithoutUndo(frame);
-    UndoRemoveKeyFrame *undo =
-        new UndoRemoveKeyFrame(pegbar->getId(), frame, key, m_xsheetHandle);
+
+    // Move frame center back to origin
+    TPointD center, offset;
+    pegbar->getCenterAndOffset(center, offset);
+    if (center != TPointD()) pegbar->setCenter(frame, center, true);
+
+    UndoRemoveKeyFrame *undo = new UndoRemoveKeyFrame(
+        pegbar->getId(), frame, key, center, offset, m_xsheetHandle);
     undo->setObjectHandle(m_objectHandle);
     TUndoManager::manager()->add(undo);
   } else {


### PR DESCRIPTION
This fixes the following issues related to a layer moved via the Animate tool causing a permanent offset from center.

An example of this issue can be seen by doing the following:
- Move Center
- Rotate
- Move Center
- Rotate
- Delete Key

1. Fixed undo `Reset Center` to restore the position/orientation of the layer
2. Fixed the resetting of layer offset after deleting keys. In case of channel key deletes, the reset only happens after the last key for that frame is deleted.


