### PR TITLE
Fix reading empty xml tags

### DIFF
--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -681,7 +681,7 @@ bool TIStream::Imp::matchIdent(string &ident) {
   // 
   //while (c = is.peek(), isalnum(c) || c == '_' || c == '.' || c == '-') {
   while (c = is.peek()) {
-    if (c == '>' || c == ' ' || c == '=' || (int)c == EOF) break;
+    if (c == '/' || c == '>' || c == ' ' || c == '=' || (int)c == EOF) break;
     is.get(c);
     ident.append(1, c);
   }


### PR DESCRIPTION
This fixes an issue caused by changes in reading xml tags (#2108) causing a number of Fx to have blank settings.

Tags with no values noted as `<tag/>` were not being read correctly causing a failure to read and load the Fx configuration.