### PR TITLE
Fix macOS missing dylib

### DIFF
--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -133,7 +133,7 @@ function checkLibFile() {
          then
             local SRC=$DEPFILE
             local Z=`echo $DEPFILE | cut -c 1-16`
-            local Z2=`echo $DEPFILE | cut -c 1.6.1`
+            local Z2=`echo $DEPFILE | cut -c 1-6`
             if [ "$Z" = "@loader_path/../" ]
             then
                local V=`echo $DEPFILE | sed -e"s/^.*\/\.\.\///"`


### PR DESCRIPTION
This fixes an issue with a missing dylib on macOS builds causing it to crash while opening.

This was caused by my update version script updating an unexpected line in the macOS packaging script.

Will merge once I confirm the missing library file is in the macOS build.