### PR TITLE
Drop actions/checkout to v5

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -17,7 +17,7 @@ jobs:
             cc: clang
             cxx: clang++
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -6,7 +6,7 @@ jobs:
   macOS:
     runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -6,7 +6,7 @@ jobs:
   Windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         run: |
           ci-scripts\windows\tahoma-install.bat


### PR DESCRIPTION
Updating to `actions/checkout@v6` has caused uploads to the `tahoma2d_nightlies` repo to fail due to some authentication issue that appears to be caused by something in that version.  I've opened an issue with `actions/checkout`.

In the meantime, I will drop back to `v5` which I confirmed still works correctly and allows us to keep using Node.js 24.
