### PR TITLE
Fix Drawing Substitution with implicit cells

### DIFF
--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1043,11 +1043,6 @@ public:
     TXsheetP xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     while (c <= m_range.m_c1) {
       col = c;
-      // Convert implicit cell at end of selected range into a populated cell
-      if (xsh->isImplicitCell((m_range.m_r1 + 1), col)) {
-        TXshCell origCell = xsh->getCell((m_range.m_r1 + 1), col);
-        xsh->setCell((m_range.m_r1 + 1), col, origCell);
-      }
       while (r <= m_range.m_r1) {
         row = r;
         if (row == m_range.m_r0 || !xsh->isImplicitCell(row, col))
@@ -1199,9 +1194,9 @@ bool DrawingSubtitutionUndo::changeDrawing(int delta, int row, int col) {
   TTool::Application *app = TTool::getApplication();
   TXsheet *xsh            = app->getCurrentScene()->getScene()->getXsheet();
   TXshCell cell           = xsh->getCell(row, col);
+  TXshCell prevCell       = xsh->getCell(row - 1, col);
   bool usePrevCell        = false;
   if (cell.isEmpty()) {
-    TXshCell prevCell = xsh->getCell(row - 1, col);
     if (prevCell.isEmpty() || !(prevCell.m_level->getSimpleLevel() ||
                                 prevCell.m_level->getChildLevel() ||
                                 prevCell.m_level->getSoundTextLevel()))
@@ -1268,7 +1263,11 @@ bool DrawingSubtitutionUndo::changeDrawing(int delta, int row, int col) {
   else
     cellFrameId = TFrameId(index);
 
-  setDrawing(cellFrameId, row, col, cell, level);
+  if (Preferences::instance()->isImplicitHoldEnabled() && !prevCell.isEmpty() &&
+      prevCell.getFrameId() == cellFrameId)
+    setDrawing(TFrameId::EMPTY_FRAME, row, col, TXshCell(), nullptr);
+  else
+    setDrawing(cellFrameId, row, col, cell, level);
 
   return true;
 }


### PR DESCRIPTION
This change technically restores the original intent of `Drawing Substitution` (shortcuts Q/W) when working with implicit cells. 

The original intent of the command was just to switch the currently selected frame's drawing without affecting anything else.  In Explicit mode, this causes the next frame to appear to show the original frame, which makes sense as it's an explicit hold.  When I implemented implicit mode, I forced this behavior unto implicit frames, when it really shouldn't have.  There is no frame there.

So now, when substituting a drawing, the adjacent implicit frame is no longer forced to be an explicit frame of the original drawing. Per implicit logic, it is now an implicit hold of the substituted drawing.  No other frames will be modified.

As a result of this change, the `Similar Drawing Substitution` (shortcuts Alt+Q/W) is somewhat obsolete in Implicit mode. The only difference between both sets is what happens when the next frame matches the substituted frame. 

Also, due to this change, it is possible that you will have an adjacent explicit held frame if the substitution matches the next frame.  For example, if you have frames `5 6` and substitute the `5`, it will be come `6 6` not `6 _`. Another example would be `5 _ _ _ 6` -> `6 _ _ _ 6`
