### PR TITLE
Level Edit switch level with column change

### DIFF
--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -355,12 +355,13 @@ int TApp::getCurrentImageType() {
 
 //-----------------------------------------------------------------------------
 
-void TApp::updateXshLevel() {
+void TApp::updateXshLevel(bool isColumnSwitch) {
   TXshLevel *xl = 0;
-  if (m_currentFrame->isEditingScene()) {
+  if (isColumnSwitch || m_currentFrame->isEditingScene()) {
     int frame       = m_currentFrame->getFrame();
     int column      = m_currentColumn->getColumnIndex();
     TXsheet *xsheet = m_currentXsheet->getXsheet();
+    TFrameId fid    = TFrameId::EMPTY_FRAME;
 
     bool isSoundColumn = false;
     if (xsheet->getColumn(column) &&
@@ -379,12 +380,14 @@ void TApp::updateXshLevel() {
                !xsheet->isColumnEmpty(column)) {
       TXshCell cell = xsheet->getCell(frame, column);
       xl            = cell.m_level.getPointer();
+      fid           = cell.getFrameId();
 
       // If I'm on an empty cell next to cells of a certain level
       // I take this as the current level.
       if (!xl && frame > 0) {
         TXshCell cell = xsheet->getCell(frame - 1, column);
         xl            = cell.m_level.getPointer();
+        fid           = cell.getFrameId();
       }
 
       // If we're on an empty cell and auto create is enabled,
@@ -396,12 +399,20 @@ void TApp::updateXshLevel() {
           TXshCell cell = xsheet->getCell(r, column);
           if (cell.isEmpty()) continue;
           xl = cell.m_level.getPointer();
+          fid = cell.getFrameId();
           break;
         }
+      }
+
+      if (xl && fid == TFrameId::STOP_FRAME) {
+        std::vector<TFrameId> fids;
+        xl->getFids(fids);
+        if (fids.size()) fid = fids[0];
       }
     }
 
     m_currentLevel->setLevel(xl);
+    if (m_currentFrame->isEditingLevel()) m_currentFrame->setFid(fid);
 
     // level could be the same, but palette could have changed
     if (xl && xl->getSimpleLevel()) {
@@ -555,7 +566,7 @@ void TApp::onFxSwitched() {
 
 void TApp::onColumnIndexSwitched() {
   // update xsheetlevel
-  updateXshLevel();
+  updateXshLevel(true);
 
   // update current object
   int columnIndex = m_currentColumn->getColumnIndex();

--- a/toonz/sources/toonz/tapp.h
+++ b/toonz/sources/toonz/tapp.h
@@ -238,7 +238,7 @@ protected:
   bool m_canHideTitleBars = false;
 
 private:
-  void updateXshLevel();
+  void updateXshLevel(bool isColumnSwitch = false);
   void updateCurrentFrame();
 
 protected slots:


### PR DESCRIPTION
In Scene Edit mode, when changing columns, the Level Strip changes level to match the level and drawing at the current cell indicator. 

This PR allows the same thing to happen in Level Edit mode.