### PR TITLE
Updates to Skeleton and Plastic Tool option bars

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -85,6 +85,11 @@ class QStackedWidget;
 
 #define TOOL_OPTIONS_LEFT_MARGIN 5
 
+static QIcon m_noKeyIcon, m_partialKeyIcon, m_fullKeyIcon;
+
+const int ITEM_SPACING  = 10;
+const int LABEL_SPACING = 3;
+
 //=============================================================================
 
 //***********************************************************************************************
@@ -334,6 +339,63 @@ protected slots:
   void onRotateRight();
   void onSetKey();
   void onResetCenter();
+};
+
+//=============================================================================
+//
+// SkeletonToolOptionsBox
+//
+//=============================================================================
+
+class SkeletonToolOptionsBox final : public ToolOptionsBox {
+  Q_OBJECT
+
+  TTool *m_tool;
+  TFrameHandle *m_frameHandle;
+  TObjectHandle *m_objHandle;
+  TXsheetHandle *m_xshHandle;
+
+  ToolOptionCheckbox *m_globalKey;
+  ToolOptionCombo *m_mode;
+
+  QComboBox *m_interpolationCombo;
+  QPushButton *m_leftRotateButton, *m_rightRotateButton, *m_setKeyButton;
+
+  PegbarChannelField *m_ewPosField, *m_nsPosField, *m_rotationField;
+
+  PegbarCenterField  *m_ewCenterField, *m_nsCenterField;
+
+  ClickableLabel *m_ewPosLabel, *m_nsPosLabel, *m_rotationLabel,
+      *m_ewCenterLabel, *m_nsCenterLabel;
+
+  bool m_updateControls;
+
+public:
+  SkeletonToolOptionsBox(QWidget *parent, TTool *tool,
+                         TFrameHandle *frameHandle, TObjectHandle *objHandle,
+                         TXsheetHandle *xshHandle, ToolHandle *toolHandle);
+
+  void updateControls();
+  void updateStatus();
+  void onStageObjectChange(bool isDragging = false);
+
+protected:
+  void connectLabelAndField(ClickableLabel *label, MeasuredValueField *field);
+  void showEvent(QShowEvent *);
+  void hideEvent(QShowEvent *);
+
+  int getKeysStatus(TStageObject::Keyframe keys);
+  bool canSetInterpolation(int frame, TStageObject *stageObj);
+
+protected slots:
+  void onFrameSwitched();
+  void onModeChanged(int);
+  void onGlobalKeyChanged(bool);
+  void onPlayingStatusChanged();
+  void onRotateLeft();
+  void onRotateRight();
+  void onSetKey();
+  void onInterpolationComboActivated(int index);
 };
 
 //=============================================================================

--- a/toonz/sources/include/toonz/tstageobject.h
+++ b/toonz/sources/include/toonz/tstageobject.h
@@ -376,6 +376,8 @@ with the frame.
   /** Gets a range of keyframes */
   void getKeyframes(KeyframeMap &keyframes) const;
   bool getKeyframeRange(int &r0, int &r1) const;
+  void getSDKeyframes(KeyframeMap &keyframes) const;
+  bool getSDKeyframeRange(int &r0, int &r1) const;
 
   bool getKeyframeSpan(int row, int &r0, double &ease0, int &r1,
                        double &ease1) const;

--- a/toonz/sources/tnztools/edittool.h
+++ b/toonz/sources/tnztools/edittool.h
@@ -119,6 +119,8 @@ public:
   void leftButtonDrag(const TPointD& pos, const TMouseEvent&) override;
   void leftButtonUp(const TPointD& pos, const TMouseEvent&) override;
 
+  bool isDragging() const override { return m_dragTool ? true : false; }
+
   void mouseMove(const TPointD&, const TMouseEvent& e) override;
 
   void draw() override;

--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -3,7 +3,6 @@
 #include "plastictool.h"
 
 // TnzTools includes
-#include "tooloptionscontrols.h"
 #include "tools/toolcommandids.h"
 
 // TnzQt includes
@@ -388,11 +387,18 @@ void PlasticToolOptionsBox::SkelIdsComboBox::updateCurrentSkeleton() {
 
 PlasticToolOptionsBox::PlasticToolOptionsBox(QWidget *parent, TTool *tool,
                                              TPaletteHandle *pltHandle,
-                                             ToolHandle *toolHandle)
+                                             ToolHandle *toolHandle,
+                                             TFrameHandle *frameHandle,
+                                             TObjectHandle *objHandle,
+                                             TXsheetHandle *xshHandle)
     : GenericToolOptionsBox(parent, tool, pltHandle, PlasticTool::MODES_COUNT,
                             toolHandle)
     , m_tool(tool)
+    , m_frameHandle(frameHandle)
+    , m_objHandle(objHandle)
+    , m_xshHandle(xshHandle)
     , m_subToolbars(new GenericToolOptionsBox *[PlasticTool::MODES_COUNT])
