### PR TITLE
Fix raster brush memory usage

### DIFF
--- a/toonz/sources/tnztools/bluredbrush.cpp
+++ b/toonz/sources/tnztools/bluredbrush.cpp
@@ -673,6 +673,14 @@ RasterBlurredBrush::RasterBlurredBrush(const TRaster32P &ras, double size,
 
 //------------------------------------------------------------------
 
+RasterBlurredBrush::~RasterBlurredBrush() {
+  for (BluredBrush *brush : m_blurredBrushes) {
+    delete brush;
+  }
+}
+
+//------------------------------------------------------------------
+
 void RasterBlurredBrush::addSymmetryBrushes(double lines, double rotation,
                                             TPointD centerPoint,
                                             bool useLineSymmetry,

--- a/toonz/sources/tnztools/bluredbrush.h
+++ b/toonz/sources/tnztools/bluredbrush.h
@@ -95,6 +95,8 @@ public:
                      BrushTipData *brushTip = 0, double spacing = 1,
                      double rotation = 0, bool flipH = false,
                      bool flipV = false, double scatter = 0);
+  
+  ~RasterBlurredBrush();
 
   void addSymmetryBrushes(double lines, double rotation, TPointD centerPoint,
                           bool useLineSymmetry, TPointD dpiScale);

--- a/toonz/sources/tnztools/cmrasterbrush.cpp
+++ b/toonz/sources/tnztools/cmrasterbrush.cpp
@@ -32,6 +32,14 @@ CMRasterBrush::CMRasterBrush(const TRasterCM32P &raster, Tasks task,
 
 //------------------------------------------------------------------
 
+CMRasterBrush::~CMRasterBrush() {
+  for (RasterStrokeGenerator *track : m_rasterTracks) {
+    delete track;
+  }
+}
+
+//------------------------------------------------------------------
+
 void CMRasterBrush::addSymmetryBrushes(double lines, double rotation,
                                        TPointD centerPoint,
                                        bool useLineSymmetry, TPointD dpiScale) {

--- a/toonz/sources/tnztools/cmrasterbrush.h
+++ b/toonz/sources/tnztools/cmrasterbrush.h
@@ -35,7 +35,7 @@ public:
                 int styleId, const TThickPoint &p, bool selective,
                 int selectedStyle, bool lockAlpha, bool keepAntialias,
                 bool isPaletteOrder = false);
-  ~CMRasterBrush(){};
+  ~CMRasterBrush();
 
   void addSymmetryBrushes(double lines, double rotation, TPointD centerPoint,
                           bool useLineSymmetry, TPointD dpiScale);

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -1288,7 +1288,6 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   TXshSimpleLevelP simLevel = level->getSimpleLevel();
 
   if (m_tileSet->getTileCount() > 0) {
-    delete m_tileSaver;
     TFrameId frameId = getCurrentFid();
     TRasterP subras  = ras->extract(m_strokeRect)->clone();
     TUndoManager::manager()->add(new FullColorBrushUndo(
@@ -1314,11 +1313,13 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
 
   notifyImageChanged();
   m_strokeRect.empty();
+  delete m_tileSaver;
   m_mousePressed     = false;
   m_isStraight       = false;
   m_oldPressure      = -1.0;
   m_perspectiveIndex = -1;
   m_tiltAngle        = 0;
+  m_tileSaver        = 0;
 }
 
 //---------------------------------------------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/brushtipmanager.cpp
+++ b/toonz/sources/toonzlib/brushtipmanager.cpp
@@ -232,6 +232,11 @@ void BrushTipLoaderTask::run() {
     imageContour = createImagecontour(tmp);
 #endif
 
+    if (tmp) {
+      delete tmp;
+      tmp = nullptr;
+    }
+
     QString name   = QString::fromStdString(m_fp.getName());
     std::string id = TTextureStyle::staticBrushIdName(m_rpath.toStdWString());
     QString folder = (m_rpath.toStdString() != m_fp.getLevelName())


### PR DESCRIPTION
It was reported that memory usage while drawing on a raster level was excessive when using the standard brush.

I found that memory was not being freed properly after a brush stroke so it would constantly consume more memory over time.  This would also happen on a Smart Raster level when `Hardness` < 100 as it uses the same anti-aliased brush logic as Raster.

Not sure why it wasn't happening with Smart Raster when `Hardness` = 100 or using `Pencil` mode, as it was also missing logic for freeing up memory after a brush stroke, I added the logic there just in case.