### PR TITLE
Change order of uploading nightlies

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -90,18 +90,6 @@ jobs:
         run: |
           echo "NIGHTLYDATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
           echo "NIGHTLYDATETIME=$(date '+%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_ENV
-      - name: Create/Update Nightlies Tag
-        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        run: |
-          git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
-          git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
-          git fetch --unshallow
-          git tag -f nightly
-          git push -f origin nightly
-          git tag -f nightly-${{ github.sha }}
-          git config --unset-all http.https://github.com/.extraheader
-          git push -f nightly_repo nightly-${{ github.sha }}
-          git remote rm nightly_repo
       - name: Update Latest Nightly Release
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
@@ -116,6 +104,18 @@ jobs:
           replacesArtifacts: true
           tag: nightly
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create/Update Nightlies Tag
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: |
+          git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
+          git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
+          git fetch --unshallow
+          git tag -f nightly
+          git push -f origin nightly
+          git tag -f nightly-${{ github.sha }}
+          git config --unset-all http.https://github.com/.extraheader
+          git push -f nightly_repo nightly-${{ github.sha }}
+          git remote rm nightly_repo
       - name: Create Nightlies Release
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -76,18 +76,6 @@ jobs:
         run: |
           echo "NIGHTLYDATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
           echo "NIGHTLYDATETIME=$(date '+%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_ENV
-      - name: Create/Update Nightlies Tag
-        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        run: |
-          git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
-          git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
-          git fetch --unshallow
-          git tag -f nightly
-          git push -f origin nightly
-          git tag -f nightly-${{ github.sha }}
-          git config --unset-all http.https://github.com/.extraheader
-          git push -f nightly_repo nightly-${{ github.sha }}
-          git remote rm nightly_repo
       - name: Update Latest Nightly Release
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
@@ -102,6 +90,18 @@ jobs:
           replacesArtifacts: true
           tag: nightly
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create/Update Nightlies Tag
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: |
+          git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
+          git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
+          git fetch --unshallow
+          git tag -f nightly
+          git push -f origin nightly
+          git tag -f nightly-${{ github.sha }}
+          git config --unset-all http.https://github.com/.extraheader
+          git push -f nightly_repo nightly-${{ github.sha }}
+          git remote rm nightly_repo
       - name: Create Nightlies Release
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -55,18 +55,6 @@ jobs:
           chcp 65001 #set code page to utf-8
           echo ("NIGHTLYDATE=" + (Get-Date -format "yyyy-MM-dd")) >> $env:GITHUB_ENV
           echo ("NIGHTLYDATETIME=" + (Get-Date -format "yyyy-MM-dd HH:mm:ss UTC")) >> $env:GITHUB_ENV
-      - name: Create/Update Nightlies Tag
-        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        run: |
-          git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
-          git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
-          git fetch --unshallow
-          git tag -f nightly
-          git push -f origin nightly
-          git tag -f nightly-${{ github.sha }}
-          git config --unset-all http.https://github.com/.extraheader
-          git push -f nightly_repo nightly-${{ github.sha }}
-          git remote rm nightly_repo
       - name: Update Latest Nightly Release
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1
@@ -81,6 +69,18 @@ jobs:
           replacesArtifacts: true
           tag: nightly
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create/Update Nightlies Tag
+        if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: |
+          git remote add nightly_repo https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git
+          git config lfs.https://tahoma2d:${{ secrets.TAHOMA2D_TOKEN }}@github.com/tahoma2d/tahoma2d_nightlies.git.lfs.locksverify false
+          git fetch --unshallow
+          git tag -f nightly
+          git push -f origin nightly
+          git tag -f nightly-${{ github.sha }}
+          git config --unset-all http.https://github.com/.extraheader
+          git push -f nightly_repo nightly-${{ github.sha }}
+          git remote rm nightly_repo
       - name: Create Nightlies Release
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Currently, nightlies are uploaded to the `tahoma2d_nightlies` repo before updating the main `tahoma2d` repo. When uploading to the tahoma2d_nightlies fails (currently happening) the main tahoma2d repo also doesn't get updated. 

This changes the order so at least tahoma2d repo will have the latest nightly.

As this change is not testable in a PR, I'll merge this as soon as the builds are done here and verify when it builds against the master.