+    , m_updateControls(true)
 //, m_subToolbarActions(new QAction*[PlasticTool::MODES_COUNT])
 {
   struct locals {
@@ -470,66 +476,115 @@ PlasticToolOptionsBox::PlasticToolOptionsBox(QWidget *parent, TTool *tool,
   }
 
   // Distance
-  ToolOptionParamRelayField *distanceField = new ToolOptionParamRelayField(
+  m_distanceField = new ToolOptionParamRelayField(
       &l_plasticTool, &l_plasticTool.m_distanceRelay);
-  distanceField->setGlobalKey(&l_plasticTool.m_globalKey,
-                              &l_plasticTool.m_relayGroup);
+  m_distanceField->setGlobalKey(&l_plasticTool.m_globalKey,
+                                &l_plasticTool.m_relayGroup);
 
   ClickableLabel *distanceLabel = new ClickableLabel(tr("Distance"));
   distanceLabel->setFixedHeight(20);
 
   // Angle
-  ToolOptionParamRelayField *angleField = new ToolOptionParamRelayField(
-      &l_plasticTool, &l_plasticTool.m_angleRelay);
-  angleField->setGlobalKey(&l_plasticTool.m_globalKey,
-                           &l_plasticTool.m_relayGroup);
+  m_angleField = new ToolOptionParamRelayField(&l_plasticTool,
+                                               &l_plasticTool.m_angleRelay);
+  m_angleField->setGlobalKey(&l_plasticTool.m_globalKey,
+                             &l_plasticTool.m_relayGroup);
 
   ClickableLabel *angleLabel = new ClickableLabel(tr("Angle"));
   angleLabel->setFixedHeight(20);
 
   // SO
-  ToolOptionParamRelayField *soField =
+  m_soField =
       new ToolOptionParamRelayField(&l_plasticTool, &l_plasticTool.m_soRelay);
-  soField->setGlobalKey(&l_plasticTool.m_globalKey,
-                        &l_plasticTool.m_relayGroup);
+  m_soField->setGlobalKey(&l_plasticTool.m_globalKey,
+                          &l_plasticTool.m_relayGroup);
 
   ClickableLabel *soLabel = new ClickableLabel(tr("SO"));
   soLabel->setFixedHeight(20);
 
+  m_noKeyIcon      = createQIcon("key_off");
+  m_partialKeyIcon = createQIcon("key_partial");
+  m_fullKeyIcon    = createQIcon("key_on");
+
+  m_setKeyButton = new QPushButton(this);
+  m_setKeyButton->setFixedSize(QSize(22, 20));
+  m_setKeyButton->setIconSize(QSize(20, 20));
+  m_setKeyButton->setToolTip(tr("Set Key"));
+
+  m_interpolationCombo = new QComboBox(this);
+  m_interpolationCombo->setSizeAdjustPolicy(
+      QComboBox::SizeAdjustPolicy::AdjustToContents);
+  m_interpolationCombo->setToolTip(tr("Default Interpolation"));
+  // This list must match what's in preferences
+  m_interpolationCombo->addItem(tr("Constant"), 1);
+  m_interpolationCombo->addItem(tr("Linear"), 2);
+  m_interpolationCombo->addItem(tr("Speed In / Speed Out"), 3);
+  m_interpolationCombo->addItem(tr("Ease In / Ease Out"), 4);
+  m_interpolationCombo->addItem(tr("Ease In / Ease Out %"), 5);
+  m_interpolationCombo->addItem(tr("Exponential"), 6);
+  m_interpolationCombo->addItem(tr("Expression "), 7);
+  m_interpolationCombo->addItem(tr("File"), 8);
+
+  m_setRestKeyButton = new QPushButton(this);
+  m_setRestKeyButton->setFixedSize(QSize(22, 20));
+  m_setRestKeyButton->setIconSize(QSize(20, 20));
+  m_setRestKeyButton->setToolTip(tr("Set Rest Key"));
+  m_setRestKeyButton->setIcon(createQIcon("rest_key"));
+
   QHBoxLayout *animateLayout = animateOptionsBox->hLayout();
-  animateLayout->insertWidget(0, soField);
+  animateLayout->insertWidget(0, m_soField);
   animateLayout->insertWidget(0, soLabel);
-  animateLayout->insertWidget(0, angleField);
+  animateLayout->insertWidget(0, m_angleField);
   animateLayout->insertWidget(0, angleLabel);
-  animateLayout->insertWidget(0, distanceField);
+  animateLayout->insertWidget(0, m_distanceField);
   animateLayout->insertWidget(0, distanceLabel);
+  animateLayout->insertWidget(0, m_setRestKeyButton);
+  animateLayout->insertWidget(0, m_setKeyButton);
+  animateLayout->insertWidget(0, m_interpolationCombo);
 
   ret = ret && connect(distanceLabel, SIGNAL(onMousePress(QMouseEvent *)),
-                       distanceField, SLOT(receiveMousePress(QMouseEvent *)));
+                       m_distanceField, SLOT(receiveMousePress(QMouseEvent *)));
   ret = ret && connect(distanceLabel, SIGNAL(onMouseMove(QMouseEvent *)),
-                       distanceField, SLOT(receiveMouseMove(QMouseEvent *)));
-  ret = ret && connect(distanceLabel, SIGNAL(onMouseRelease(QMouseEvent *)),
-                       distanceField, SLOT(receiveMouseRelease(QMouseEvent *)));
+                       m_distanceField, SLOT(receiveMouseMove(QMouseEvent *)));
+  ret =
+      ret && connect(distanceLabel, SIGNAL(onMouseRelease(QMouseEvent *)),
+                     m_distanceField, SLOT(receiveMouseRelease(QMouseEvent *)));
   ret = ret && connect(angleLabel, SIGNAL(onMousePress(QMouseEvent *)),
-                       angleField, SLOT(receiveMousePress(QMouseEvent *)));
+                       m_angleField, SLOT(receiveMousePress(QMouseEvent *)));
   ret = ret && connect(angleLabel, SIGNAL(onMouseMove(QMouseEvent *)),
-                       angleField, SLOT(receiveMouseMove(QMouseEvent *)));
+                       m_angleField, SLOT(receiveMouseMove(QMouseEvent *)));
   ret = ret && connect(angleLabel, SIGNAL(onMouseRelease(QMouseEvent *)),
-                       angleField, SLOT(receiveMouseRelease(QMouseEvent *)));
-  ret = ret && connect(soLabel, SIGNAL(onMousePress(QMouseEvent *)), soField,
+                       m_angleField, SLOT(receiveMouseRelease(QMouseEvent *)));
+  ret = ret && connect(soLabel, SIGNAL(onMousePress(QMouseEvent *)), m_soField,
                        SLOT(receiveMousePress(QMouseEvent *)));
