### PR TITLE
Output (Render) settings enhancements

### DIFF
--- a/toonz/sources/include/toutputproperties.h
+++ b/toonz/sources/include/toutputproperties.h
@@ -71,6 +71,8 @@ Can set in output to all levels, only selected levels or only animated levels.
 
   enum MaxTileSizeValues { LargeVal = 50, MediumVal = 10, SmallVal = 2 };
 
+  enum AppendVersionFormat { None = 0, Sequence, Timestamp };
+
 private:
   TFilePath m_path;
 
@@ -107,6 +109,8 @@ private:
   int m_nonlinearBpp;
 
   bool m_syncWithPlayRange;
+
+  AppendVersionFormat m_appendVersionFormat;
 
 public:
   /*!
@@ -254,6 +258,11 @@ machine's CPU).
 
   bool isSyncWithPlayRangeEnabled() { return m_syncWithPlayRange; }
   void setSyncWithPlayRangeEnabled(bool sync) { m_syncWithPlayRange = sync; }
+
+  AppendVersionFormat getAppendVersionFormat() { return m_appendVersionFormat; }
+  void setAppendVersionFormat(AppendVersionFormat format) {
+    m_appendVersionFormat = format;
+  }
 };
 
 //--------------------------------------------

--- a/toonz/sources/include/toutputproperties.h
+++ b/toonz/sources/include/toutputproperties.h
@@ -106,6 +106,8 @@ private:
   // for restoring bpp when setting the color space back to nonlinear
   int m_nonlinearBpp;
 
+  bool m_syncWithPlayRange;
+
 public:
   /*!
 Constructs TOutputProperties with default value.
@@ -249,6 +251,9 @@ machine's CPU).
   void syncColorSettings(bool sync) { m_syncColorSettings = sync; }
   int getNonlinearBpp() { return m_nonlinearBpp; }
   void setNonlinearBpp(int bpp) { m_nonlinearBpp = bpp; }
+
+  bool isSyncWithPlayRangeEnabled() { return m_syncWithPlayRange; }
+  void setSyncWithPlayRangeEnabled(bool sync) { m_syncWithPlayRange = sync; }
 };
 
 //--------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2338,10 +2338,10 @@ void MainWindow::defineActions() {
   // Menu - Render
 
   createMenuRenderAction(
-      MI_OutputSettings, QT_TR_NOOP("&Output Settings..."), "Ctrl+O",
+      MI_OutputSettings, QT_TR_NOOP("&Render Settings..."), "Ctrl+O",
       "output_settings",
-      tr("Control the output settings for the current scene.") + separator +
-          tr("You can render from the output settings window also."));
+      tr("Control the render settings for the current scene.") + separator +
+          tr("You can render from the render settings window also."));
   createMenuRenderAction(
       MI_PreviewSettings, QT_TR_NOOP("&Preview Settings..."), "",
       "preview_settings",
@@ -2349,13 +2349,13 @@ void MainWindow::defineActions() {
   createMenuRenderAction(MI_Render, QT_TR_NOOP("&Render"), "Ctrl+Shift+R",
                          "render",
                          tr("Renders according to the settings and "
-                            "location set in Output Settings."));
+                            "location set in Render Settings."));
   createMenuRenderAction(
       MI_FastRender, QT_TR_NOOP("&Fast Render to MP4"), "Alt+R",
       "fast_render_mp4",
       tr("Exports an MP4 file to the location specified in the preferences.") +
           separator +
-          tr("This is quicker than going into the Output Settings "
+          tr("This is quicker than going into the Render Settings "
              "and setting up an MP4 render."));
   createMenuRenderAction(
       MI_Preview, QT_TR_NOOP("&Preview"), "Ctrl+R", "preview",
@@ -2373,7 +2373,7 @@ void MainWindow::defineActions() {
   createMenuRenderAction(
       MI_SaveAndRender, QT_TR_NOOP("&Save and Render"), "", "render",
       tr("Saves the current scene and renders according to the settings and "
-         "location set in Output Settings."));
+         "location set in Render Settings."));
 
   // Menu - View
 

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -53,6 +53,9 @@
 #include <QPropertyAnimation>
 #include <QSpacerItem>
 #include <QEvent>
+
+TEnv::IntVar SyncOutputWithPlayRange("SyncOutputWithPlayRange", 0);
+
 //-----------------------------------------------------------------------------
 namespace {
 
@@ -325,6 +328,14 @@ void OutputSettingsPopup::onCategoryActivated(QListWidgetItem *item) {
 
 //-----------------------------------------------------------------------------
 
+void OutputSettingsPopup::onSyncWithPlayRangeChanged(int state) {
+  bool enabled = (state == Qt::Checked);
+  getProperties()->setSyncWithPlayRangeEnabled(enabled);
+  SyncOutputWithPlayRange = enabled;
+}
+
+//-----------------------------------------------------------------------------
+
 QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
   QFrame *panel = new QFrame(this);
 
@@ -512,6 +523,11 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
     m_fileFormat->addItems(formats);
     m_fileFormat->setFocusPolicy(Qt::StrongFocus);
     m_fileFormat->installEventFilter(this);
+
+    m_syncWithPlayRange = new DVGui::CheckBox("Sync with Play Range", this);
+
+    m_syncWithPlayRange->setChecked(SyncOutputWithPlayRange);
+    getProperties()->setSyncWithPlayRangeEnabled(SyncOutputWithPlayRange);
   }
 
   //-----
@@ -539,9 +555,11 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
       frameStepLay->addWidget(new QLabel(tr("Step:"), this), 0, 6,
         Qt::AlignRight | Qt::AlignVCenter);
       frameStepLay->addWidget(m_stepFld, 0, 7);
-
+      frameStepLay->addItem(
+          new QSpacerItem(10, 1, QSizePolicy::Fixed, QSizePolicy::Fixed), 0, 8);
+      frameStepLay->addWidget(m_syncWithPlayRange, 0, 9);
     }
-    frameStepLay->setColumnStretch(8, 1);
+    frameStepLay->setColumnStretch(10, 1);
 
     lay->addLayout(frameStepLay);
 
@@ -589,6 +607,9 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
   ret = ret && connect(m_fileFormatButton, SIGNAL(pressed()), this,
     SLOT(openSettingsPopup()));
 
+  if (!isPreview)
+    ret = ret && connect(m_syncWithPlayRange, SIGNAL(stateChanged(int)), this,
+                         SLOT(onSyncWithPlayRangeChanged(int))); 
   assert(ret);
   return generalSettingsBox;
 }

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -223,7 +223,7 @@ OutputSettingsPopup::OutputSettingsPopup(QWidget *parent, bool isPreview)
   addPresetButton->setObjectName("PushButton_NoPadding");
   removePresetButton->setObjectName("PushButton_NoPadding");
   QString tooltip =
-      tr("Save current output settings.\nThe parameters to be saved are:\n- "
+      tr("Save current render settings.\nThe parameters to be saved are:\n- "
          "Camera settings\n- Project folder to be saved in\n- File format\n- "
          "File options\n- Resample Balance\n- Channel width\n- Linear Color "
          "Space\n- Color Space Gamma");
@@ -371,7 +371,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
 
   if (isPreview)
     m_syncColorSettingsButton =
-        new DVGui::CheckBox(tr("Sync with Output Settings"));
+        new DVGui::CheckBox(tr("Sync with Render Settings"));
 
   if (!isPreview) {
     m_showCameraSettingsButton = new QPushButton("", this);
@@ -836,7 +836,7 @@ QFrame *OutputSettingsPopup::createColorSettingsBox(bool isPreview) {
          "when the \"Linear Color Space\" option is enabled.");
   if (m_isPreviewSettings)
     colorSpaceGammaTooltip +=
-        tr("\nInput less than 1.0 to sync the value with the output settings.");
+        tr("\nInput less than 1.0 to sync the value with the render settings.");
   m_colorSpaceGammaFld->setToolTip(colorSpaceGammaTooltip);
 
   if (!isPreview) {
@@ -1979,7 +1979,7 @@ void OutputSettingsPopup::onAddPresetButtonPressed() {
   //*-- プリセット名を取得 --*/
   bool ok;
   QString qs = DVGui::getText(
-      tr("Add preset"), tr("Enter the name for the output settings preset."),
+      tr("Add preset"), tr("Enter the name for the render settings preset."),
       "", &ok);
   if (!ok || qs.isEmpty()) return;
 
