### PR TITLE
Vector selection toolbar options: Show/Flip stroke direction

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -434,7 +434,7 @@ class SelectionToolOptionsBox final : public ToolOptionsBox,
   ToolOptionIntSlider *m_miterField;
 
   QPushButton *m_hFlipButton, *m_vFlipButton, *m_leftRotateButton,
-      *m_rightRotateButton;
+      *m_rightRotateButton, *m_flipStrokeButton;
 
 public:
   SelectionToolOptionsBox(QWidget *parent, TTool *tool,
@@ -453,6 +453,7 @@ protected slots:
   void onFlipVertical();
   void onRotateLeft();
   void onRotateRight();
+  void onFlipDirection();
 };
 
 //=============================================================================

--- a/toonz/sources/tnztools/selectiontool.h
+++ b/toonz/sources/tnztools/selectiontool.h
@@ -475,6 +475,7 @@ signals:
   void clickFlipVertical();
   void clickRotateLeft();
   void clickRotateRight();
+  void clickFlipDirection();
 };
 
 #endif  // SELECTIONTOOL_INCLUDED

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1808,6 +1808,18 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
     m_miterField->setEnabled(m_joinStyle->currentIndex() ==
                              TStroke::OutlineOptions::MITER_JOIN);
 
+    addSeparator();
+    if (tool && tool->getProperties(2)) tool->getProperties(2)->accept(builder);
+
+    m_flipStrokeButton = new QPushButton(tr("Flip Direction"), this);
+    int buttonWidth =
+        fontMetrics().horizontalAdvance(m_flipStrokeButton->text()) + 10;
+    m_flipStrokeButton->setFixedWidth(buttonWidth);
+    m_flipStrokeButton->setFixedHeight(20);
+    connect(m_flipStrokeButton, SIGNAL(clicked()), this, SLOT(onFlipDirection()));
+
+    hLayout()->addWidget(m_flipStrokeButton);
+
     onPropertyChanged();
   }
 
@@ -1860,6 +1872,8 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   connect(selectionTool, SIGNAL(clickFlipVertical()), SLOT(onFlipVertical()));
   connect(selectionTool, SIGNAL(clickRotateLeft()), SLOT(onRotateLeft()));
   connect(selectionTool, SIGNAL(clickRotateRight()), SLOT(onRotateRight()));
+
+  connect(selectionTool, SIGNAL(clickFlipDirection()), SLOT(onFlipDirection()));
 
   // assert(ret);
 
@@ -1959,6 +1973,14 @@ void SelectionToolOptionsBox::onRotateLeft() {
 void SelectionToolOptionsBox::onRotateRight() {
   m_rotationField->setValue(m_rotationField->getValue() - 90);
   m_rotationField->applyChange(true);
+}
+
+//-----------------------------------------------------------------------------
+
+void SelectionToolOptionsBox::onFlipDirection() {
+  VectorSelectionTool *vectorSelectionTool =
+      dynamic_cast<VectorSelectionTool *>(m_tool);
+  if (vectorSelectionTool) vectorSelectionTool->onPropertyChanged("FlipDirection");
 }
 
 //-----------------------------------------------------------------------------
@@ -4451,3 +4473,17 @@ public:
     }
   }
 } rotateRightCHInstance("A_ToolOption_RotateRight");
+
+class FlipDirectionCommandHandler final : public MenuItemHandler {
+public:
+  FlipDirectionCommandHandler(CommandId cmdId) : MenuItemHandler(cmdId) {}
+  void execute() override {
+    TTool::Application *app = TTool::getApplication();
+    TTool *tool             = app->getCurrentTool()->getTool();
+    if (!tool) return;
+    if (tool->getName() == T_Selection) {
+      SelectionTool *selectionTool = dynamic_cast<SelectionTool *>(tool);
+      emit selectionTool->clickFlipDirection();
+    }
+  }
+} flipDirectionCHInstance("A_ToolOption_FlipDirection");

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -1212,6 +1212,7 @@ VectorSelectionTool::VectorSelectionTool(int targetType)
     , m_selectionTarget("Mode:")
     , m_includeIntersection("Include Intersection", false)
     , m_constantThickness("Preserve Thickness", false)
+    , m_showStrokeDirection("Show Direction", false)
     , m_levelSelection(m_strokeSelection)
     , m_capStyle("Cap")
     , m_joinStyle("Join")