-  ret = ret && connect(soLabel, SIGNAL(onMouseMove(QMouseEvent *)), soField,
+  ret = ret && connect(soLabel, SIGNAL(onMouseMove(QMouseEvent *)), m_soField,
                        SLOT(receiveMouseMove(QMouseEvent *)));
-  ret = ret && connect(soLabel, SIGNAL(onMouseRelease(QMouseEvent *)), soField,
-                       SLOT(receiveMouseRelease(QMouseEvent *)));
+  ret = ret && connect(soLabel, SIGNAL(onMouseRelease(QMouseEvent *)),
+                       m_soField, SLOT(receiveMouseRelease(QMouseEvent *)));
+
+  ret = ret && connect(m_setKeyButton, SIGNAL(clicked()), SLOT(onSetKey()));
+
+  ret = ret && connect(m_setRestKeyButton, SIGNAL(clicked()), SLOT(onSetRestKey()));
+
+  ret = ret && connect(m_interpolationCombo, SIGNAL(activated(int)), this,
+                       SLOT(onInterpolationComboActivated(int)));
+
   assert(ret);
 
   onPropertyChanged();
+  updateStatus();
 }
 
 //------------------------------------------------------------------------
 
 void PlasticToolOptionsBox::showEvent(QShowEvent *se) {
+  int interpolationType = Preferences::instance()->getKeyframeType();
+  for (int i = 0; i < m_interpolationCombo->count(); ++i)
+    if (m_interpolationCombo->itemData(i) == interpolationType) {
+      m_interpolationCombo->setCurrentIndex(i);
+      break;
+    }
+
   bool ret = true;
 
   ret = ret && connect(&l_plasticTool, SIGNAL(skelIdsListChanged()),
@@ -543,9 +598,15 @@ void PlasticToolOptionsBox::showEvent(QShowEvent *se) {
   ret = ret && connect(m_removeSkelButton, SIGNAL(released()),
                        SLOT(onRemoveSkeleton()));
 
+  ret = ret && connect(m_frameHandle, SIGNAL(frameSwitched()),
+                       SLOT(onFrameSwitched()));
+  ret = ret && connect(m_frameHandle, SIGNAL(isPlayingStatusChanged()),
+                       SLOT(onPlayingStatusChanged()));
+
   assert(ret);
 
   m_skelIdComboBox->updateSkeletonsList();
+  updateStatus();
 }
 
 //------------------------------------------------------------------------
@@ -555,6 +616,181 @@ void PlasticToolOptionsBox::hideEvent(QHideEvent *he) {
   disconnect(m_skelIdComboBox, 0, this, 0);
   disconnect(m_addSkelButton, 0, this, 0);
   disconnect(m_removeSkelButton, 0, this, 0);
+  disconnect(m_frameHandle, 0, this, 0);
+}
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::updateStatus() {
+  if (m_updateControls) updateControls();
+}
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::updateControls() {
+  if (l_plasticTool.m_mode.getIndex() != l_plasticTool.ANIMATE_IDX) return;
+
+  TStageObjectId objId        = m_objHandle->getObjectId();
+  TStageObject *stageObj      = m_xshHandle->getXsheet()->getStageObject(objId);
+  int frame                   = m_frameHandle->getFrameIndex();
+
+  PlasticSkeletonDeformationP sd = l_plasticTool.m_sd;
+
+  SkVD *vd   = 0;
+  int skelId = ::skeletonId();
+  if (sd && l_plasticTool.m_svSel.hasSingleObject())
+    vd = sd->vertexDeformation(skelId, l_plasticTool.m_svSel);
+
+  QString keyColorName       = getKeyFrameBorderColor().name();
+  QString inBetweenColorName = getInBetweenBorderColor().name();
+
+  bool isPlaying = m_frameHandle->isPlaying();
+  if (isPlaying) m_updateControls = false;  // Stop updating on next pass
+
+  QString highlightKey =
+      isPlaying ? "" : "QLineEdit {background-color: " + keyColorName + ";}";
+  QString highlightInbetween =
+      isPlaying ? ""
+                : "QLineEdit {background-color: " + inBetweenColorName + ";}";
+
+  bool enableWidget = vd;  //&& objId.is;
+
+  m_distanceField->setStyleSheet(
+      vd && vd->m_params[SkVD::DISTANCE]->isKeyframe(frame)
+          ? highlightKey
+          : (isSDChannelInterpolated(vd, SkVD::DISTANCE, frame)
+                 ? highlightInbetween
+                 : ""));
+  m_angleField->setStyleSheet(
+      vd && vd->m_params[SkVD::ANGLE]->isKeyframe(frame)
+          ? highlightKey
+          : (isSDChannelInterpolated(vd, SkVD::ANGLE, frame)
+                 ? highlightInbetween
+                 : ""));
+  m_soField->setStyleSheet(vd && vd->m_params[SkVD::SO]->isKeyframe(frame)
+                               ? highlightKey
+                               : (isSDChannelInterpolated(vd, SkVD::SO, frame)
+                                      ? highlightInbetween
+                                      : ""));
+
+  m_setKeyButton->setEnabled(enableWidget);
+  m_setRestKeyButton->setEnabled(enableWidget);
+
+  bool enableInterpolation =
+      enableWidget && canSetInterpolation(frame, stageObj);
+  if (!isPlaying) m_interpolationCombo->setEnabled(enableInterpolation);
+
+  bool isKey = sd && sd->isKeyframe(frame);
+  if (!isKey || isPlaying) {
+    m_setKeyButton->setIcon(m_noKeyIcon);
+    return;
+  }
+
+  int keysStatus = getKeysStatus(frame, vd);
+
+  m_setKeyButton->setIcon(
+      !keysStatus ? m_noKeyIcon
+                  : (keysStatus == 1 ? m_partialKeyIcon : m_fullKeyIcon));
+}
+
+//------------------------------------------------------------------------
+
+int PlasticToolOptionsBox::getKeysStatus(int frame, SkVD* vd) {
+  if (!vd) return 0;
+
+  int keysFound = 0;
+  
+  if (vd->m_params[SkVD::DISTANCE]->isKeyframe(frame)) keysFound++;
+  if (vd->m_params[SkVD::ANGLE]->isKeyframe(frame)) keysFound++;
+  if (vd->m_params[SkVD::SO]->isKeyframe(frame)) keysFound++;
+
+  if (keysFound > 0 && keysFound == 3) return 2;  // Full
+  if (keysFound > 0 && keysFound != 3) return 1;  // Partial
+  
+  return 0;
+}
+
+//-----------------------------------------------------------------------------
+
+bool PlasticToolOptionsBox::canSetInterpolation(int frame, TStageObject *stageObj) {
+  bool canSet = true;
+
+  int r0, r1;
+  TStageObject::KeyframeMap keyframes;
+  stageObj->getSDKeyframes(keyframes);
+  stageObj->getSDKeyframeRange(r0, r1);
+
+  if (frame >= r0 && frame <= r1) {
+    auto it    = keyframes.lower_bound(frame);
+    bool isKey = frame == it->first;
+    PlasticSkeletonDeformationP sd = l_plasticTool.m_sd;
+    int skelId                     = ::skeletonId();
+    SkVD *vd                       = 0;
+    if (sd && l_plasticTool.m_svSel.hasSingleObject())
+      vd = sd->vertexDeformation(skelId, l_plasticTool.m_svSel);
+
+    if ((frame == r0 && it->first == r0) || (frame == r1 && it->first == r1)) {
+      canSet = getKeysStatus(frame, vd) != 2;
+    } else {
+      int keyCount  = 3;
+      int keysFound = 0;
+
+      if (vd && (vd->m_params[SkVD::DISTANCE]->isKeyframe(frame) ||
+                 isSDChannelInterpolated(vd, SkVD::DISTANCE, frame)))
+        keysFound++;
+      if (vd && vd->m_params[SkVD::ANGLE]->isKeyframe(frame) ||
+          isSDChannelInterpolated(vd, SkVD::ANGLE, frame))
+        keysFound++;
+      if (vd && vd->m_params[SkVD::SO]->isKeyframe(frame) ||
+          isSDChannelInterpolated(vd, SkVD::SO, frame))
+        keysFound++;
+
+      canSet = keyCount != keysFound;
+    }
+  }
+
+  return canSet;
+}
+
+//-----------------------------------------------------------------------------
+
+bool PlasticToolOptionsBox::isSDChannelInterpolated(SkVD *vd,
+                                                    SkVD::Params param,
+                                                    int frame) {
+  if (!vd || frame < 0) return false;
+
+  TStageObjectId objId   = m_objHandle->getObjectId();
+  TStageObject *stageObj = m_xshHandle->getXsheet()->getStageObject(objId);
+
+  TStageObject::KeyframeMap keyframes;
+  stageObj->getSDKeyframes(keyframes);
+
+  if (keyframes.empty() || frame < keyframes.begin()->first ||
+      frame > keyframes.rbegin()->first)
+    return false;
+
+  bool upperKeyFound = false, lowerKeyFound = false;
+
+  auto it = keyframes.lower_bound(frame);
+  while (it != keyframes.end()) {
+    if (vd->m_params[param]->isKeyframe(it->first)) {
+      upperKeyFound = true;
+      break;
+    }
+    it++;
+  }
+
+  it = keyframes.lower_bound(frame);
+  std::map<int, TStageObject::Keyframe>::reverse_iterator rit(it);
+  while (rit != keyframes.rend()) {
+    if (vd->m_params[param]->isKeyframe(rit->first)) {
+      lowerKeyFound = true;
+      break;
+    }
+    rit++;
+  }
+
+  return upperKeyFound && lowerKeyFound;
 }
 
 //------------------------------------------------------------------------
@@ -620,6 +856,51 @@ void PlasticToolOptionsBox::onRemoveSkeleton() {
       l_plasticTool.m_mode.notifyListeners();
     }
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::onSetKey() {
+  if (l_plasticTool.m_globalKey.getValue())
+    l_plasticTool.setGlobalKey_undo();
+  else if (TSelection::getCurrent() == &l_plasticTool.m_svSel)
+    l_plasticTool.setKey_undo();
+}
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::onSetRestKey() {
+  if (l_plasticTool.m_globalKey.getValue())
+    l_plasticTool.setGlobalRestKey_undo();
+  else if (TSelection::getCurrent() == &l_plasticTool.m_svSel)
+    l_plasticTool.setRestKey_undo();
+}
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::onInterpolationComboActivated(int index) {
+  Preferences::instance()->setValue(keyframeType,
+                                    m_interpolationCombo->itemData(index));
+}
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::onFrameSwitched() { updateControls(); }
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::onPlayingStatusChanged() {
+  if (!m_frameHandle->isPlaying()) {
+    m_updateControls = true;
+    updateControls();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void PlasticToolOptionsBox::onStageObjectChange(bool isDragging) {
+  m_updateControls = !isDragging && !m_tool->isDragging();
+  updateStatus();
 }
 
 //****************************************************************************************
@@ -757,9 +1038,13 @@ ToolOptionsBox *PlasticTool::createOptionsBox() {
   // Create the options box
   TPaletteHandle *currPalette =
       TTool::getApplication()->getPaletteController()->getCurrentLevelPalette();
-  ToolHandle *currTool = m_application->getCurrentTool();
-  PlasticToolOptionsBox *optionsBox =
-      new PlasticToolOptionsBox(0, this, currPalette, currTool);
+  ToolHandle *currTool      = m_application->getCurrentTool();
+  TFrameHandle *currFrame   = m_application->getCurrentFrame();
+  TObjectHandle *currObj    = m_application->getCurrentObject();
+  TXsheetHandle *currXsheet = m_application->getCurrentXsheet();
+
+  PlasticToolOptionsBox *optionsBox = new PlasticToolOptionsBox(
+      0, this, currPalette, currTool, currFrame, currObj, currXsheet);
 
   // Connect it to receive m_mode notifications
   m_mode.addListener(optionsBox);
@@ -1143,6 +1428,7 @@ void PlasticTool::setSkeletonSelection(const PlasticVertexSelection &vSel) {
     m_svSel.selectNone();
     m_svSel.makeNotCurrent();
 
+    TTool::getApplication()->getCurrentObject()->notifyObjectIdChanged(false);
     return;
   }
 

--- a/toonz/sources/tnztools/plastictool.h
+++ b/toonz/sources/tnztools/plastictool.h
@@ -6,6 +6,7 @@
 // TnzCore includes
 #include "tproperty.h"
 #include "tmeshimage.h"
+#include "tooloptionscontrols.h"
 
 // TnzBase includes
 #include "tparamchange.h"
@@ -215,6 +216,8 @@ public:
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &me) override;
   void leftButtonUp(const TPointD &pos, const TMouseEvent &me) override;
 
+  bool isDragging() const override { return m_dragged; }
+
   void draw() override;
 
 public:
@@ -405,17 +408,36 @@ class PlasticToolOptionsBox final : public GenericToolOptionsBox,
 
 public:
   PlasticToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
-                        ToolHandle *toolHandle);
+                        ToolHandle *toolHandle, TFrameHandle *frameHandle,
+                        TObjectHandle *objHandle, TXsheetHandle *xshHandle);
 
 private:
   class SkelIdsComboBox;
 
 private:
   TTool *m_tool;
+  TFrameHandle *m_frameHandle; 
+  TObjectHandle *m_objHandle;
+  TXsheetHandle *m_xshHandle;
   GenericToolOptionsBox **m_subToolbars;
 
   SkelIdsComboBox *m_skelIdComboBox;
   QPushButton *m_addSkelButton, *m_removeSkelButton;
+
+  // Animate
+  ToolOptionParamRelayField *m_distanceField, *m_angleField, *m_soField;
+  QComboBox *m_interpolationCombo;
+  QPushButton *m_setKeyButton, *m_setRestKeyButton;
+  bool m_updateControls;
+
+  void updateControls();
+  void updateStatus();
+  void onStageObjectChange(bool isDragging = false);
+
+  int getKeysStatus(int frame, SkVD *vd);
+  bool canSetInterpolation(int frame, TStageObject *stageObj);
+
+  bool isSDChannelInterpolated(SkVD *vd, SkVD::Params param, int frame);
 
 private:
   void showEvent(QShowEvent *se) override;
@@ -431,6 +453,12 @@ private slots:
 
   void onAddSkeleton();
   void onRemoveSkeleton();
+
+  void onSetKey();
+  void onSetRestKey();
+  void onInterpolationComboActivated(int index);
+  void onFrameSwitched();
+  void onPlayingStatusChanged();
 };
 
 //****************************************************************************************

--- a/toonz/sources/tnztools/plastictool_animate.cpp
+++ b/toonz/sources/tnztools/plastictool_animate.cpp
@@ -175,6 +175,8 @@ void PlasticTool::leftButtonUp_animate(const TPointD &pos,
 
     TUndoManager::manager()->add(undo);
 
+    m_dragged = false; // Turn this off now so toolbar updates
+
     // This is needed to refresh the xsheet (there may be new keyframes)
     TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
     TTool::getApplication()->getCurrentObject()->notifyObjectIdChanged(false);

--- a/toonz/sources/tnztools/plastictool_build.cpp
+++ b/toonz/sources/tnztools/plastictool_build.cpp
@@ -640,6 +640,8 @@ void PlasticTool::leftButtonUp_build(const TPointD &pos,
     TUndoManager::manager()->add(new MoveVertexUndo_Build(
         m_svSel.objects(), m_pressedVxsPos, m_pos - m_pressedPos));
 
+    m_dragged = false;  // Turn this off now so toolbar updates
+
     ::stageObject()
         ->invalidate();  // Should be a TStageObject's implementation detail ...
     invalidate();        // .. it's that it caches placement data and we must

--- a/toonz/sources/tnztools/skeletonsubtools.cpp
+++ b/toonz/sources/tnztools/skeletonsubtools.cpp
@@ -59,6 +59,10 @@ void DragCenterTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
   m_center      = m_oldCenter + (m_affine * (pos - m_firstPos)) * factor;
   TTool::getApplication()->getCurrentXsheet()->getXsheet()->setCenter(
       m_objId, m_frame, m_center);
+
+  TTool::Application *app = TTool::getApplication();
+  app->getCurrentObject()->notifyObjectIdChanged(
+      true);  // Keyframes navigator reads this
 }
 
 //------------------------------------------------------------
@@ -205,6 +209,10 @@ void DragPositionTool::leftButtonDrag(const TPointD &pos,
   setValues(getOldValue(0) + delta.x * factor,
             getOldValue(1) + delta.y * factor);
   m_dragged = true;
+
+  TTool::Application *app = TTool::getApplication();
+  app->getCurrentObject()->notifyObjectIdChanged(
+      true);  // Keyframes navigator reads this
 }
 
 //============================================================
@@ -247,6 +255,10 @@ void DragRotationTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
   m_dragged = true;
 
   m_lastPos = pos;
+
+  TTool::Application *app = TTool::getApplication();
+  app->getCurrentObject()->notifyObjectIdChanged(
+      true);  // Keyframes navigator reads this
 }
 
 //============================================================

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -54,10 +54,6 @@ using namespace SkeletonSubtools;
 TEnv::IntVar SkeletonGlobalKeyFrame("SkeletonToolGlobalKeyFrame", 0);
 TEnv::IntVar SkeletonInverseKinematics("SkeletonToolInverseKinematics", 0);
 
-#define BUILD_SKELETON L"Build Skeleton"
-#define ANIMATE L"Animate"
-#define INVERSE_KINEMATICS L"Inverse Kinematics"
-
 const double alpha = 0.4;
 
 using SkeletonSubtools::HookData;

--- a/toonz/sources/tnztools/skeletontool.h
+++ b/toonz/sources/tnztools/skeletontool.h
@@ -35,7 +35,11 @@ public:
       : m_h0(h0), m_h1(h1), m_dist2(dist2) {}
   bool operator<(const MagicLink &link) const { return m_dist2 < link.m_dist2; }
 };