@@ -1991,7 +1991,7 @@ void OutputSettingsPopup::onAddPresetButtonPressed() {
   /*-- すでに存在する場合、上書きを確認 --*/
   if (TFileStatus(fp).doesExist()) {
     int ret = QMessageBox::question(
-        this, tr("Add output settings preset"),
+        this, tr("Add render settings preset"),
         QString(tr("The file %1 does already exist.\nDo you want to overwrite it?"))
             .arg(qs),
         QMessageBox::Save | QMessageBox::Cancel, QMessageBox::Save);

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -53,8 +53,11 @@
 #include <QPropertyAnimation>
 #include <QSpacerItem>
 #include <QEvent>
+#include <QRadioButton>
+#include <QButtonGroup>
 
 TEnv::IntVar SyncOutputWithPlayRange("SyncOutputWithPlayRange", 0);
+TEnv::IntVar AppendVersionFormat("AppendVersionFormat", 0);
 
 //-----------------------------------------------------------------------------
 namespace {
@@ -336,6 +339,14 @@ void OutputSettingsPopup::onSyncWithPlayRangeChanged(int state) {
 
 //-----------------------------------------------------------------------------
 
+void OutputSettingsPopup::onAppendVersionFormatChanged(int formatVersion) {
+  getProperties()->setAppendVersionFormat(
+      (TOutputProperties::AppendVersionFormat)formatVersion);
+  AppendVersionFormat = formatVersion;
+}
+
+//-----------------------------------------------------------------------------
+
 QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
   QFrame *panel = new QFrame(this);
 
@@ -505,6 +516,8 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
   // Step
   m_stepFld = new DVGui::IntLineEdit(this);
 
+  QRadioButton *vfNone = nullptr, *vfSequence = nullptr, *vfTimestamp = nullptr;
+
   if (!isPreview) {
     // Save In
     m_saveInFileFld = new DVGui::FileField(0, QString(""));
@@ -528,6 +541,27 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
 
     m_syncWithPlayRange->setChecked(SyncOutputWithPlayRange);
     getProperties()->setSyncWithPlayRangeEnabled(SyncOutputWithPlayRange);
+
+    vfNone      = new QRadioButton(tr("None"), this);
+    vfSequence  = new QRadioButton(tr("Sequence"), this);
+    vfTimestamp = new QRadioButton(tr("Timestamp"), this);
+
+    switch (AppendVersionFormat) {
+    case 0:
+      vfNone->setChecked(true);
+      break;
+    case 1:
+      vfSequence->setChecked(true);
+      break;
+    case 2:
+      vfTimestamp->setChecked(true);
+      break;
+    }
+
+    m_appendVersionFormatBG = new QButtonGroup;
+    m_appendVersionFormatBG->addButton(vfNone, 0);
+    m_appendVersionFormatBG->addButton(vfSequence, 1);
+    m_appendVersionFormatBG->addButton(vfTimestamp, 2);
   }
 
   //-----
@@ -584,6 +618,21 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
 
     lay->addLayout(fileGridLay);
 
+    // Version output
+    QGridLayout* versionLay = new QGridLayout();
+    versionLay->setContentsMargins(0, 0, 0, 0);
+    versionLay->setHorizontalSpacing(5);
+    versionLay->setVerticalSpacing(10);
+    {
+        versionLay->addWidget(new QLabel(tr("Append to Name:"), this), 0, 0,
+            Qt::AlignRight | Qt::AlignVCenter);
+        versionLay->addWidget(vfNone, 0, 1);
+        versionLay->addWidget(vfSequence, 0, 2);
+        versionLay->addWidget(vfTimestamp, 0, 3);
+    }
+    versionLay->setColumnStretch(4, 1);
+
+    lay->addLayout(versionLay);
   }
   generalSettingsBox->setLayout(lay);
 
@@ -607,9 +656,13 @@ QFrame *OutputSettingsPopup::createGeneralSettingsBox(bool isPreview) {
   ret = ret && connect(m_fileFormatButton, SIGNAL(pressed()), this,
     SLOT(openSettingsPopup()));
 
-  if (!isPreview)
+  if (!isPreview) {
     ret = ret && connect(m_syncWithPlayRange, SIGNAL(stateChanged(int)), this,
-                         SLOT(onSyncWithPlayRangeChanged(int))); 
+                         SLOT(onSyncWithPlayRangeChanged(int)));
+
+    ret = ret && connect(m_appendVersionFormatBG, SIGNAL(idClicked(int)), this,
+                         SLOT(onAppendVersionFormatChanged(int)));
+  }
   assert(ret);
   return generalSettingsBox;
 }
@@ -1203,6 +1256,8 @@ void OutputSettingsPopup::updateField() {
     m_renderToFolders->setChecked(prop->isRenderToFolders());
     m_renderKeysOnly->setEnabled(prop->getMultimediaRendering());
     m_renderToFolders->setEnabled(prop->getMultimediaRendering());
+
+    prop->setAppendVersionFormat((TOutputProperties::AppendVersionFormat)(int)AppendVersionFormat);
   }
 
   // Refresh format if allow-multithread was toggled

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -95,6 +95,8 @@ class OutputSettingsPopup : public QFrame, public SaveLoadQSettings {
   QPushButton *m_showCameraSettingsButton, *m_showColorSettingsButton,
       *m_showAdvancedSettingsButton, *m_showMoreSettingsButton;
 
+  DVGui::CheckBox *m_syncWithPlayRange;
+
   bool m_isPreviewSettings;
   bool m_hideAlreadyCalled = false;
 
@@ -166,6 +168,8 @@ protected slots:
   void onBoardSettingsBtnClicked();
 
   void onCategoryActivated(QListWidgetItem *);
+
+  void onSyncWithPlayRangeChanged(int);
 };
 
 class PreviewSettingsPopup final : public OutputSettingsPopup {

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -15,6 +15,7 @@ class ToonzScene;
 class QComboBox;
 class QScrollArea;
 class QListWidgetItem;
+class QButtonGroup;
 
 namespace DVGui {
 class FileField;
@@ -97,6 +98,8 @@ class OutputSettingsPopup : public QFrame, public SaveLoadQSettings {
 
   DVGui::CheckBox *m_syncWithPlayRange;
 
+  QButtonGroup *m_appendVersionFormatBG;
+
   bool m_isPreviewSettings;
   bool m_hideAlreadyCalled = false;
 
@@ -170,6 +173,7 @@ protected slots:
   void onCategoryActivated(QListWidgetItem *);
 
   void onSyncWithPlayRangeChanged(int);
+  void onAppendVersionFormatChanged(int);
 };
 
 class PreviewSettingsPopup final : public OutputSettingsPopup {

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -58,6 +58,48 @@
 
 //---------------------------------------------------------
 
+namespace {
+TFilePath appendVersionSequence(TFilePath fp) {
+  int seq = 0;
+
+  TFilePathSet fileList;
+  QString filePattern = ((TFileType::getInfo(fp) == TFileType::RASTER_IMAGE ||
+                          TFileType::getInfo(fp) == TFileType::RASTER_LEVEL) &&
+                                 !fp.isFfmpegType()
+                             ? "*.*.*."
+                             : "*.*.") +
+                        QString::fromStdString(fp.getType());
+  QDir patternDir(fp.getParentDir().getQString());
+  patternDir.setNameFilters(QStringList(filePattern));
+  TSystem::readDirectory(fileList, patternDir, false);
+
+  TFilePathSet::iterator it;
+  for (it = fileList.begin(); it != fileList.end(); it++) {
+    std::string filename = it->getName();
+    QString seqStr = QString::fromStdString(filename).section('.', 1, 1);
+    bool ok;
+    int fileSeq = seqStr.toInt(&ok);
+    if (ok && fileSeq > seq) seq = fileSeq;
+  }
+
+  seq++;
+
+  QString seqStr = QString("%1").arg(seq, 4, 10, QChar('0'));
+  QString newName = QString::fromStdString(fp.getName()) + "." + seqStr;
+
+  return fp.withName(newName.toStdWString());
+}
+
+TFilePath appendVersionTimestamp(TFilePath fp) {
+  QDateTime date  = QDateTime::currentDateTime();
+  QString dateStr = date.toString("yyyyMMddThhmmss");
+
+  QString newName = QString::fromStdString(fp.getName()) + "." + dateStr;
+
+  return fp.withName(newName.toStdWString());
+}
+}  // namespace
+
 //=========================================================
 
 class OnRenderCompleted final : public TThread::Message {
@@ -265,9 +307,18 @@ sprop->getOutputProperties()->setRenderSettings(rso);*/
   if (fp.getWideName() == L"")
     fp = fp.withName(scene->getScenePath().getName());
   /*-- For raster images, add the frame number to the filename --*/
-  if (TFileType::getInfo(fp) == TFileType::RASTER_IMAGE) 
+  if (TFileType::getInfo(fp) == TFileType::RASTER_IMAGE)
     fp = fp.withFrame(TFrameId::EMPTY_FRAME);
-  fp   = scene->decodeFilePath(fp);
+  fp = scene->decodeFilePath(fp);
+
+  switch (outputSettings.getAppendVersionFormat()) {
+  case TOutputProperties::AppendVersionFormat::Sequence:
+    fp = appendVersionSequence(fp);
+    break;
+  case TOutputProperties::AppendVersionFormat::Timestamp:
+    fp = appendVersionTimestamp(fp);
+    break;
+  }
 
   // make sure there is a destination to write to.
   if (!TFileStatus(fp.getParentDir()).doesExist()) {

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1982,7 +1982,7 @@ public:
   TPanel *createPanel(QWidget *parent) override {
     TPanel *panel = new OutputSettingsPanel(parent);
     panel->setObjectName(getPanelType());
-    panel->setWindowTitle(QObject::tr("Output Settings"));
+    panel->setWindowTitle(QObject::tr("Render Settings"));
     panel->setMinimumWidth(378);
     panel->getTitleBar()->showTitleBar(TApp::instance()->getShowTitleBars());
     connect(TApp::instance(), SIGNAL(showTitleBars(bool)), panel->getTitleBar(),
@@ -1996,7 +1996,7 @@ public:
 //=============================================================================
 OpenFloatingPanel openOutputSettingsPanelCommand(
     MI_OutputSettings, "OutputSettingsPanel",
-    QObject::tr("Output Settings"));
+    QObject::tr("Render Settings"));
 
 //=========================================================
 // PreviewSettingsPanel

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -347,6 +347,10 @@ void XsheetGUI::setPlayRange(int r0, int r1, int step, bool withUndo) {
   }
   ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
   scene->getProperties()->getPreviewProperties()->setRange(r0, r1, step);
+  if (scene->getProperties()
+          ->getOutputProperties()
+          ->isSyncWithPlayRangeEnabled())
+    scene->getProperties()->getOutputProperties()->setRange(r0, r1, step);
   TApp::instance()->getCurrentScene()->notifySceneChanged();
 }
 

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -46,7 +46,8 @@ TOutputProperties::TOutputProperties()
     , m_boardSettings(new BoardSettings())
     , m_formatTemplateFId()
     , m_syncColorSettings(true)
-    , m_syncWithPlayRange(false) {
+    , m_syncWithPlayRange(false)
+    , m_appendVersionFormat(AppendVersionFormat::None) {
   m_renderSettings = new TRenderSettings();
   m_nonlinearBpp   = m_renderSettings->m_bpp;
 }
@@ -72,7 +73,8 @@ TOutputProperties::TOutputProperties(const TOutputProperties &src)
     , m_boardSettings(new BoardSettings(*src.m_boardSettings))
     , m_formatTemplateFId(src.m_formatTemplateFId)
     , m_syncColorSettings(src.m_syncColorSettings)
-    , m_nonlinearBpp(src.m_nonlinearBpp) {
+    , m_nonlinearBpp(src.m_nonlinearBpp)
+    , m_appendVersionFormat(src.m_appendVersionFormat) {
   std::map<std::string, TPropertyGroup *>::iterator ft,
       fEnd = m_formatProperties.end();
   for (ft = m_formatProperties.begin(); ft != fEnd; ++ft) {
@@ -122,6 +124,8 @@ TOutputProperties &TOutputProperties::operator=(const TOutputProperties &src) {
   m_boardSettings = new BoardSettings(*src.m_boardSettings);
 
   m_formatTemplateFId = src.m_formatTemplateFId;
+
+  m_appendVersionFormat = src.m_appendVersionFormat;
 
   return *this;
 }

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -45,7 +45,8 @@ TOutputProperties::TOutputProperties()
     , m_subcameraPreview(false)
     , m_boardSettings(new BoardSettings())
     , m_formatTemplateFId()
-    , m_syncColorSettings(true) {
+    , m_syncColorSettings(true)
+    , m_syncWithPlayRange(false) {
   m_renderSettings = new TRenderSettings();
   m_nonlinearBpp   = m_renderSettings->m_bpp;
 }


### PR DESCRIPTION
Following enhancements have been made to `Output Settings`

<img width="70%" height="70%" alt="image" src="https://github.com/user-attachments/assets/c410f0cc-8bda-43bb-837f-65565ffa79f6" />

1. Adds `Sync with Play Range` which will sync the render range to the play markers as they are moved.
  `Preview Settings` panel does this automatically so it was not added there.

2. Adds `Append to Name` which will add a sequence number or timestamp to the filename.
   For raster file renders, the sequence # or timestamp (formatted `yyyyMMddThhmmss`) is added between the name and the drawing sequence #:   `<filename>.<version>.<drawing #>`

4. Relabeled `Output Settings` to `Render Settings`

closes #1405 
closes #827
closes #579