### PR TITLE
Convert tool option size/thickness range to decimal precision

### DIFF
--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -101,7 +101,7 @@ void drawRectWhitArrow(const TPointD &pos, double r);
 
 //-----------------------------------------------------------------------------
 
-QRadialGradient getBrushPad(int size, double hardness);
+QRadialGradient getBrushPad(double size, double hardness);
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/tnztools/bluredbrush.cpp
+++ b/toonz/sources/tnztools/bluredbrush.cpp
@@ -208,7 +208,7 @@ void putOnRaster(const TRaster32P &out, const TRaster32P &in) {
 //
 //=======================================================
 
-BluredBrush::BluredBrush(const TRaster32P &ras, int size,
+BluredBrush::BluredBrush(const TRaster32P &ras, double size,
                          const QRadialGradient &gradient,
                          BrushTipData *brushTip, double spacing,
                          double rotation, bool flipH, bool flipV,
@@ -658,7 +658,7 @@ TRect BluredBrush::getBoundFromPoints(
 //    Blurred Brush implementation
 //*******************************************************************************
 
-RasterBlurredBrush::RasterBlurredBrush(const TRaster32P &ras, int size,
+RasterBlurredBrush::RasterBlurredBrush(const TRaster32P &ras, double size,
                                        const QRadialGradient &gradient,
                                        BrushTipData *brushTip, double spacing,
                                        double rotation, bool flipH, bool flipV,

--- a/toonz/sources/tnztools/bluredbrush.h
+++ b/toonz/sources/tnztools/bluredbrush.h
@@ -24,7 +24,7 @@ class BluredBrush {
   QImage m_workImage;
   TRaster32P m_ras;
   QImage m_rasImage;
-  int m_size;
+  double m_size;
   QRadialGradient m_gradient;
   TThickPoint m_lastPoint;
   double m_oldOpacity;
@@ -43,7 +43,7 @@ class BluredBrush {
   double getNextPadPosition(const TThickQuadratic &q, double t) const;
 
 public:
-  BluredBrush(const TRaster32P &ras, int size, const QRadialGradient &gradient,
+  BluredBrush(const TRaster32P &ras, double size, const QRadialGradient &gradient,
               BrushTipData *brushTip = 0, double spacing = 1,
               double rotation = 0, bool flipH = false, bool flipV = false,
               double scatter = 0);
@@ -90,7 +90,7 @@ private:
   TPointD m_rasCenter, m_dpiScale;
 
 public:
-  RasterBlurredBrush(const TRaster32P &ras, int size,
+  RasterBlurredBrush(const TRaster32P &ras, double size,
                      const QRadialGradient &gradient,
                      BrushTipData *brushTip = 0, double spacing = 1,
                      double rotation = 0, bool flipH = false,

--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -69,12 +69,12 @@ TEnv::IntVar FullcolorEraserPressure("FullcolorEraserPressure", 1);
 
 namespace {
 
-int computeThickness(double pressure, const TIntPairProperty &property) {
-  double t = pressure * pressure * pressure;
-  int thick0 = property.getValue().first;
-  int thick1 = property.getValue().second;
-
-  return tround(thick0 + (thick1 - thick0) * t);
+double computeThickness(double pressure, const TDoublePairProperty &property) {
+  double t      = pressure * pressure * pressure;
+  double thick0 = property.getValue().first;
+  double thick1 = property.getValue().second;
+  if (thick1 < 0.0001) thick0 = thick1 = 0.0;
+  return (thick0 + (thick1 - thick0) * t);
 }
 
 //----------------------------------------------------------------------------------
@@ -191,7 +191,7 @@ public:
 
 class FullColorEraserUndo final : public TFullColorRasterUndo {
   std::vector<TThickPoint> m_points;
-  int m_size;
+  double m_size;
   double m_hardness;
   double m_opacity;
   TPointD m_dpiScale;
@@ -203,7 +203,7 @@ class FullColorEraserUndo final : public TFullColorRasterUndo {
 public:
   FullColorEraserUndo(TTileSetFullColor *tileSet,
                       const std::vector<TThickPoint> &points,
-                      TXshSimpleLevel *level, const TFrameId &frameId, int size,
+                      TXshSimpleLevel *level, const TFrameId &frameId, double size,
                       double hardness, double opacity, TPointD dpiScale,
                       double symmetryLines, double rotation,
                       TPointD centerPoint, bool useLineSymmetry)
@@ -359,7 +359,7 @@ public:
 private:
   TPropertyGroup m_prop;
 
-  TIntPairProperty m_size;
+  TDoublePairProperty m_size;
   TBoolProperty m_pressure;
   TDoubleProperty m_opacity;
   TDoubleProperty m_hardness;
@@ -483,7 +483,7 @@ void FullColorEraserTool::onActivate() {
   if (m_firstTime) {
     m_firstTime = false;
     m_size.setValue(
-        TIntPairProperty::Value(FullcolorEraseMinSize, FullcolorEraseSize));
+        TDoublePairProperty::Value(FullcolorEraseMinSize, FullcolorEraseSize));
     m_opacity.setValue(FullcolorEraserOpacity);
     m_hardness.setValue(FullcolorEraseHardness);
     m_eraseType.setValue(::to_wstring(FullcolorEraserType.getValue()));
@@ -534,10 +534,10 @@ void FullColorEraserTool::leftButtonDown(const TPointD &pos,
     m_workRaster->clear();
     m_backUpRas = ras->clone();
 
-    int maxThick  = m_size.getValue().second;
-    int thickness = (m_pressure.getValue() && e.isTablet())
-                        ? computeThickness(e.m_pressure, m_size)
-                        : maxThick;
+    double maxThick   = m_size.getValue().second;
+    double thickness  = (m_pressure.getValue() && e.isTablet())
+                            ? computeThickness(e.m_pressure, m_size)
+                            : maxThick;
     TPointD rasCenter = ras->getCenterD();
     TThickPoint point(pos + rasCenter, thickness);
     TPointD halfThick(maxThick * 0.5, maxThick * 0.5);
@@ -620,7 +620,7 @@ void FullColorEraserTool::leftButtonDown(const TPointD &pos,
         m_polyline.push_back(pos);
     }
 
-    int maxThick = 2 * m_thick;
+    double maxThick = 2 * m_thick;
     TPointD halfThick(maxThick * 0.5, maxThick * 0.5);
     invalidateRect = TRectD(pos - halfThick, pos + halfThick);
   }
@@ -640,10 +640,10 @@ void FullColorEraserTool::leftButtonDrag(const TPointD &pos,
   TRasterImageP ri = (TRasterImageP)getImage(true);
   if (!ri) return;
   if (m_eraseType.getValue() == NORMALERASE) {
-    int maxThick  = m_size.getValue().second;
-    int thickness = (m_pressure.getValue() && e.isTablet())
-                        ? computeThickness(e.m_pressure, m_size)
-                        : maxThick;
+    double maxThick   = m_size.getValue().second;
+    double thickness  = (m_pressure.getValue() && e.isTablet())
+                            ? computeThickness(e.m_pressure, m_size)
+                            : maxThick;
     TDimension size   = m_workRaster->getSize();
     TPointD rasCenter = ri->getRaster()->getCenterD();
     TThickPoint point(pos + rasCenter, thickness);
@@ -732,10 +732,10 @@ void FullColorEraserTool::leftButtonUp(const TPointD &pos,
   if (m_eraseType.getValue() == NORMALERASE) {
     if (!m_brush) return;
 
-    int maxThick  = m_size.getValue().second;
-    int thickness = (m_pressure.getValue() && e.isTablet())
-                        ? computeThickness(e.m_pressure, m_size)
-                        : maxThick;
+    double maxThick  = m_size.getValue().second;
+    double thickness = (m_pressure.getValue() && e.isTablet())
+                           ? computeThickness(e.m_pressure, m_size)
+                           : maxThick;
 
     if (m_points.size() != 1) {
       TPointD rasCenter = ri->getRaster()->getCenterD();
@@ -1104,35 +1104,35 @@ void FullColorEraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   struct Locals {
     FullColorEraserTool *m_this;
 
-    void setValue(TIntPairProperty &prop,
-                  const TIntPairProperty::Value &value) {
+    void setValue(TDoublePairProperty &prop,
+                  const TDoublePairProperty::Value &value) {
       prop.setValue(value);
 
       m_this->onPropertyChanged(prop.getName());
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
-    void addMinMax(TIntPairProperty &prop, double add) {
-      const TIntPairProperty::Range &range = prop.getRange();
+    void addMinMax(TDoublePairProperty &prop, double add) {
+      if (add == 0.0) return;
+      const TDoublePairProperty::Range &range = prop.getRange();
 
-      TIntPairProperty::Value value = prop.getValue();
-      value.second =
-          tcrop<double>(value.second + add, range.first, range.second);
-      value.first = tcrop<double>(value.first + add, range.first, range.second);
+      TDoublePairProperty::Value value = prop.getValue();
+      value.first  = tcrop(value.first + add, range.first, range.second);
+      value.second = tcrop(value.second + add, range.first, range.second);
 
       setValue(prop, value);
     }
 
-    void addMinMaxSeparate(TIntPairProperty &prop, double min, double max) {
+    void addMinMaxSeparate(TDoublePairProperty &prop, double min, double max) {
       if (min == 0.0 && max == 0.0) return;
-      const TIntPairProperty::Range &range = prop.getRange();
+      const TDoublePairProperty::Range &range = prop.getRange();
 
-      TIntPairProperty::Value value = prop.getValue();
+      TDoublePairProperty::Value value = prop.getValue();
       value.first += min;
       value.second += max;
       if (value.first > value.second) value.first = value.second;
-      value.first  = tcrop<double>(value.first, range.first, range.second);
-      value.second = tcrop<double>(value.second, range.first, range.second);
+      value.first  = tcrop(value.first, range.first, range.second);
+      value.second = tcrop(value.second, range.first, range.second);
 
       setValue(prop, value);
     }

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -129,7 +129,7 @@ static TPointD computeSpeed(TPointD p0, TPointD p1, double factor) {
 //-----------------------------------------------------------------------------
 
 static TRect drawBluredBrush(const TRasterImageP &ri, TStroke *stroke,
-                             int thick, double hardness, double opacity) {
+                             double thick, double hardness, double opacity) {
   TStroke *s       = new TStroke(*stroke);
   TPointD riCenter = ri->getRaster()->getCenterD();
   s->transform(TTranslation(riCenter));
@@ -173,7 +173,7 @@ static TRect drawBluredBrush(const TRasterImageP &ri, TStroke *stroke,
 
 //-----------------------------------------------------------------------------
 
-static TRect drawBluredBrush(const TToonzImageP &ti, TStroke *stroke, int thick,
+static TRect drawBluredBrush(const TToonzImageP &ti, TStroke *stroke, double thick,
                              double hardness, bool selective) {
   TStroke *s       = new TStroke(*stroke);
   TPointD riCenter = ti->getRaster()->getCenterD();
@@ -409,12 +409,12 @@ public:
 //-----------------------------------------------------------------------------
 
 class FullColorBluredPrimitiveUndo final : public UndoFullColorPencil {
-  int m_thickness;
+  double m_thickness;
   double m_hardness;
 
 public:
   FullColorBluredPrimitiveUndo(TXshSimpleLevel *level, const TFrameId &frameId,
-                               TStroke *stroke, int thickness, double hardness,
+                               TStroke *stroke, double thickness, double hardness,
                                double opacity, bool doAntialias,
                                bool createdFrame, bool createdLevel)
       : UndoFullColorPencil(level, frameId, stroke, opacity, doAntialias,
@@ -449,13 +449,13 @@ public:
 //-----------------------------------------------------------------------------
 /*-- Hardness<100 のときの GeometricToolのUndo --*/
 class CMBluredPrimitiveUndo final : public UndoRasterPencil {
-  int m_thickness;
+  double m_thickness;
   double m_hardness;
   bool m_selective;
 
 public:
   CMBluredPrimitiveUndo(TXshSimpleLevel *level, const TFrameId &frameId,
-                        TStroke *stroke, int thickness, double hardness,
+                        TStroke *stroke, double thickness, double hardness,
                         bool selective, bool doAntialias, bool createdFrame,
                         bool createdLevel, std::string primitiveName)
       : UndoRasterPencil(level, frameId, stroke, selective, false, doAntialias,
@@ -495,7 +495,7 @@ class PrimitiveParam {
 
 public:
   TDoubleProperty m_toolSize;
-  TIntProperty m_rasterToolSize;
+  TDoubleProperty m_rasterToolSize;
   TDoubleProperty m_opacity;
   TDoubleProperty m_hardness;
   TEnumProperty m_type;
@@ -1943,7 +1943,7 @@ public:
                                                 filled, TConsts::infiniteRectD,
                                                 !m_param.m_pencil.getValue());
       } else {
-        int thickness = m_param.m_rasterToolSize.getValue();
+        double thickness = m_param.m_rasterToolSize.getValue();
         TUndoManager::manager()->add(new CMBluredPrimitiveUndo(
             sl, id, stroke, thickness, hardness, selective, false,
             m_isFrameCreated, m_isLevelCreated, m_primitive->getName()));
@@ -2056,7 +2056,7 @@ public:
             sl, id, stroke, opacity, true, m_isFrameCreated, m_isLevelCreated));
         savebox = TRasterImageUtils::addStroke(ri, stroke, TRectD(), opacity);
       } else {
-        int thickness = m_param.m_rasterToolSize.getValue();
+        double thickness = m_param.m_rasterToolSize.getValue();
         TUndoManager::manager()->add(new FullColorBluredPrimitiveUndo(
             sl, id, stroke, thickness, hardness, opacity, true,
             m_isFrameCreated, m_isLevelCreated));
@@ -2565,7 +2565,7 @@ void RectanglePrimitive::leftButtonDown(const TPointD &pos,
   if (m_param->m_pencil.getValue() &&
       (m_param->m_targetType & TTool::ToonzImage ||
        m_param->m_targetType & TTool::RasterImage)) {
-    if (m_param->m_rasterToolSize.getValue() % 2 != 0)
+    if ((int)m_param->m_rasterToolSize.getValue() % 2 != 0)
       m_startPoint = TPointD((int)pos.x, (int)pos.y);
     else
       m_startPoint = TPointD((int)pos.x + 0.5, (int)pos.y + 0.5);
@@ -2613,7 +2613,7 @@ void RectanglePrimitive::leftButtonDrag(const TPointD &realPos,
   if (m_param->m_pencil.getValue() &&
       (m_param->m_targetType & TTool::ToonzImage ||
        m_param->m_targetType & TTool::RasterImage)) {
-    if (m_param->m_rasterToolSize.getValue() % 2 != 0)
+    if ((int)m_param->m_rasterToolSize.getValue() % 2 != 0)
       pos = TPointD((int)pos.x, (int)pos.y);
     else
       pos = TPointD((int)pos.x + 0.5, (int)pos.y + 0.5);
@@ -3326,7 +3326,7 @@ void LinePrimitive::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
   if (m_param->m_pencil.getValue() &&
       (m_param->m_targetType & TTool::ToonzImage ||
        m_param->m_targetType & TTool::RasterImage)) {
-    if (m_param->m_rasterToolSize.getValue() % 2 != 0)
+    if ((int)m_param->m_rasterToolSize.getValue() % 2 != 0)
       _pos = TPointD((int)newPos.x, (int)newPos.y);
     else
       _pos = TPointD((int)newPos.x + 0.5, (int)newPos.y + 0.5);

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -86,12 +86,12 @@ TEnv::IntVar ErasePressure("InknpaintErasePressure", 1);
 
 namespace {
 
-int computeThickness(double pressure, const TIntPairProperty &property) {
-  double t   = pressure * pressure * pressure;
-  int thick0 = property.getValue().first;
-  int thick1 = property.getValue().second;
-
-  return tround(thick0 + (thick1 - thick0) * t);
+double computeThickness(double pressure, const TDoublePairProperty &property) {
+  double t      = pressure * pressure * pressure;
+  double thick0 = property.getValue().first;
+  double thick1 = property.getValue().second;
+  if (thick1 < 0.0001) thick0 = thick1 = 0.0;
+  return (thick0 + (thick1 - thick0) * t);
 }
 
 //==============================================================================
@@ -238,7 +238,7 @@ class RasterBluredEraserUndo final : public TRasterUndo {
   std::vector<TThickPoint> m_points;
   int m_styleId;
   bool m_selective;
-  int m_size;
+  double m_size;
   double m_hardness;
   std::wstring m_mode;
   TPointD m_dpiScale;
@@ -251,7 +251,7 @@ public:
   RasterBluredEraserUndo(TTileSetCM32 *tileSet,
                          const std::vector<TThickPoint> &points, int styleId,
                          bool selective, TXshSimpleLevel *level,
-                         const TFrameId &frameId, int size, double hardness,
+                         const TFrameId &frameId, double size, double hardness,
                          const std::wstring &mode, TPointD dpiScale,
                          double symmetryLines, double rotation,
                          TPointD centerPoint, bool useLineSymmetry)
@@ -652,7 +652,7 @@ void drawLine(const TPointD &point, const TPointD &centre, bool horizontal,
 
 //-------------------------------------------------------------------------------------------------------
 
-void drawEmptyCircle(int thick, const TPointD &mousePos, bool isPencil,
+void drawEmptyCircle(double thick, const TPointD &mousePos, bool isPencil,
                      bool isLxEven, bool isLyEven) {
   TPointD pos = mousePos;
   if (isLxEven) pos.x += 0.5;
@@ -662,7 +662,7 @@ void drawEmptyCircle(int thick, const TPointD &mousePos, bool isPencil,
   else {
     int x = 0, y = tround((thick * 0.5) - 0.5);
     int d           = 3 - 2 * (int)(thick * 0.5);
-    bool horizontal = true, isDecimal = thick % 2 != 0;
+    bool horizontal = true, isDecimal = (int)thick % 2 != 0;
     drawLine(TPointD(x, y), pos, horizontal, isDecimal);
     while (y > x) {
       if (d < 0) {
@@ -758,7 +758,7 @@ private:
   TPropertyGroup m_prop;
 
   TEnumProperty m_eraseType;
-  TIntPairProperty m_toolSize;
+  TDoublePairProperty m_toolSize;
   TBoolProperty m_pressure;
   TDoubleProperty m_hardness;
   TBoolProperty m_invertOption;
@@ -1017,10 +1017,10 @@ void EraserTool::draw() {
       glColor3d(0.5, 0.8, 0.8);
     else
       glColor3d(1.0, 0.0, 0.0);
-    drawEmptyCircle(tround(m_toolSize.getValue().first), m_brushPos,
+    drawEmptyCircle(m_toolSize.getValue().first, m_brushPos,
                     (m_pencil.getValue() || m_colorType.getValue() == AREAS),
                     lx % 2 == 0, ly % 2 == 0);
-    drawEmptyCircle(tround(m_toolSize.getValue().second), m_brushPos,
+    drawEmptyCircle(m_toolSize.getValue().second, m_brushPos,
                     (m_pencil.getValue() || m_colorType.getValue() == AREAS),
                     lx % 2 == 0, ly % 2 == 0);
   }
@@ -1325,10 +1325,10 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
     if (m_eraseType.getValue() == NORMALERASE) {
       TRasterCM32P raster = ti->getRaster();
       TPointD fixedPos    = fixMousePos(pos);
-      int maxThick        = m_toolSize.getValue().second;
-      int thickness       = (m_pressure.getValue() && e.isTablet())
-                          ? computeThickness(e.m_pressure, m_toolSize)
-                          : maxThick;
+      double maxThick     = m_toolSize.getValue().second;
+      double thickness    = (m_pressure.getValue() && e.isTablet())
+                                ? computeThickness(e.m_pressure, m_toolSize)
+                                : maxThick;
 
       TThickPoint intPos;
       /*--Areasタイプの時は常にPencilと同じ消し方にする--*/
@@ -1435,7 +1435,7 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
           m_polyline.push_back(pos);
       }
 
-      int maxThick = 2 * m_thick;
+      double maxThick = 2 * m_thick;
       TPointD halfThick(maxThick * 0.5, maxThick * 0.5);
       invalidateRect = TRectD(pos - halfThick, pos + halfThick);
     }
@@ -1485,10 +1485,10 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     }
     if (m_eraseType.getValue() == NORMALERASE) {
       TPointD fixedPos = fixMousePos(pos);
-      int maxThick     = m_toolSize.getValue().second;
-      int thickness    = (m_pressure.getValue() && e.isTablet())
-                          ? computeThickness(e.m_pressure, m_toolSize)
-                          : maxThick;
+      double maxThick  = m_toolSize.getValue().second;
+      double thickness = (m_pressure.getValue() && e.isTablet())
+                             ? computeThickness(e.m_pressure, m_toolSize)
+                             : maxThick;
 
       if (m_normalEraser &&
           (m_hardness.getValue() == 100 || m_pencil.getValue() ||
@@ -1764,10 +1764,10 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       SymmetryTool *symmetryTool = dynamic_cast<SymmetryTool *>(
           TTool::getTool("T_Symmetry", TTool::RasterImage));
 
-      int maxThick  = m_toolSize.getValue().second;
-      int thickness = (m_pressure.getValue() && e.isTablet())
-                          ? computeThickness(e.m_pressure, m_toolSize)
-                          : maxThick;
+      double maxThick  = m_toolSize.getValue().second;
+      double thickness = (m_pressure.getValue() && e.isTablet())
+                             ? computeThickness(e.m_pressure, m_toolSize)
+                             : maxThick;
 
       if (m_normalEraser &&
           (m_hardness.getValue() == 100 || m_pencil.getValue() ||
@@ -2221,35 +2221,35 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   struct Locals {
     EraserTool *m_this;
 
-    void setValue(TIntPairProperty &prop,
-                  const TIntPairProperty::Value &value) {
+    void setValue(TDoublePairProperty &prop,
+                  const TDoublePairProperty::Value &value) {
       prop.setValue(value);
 
       m_this->onPropertyChanged(prop.getName());
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
-    void addMinMax(TIntPairProperty &prop, double add) {
-      const TIntPairProperty::Range &range = prop.getRange();
+    void addMinMax(TDoublePairProperty &prop, double add) {
+      if (add == 0.0) return;
+      const TDoublePairProperty::Range &range = prop.getRange();
 
-      TIntPairProperty::Value value = prop.getValue();
-      value.second =
-          tcrop<double>(value.second + add, range.first, range.second);
-      value.first = tcrop<double>(value.first + add, range.first, range.second);
+      TDoublePairProperty::Value value = prop.getValue();
+      value.first  = tcrop(value.first + add, range.first, range.second);
+      value.second = tcrop(value.second + add, range.first, range.second);
 
       setValue(prop, value);
     }
 
-    void addMinMaxSeparate(TIntPairProperty &prop, double min, double max) {
+    void addMinMaxSeparate(TDoublePairProperty &prop, double min, double max) {
       if (min == 0.0 && max == 0.0) return;
-      const TIntPairProperty::Range &range = prop.getRange();
+      const TDoublePairProperty::Range &range = prop.getRange();
 
-      TIntPairProperty::Value value = prop.getValue();
+      TDoublePairProperty::Value value = prop.getValue();
       value.first += min;
       value.second += max;
       if (value.first > value.second) value.first = value.second;
-      value.first  = tcrop<double>(value.first, range.first, range.second);
-      value.second = tcrop<double>(value.second, range.first, range.second);
+      value.first  = tcrop(value.first, range.first, range.second);
+      value.second = tcrop(value.second, range.first, range.second);
 
       setValue(prop, value);
     }
@@ -2278,7 +2278,7 @@ void EraserTool::onEnter() {
   TToonzImageP ti(getImage(false));
   if (!ti) return;
   if (m_firstTime) {
-    m_toolSize.setValue(TIntPairProperty::Value(EraseMinSize, EraseSize));
+    m_toolSize.setValue(TDoublePairProperty::Value(EraseMinSize, EraseSize));
     m_eraseType.setValue(::to_wstring(EraseType.getValue()));
     m_pressure.setValue(ErasePressure ? 1 : 0);
     m_currentStyle.setValue(EraseSelective ? 1 : 0);

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -317,7 +317,7 @@ void ToolUtils::drawRectWhitArrow(const TPointD &pos, double r) {
 
 //-----------------------------------------------------------------------------
 
-QRadialGradient ToolUtils::getBrushPad(int size, double hardness) {
+QRadialGradient ToolUtils::getBrushPad(double size, double hardness) {
   hardness        = tcrop(hardness, 0.0, 0.97);
   double halfSize = size * 0.5;
   double x        = halfSize * hardness;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -543,7 +543,7 @@ class RasterBluredBrushUndo final : public TRasterUndo {
   std::vector<TThickPoint> m_points;
   int m_styleId;
   DrawOrder m_drawOrder;
-  int m_maxThick;
+  double m_maxThick;
   double m_hardness;
   bool m_isStraight;
   bool m_modifierLockAlpha;
@@ -563,7 +563,7 @@ public:
   RasterBluredBrushUndo(
       TTileSetCM32 *tileSet, const std::vector<TThickPoint> &points,
       int styleId, DrawOrder drawOrder, bool lockAlpha, TXshSimpleLevel *level,
-      const TFrameId &frameId, int maxThick, double hardness,
+      const TFrameId &frameId, double maxThick, double hardness,
       bool isFrameCreated, bool isLevelCreated, TPointD dpiScale,
       double symmetryLines, double rotation, TPointD centerPoint,
       bool useLineSymmetry, double brushTipRotation, double brushTipSpacing,


### PR DESCRIPTION
This updates the tool option size/thickness range from whole numbers to decimal in the following tools:

- Geometric Tool
- Eraser Tool (Raster and Smart Raster)

Indirectly impacted:
- Brush Tool (Raster and Smart Raster) - Standard anti-aliased brush (hardness < 100) 
