### PR TITLE
Save/Restore current frame

### DIFF
--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -276,6 +276,12 @@ If \b scene is in +scenes/name.tnz return name,
 
   int getPreviewFrameCount();
 
+  int getStartRow() const { return m_startRow; }
+  void setStartRow(int startRow) { m_startRow = startRow; }
+
+  int getStartCol() const { return m_startCol; }
+  void setStartCol(int startCol) { m_startCol = startCol; }
+
 private:
   TFilePath m_scenePath;  //!< Full path to the scene file (.tnz).
 
@@ -300,6 +306,8 @@ private:
   int m_overlayOpacity;
   TXshLevelColumn *m_overlayLevelColumn;
   TLevelColumnFx *m_overlayFx;
+
+  int m_startRow, m_startCol;
 
 private:
   // noncopyable

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1618,6 +1618,8 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   
   TApp::instance()->setSaveInProgress(true);
   try {
+    scene->setStartRow(TApp::instance()->getCurrentFrame()->getFrameIndex());
+    scene->setStartCol(TApp::instance()->getCurrentColumn()->getColumnIndex());
     scene->save(scenePath, xsheet);
   } catch (const TSystemException &se) {
     DVGui::warning(QString::fromStdWString(se.getMessage()));
@@ -2109,8 +2111,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   }
   app->getCurrentScene()->setScene(scene);
   app->getCurrentScene()->notifyNameSceneChange();
-  app->getCurrentFrame()->setFrame(0);
-  app->getCurrentColumn()->setColumnIndex(0);
+  app->getCurrentFrame()->setFrame(scene->getStartRow());
+  app->getCurrentColumn()->setColumnIndex(scene->getStartCol());
   TPalette *palette = 0;
   if (app->getCurrentLevel() && app->getCurrentLevel()->getSimpleLevel())
     palette = app->getCurrentLevel()->getSimpleLevel()->getPalette();

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -287,7 +287,9 @@ ToonzScene::ToonzScene()
     , m_overlayLevelColumn(0)
     , m_overlayFx(0)
     , m_overlayOpacity(255)
-    , m_overlayLoaded(false) {
+    , m_overlayLoaded(false)
+    , m_startRow(0)
+    , m_startCol(0) {
   m_childStack = new ChildStack(this);
   m_properties = new TSceneProperties();
   m_levelSet   = new TLevelSet();
@@ -501,9 +503,15 @@ void ToonzScene::loadTnzFile(const TFilePath &fp) {
               m_levelSet->insertLevel(xshLevel);
             }
           }
-        } else if (tagName == "xsheet")
+        } else if (tagName == "xsheet") {
+          std::string str = is.getTagAttribute("startRow");
+          m_startRow      = str == "" ? 0 : std::stoi(str);
+          if (m_startRow < 0) m_startRow = 0;
+          str        = is.getTagAttribute("startol");
+          m_startCol = str == "" ? 0 : std::stoi(str);
+          if (m_startCol < 0) m_startCol = 0;
           is >> *getXsheet();
-        else if (tagName == "history") {
+        } else if (tagName == "history") {
           std::string historyData, s;
           while (!is.eos()) {
             is >> s;
@@ -696,7 +704,10 @@ void ToonzScene::save(const TFilePath &fp, TXsheet *subxsh) {
     std::set<TXshLevel *> emptySaveSet;
     m_levelSet->setSaveSet(emptySaveSet);
 
-    os.openChild("xsheet");
+    attr.clear();
+    attr["startRow"] = std::to_string(m_startRow);
+    attr["startCol"] = std::to_string(m_startCol);
+    os.openChild("xsheet", attr);
     os << *xsh;
     os.closeChild();
 


### PR DESCRIPTION
The current frame (row and column) is now saved when you save and leave a scene.  When you restore, you will start off at the current frame that was previously saved.

This is per scene but does not affect the scene file loading in an older versions.