### PR TITLE
Add Wayland support

### DIFF
--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -95,6 +95,7 @@ fi
 
 export LD_LIBRARY_PATH=appdir/usr/lib/tahoma2d
 $LINUXDEPLOYQT appdir/usr/bin/Tahoma2D -bundle-non-qt-libs -verbose=0 -always-overwrite -no-strip \
+   -extra-plugins=platforms/libqwayland-xcomposite-glx.so,platforms/libqwayland-generic.so,platforms/libqwayland-egl.so,platforms/libqwayland-xcomposite-egl.so,wayland-decoration-client,wayland-graphics-integration-client,wayland-graphics-integration-server,wayland-shell-integration \
    -executable=appdir/usr/bin/lzocompress \
    -executable=appdir/usr/bin/lzodecompress \
    -executable=appdir/usr/bin/tcleanup \

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -2,7 +2,7 @@
 sudo apt-get update
 sudo apt-get install -y cmake liblzo2-dev liblz4-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev libsuperlu-dev wget libboost-all-dev liblzma-dev libjson-c-dev libjpeg8-dev libjpeg-turbo8-dev libturbojpeg0-dev libglib2.0-dev
 
-sudo apt-get install -y qtscript5-dev libqt5svg5-dev qtmultimedia5-dev libqt5serialport5-dev qttools5-dev libqt5multimedia5-plugins
+sudo apt-get install -y qtscript5-dev libqt5svg5-dev qtmultimedia5-dev libqt5serialport5-dev qttools5-dev libqt5multimedia5-plugins qtwayland5 qtdeclarative5-dev libqt5waylandclient5-dev libqt5waylandcompositor5-dev
 
 # Removed: libopenjpeg-dev 
 sudo apt-get install -y nasm yasm libgnutls28-dev libunistring-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libopencore-amrnb-dev libopencore-amrwb-dev libspeex-dev libsoxr-dev libopenjp2-7-dev

--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -19,7 +19,7 @@ Building Tahoma2D from source requires the following dependencies:
 ### Installing Dependencies on Debian / Ubuntu 16.04 (Xenial) / Devuan
 
 ```
-$ sudo apt-get install build-essential git cmake freeglut3-dev libboost-all-dev libegl1-mesa-dev libfreetype6-dev libgles2-mesa-dev libglew-dev libglib2.0-dev libjpeg-dev libjpeg-turbo8-dev libjson-c-dev liblz4-dev liblzma-dev liblzo2-dev libpng-dev libsuperlu-dev pkg-config qt5-default qtbase5-dev libqt5svg5-dev qtscript5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev qtmultimedia5-dev qtwayland5 libqt5multimedia5-plugins
+$ sudo apt-get install build-essential git cmake freeglut3-dev libboost-all-dev libegl1-mesa-dev libfreetype6-dev libgles2-mesa-dev libglew-dev libglib2.0-dev libjpeg-dev libjpeg-turbo8-dev libjson-c-dev liblz4-dev liblzma-dev liblzo2-dev libpng-dev libsuperlu-dev pkg-config qt5-default qtbase5-dev libqt5svg5-dev qtscript5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins qtwayland5 qtdeclarative5-dev libqt5waylandclient5-dev libqt5waylandcompositor5-dev
 ```
 In Debian / Devuan: replace `libjpeg-turbo8-dev` with `libturbojpg0-dev` and `qt5-default` with `libqt5serialport5-dev` and add: `libsuperlu-dev liblz4-dev liblzo-dev libmypaint-dev libglew-dev freeglut3-dev` 
 

--- a/toonz/sources/scripts/AppRun
+++ b/toonz/sources/scripts/AppRun
@@ -14,4 +14,12 @@ echo "IOLIBS: $IOLIBS"
 export QT_PLUGIN_PATH="$(readlink -f "$(dirname "$(find "${APPDIR}" -type d -path '*/plugins/platforms' 2>/dev/null)" 2>/dev/null)" 2>/dev/null)"
 echo "QT_PLUGIN_PATH=$QT_PLUGIN_PATH"
 
