### PR TITLE
Fix Release v1.6.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,8 +40,9 @@ body:
       label: Software Version
       description: What version of the software are you running?
       options:
-        - 1.6
+        - 1.6.1
         - Nightly (Specify below)
+        - 1.6.0
         - 1.5.4
         - 1.5.3
         - 1.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-05-01
+
+### Fixed
+
+- Write lipsync script file as explicit UTF-8 [#2073]
+- Fix Tip's release link [#2079]
+- Fix Function Editor UI issues [#2094]
+- Fix erratic ping pong playback behavior [#2100]
+- Block more incompatible dlls [#2102]
+- Fixes for ease handles and interpolation management from timeline/xsheet [#2104]
+- Fix reading xml tags with special characters [#2108, #2134]
+- Fix looped frame logic crash [#2110]
+- Additional fixes for timeline/xsheet ease handles and interpolation [#2116]
+- Fix standard raster brush with grid option enabled [#2128]
+- Fix permanent layer offset after key delete [#2132]
+- Fix crashing on version check [#2133]
+- Fix Drawing Substitution with implicit cells [#2142]
+
+### Other
+
+- Fix compiling without Libgphoto2 [#2074]
+- Fix non-Ubuntu linux build errors [#2121]
+- Update OS X reference to macOS in README [#2129]
+- Update build actions to use Node.js 24 [#2145]
+- Change order of uploading nightlies [#2146]
+- Stop failing fast on linux builds [#2147]
+- Drop actions/checkout to v5 [#2149]
+
 ## [1.6.0] - 2026-03-01
 
 ### Added
@@ -1039,6 +1067,7 @@ Some features, when used, are saved to the scene file and will prevent the scene
 [^10]: Partial. Changes not relevant to T2D were not applied
 [^11]: Partial. Similar changes already in T2D were not applied
 
+[1.6.1]: https://github.com/tahoma2d/tahoma2d/compare/v1.6...v1.6.1
 [1.6.0]: https://github.com/tahoma2d/tahoma2d/compare/v1.5.4...v1.6
 [1.5.4]: https://github.com/tahoma2d/tahoma2d/compare/v1.5.3...v1.5.4
 [1.5.3]: https://github.com/tahoma2d/tahoma2d/compare/v1.5.2...v1.5.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.6.0{build}
+version: 1.6.1{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export TAHOMA2DVERSION=1.6
+export TAHOMA2DVERSION=1.6.1
 #source /opt/qt515/bin/qt515-env.sh
 
 echo ">>> Temporary install of Tahoma2D"

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export TAHOMA2DVERSION=1.6
+export TAHOMA2DVERSION=1.6.1
 
 if [ -d /usr/local/Cellar/qt@5 ]
 then
@@ -133,7 +133,7 @@ function checkLibFile() {
          then
             local SRC=$DEPFILE
             local Z=`echo $DEPFILE | cut -c 1-16`
-            local Z2=`echo $DEPFILE | cut -c 1-6`
+            local Z2=`echo $DEPFILE | cut -c 1.6.1`
             if [ "$Z" = "@loader_path/../" ]
             then
                local V=`echo $DEPFILE | sed -e"s/^.*\/\.\.\///"`

--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>

--- a/toonz/installer/linux/deb-creator/deb-template/DEBIAN/control
+++ b/toonz/installer/linux/deb-creator/deb-template/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: tahoma2d
-Version: 1.6
+Version: 1.6.1
 Maintainer: Tahoma2D
 Section: graphics
 Installed-Size: 
@@ -7,7 +7,7 @@ Homepage: https://tahoma2d.org/
 Architecture: amd64
 Priority: optional
 Depends: gphoto2
-Description: Tahoma 2D Version 1.6
+Description: Tahoma 2D Version 1.6.1
  Tahoma2D is a 2D and stop motion animation software. 
  .
  It is a fork of OpenToonz which is based on Toonz Studio Ghibli Version, originally developed in Italy by Digital Video, Inc., and customized by Studio Ghibli over many years of production.

--- a/toonz/installer/windows/setup.iss
+++ b/toonz/installer/windows/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Tahoma2D"
-#define MyAppVersion "1.6"
+#define MyAppVersion "1.6.1"
 #define MyAppPublisher "Tahoma2D"
 #define MyAppURL "https://tahoma2d.org/"
 #define MyAppExeName "Tahoma2D.exe"

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -19,7 +19,7 @@ public:
 private:
   const char *applicationName     = "Tahoma2D";
   const float applicationVersion  = 1.6f;
-  const float applicationRevision = 0;
+  const float applicationRevision = 1;
   const char *applicationNote     = "";
 };
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(VERSION 1.6.0)
+set(VERSION 1.6.1)
 
 set(MOC_HEADERS
     aboutpopup.h

--- a/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
+++ b/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
@@ -20,6 +20,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.6.1" date="2026-05-01"/>
     <release version="1.6.0" date="2026-03-01"/>
     <release version="1.5.4" date="2025-08-01"/>
     <release version="1.5.3" date="2025-06-01"/>


### PR DESCRIPTION
This is to mark and update the nightly to fix release version v1.6.1 in the master.

Version 1.6.1 is being build in a separate branch containing primarily fix PRs which I will be releasing tomorrow (5/1)