-}
+}  // namespace SkeletonSubtools
+
+#define BUILD_SKELETON L"Build Skeleton"
+#define ANIMATE L"Animate"
+#define INVERSE_KINEMATICS L"Inverse Kinematics"
 
 class SkeletonTool : public TTool {
   Q_DECLARE_TR_FUNCTIONS(SkeletonTool)
@@ -90,6 +94,8 @@ public:
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
   void mouseMove(const TPointD &, const TMouseEvent &e) override;
+
+  bool isDragging() const override { return m_dragTool ? true : false; }
 
   void onImageChanged() override { invalidate(); }
 

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -21,6 +21,7 @@
 #include "shifttracetool.h"
 #include "perspectivetool.h"
 #include "symmetrytool.h"
+#include "skeletontool.h"
 
 // TnzQt includes
 #include "toonzqt/dvdialog.h"
@@ -92,6 +93,10 @@ ToolOptionsBox::ToolOptionsBox(QWidget *parent, bool isScrollable)
 
   setFrameStyle(QFrame::StyledPanel);
   setFixedHeight(26);
+
+  m_noKeyIcon      = createQIcon("key_off");
+  m_partialKeyIcon = createQIcon("key_partial");
+  m_fullKeyIcon    = createQIcon("key_on");
 
   m_layout = new QHBoxLayout;
   m_layout->setContentsMargins(0, 0, 0, 0);
@@ -661,8 +666,6 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   if (splined != m_splined) m_splined = splined;
   setSplined(m_splined);
 
-  const int ITEM_SPACING  = 10;
-  const int LABEL_SPACING = 3;
   /* --- Layout --- */
   QHBoxLayout *mainLay = m_layout;
   {
@@ -1354,21 +1357,17 @@ void ArrowToolOptionsBox::updateControls() {
       canSetInterpolation(axisId, allKeys, frame, stageObj);
   if (!isPlaying) m_interpolationCombo->setEnabled(enableInterpolation);
 
-  static QIcon noKeyIcon      = createQIcon("key_off");
-  static QIcon partialKeyIcon = createQIcon("key_partial");
-  static QIcon fullKeyIcon    = createQIcon("key_on");
-
   bool isKey = stageObj->isKeyframe(frame);
   if (!isKey || isPlaying) {
-    m_setKeyButton->setIcon(noKeyIcon);
+    m_setKeyButton->setIcon(m_noKeyIcon);
     return;
   }
 
   int keysStatus = getKeysStatus(axisId, allKeys, keys);
 
   m_setKeyButton->setIcon(
-      !keysStatus ? noKeyIcon
-                  : (keysStatus == 1 ? partialKeyIcon : fullKeyIcon));
+      !keysStatus ? m_noKeyIcon
+                  : (keysStatus == 1 ? m_partialKeyIcon : m_fullKeyIcon));
 }
 
 //-----------------------------------------------------------------------------
@@ -1628,6 +1627,470 @@ void ArrowToolOptionsBox::onResetCenter() {
 //------------------------------------------------------------------------------
 
 void ArrowToolOptionsBox::onInterpolationComboActivated(int index) {
+  Preferences::instance()->setValue(keyframeType,
+                                    m_interpolationCombo->itemData(index));
+}
+
+//=============================================================================
+//
+// SkeletonToolOptionsBox
+//
+//=============================================================================
+
+SkeletonToolOptionsBox::SkeletonToolOptionsBox(QWidget *parent, TTool *tool,
+                                               TFrameHandle *frameHandle,
+                                               TObjectHandle *objHandle,
+                                               TXsheetHandle *xshHandle,
+                                               ToolHandle *toolHandle)
+    : ToolOptionsBox(parent, true)
+    , m_tool(tool)
+    , m_frameHandle(frameHandle)
+    , m_objHandle(objHandle)
+    , m_xshHandle(xshHandle)
+    , m_updateControls(true) {
+  setFrameStyle(QFrame::StyledPanel);
+  setObjectName("toolOptionsPanel");
+  setFixedHeight(26);
+
+  m_leftRotateButton = new QPushButton(this);
+  m_leftRotateButton->setFixedSize(QSize(20, 20));
+  m_leftRotateButton->setIcon(createQIcon("rotateleft"));
+  m_leftRotateButton->setIconSize(QSize(20, 20));
+  m_leftRotateButton->setToolTip(tr("Rotate Object Left"));
+
+  m_rightRotateButton = new QPushButton(this);
+  m_rightRotateButton->setFixedSize(QSize(20, 20));
+  m_rightRotateButton->setIcon(createQIcon("rotateright"));
+  m_rightRotateButton->setIconSize(QSize(20, 20));
+  m_rightRotateButton->setToolTip(tr("Rotate Object Right"));
+
+  m_setKeyButton = new QPushButton(this);
+  m_setKeyButton->setFixedSize(QSize(22, 20));
+  m_setKeyButton->setIconSize(QSize(20, 20));
+  m_setKeyButton->setToolTip(tr("Set Key"));
+
+  m_interpolationCombo = new QComboBox(this);
+  m_interpolationCombo->setSizeAdjustPolicy(
+      QComboBox::SizeAdjustPolicy::AdjustToContents);
+  m_interpolationCombo->setToolTip(tr("Default Interpolation"));
+  // This list must match what's in preferences
+  m_interpolationCombo->addItem(tr("Constant"), 1);
+  m_interpolationCombo->addItem(tr("Linear"), 2);
+  m_interpolationCombo->addItem(tr("Speed In / Speed Out"), 3);
+  m_interpolationCombo->addItem(tr("Ease In / Ease Out"), 4);
+  m_interpolationCombo->addItem(tr("Ease In / Ease Out %"), 5);
+  m_interpolationCombo->addItem(tr("Exponential"), 6);
+  m_interpolationCombo->addItem(tr("Expression "), 7);
+  m_interpolationCombo->addItem(tr("File"), 8);
+
+  // Position
+  m_ewPosLabel = new ClickableLabel(tr("X:"), this);
+  m_ewPosField =
+      new PegbarChannelField(m_tool, TStageObject::T_X, "field", frameHandle,
+                             objHandle, xshHandle, this);
+  m_nsPosLabel = new ClickableLabel(tr("Y:"), this);
+  m_nsPosField =
+      new PegbarChannelField(m_tool, TStageObject::T_Y, "field", frameHandle,
+                             objHandle, xshHandle, this);
+
+  // Rotation
+  m_rotationLabel = new ClickableLabel(tr("Rotation:"), this);
+  m_rotationField =
+      new PegbarChannelField(m_tool, TStageObject::T_Angle, "field",
+                             frameHandle, objHandle, xshHandle, this);
+
+  // Center
+  m_ewCenterLabel = new ClickableLabel(tr("X:"), this);
+  m_ewCenterField =
+      new PegbarCenterField(m_tool, 0, "field", objHandle, xshHandle, this);
+  m_nsCenterLabel = new ClickableLabel(tr("Y:"), this);
+  m_nsCenterField =
+      new PegbarCenterField(m_tool, 1, "field", objHandle, xshHandle, this);
+
+  TPropertyGroup *props = tool->getProperties(0);
+  assert(props->getPropertyCount() > 0);
+
+  ToolOptionControlBuilder builder(this, tool, nullptr, toolHandle);
+  if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
+
+  m_mode = dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
+  m_globalKey =
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Global Key"));
+
+  addSeparator();
+
+  hLayout()->addWidget(m_interpolationCombo);
+  hLayout()->addWidget(m_setKeyButton);
+
+  addSeparator();
+
+  {
+    // Keyframe
+    QFrame *keyFrame    = new QFrame(this);
+    QHBoxLayout *keyLay = new QHBoxLayout();
+    keyLay->setContentsMargins(0, 0, 0, 0);
+    keyLay->setSpacing(0);
+    keyFrame->setLayout(keyLay);
+    {
+      keyLay->addWidget(
+          new SimpleIconViewField("edit_position", tr("Position"), this), 0);
+      keyLay->addSpacing(LABEL_SPACING * 2);
+
+      keyLay->addWidget(m_ewPosLabel, 0);
+      keyLay->addSpacing(LABEL_SPACING);
+      keyLay->addWidget(m_ewPosField, 10);
+
+      keyLay->addSpacing(ITEM_SPACING);
+
+      keyLay->addWidget(m_nsPosLabel, 0);
+      keyLay->addSpacing(LABEL_SPACING);
+      keyLay->addWidget(m_nsPosField, 10);
+
+      keyLay->addSpacing(ITEM_SPACING);
+
+      keyLay->addWidget(new DVGui::Separator("", this, false));
+
+      keyLay->addWidget(
+          new SimpleIconViewField("edit_rotation", tr("Rotation"), this), 0);
+      keyLay->addSpacing(LABEL_SPACING * 2);
+      keyLay->addWidget(m_rotationLabel, 0);
+      keyLay->addSpacing(LABEL_SPACING);
+      keyLay->addWidget(m_rotationField, 10);
+      keyLay->addWidget(m_leftRotateButton);
+      keyLay->addWidget(m_rightRotateButton);
+
+      keyLay->addSpacing(ITEM_SPACING);
+
+      keyLay->addWidget(new DVGui::Separator("", this, false));
+
+      keyLay->addWidget(
+          new SimpleIconViewField("edit_center", tr("Center Position"), this),
+          0);
+      keyLay->addSpacing(LABEL_SPACING * 2);
+
+      keyLay->addWidget(m_ewCenterLabel, 0);
+      keyLay->addSpacing(LABEL_SPACING);
+      keyLay->addWidget(m_ewCenterField, 10);
+
+      keyLay->addSpacing(ITEM_SPACING);
+
+      keyLay->addWidget(m_nsCenterLabel, 0);
+      keyLay->addSpacing(LABEL_SPACING);
+      keyLay->addWidget(m_nsCenterField, 10);
+
+      keyLay->addSpacing(ITEM_SPACING);
+      keyLay->addWidget(new DVGui::Separator("", this, false));
+
+      keyLay->addStretch(1);
+    }
+    hLayout()->addWidget(keyFrame);
+  }
+
+  hLayout()->addStretch(1);
+
+  connectLabelAndField(m_ewPosLabel, m_ewPosField);
+  connectLabelAndField(m_nsPosLabel, m_nsPosField);
+  connectLabelAndField(m_rotationLabel, m_rotationField);
+  connectLabelAndField(m_ewCenterLabel, m_ewCenterField);
+  connectLabelAndField(m_nsCenterLabel, m_nsCenterField);
+
+  connect(m_mode, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(onModeChanged(int)));
+  connect(m_globalKey, SIGNAL(toggled(bool)), this, SLOT(onGlobalKeyChanged(bool)));
+
+  connect(m_leftRotateButton, SIGNAL(clicked()), SLOT(onRotateLeft()));
+  connect(m_rightRotateButton, SIGNAL(clicked()), SLOT(onRotateRight()));
+
+  connect(m_setKeyButton, SIGNAL(clicked()), SLOT(onSetKey()));
+
+  connect(m_interpolationCombo, SIGNAL(activated(int)), this,
+          SLOT(onInterpolationComboActivated(int)));
+
+  onModeChanged(0);
+  onGlobalKeyChanged(m_globalKey->isChecked());
+  updateStatus();
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::connectLabelAndField(ClickableLabel *label,
+                                                  MeasuredValueField *field) {
+  connect(label, SIGNAL(onMousePress(QMouseEvent *)), field,
+          SLOT(receiveMousePress(QMouseEvent *)));
+  connect(label, SIGNAL(onMouseMove(QMouseEvent *)), field,
+          SLOT(receiveMouseMove(QMouseEvent *)));
+  connect(label, SIGNAL(onMouseRelease(QMouseEvent *)), field,
+          SLOT(receiveMouseRelease(QMouseEvent *)));
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::showEvent(QShowEvent *) {
+  int interpolationType = Preferences::instance()->getKeyframeType();
+  for (int i = 0; i < m_interpolationCombo->count(); ++i)
+    if (m_interpolationCombo->itemData(i) == interpolationType) {
+      m_interpolationCombo->setCurrentIndex(i);
+      break;
+    }
+
+  connect(m_frameHandle, SIGNAL(frameSwitched()), SLOT(onFrameSwitched()));
+  connect(m_frameHandle, SIGNAL(isPlayingStatusChanged()),
+          SLOT(onPlayingStatusChanged()));
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::hideEvent(QShowEvent *) {
+  disconnect(m_frameHandle, SIGNAL(frameSwitched()), this,
+             SLOT(onFrameSwitched()));
+  disconnect(m_frameHandle, SIGNAL(isPlayingStatusChanged()), this,
+             SLOT(onPlayingStatusChanged()));
+}
+
+//-----------------------------------------------------------------------------
+
+int SkeletonToolOptionsBox::getKeysStatus(TStageObject::Keyframe keys) {
+  int keyCount  = 3;
+  int keysFound = 0;
+
+  if (keys.m_channels[TStageObject::T_X].m_isKeyframe) keysFound++;
+  if (keys.m_channels[TStageObject::T_Y].m_isKeyframe) keysFound++;
+
+  if (keys.m_channels[TStageObject::T_Angle].m_isKeyframe) keysFound++;
+
+  if (keysFound > 0 && keysFound == keyCount) return 2;  // Full
+  if (keysFound > 0 && keysFound != keyCount) return 1;  // Partial
+  return 0;                                              // None
+}
+
+bool SkeletonToolOptionsBox::canSetInterpolation(int frame,
+                                                 TStageObject *stageObj) {
+  bool canSet = true;
+  int r0, r1;
+  TStageObject::KeyframeMap keyframes;
+  stageObj->getKeyframes(keyframes);
+  stageObj->getKeyframeRange(r0, r1);
+
+  if (frame >= r0 && frame <= r1) {
+    auto it    = keyframes.lower_bound(frame);
+    bool isKey = frame == it->first;
+    if ((frame == r0 && it->first == r0) || (frame == r1 && it->first == r1))
+      canSet = getKeysStatus(it->second) != 2;
+    else {
+      int keyCount                = 3;
+      int keysFound               = 0;
+      TStageObject::Keyframe keys = it->second;
+
+      if ((isKey && keys.m_channels[TStageObject::T_X].m_isKeyframe) ||
+          stageObj->isChannelInterpolated(TStageObject::T_X, frame))
+        keysFound++;
+      if ((isKey && keys.m_channels[TStageObject::T_Y].m_isKeyframe) ||
+          stageObj->isChannelInterpolated(TStageObject::T_Y, frame))
+        keysFound++;
+      if ((isKey && keys.m_channels[TStageObject::T_Angle].m_isKeyframe) ||
+          stageObj->isChannelInterpolated(TStageObject::T_Angle, frame))
+        keysFound++;
+
+      canSet = keyCount != keysFound;
+    }
+  }
+
+  return canSet;
+}
+
+void SkeletonToolOptionsBox::updateStatus() {
+  // Position
+  m_ewPosField->updateStatus();
+  m_nsPosField->updateStatus();
+
+  // Rotation
+  m_rotationField->updateStatus();
+
+  // Center
+  m_ewCenterField->updateStatus();
+  m_nsCenterField->updateStatus();
+
+  if (m_updateControls) updateControls();
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::updateControls() {
+  TStageObjectId objId        = m_objHandle->getObjectId();
+  TStageObject *stageObj      = m_xshHandle->getXsheet()->getStageObject(objId);
+  int frame                   = m_frameHandle->getFrameIndex();
+  TStageObject::Keyframe keys = stageObj->getKeyframe(frame);
+
+  TStageObject::KeyframeMap keyframes;
+  stageObj->getKeyframes(keyframes);
+
+  QString keyColorName       = getKeyFrameBorderColor().name();
+  QString inBetweenColorName = getInBetweenBorderColor().name();
+
+  bool isPlaying = m_frameHandle->isPlaying();
+  if (isPlaying) m_updateControls = false;  // Stop updating on next pass
+
+  QString highlightKey =
+      isPlaying ? "" : "QLineEdit {background-color: " + keyColorName + ";}";
+  QString highlightInbetween =
+      isPlaying ? ""
+                : "QLineEdit {background-color: " + inBetweenColorName + ";}";
+
+  bool buildMode    = (m_mode->getProperty()->getValue() == BUILD_SKELETON);
+  bool enableWidget = !buildMode && objId.isColumn();
+
+  m_ewPosLabel->setEnabled(enableWidget);
+  m_ewPosField->setEnabled(enableWidget);
+  m_nsPosLabel->setEnabled(enableWidget);
+  m_nsPosField->setEnabled(enableWidget);
+  m_ewPosField->setStyleSheet(
+      keys.m_channels[TStageObject::T_X].m_isKeyframe
+          ? highlightKey
+          : (stageObj->isChannelInterpolated(TStageObject::T_X, frame)
+                 ? highlightInbetween
+                 : ""));
+  m_nsPosField->setStyleSheet(
+      keys.m_channels[TStageObject::T_Y].m_isKeyframe
+          ? highlightKey
+          : (stageObj->isChannelInterpolated(TStageObject::T_Y, frame)
+                 ? highlightInbetween
+                 : ""));
+
+  m_rotationLabel->setEnabled(enableWidget);
+  m_rotationField->setEnabled(enableWidget);
+  m_leftRotateButton->setEnabled(enableWidget);
+  m_rightRotateButton->setEnabled(enableWidget);
+  m_rotationField->setStyleSheet(
+      keys.m_channels[TStageObject::T_Angle].m_isKeyframe
+          ? highlightKey
+          : (stageObj->isChannelInterpolated(TStageObject::T_Angle, frame)
+                 ? highlightInbetween
+                 : ""));
+
+  m_ewCenterLabel->setEnabled(enableWidget);
+  m_ewCenterField->setEnabled(enableWidget);
+  m_nsCenterLabel->setEnabled(enableWidget);
+  m_nsCenterField->setEnabled(enableWidget);
+
+  m_setKeyButton->setEnabled(enableWidget);
+
+  bool enableInterpolation =
+      enableWidget && canSetInterpolation(frame, stageObj);
+  if (!isPlaying) m_interpolationCombo->setEnabled(enableInterpolation);
+
+  bool isKey = stageObj->isKeyframe(frame);
+  if (!isKey || isPlaying) {
+    m_setKeyButton->setIcon(m_noKeyIcon);
+    return;
+  }
+
+  int keysStatus = getKeysStatus(keys);
+
+  m_setKeyButton->setIcon(
+      !keysStatus ? m_noKeyIcon
+                  : (keysStatus == 1 ? m_partialKeyIcon : m_fullKeyIcon));
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onStageObjectChange(bool isDragging) {
+  m_updateControls = !isDragging && !m_tool->isDragging();
+  updateStatus();
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onModeChanged(int index) { updateControls(); }
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onGlobalKeyChanged(bool enabled) {
+  m_ewPosField->enableGlobalKeyframe(enabled);
+  m_nsPosField->enableGlobalKeyframe(enabled);
+  m_rotationField->enableGlobalKeyframe(enabled);
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onFrameSwitched() { updateStatus(); }
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onPlayingStatusChanged() {
+  if (!m_frameHandle->isPlaying()) {
+    m_updateControls = true;
+    updateStatus();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onRotateLeft() {
+  m_rotationField->setValue(m_rotationField->getValue() + 90);
+  emit m_rotationField->measuredValueChanged(
+      m_rotationField->getMeasuredValue());
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onRotateRight() {
+  m_rotationField->setValue(m_rotationField->getValue() - 90);
+  emit m_rotationField->measuredValueChanged(
+      m_rotationField->getMeasuredValue());
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onSetKey() {
+  TStageObjectId objId        = m_objHandle->getObjectId();
+  TStageObject *stageObj      = m_xshHandle->getXsheet()->getStageObject(objId);
+  int frame                   = m_frameHandle->getFrameIndex();
+  TStageObject::Keyframe keys = stageObj->getKeyframe(frame);
+
+  // keysStatus: 0 = none, 1 = partial, 2 = full
+  int keysStatus     = getKeysStatus(keys);
+  bool removeAllKeys = keysStatus == 2;
+
+  TUndoManager::manager()->beginBlock();
+
+  if (removeAllKeys) {
+    emit m_ewPosField->measuredValueDeleted();
+    emit m_nsPosField->measuredValueDeleted();
+    emit m_rotationField->measuredValueDeleted();
+  } else {
+    if (!keys.m_channels[TStageObject::T_X].m_isKeyframe)
+      emit m_ewPosField->measuredValueChanged(m_ewPosField->getMeasuredValue());
+    if (!keys.m_channels[TStageObject::T_Y].m_isKeyframe)
+      emit m_nsPosField->measuredValueChanged(m_nsPosField->getMeasuredValue());
+    if (!keys.m_channels[TStageObject::T_Angle].m_isKeyframe)
+      emit m_rotationField->measuredValueChanged(
+          m_rotationField->getMeasuredValue());
+  }
+
+  // Removes all other keys
+  if (removeAllKeys) {
+    UndoSetKeyFrame *undo =
+        new UndoSetKeyFrame(stageObj->getId(), frame, m_xshHandle);
+    stageObj->getParam(TStageObject::T_Z)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_SO)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_Path)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_ScaleX)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_ScaleY)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_Scale)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_ShearX)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_ShearY)->deleteKeyframe(frame);
+    stageObj->getParam(TStageObject::T_DrawingNumber)->deleteKeyframe(frame);
+    undo->setObjectHandle(m_objHandle);
+    TUndoManager::manager()->add(undo);
+  }
+  TUndoManager::manager()->endBlock();
+
+  m_xshHandle->notifyXsheetChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+void SkeletonToolOptionsBox::onInterpolationComboActivated(int index) {
   Preferences::instance()->setValue(keyframeType,
                                     m_interpolationCombo->itemData(index));
 }
@@ -4286,7 +4749,10 @@ void ToolOptions::onToolSwitched() {
         TPropertyGroup *pg = tool->getProperties(0);
         panel = new ArrowToolOptionsBox(0, tool, pg, currFrame, currObject,
                                         currXsheet, currTool);
-      } else if (tool->getName() == T_Selection)
+      } else if (tool->getName() == T_Skeleton)
+        panel = new SkeletonToolOptionsBox(0, tool, currFrame, currObject,
+                                           currXsheet, currTool);
+      else if (tool->getName() == T_Selection)
         panel = new SelectionToolOptionsBox(0, tool, currPalette, currTool);
       else if (tool->getName() == T_Geometric)
         panel = new GeometricToolOptionsBox(0, tool, currPalette, currTool);

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -657,13 +657,6 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_resetCenterButton->setIconSize(QSize(20, 20));
   m_resetCenterButton->setToolTip(tr("Reset Center"));
 
-  int interpolationType = Preferences::instance()->getKeyframeType();
-  for (int i = 0; i < m_interpolationCombo->count(); ++i)
-    if (m_interpolationCombo->itemData(i) == interpolationType) {
-      m_interpolationCombo->setCurrentIndex(i);
-      break;
-    }
-
   bool splined                        = isCurrentObjectSplined();
   if (splined != m_splined) m_splined = splined;
   setSplined(m_splined);
@@ -982,6 +975,13 @@ void ArrowToolOptionsBox::connectLabelAndField(ClickableLabel *label,
 //-----------------------------------------------------------------------------
 
 void ArrowToolOptionsBox::showEvent(QShowEvent *) {
+  int interpolationType = Preferences::instance()->getKeyframeType();
+  for (int i = 0; i < m_interpolationCombo->count(); ++i)
+    if (m_interpolationCombo->itemData(i) == interpolationType) {
+      m_interpolationCombo->setCurrentIndex(i);
+      break;
+    }
+
   connect(m_frameHandle, SIGNAL(frameSwitched()), SLOT(onFrameSwitched()));
   connect(m_frameHandle, SIGNAL(isPlayingStatusChanged()),
           SLOT(onPlayingStatusChanged()));
@@ -1088,6 +1088,8 @@ int ArrowToolOptionsBox::getKeysStatus(int axisId, bool allKeys,
   return 0;                                              // None
 }
 
+//-----------------------------------------------------------------------------
+
 bool ArrowToolOptionsBox::canSetInterpolation(int axisId, bool allKeys,
                                               int frame,
                                               TStageObject *stageObj) {
@@ -1176,6 +1178,8 @@ bool ArrowToolOptionsBox::canSetInterpolation(int axisId, bool allKeys,
 
   return canSet;
 }
+
+//-----------------------------------------------------------------------------
 
 void ArrowToolOptionsBox::updateStatus() {
   // General
@@ -1385,7 +1389,7 @@ void ArrowToolOptionsBox::onPlayingStatusChanged() {
 //-----------------------------------------------------------------------------
 
 void ArrowToolOptionsBox::onStageObjectChange(bool isDragging) {
-  m_updateControls = !isDragging;
+  m_updateControls = !isDragging && !m_tool->isDragging();
   updateStatus();
 }
 

--- a/toonz/sources/toonz/icons/dark/actions/16/global_rest_key.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/global_rest_key.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg4"
+   sodipodi:docname="global_rest_key.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs4">
+        
+    
+            
+            
+        
+                
+                
+            
+                    
+                
+                    
+                </defs><sodipodi:namedview
+   id="namedview4"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="56.062498"
+   inkscape:cx="8.0000002"
+   inkscape:cy="5.9665554"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g11"
+   inkscape:pageshadow="2"
+   showgrid="true"><inkscape:grid
+     type="xygrid"
+     id="grid824"
+     originx="0"
+     originy="0"
+     spacingy="1"
+     spacingx="1"
+     units="px" /></sodipodi:namedview>
+    <rect
+   id="bg"
+   x="0"
+   y="0"
+   width="16"
+   height="16"
+   style="fill-opacity:0" />
+<g
+   transform="translate(-109.99969,-390)"
+   id="g14"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"><g
+     id="set_key"><rect
+       id="bg-3"
+       x="110"
+       y="390"
+       width="16"
+       height="16"
+       style="fill-opacity:0" /><g
+       transform="matrix(1,0,0,0.9999985,107.46117,387.46153)"
+       id="g11"><g
+         transform="matrix(0.91666667,0,0,0.91666667,0.45518662,0.45516068)"
+         id="g9"><path
+           d="m 11,5 6,6 -6,6 -6,-6 z M 6.305,11 11,15.695 15.695,11 11,6.305 Z"
+           id="path7" /></g><text
+         xml:space="preserve"
+         style="font-size:8.000006px;line-height:1.25;font-family:'Segoe UI';-inkscape-font-specification:'Segoe UI'"
+         x="9.6377468"
+         y="11.082514"
+         id="text1"><tspan
+           sodipodi:role="line"
+           id="tspan1"></tspan></text><text
+         xml:space="preserve"
+         style="font-size:13.33334333px;line-height:1.25;font-family:'Segoe UI';-inkscape-font-specification:'Segoe UI'"
+         x="8.9777689"
+         y="13.490542"
+         id="text2"><tspan
+           sodipodi:role="line"
+           id="tspan2"></tspan></text><text
+         xml:space="preserve"
+         style="font-size:13.33334333px;line-height:1.25;font-family:'Segoe UI';-inkscape-font-specification:'Segoe UI'"
+         x="8.6745358"
+         y="13.882963"
+         id="text3"><tspan
+           sodipodi:role="line"
+           id="tspan3"></tspan></text><text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.23324px;line-height:1.25;font-family:Consolas;-inkscape-font-specification:'Consolas Bold';stroke-width:0.779154"
+         x="9.227211"
+         y="12.107779"
+         id="text4"
+         transform="scale(0.96120195,1.0403641)"><tspan
+           sodipodi:role="line"
+           id="tspan4"
+           x="9.227211"
+           y="12.107779"
+           style="stroke-width:0.779154">0</tspan></text></g></g></g><circle
+   style="fill:none;stroke:#000000;stroke-width:0.81356;stroke-linecap:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0.9"
+   id="path2691"
+   cx="8"
+   cy="8"
+   r="7.5932202" /></svg>

--- a/toonz/sources/toonz/icons/dark/actions/16/rest_key.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/rest_key.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg4"
+   sodipodi:docname="rest_key.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs4">
+        
+    
+            
+            
+        
+                
+                
+            </defs><sodipodi:namedview
+   id="namedview4"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="56.0625"
+   inkscape:cx="8"
+   inkscape:cy="8"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg4"
+   showgrid="true"><inkscape:grid
+     id="grid4"
+     units="px"
+     originx="0"
+     originy="0"
+     spacingx="1"
+     spacingy="1"
+     empcolor="#0099e5"
+     empopacity="0.30196078"
+     color="#0099e5"
+     opacity="0.14901961"
+     empspacing="5"
+     enabled="true"
+     visible="true" /></sodipodi:namedview>
+    <rect
+   id="bg"
+   x="0"
+   y="0"
+   width="16"
+   height="16"
+   style="fill-opacity:0" /><g
+   transform="matrix(1.08333,0,0,1.08333,-3.9169395,-3.91696)"
+   id="g2">
+                    <path
+   d="m 11,5 6,6 -6,6 -6,-6 z M 6.305,11 11,15.695 15.695,11 11,6.305 Z"
+   id="path2" />
+                </g>
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.9027px;line-height:1.25;font-family:Consolas;-inkscape-font-specification:'Consolas Bold';stroke-width:0.834626"
+   x="5.7563534"
+   y="10.599645"
+   id="text4"
+   transform="scale(0.97271931,1.0280458)"><tspan
+     sodipodi:role="line"
+     id="tspan4"
+     x="5.7563534"
+     y="10.599645"
+     style="stroke-width:0.834626">0</tspan></text></svg>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2645,11 +2645,12 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_SetKeyframes, QT_TR_NOOP("&Set Key"), "Z",
                              "set_key");
   createRightClickMenuAction(MI_SetRestKeyframes, QT_TR_NOOP("&Set Rest Key"),
-                             "", "");
+                             "", "rest_key");
   createRightClickMenuAction(MI_SetGlobalKeyframes,
-                             QT_TR_NOOP("&Set Global Key"), "", "");
+                             QT_TR_NOOP("&Set Global Key"), "", "global_key");
   createRightClickMenuAction(MI_SetGlobalRestKeyframes,
-                             QT_TR_NOOP("&Set Global Rest Key"), "", "");
+                             QT_TR_NOOP("&Set Global Rest Key"), "",
+                             "global_rest_key");
 
   createRightClickMenuAction(MI_ShiftKeyframesDown,
                              QT_TR_NOOP("&Shift Keys Down"), "",

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -333,6 +333,8 @@
 		<file>icons/dark/actions/16/rolldown.svg</file>
 		<file>icons/dark/actions/16/remove_empty_columns.svg</file>
 		<file>icons/dark/actions/16/merge.svg</file>
+		<file>icons/dark/actions/16/rest_key.svg</file>
+		<file>icons/dark/actions/16/global_rest_key.svg</file>
 
 		<file>icons/dark/actions/16/new_level.svg</file>
 		<file>icons/dark/actions/16/new_raster_level.svg</file>

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -1155,6 +1155,34 @@ bool TStageObject::getKeyframeRange(int &r0, int &r1) const {
 
 //-----------------------------------------------------------------------------
 
+void TStageObject::getSDKeyframes(KeyframeMap &keyframes) const {
+  const KeyframeMap &data = lazyData().m_keyframes;
+  KeyframeMap::const_iterator it;
+  for (it = data.begin(); it != data.end(); it++) {
+    if (it->second.m_skeletonKeyframe.m_vertexKeyframes.size())
+      keyframes.insert(*it);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+bool TStageObject::getSDKeyframeRange(int &r0, int &r1) const {
+  KeyframeMap keyframes;
+  getSDKeyframes(keyframes);
+
+  if (keyframes.empty()) {
+    r0 = 0;
+    r1 = -1;
+    return false;
+  }
+  r0 = keyframes.begin()->first;
+  r1 = keyframes.rbegin()->first;
+
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
 bool TStageObject::getKeyframeSpan(int row, int &r0, double &ease0, int &r1,
                                    double &ease1) const {
   const KeyframeMap &keyframes = lazyData().m_keyframes;


### PR DESCRIPTION
Similar to the Animate Tool option bar changes (#2061), I've added the following to the following tool's option bar

### Skeleton Tool
<img width="2685" height="57" alt="image" src="https://github.com/user-attachments/assets/40ea17cf-aed4-4adf-93e5-9c55381fde01" />

- `Interpolation` dropdown
- `Set Key` button
- `Position`, `Rotation` and `Center` fields

### Plastic Tool
<img width="2685" height="64" alt="image" src="https://github.com/user-attachments/assets/7ee7e23f-336d-4a69-998e-1aef7fdcaae0" />

- `Interpolation` dropdown
- `Set Key` button
- `Set Rest Key` button

Fields change colors to show if it is key'd or interpolated

Also fixed additional cause of lag (#2157) when the Function Editor was open and using the Animate tool. (applies to tools above now too).
