### PR TITLE
Stop failing fast on linux builds

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -6,6 +6,7 @@ jobs:
   Linux:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         compiler: [ gcc, clang ]
         include:


### PR DESCRIPTION
Minor change to linux builds to not fail fast, meaning if 1 of the 2 linux builds fails first, it won't cancel the other linux build immediately and allow it to fail on its own.