@@ -1239,6 +1240,7 @@ VectorSelectionTool::VectorSelectionTool(int targetType)
   m_includeIntersection.setId("IncludeIntersection");
   m_constantThickness.setId("PreserveThickness");
   m_selectionTarget.setId("SelectionMode");
+  m_showStrokeDirection.setId("ShowDirection");
 
   m_capStyle.addValue(BUTT_WSTR, QString::fromStdWString(BUTT_WSTR));
   m_capStyle.addValue(ROUNDC_WSTR, QString::fromStdWString(ROUNDC_WSTR));
@@ -1256,6 +1258,8 @@ VectorSelectionTool::VectorSelectionTool(int targetType)
   m_outlineProps.bind(m_capStyle);
   m_outlineProps.bind(m_joinStyle);
   m_outlineProps.bind(m_miterJoinLimit);
+
+  m_otherProps.bind(m_showStrokeDirection);
 }
 
 //------------------------------------------------------------------------------
@@ -1358,6 +1362,9 @@ void VectorSelectionTool::updateTranslation() {
   m_joinStyle.setItemUIName(BEVEL_WSTR, tr("Bevel join"));
 
   m_miterJoinLimit.setQStringName(tr("Miter:"));
+
+  m_showStrokeDirection.setQStringName(tr("Show Direction"));
+
   SelectionTool::updateTranslation();
 }
 
@@ -1777,8 +1784,62 @@ void VectorSelectionTool::drawInLevelType(const TVectorImage &vi) {
 }
 
 //-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+static void drawArrows(TStroke *stroke) {
+  double length = stroke->getLength(0.0, 1.0);
+  int points    = length / 20;
+  if (points < 2) points += 1;
+  double currentPosition = 0.0;
+
+  TPointD prePoint, point, postPoint;
+  TPointD point2;
+  for (int i = 0; i <= points; i++) {
+    currentPosition = i / (double)points;
+    point           = stroke->getPointAtLength(length * currentPosition);
+    prePoint =
+        (i == 0) ? point
+                 : stroke->getPointAtLength(length * (currentPosition - 0.02));
+    postPoint =
+        (i == points)
+            ? point
+            : stroke->getPointAtLength(length * (currentPosition + 0.02));
+
+    if (prePoint == postPoint) continue;
+
+    double radian =
+        std::atan2(postPoint.y - prePoint.y, postPoint.x - prePoint.x);
+    double degree = radian * 180.0 / 3.14159265;
+
+    glPushMatrix();
+
+    glTranslated(point.x, point.y, 0);
+    glRotated(degree, 0, 0, 1);
+
+    glBegin(GL_LINES);
+    glVertex2d(0, 0);
+    glVertex2d(-4, -4);
+    glVertex2d(0, 0);
+    glVertex2d(-4, 4);
+    glEnd();
+
+    glPopMatrix();
+  }
+}
 
 void VectorSelectionTool::drawSelectedStrokes(const TVectorImage &vi) {
+  GLint src, dst;
+  bool isEnabled;
+
+  int devPixRatio = m_viewer->getDevPixRatio();
+
+  tglColor(TPixel32::White);
+  isEnabled = glIsEnabled(GL_BLEND);
+  glGetIntegerv(GL_BLEND_SRC, &src);
+  glGetIntegerv(GL_BLEND_DST, &dst);
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_ONE_MINUS_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+
   glEnable(GL_LINE_STIPPLE);
 
   double pixelSize = getPixelSize();
@@ -1789,16 +1850,21 @@ void VectorSelectionTool::drawSelectedStrokes(const TVectorImage &vi) {
       TStroke *stroke = vi.getStroke(s);
 
       glLineStipple(1, 0xF0F0);
-      tglColor(TPixel32::Black);
       drawStrokeCenterline(*stroke, pixelSize);
 
-      glLineStipple(1, 0x0F0F);
-      tglColor(TPixel32::White);
-      drawStrokeCenterline(*stroke, pixelSize);
+      if (m_showStrokeDirection.getValue()) {
+        glLineWidth(2.0 * devPixRatio);
+        glLineStipple(1, 0xFFFF);
+        drawArrows(stroke);
+        glLineWidth(1.0 * devPixRatio);
+      }
     }
   }
 
   glDisable(GL_LINE_STIPPLE);
+
+  if (!isEnabled) glDisable(GL_BLEND);
+  glBlendFunc(src, dst);
 }
 
 //-----------------------------------------------------------------------------