+# Let's force wayland if platform isn't specified
+if [ xx$QT_QPA_PLATFORM = xx ]
+then
+   echo "Setting QT_QPA_PLATFORM..."
+   export QT_QPA_PLATFORM=wayland
+fi
+echo "QT_QPA_PLATFORM=$QT_QPA_PLATFORM"
+
 $APPDIR/usr/bin/Tahoma2D "$@"

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -356,7 +356,7 @@ void ToolOptionControlBuilder::visit(TColorChipProperty *p) {
 
 void ToolOptionControlBuilder::visit(TStylusProperty *p) {
   ToolOptionStylusConfigButton *obj =
-      new ToolOptionStylusConfigButton(m_tool, p);
+      new ToolOptionStylusConfigButton(m_panel, m_tool, p);
   obj->setToolTip(p->getQStringName());
 
   // This should be following another control.  Remove space item added after
@@ -374,7 +374,8 @@ void ToolOptionControlBuilder::visit(TStylusProperty *p) {
 //-----------------------------------------------------------------------------
 
 void ToolOptionControlBuilder::visit(TBrushTipProperty *p) {
-  ToolOptionBrushTipButton *obj = new ToolOptionBrushTipButton(m_tool, p);
+  ToolOptionBrushTipButton *obj =
+      new ToolOptionBrushTipButton(m_panel, m_tool, p);
   obj->setToolTip(p->getQStringName());
 
   hLayout()->addWidget(obj, 100);

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -514,7 +514,7 @@ void ToolOptionTextField::onValueChanged() {
 //=============================================================================
 
 ToolOptionStylusConfigButton::ToolOptionStylusConfigButton(
-    TTool *tool, TStylusProperty *property)
+    QWidget *parent, TTool *tool, TStylusProperty *property)
     : QPushButton()
     , ToolOptionControl(tool, property->getName())
     , m_property(property) {
@@ -525,7 +525,7 @@ ToolOptionStylusConfigButton::ToolOptionStylusConfigButton(
 
   m_property->addListener(this);
 
-  m_stylusConfig = new StylusConfigPopup(m_property->getQStringName(), 0);
+  m_stylusConfig = new StylusConfigPopup(m_property->getQStringName(), parent);
 
   bool useLinearCurves = m_property->useLinearCurves();
   QList<TPointD> defaultPressureCurve =
@@ -595,7 +595,6 @@ void ToolOptionStylusConfigButton::onClicked() {
 
   updateStatus();
 
-  m_stylusConfig->show();
   QPoint configPos= mapToGlobal(QPoint(0, pos().y()));
   configPos.setY(configPos.y() + height());
   m_stylusConfig->move(configPos);
@@ -617,6 +616,8 @@ void ToolOptionStylusConfigButton::onClicked() {
   if (distanceX != 0 || distanceY != 0)
     m_stylusConfig->move(m_stylusConfig->x() - distanceX,
                          m_stylusConfig->y() - distanceY);
+
+  m_stylusConfig->show();
 }
 
 //-----------------------------------------------------------------------------
@@ -648,8 +649,8 @@ void ToolOptionStylusConfigButton::onConfigCurveChanged(int configId, bool isDra
 
 //=============================================================================
 
-ToolOptionBrushTipButton::ToolOptionBrushTipButton(
-    TTool *tool, TBrushTipProperty *property)
+ToolOptionBrushTipButton::ToolOptionBrushTipButton(QWidget *parent, TTool *tool,
+                                                   TBrushTipProperty *property)
     : QPushButton()
     , ToolOptionControl(tool, property->getName())
     , m_property(property) {
@@ -659,7 +660,7 @@ ToolOptionBrushTipButton::ToolOptionBrushTipButton(
 
   m_property->addListener(this);
 
-  m_brushTips = new BrushTipPopup(0);
+  m_brushTips = new BrushTipPopup(parent);
 
   updateStatus();
 
@@ -706,7 +707,6 @@ void ToolOptionBrushTipButton::onClicked() {
 
   updateStatus();
 
-  m_brushTips->show();
   QPoint configPos = mapToGlobal(QPoint(0, pos().y()));
   configPos.setY(configPos.y() + height());
   m_brushTips->move(configPos);
@@ -728,6 +728,8 @@ void ToolOptionBrushTipButton::onClicked() {
   if (distanceX != 0 || distanceY != 0)
     m_brushTips->move(m_brushTips->x() - distanceX,
                       m_brushTips->y() - distanceY);
+
+  m_brushTips->show();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -274,7 +274,8 @@ protected:
   int m_pressureId, m_tiltId;
 
 public:
-  ToolOptionStylusConfigButton(TTool *tool, TStylusProperty *property);
+  ToolOptionStylusConfigButton(QWidget *parent, TTool *tool,
+                               TStylusProperty *property);
   void updateStatus() override;
   TStylusProperty *getProperty() { return m_property; }
 
@@ -297,7 +298,8 @@ protected:
   int m_pressureId, m_tiltId;
 
 public:
-  ToolOptionBrushTipButton(TTool *tool, TBrushTipProperty *property);
+  ToolOptionBrushTipButton(QWidget *parent, TTool *tool,
+                           TBrushTipProperty *property);
   void updateStatus() override;
   TBrushTipProperty *getProperty() { return m_property; }
 

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -4180,8 +4180,6 @@ void SettingsPage::onOpenStylusConfig() {
   m_stylusConfig->blockSignals(false);
 
   // Display Popup -- Accounts for scrolled panel
-  m_stylusConfig->show();
-
   QScrollArea *sa = (QScrollArea *)senderWidget->parentWidget()
                         ->parentWidget()
                         ->parentWidget();
@@ -4209,6 +4207,8 @@ void SettingsPage::onOpenStylusConfig() {
   if (distanceX != 0 || distanceY != 0)
     m_stylusConfig->move(m_stylusConfig->x() - distanceX,
                          m_stylusConfig->y() - distanceY);
+
+  m_stylusConfig->show();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This updates the linux dependency installation and linux packaging to include the necessary libraries for running Tahoma2D as a native Wayland application.

As support for X11 is being deprecated/removed in favor of Wayland, I've modified the startup script to set `QT_QPA_PLATFORM=wayland;xcb` if the environment variable isn't already set prior to starting T2D.

Additionally, fixed the incorrect popup location of the Brush Tip and Stylus Config popups that occurs in Wayland.

fixes #2159
fixes #1811

I've marked this for 1.7, but I may release this under fix release 1.6.2.