### PR TITLE
Fix crashing on version check

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1394,6 +1394,10 @@ void MainWindow::onUpdateCheckerDone(bool error) {
   int const software_version =
       get_version_code_from(TEnv::getApplicationVersion());
   QString latestVersionStr = m_updateChecker->getLatestVersion();
+  // Check result for valid version format. If we get garbage back, likely not
+  // connected to internet or other issue so skip check
+  if (!QRegularExpression("^[0-9.]*$").match(latestVersionStr).hasMatch())
+    return;
   int const latest_version =
       get_version_code_from(latestVersionStr.toStdString());
   int skip_version = get_version_code_from(SkipVersion.getValue());


### PR DESCRIPTION
This fixes a crash that occurs during the startup version check when it fails to connect to the site to retrieve the current version information due to no internet connection or other error getting to the site.

If a valid version string isn't detected (expecting numbers and decimals), it will just skip the version check without any warning.