@@ -2119,6 +2185,8 @@ TPropertyGroup *VectorSelectionTool::getProperties(int idx) {
     return &m_prop;
   case 1:
     return &m_outlineProps;
+  case 2:
+    return &m_otherProps;
   default:
     return 0;
   };
@@ -2128,6 +2196,26 @@ TPropertyGroup *VectorSelectionTool::getProperties(int idx) {
 
 bool VectorSelectionTool::onPropertyChanged(std::string propertyName) {
   if (!m_strokeSelection.isEditable()) return false;
+
+  if (propertyName == "FlipDirection") {
+    TVectorImageP vi                = m_strokeSelection.getImage();
+    const std::vector<int> &indices = m_strokeSelection.getSelection();
+
+    std::vector<int>::const_iterator it;
+    for (it = indices.begin(); it != indices.end(); ++it) {
+      TStroke *stroke = vi->getStroke(*it);
+      if (!stroke) continue;
+      stroke->changeDirection();
+    }
+    TXshSimpleLevel *sl =
+        TTool::getApplication()->getCurrentLevel()->getSimpleLevel();
+
+    sl->setDirtyFlag(true);
+    getViewer()->invalidateAll();
+    m_application->getCurrentLevel()->notifyLevelChange();
+
+    return true;
+  }
 
   if (propertyName == m_strokeSelectionType.getName())
     l_strokeSelectionType = ::to_string(m_strokeSelectionType.getValue());

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -315,6 +315,8 @@ public:
 
   bool isSelectionEditable() override { return m_strokeSelection.isEditable(); }
 
+  bool onPropertyChanged(std::string propertyName) override;
+
 protected:
   void onActivate() override;
   void onDeactivate() override;
@@ -330,7 +332,6 @@ protected:
   void updateAction(TPointD pos, const TMouseEvent &e) override;
   void onSelectedFramesChanged() override;
 
-  bool onPropertyChanged(std::string propertyName) override;
   void onImageChanged() override;
 
   int getCursorId() const override {
@@ -361,6 +362,7 @@ private:
                                     //! image, styles...).
   TBoolProperty m_includeIntersection;
   TBoolProperty m_constantThickness;
+  TBoolProperty m_showStrokeDirection;
 
   StrokeSelection m_strokeSelection;        //!< Standard selection of a set of
                                             //! strokes in current image.
@@ -372,6 +374,7 @@ private:
   TIntProperty m_miterJoinLimit;  //!< Stroke joins threshold value.
 
   TPropertyGroup m_outlineProps;
+  TPropertyGroup m_otherProps;
 
   int m_selectionCount;  //!< \deprecated  This is \a not related to stroke
                          //! selections;

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3332,6 +3332,13 @@ void MainWindow::defineActions() {
                           QT_TR_NOOP("Rotate Selection/Object Right"), "");
   createToolOptionsAction("A_ToolOption_PaintBehind", QT_TR_NOOP("Paint Behind"),
                           "");
+
+  createToolOptionsAction("A_ToolOption_ShowDirection",
+                          QT_TR_NOOP("Show Direction"), "");
+  createToolOptionsAction("A_ToolOption_FlipDirection",
+                          QT_TR_NOOP("Flip Direction"), "");
+
+
   // Visualization
 
   createViewerAction(V_ZoomIn, QT_TR_NOOP("Zoom In"), "+");

--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
@@ -620,11 +620,12 @@ void ToolOptionsShortcutInvoker::onToolSwitched() {
     // amount of the property groups
     int pgCount = 1;
     if (tool->getName() == T_Geometric || tool->getName() == T_Type ||
-        (tool->getName() == T_Selection &&
-         (tool->getTargetType() & TTool::Vectors)) ||
         (tool->getName() == T_Brush &&
          (tool->getTargetType() & TTool::Vectors)))
       pgCount = 2;
+    if (tool->getName() == T_Selection &&
+        (tool->getTargetType() & TTool::Vectors))
+      pgCount = 3;
     if (tool->getName() == T_Plastic) pgCount = 5;
     for (int pgId = 0; pgId < pgCount; pgId++) {
       TPropertyGroup* pg = tool->getProperties(pgId);


### PR DESCRIPTION
At the far end of the Vector Selection Tool's option bar are 2 new options
- `Show Direction` - shows the direction of selected strokes
- `Flip Direction` - flips the direction of selected strokes
<img width="70%" height="70%" alt="image" src="https://github.com/user-attachments/assets/3a5d146f-7ce4-470f-a7dc-b2b993c95297" />

Both options can be assigned shortcuts.