### PR TITLE
Fix shortcut ambiguity issues

### DIFF
--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -845,6 +845,21 @@ bool TApp::eventFilter(QObject *watched, QEvent *e) {
     }
   }
 
+  if (e->type() == QEvent::Shortcut) {
+    QShortcutEvent *sev = dynamic_cast<QShortcutEvent *>(e);
+    if (sev && sev->isAmbiguous()) {
+      QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
+      QKeySequence keySeq = sev->key();
+      QAction *action =
+          CommandManager::instance()->getActionFromShortcut(keySeq.toString().toStdString());
+      if (action) {
+        action->trigger();
+        e->accept();
+        return true;
+      }
+    }
+  }
+
   if (e->type() == QEvent::KeyRelease) {
     QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
     if (TApp::instance()->getCurrentTool()->isTempToolActive()) {


### PR DESCRIPTION
This fixes an issue with `Create Blank Drawing` shortcut not working after the implementation of the Main Toolbar (#2136).

This is caused by the `Delete` command on the main tool bar. If the command is removed or the toolbar is hidden, the `Create Blank Drawing` shortcut works.

The ultimate reason is due to Window's inherent menu access key navigation which is initiated with the `ALT` command.  Somehow, the `Delete` command whose Windows navigation would be `ALT+D` is causing shortcut ambiguity with T2D's `Create Blank Drawing` shortcut which is `ALT+D`.  For some reason it only seems to happen with these 2.  If I put in another command that would also result in Windows navigation `ALT+D`, it doesn't seem to have any issues.

I added logic to trap when the system detects a shortcut ambiguity, it will trigger T2D's shortcut automatically.

Side Note:
Window's menu access key system uses menu mnemonics where commands are defined with `&` before the key (i.e `"&Delete"` sets it (`D`) as the access key.  The access key is shown as an underlined letter in the menu. The command only triggers if you open a menu (i.e `File`, `Edit`, etc) with the `ALT` key.

None of our main menus have mnemonics defined as it would interfere with T2D's shortcuts. Because of that, the menu access keys for commands are not accessible.  I do not know why we continue to set these key mnemonics on commands that are never used.  It's also bad practice to have multiple commands in the same menu with the same mnemonic.  I may remove them all in a future PR.

