### PR TITLE
Drawing Mark

### DIFF
--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -322,6 +322,10 @@ The oldFp is used when the current scene path change...
   bool canConvertSingleFileToSequence();
   void convertSingleFileToSequence(TXsheet *xsh);
 
+  std::map<TFrameId, int> getDrawingMarks() const { return m_drawingMarks; }
+  int getDrawingMark(const TFrameId &fid) const;
+  void setDrawingMark(const TFrameId &fid, int markId);
+
 public:
   // Auxiliary files management: hooks, tpl, etc.
   // May throw; copy and rename perform touchparentdir
@@ -400,6 +404,8 @@ private:
   bool m_isSubsequence, m_16BitChannelLevel, m_floatChannelLevel, m_isReadOnly,
       m_temporaryHookMerged;  //!< Used only during hook merge (and hence during
                               //! saving)
+
+  std::map<TFrameId, int> m_drawingMarks;
 
 private:
   //! Save simple level in scene-decoded path \p decodedFp.

--- a/toonz/sources/include/toonzqt/menubarcommand.h
+++ b/toonz/sources/include/toonzqt/menubarcommand.h
@@ -64,6 +64,7 @@ enum CommandType {
   ZoomCommandType,
   MiscCommandType,
   StopMotionCommandType,
+  DrawingMarkCommandType,
   CellMarkCommandType,
   MenuCommandType,
   VisualizationButtonCommandType,

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -116,6 +116,7 @@ CommandListTree::CommandListTree(const QString& dropTargetString,
   QTreeWidgetItem* rcmSubFolder =
       addFolder(ShortcutTree::tr("Right-click Menu Commands"),
                 RightClickMenuCommandType, advancedFolder);
+  addFolder(ShortcutTree::tr("Drawing Mark"), DrawingMarkCommandType, rcmSubFolder);
   addFolder(ShortcutTree::tr("Cell Mark"), CellMarkCommandType, rcmSubFolder);
   addFolder(ShortcutTree::tr("Tool Modifiers"), ToolModifierCommandType,
             advancedFolder);

--- a/toonz/sources/toonz/drawingdata.cpp
+++ b/toonz/sources/toonz/drawingdata.cpp
@@ -162,11 +162,13 @@ DrawingData *DrawingData::clone() const { return new DrawingData(this); }
 //-----------------------------------------------------------------------------
 
 void DrawingData::setLevelFrames(TXshSimpleLevel *sl,
-                                 std::set<TFrameId> &frames) {
+                                 std::set<TFrameId> &frames,
+                                 bool copyDrawingMarks) {
   if (!sl || frames.empty()) return;
 
   m_level = sl;
   m_imageSet.clear();
+  m_drawingMarks.clear();
 
   std::set<TFrameId>::iterator it;
 
@@ -202,6 +204,8 @@ void DrawingData::setLevelFrames(TXshSimpleLevel *sl,
       copiedHook->setAPos(frameId, levelHook->getAPos(frameId));
       copiedHook->setBPos(frameId, levelHook->getBPos(frameId));
     }
+
+    if (copyDrawingMarks) m_drawingMarks[frameId] = sl->getDrawingMark(frameId);
   }
 }
 
@@ -258,6 +262,8 @@ bool DrawingData::getLevelFrames(TXshSimpleLevel *sl,
   // framesToInsert = new frames
   std::vector<TFrameId> oldFids;
   sl->getFids(oldFids);
+
+  std::map<TFrameId, int> oldDrawingMarks = sl->getDrawingMarks();
 
   std::set<TFrameId> framesToInsert;
   if (setType == INSERT) {
@@ -336,6 +342,21 @@ bool DrawingData::getLevelFrames(TXshSimpleLevel *sl,
       levelHook->setBPos(image.first, copiedHook->getBPos((*frameIt).first));
     }
     ++frameIt;
+  }
+
+  // merge drawing marks
+  if (m_drawingMarks.size()) {
+    frameIt = m_imageSet.begin();
+    for (auto const &image : usedImageSet) {
+      TFrameId newFrameId = image.first;
+      TFrameId oldFrameId = frameIt->first;
+      int markId = m_drawingMarks.find(oldFrameId) != m_drawingMarks.end()
+                       ? m_drawingMarks.at(oldFrameId)
+                       : -1;
+      sl->setDrawingMark(newFrameId, markId);
+
+      ++frameIt;
+    }
   }
 
   sl->setDirtyFlag(true);
@@ -423,8 +444,10 @@ TImageP DrawingData::getImage(QString imageId, TXshSimpleLevel *sl,
 //-----------------------------------------------------------------------------
 
 void DrawingData::setFrames(const std::map<TFrameId, QString> &imageSet,
-                            TXshSimpleLevel *level, const HookSet &levelHooks) {
-  m_levelHooks = levelHooks;
+                            TXshSimpleLevel *level, const HookSet &levelHooks,
+                            const std::map<TFrameId, int> &drawingMarks) {
+  m_levelHooks   = levelHooks;
+  m_drawingMarks = drawingMarks;
   m_imageSet.clear();
 
   assert(!imageSet.empty());

--- a/toonz/sources/toonz/drawingdata.h
+++ b/toonz/sources/toonz/drawingdata.h
@@ -23,6 +23,7 @@ public:
   HookSet m_levelHooks;
   TXshSimpleLevelP m_level;
   bool m_keepVectorFills = false;
+  std::map<TFrameId, int> m_drawingMarks;
 
   /*! Define possible level image setting.
   *  \li INSERT Insert images before first selected;
@@ -36,7 +37,8 @@ public:
   DrawingData(const DrawingData *src)
       : m_imageSet(src->m_imageSet)
       , m_level(src->m_level)
-      , m_levelHooks(src->m_levelHooks) {}
+      , m_levelHooks(src->m_levelHooks)
+      , m_drawingMarks(src->m_drawingMarks) {}
 
   void releaseData() override;
   ~DrawingData();
@@ -44,18 +46,21 @@ public:
   DrawingData *clone() const override;
 
   // data <- filmstrip
-  void setLevelFrames(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
+  void setLevelFrames(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
+                      bool copyDrawingMarks = false);
 
   // data -> filmstrip
-  // Se setType == INSERT inserisce i frames nel livello se necessario spostando
-  // verso il basso i preesistenti. Altrimenti sostituisce i frames.
+  // If setType == INSERT, it inserts the frames into the layer, shifting
+  // any pre-existing frames downward if necessary. Otherwise, it replaces the
+  // frames.
   bool getLevelFrames(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
                       ImageSetType setType, bool cloneImages,
                       bool &keepOriginalPalette, bool isRedo = false) const;
 
   // Image must be put in cache before call this.
   void setFrames(const std::map<TFrameId, QString> &imageSet,
-                 TXshSimpleLevel *level, const HookSet &levelHooks);
+                 TXshSimpleLevel *level, const HookSet &levelHooks,
+                 const std::map<TFrameId, int> &drawingMarks);
   // Return frameId contained in m_imageSet.
   void getFrames(std::set<TFrameId> &frameId) const;
   TXshSimpleLevel *getLevel() const { return m_level.getPointer(); }

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1452,6 +1452,7 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
         markId       = sl->getDrawingMark(fid);
       }
       QAction *markAction = marksMenu->addAction(tr("None"));
+      markAction->setIconVisibleInMenu(true);
       markAction->setCheckable(true);
       markAction->setChecked(markId == -1);
       markAction->setEnabled(markId != -1);
@@ -1466,6 +1467,7 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
       for (auto mark : marks) {
         QString label = QString("%1: %2").arg(curId).arg(mark.name);
         markAction = marksMenu->addAction(getColorChipIcon(mark.color), label);
+        markAction->setIconVisibleInMenu(true);
         markAction->setCheckable(true);
         markAction->setChecked(markId == curId);
         markAction->setEnabled(markId != curId);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -35,6 +35,7 @@
 #include "toonz/toonzscene.h"
 #include "toonz/levelset.h"
 #include "toonz/preferences.h"
+#include "toonz/sceneproperties.h"
 
 // TnzCore includes
 #include "tpalette.h"
@@ -817,6 +818,35 @@ void FilmstripFrames::drawFrameIcon(QPainter &p, const QRect &r, int index,
   if (!pm.isNull()) {
     p.drawPixmap(r.left(), r.top(), pm);
 
+    int markId = sl->getDrawingMark(fid);
+    if (markId >= 0) {
+      int x0 = r.left();
+      int y0 = r.top();
+
+      QBrush origBrush = p.brush();
+      QPen origPen     = p.pen();
+
+      TPixel32 col = TApp::instance()
+                         ->getCurrentScene()
+                         ->getScene()
+                         ->getProperties()
+                         ->getCellMark(markId)
+                         .color;
+      QColor markColor   = QColor(col.r, col.g, col.b);
+      QColor borderColor = QColor(col.r + 50, col.g + 50, col.b + 50);
+
+      p.setBrush(markColor);
+      p.setPen(borderColor);
+
+      int markerHeight = 20;
+      QPoint points[4] = {QPoint(x0, y0), QPoint(x0 + markerHeight, y0),
+                          QPoint(x0, y0 + markerHeight), QPoint(x0, y0)};
+      p.drawPolygon(points, 4);
+
+      p.setBrush(origBrush);
+      p.setPen(origPen);
+    }
+
     if (sl && sl->getType() == PLI_XSHLEVEL && flags & F_INBETWEEN_RANGE) {
       if (m_isVertical) {
         int x1 = r.right();
@@ -1347,6 +1377,12 @@ void FilmstripFrames::timerEvent(QTimerEvent *) {
 
 //-----------------------------------------------------------------------------
 
+QIcon getColorChipIcon(TPixel32 color) {
+  QPixmap pm(15, 15);
+  pm.fill(QColor(color.r, color.g, color.b));
+  return QIcon(pm);
+}
+
 void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   QMenu *menu             = new QMenu();
   TXshSimpleLevel *sl     = getLevel();
@@ -1402,6 +1438,48 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
              (sl->getType() == OVL_XSHLEVEL && !sl->getPath().isUneditable())))
     menu->addAction(cm->getAction(MI_RevertToLastSaved));
   menu->addSeparator();
+
+  if (sl && (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL ||
+             sl->getType() == OVL_XSHLEVEL)) {
+    bool hasSelection = !m_selection->isEmpty();
+    int selectCount   = m_selection->getSelectedFids().size();
+    QMenu *marksMenu  = new QMenu(tr("Drawing Mark"), this);
+    marksMenu->setEnabled(hasSelection);
+    if (hasSelection) {
+      int markId = -2;
+      if (selectCount == 1) {
+        TFrameId fid = *(m_selection->getSelectedFids().begin());
+        markId       = sl->getDrawingMark(fid);
+      }
+      QAction *markAction = marksMenu->addAction(tr("None"));
+      markAction->setCheckable(true);
+      markAction->setChecked(markId == -1);
+      markAction->setEnabled(markId != -1);
+      markAction->setData(-1);
+      connect(markAction, SIGNAL(triggered()), this, SLOT(onSetDrawingMark()));
+      QList<TSceneProperties::CellMark> marks = TApp::instance()
+                                                    ->getCurrentScene()
+                                                    ->getScene()
+                                                    ->getProperties()
+                                                    ->getCellMarks();
+      int curId = 0;
+      for (auto mark : marks) {
+        QString label = QString("%1: %2").arg(curId).arg(mark.name);
+        markAction = marksMenu->addAction(getColorChipIcon(mark.color), label);
+        markAction->setCheckable(true);
+        markAction->setChecked(markId == curId);
+        markAction->setEnabled(markId != curId);
+        markAction->setData(curId);
+        connect(markAction, SIGNAL(triggered()), this,
+                SLOT(onSetDrawingMark()));
+        curId++;
+      }
+    }
+
+    menu->addMenu(marksMenu);
+
+    menu->addSeparator();
+  }
   createSelectLevelMenu(menu);
   QMenu *panelMenu           = menu->addMenu(tr("Panel Settings"));
   QAction *toggleOrientation = panelMenu->addAction(tr("Toggle Orientation"));
@@ -1451,6 +1529,24 @@ void FilmstripFrames::createSelectLevelMenu(QMenu *menu) {
       }
     }
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void FilmstripFrames::onSetDrawingMark() {
+  if (m_selection->isEmpty()) return;
+
+  QAction *senderAction = qobject_cast<QAction *>(sender());
+  if (!senderAction) return;
+
+  TXshSimpleLevel *sl = getLevel();
+  if (!sl) return;
+
+  int markId = senderAction->data().toInt();
+
+  std::set<TFrameId> fids = m_selection->getSelectedFids();
+
+  FilmstripCmd::setDrawingMark(sl, fids, markId);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -171,6 +171,7 @@ protected slots:
   void navigatorToggled(bool);
   void levelSelected(int);
   void disconnectViewer();
+  void onSetDrawingMark();
 
 private:
   // QSS Properties

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -36,6 +36,7 @@
 #include "toonz/trasterimageutils.h"
 #include "toonz/tcamera.h"
 #include "toonz/preferences.h"
+#include "toonz/sceneproperties.h"
 #include "trop.h"
 #include "tools/toolhandle.h"
 #include "tools/rasterselection.h"
@@ -162,7 +163,7 @@ void copyFramesWithoutUndo(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
   QClipboard *clipboard = QApplication::clipboard();
   TXsheet *xsh          = TApp::instance()->getCurrentXsheet()->getXsheet();
   DrawingData *data     = new DrawingData();
-  data->setLevelFrames(sl, frames);
+  data->setLevelFrames(sl, frames, true);
   clipboard->setMimeData(data, QClipboard::Clipboard);
 }
 
@@ -444,6 +445,7 @@ void cutFramesWithoutUndo(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
   std::map<TFrameId, QString> imageSet;
 
   HookSet *levelHooks   = sl->getHookSet();
+  std::map<TFrameId, int> drawingMarks = sl->getDrawingMarks();
   int currentFrameIndex = TApp::instance()->getCurrentFrame()->getFrameIndex();
   std::set<TFrameId>::const_iterator it;
   int i = 0;
@@ -462,7 +464,7 @@ void cutFramesWithoutUndo(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
 
   QClipboard *clipboard = QApplication::clipboard();
   DrawingData *data     = new DrawingData();
-  data->setFrames(imageSet, sl, *levelHooks);
+  data->setFrames(imageSet, sl, *levelHooks, drawingMarks);
   clipboard->setMimeData(data, QClipboard::Clipboard);
 
   for (it = frames.begin(); it != frames.end(); ++it, i++) {
@@ -1809,7 +1811,7 @@ void FilmstripCmd::pasteInto(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
   if (const DrawingData *drawingData =
           dynamic_cast<const DrawingData *>(clipboard->mimeData())) {
     DrawingData *data = new DrawingData();
-    data->setLevelFrames(sl, frames);
+    data->setLevelFrames(sl, frames, true);
 
     HookSet *oldLevelHooks = new HookSet();
     *oldLevelHooks         = *sl->getHookSet();
@@ -1867,10 +1869,11 @@ void FilmstripCmd::deleteFrames(TXshSimpleLevel *sl,
   sl->getFids(oldFrames);
 
   // set up the drawing data that will be necessary to undo the delete.
-  HookSet *levelHooks = sl->getHookSet();
+  HookSet *levelHooks                  = sl->getHookSet();
+  std::map<TFrameId, int> drawingMarks = sl->getDrawingMarks();
   std::map<TFrameId, QString> imageSet = deleteFramesWithoutUndo(sl, frames);
   DrawingData *oldData = new DrawingData();
-  oldData->setFrames(imageSet, sl, *levelHooks);
+  oldData->setFrames(imageSet, sl, *levelHooks, drawingMarks);
 
   TUndoManager::manager()->add(
       new DeleteFramesUndo(sl, framesToDelete, oldFrames, oldData));
@@ -1895,12 +1898,13 @@ void FilmstripCmd::clear(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
     }
   }
 
-  HookSet *levelHooks          = sl->getHookSet();
-  std::set<TFrameId> oldFrames = frames;
+  HookSet *levelHooks                  = sl->getHookSet();
+  std::map<TFrameId, int> drawingMarks = sl->getDrawingMarks();
+  std::set<TFrameId> oldFrames         = frames;
   std::map<TFrameId, QString> clearedFrames =
       clearFramesWithoutUndo(sl, frames);
   DrawingData *oldData = new DrawingData();
-  oldData->setFrames(clearedFrames, sl, *levelHooks);
+  oldData->setFrames(clearedFrames, sl, *levelHooks, drawingMarks);
   DrawingData *newData = new DrawingData();
   newData->setLevelFrames(sl, frames);
   frames.clear();
@@ -2821,4 +2825,82 @@ void FilmstripCmd::renumberDrawing(TXshSimpleLevel *sl, const TFrameId &oldFid,
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+}
+
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+namespace {
+//-----------------------------------------------------------------------------
+
+//=============================================================================
+// SetDrawingMarkUndo
+//-----------------------------------------------------------------------------
+
+class SetDrawingMarkUndo final : public TUndo {
+  TXshSimpleLevel *m_sl;
+  std::map<TFrameId, int> m_oldDrawingMarks;
+  int m_newDrawingMark;
+
+public:
+  SetDrawingMarkUndo(TXshSimpleLevel *sl, std::set<TFrameId> fids, int markId)
+      : m_sl(sl), m_newDrawingMark(markId) {
+    for (TFrameId fid : fids) {
+      m_oldDrawingMarks[fid] = sl->getDrawingMark(fid);
+    }
+  }
+  void undo() const override {
+    std::map<TFrameId, int>::const_iterator it = m_oldDrawingMarks.begin();
+    for (; it != m_oldDrawingMarks.end(); it++)
+      m_sl->setDrawingMark(it->first, it->second);
+
+    TApp::instance()->getCurrentLevel()->notifyLevelChange();
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  void redo() const override {
+    std::map<TFrameId, int>::const_iterator it = m_oldDrawingMarks.begin();
+    for (; it != m_oldDrawingMarks.end(); it++)
+      m_sl->setDrawingMark(it->first, m_newDrawingMark);
+
+    TApp::instance()->getCurrentLevel()->notifyLevelChange();
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  int getSize() const override { return sizeof *this; }
+  QString getHistoryString() override {
+    QString markName;
+    if (m_newDrawingMark < 0)
+      markName = QObject::tr("None", "Drawing Mark");
+    else
+      markName = TApp::instance()
+                     ->getCurrentScene()
+                     ->getScene()
+                     ->getProperties()
+                     ->getCellMark(m_newDrawingMark)
+                     .name;
+    if (m_oldDrawingMarks.size() > 1)
+      return QObject::tr("Set Drawing Mark on multiple frames to %1")
+          .arg(markName);
+
+    return QObject::tr("Set Drawing Mark on Frame %1 to %2")
+        .arg(QString::number(m_oldDrawingMarks.begin()->first.getNumber()))
+        .arg(markName);
+  }
+  int getHistoryType() override { return HistoryType::Xsheet; }
+};
+
+}  // namespace
+
+//=============================================================================
+// setDrawingMark
+//-----------------------------------------------------------------------------
+
+void FilmstripCmd::setDrawingMark(TXshSimpleLevel *sl,
+                                  std::set<TFrameId> &frames, int markId) {
+  if (!sl || sl->isSubsequence() || sl->isReadOnly() || !frames.size()) return;
+
+  SetDrawingMarkUndo *undo = new SetDrawingMarkUndo(sl, frames, markId);
+  undo->redo();
+  TUndoManager::manager()->add(undo);
 }

--- a/toonz/sources/toonz/filmstripcommand.h
+++ b/toonz/sources/toonz/filmstripcommand.h
@@ -60,6 +60,8 @@ void inbetween(TXshSimpleLevel *sl, const TFrameId &fid0, const TFrameId &fid1,
 
 void renumberDrawing(TXshSimpleLevel *sl, const TFrameId &oldFid,
                      const TFrameId &desiredNewFid);
+void setDrawingMark(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
+                    int markId);
 }  // namespace FilmstripCmd
 
 TFrameId operator+(const TFrameId &fid, int d);

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -451,3 +451,11 @@ void TFilmstripSelection::inbetweenEaseInOut() {
   TFrameId fid2 = *m_selectedFrames.rbegin();
   FilmstripCmd::inbetween(sl, fid1, fid2, FilmstripCmd::II_EaseInOut);
 }
+
+//-----------------------------------------------------------------------------
+
+void TFilmstripSelection::setDrawingMark(int markId) {
+  if (markId < -1) return;
+  TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
+  if (sl) FilmstripCmd::setDrawingMark(sl, m_selectedFrames, markId);
+}

--- a/toonz/sources/toonz/filmstripselection.h
+++ b/toonz/sources/toonz/filmstripselection.h
@@ -64,6 +64,7 @@ public:
   void inbetweenEaseIn();
   void inbetweenEaseOut();
   void inbetweenEaseInOut();
+  void setDrawingMark(int markId);
 };
 
 #endif  // TFILMSTRIPSELECTION_H

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3463,6 +3463,16 @@ void MainWindow::defineActions() {
   // Special Modifier Keys
   createSpecialModifierAction(V_Scrub, QT_TR_NOOP("Viewer Scrub"), "#");
 
+  // create drawing mark actions
+  for (int markId = 0; markId < 12; markId++) {
+    std::string cmdId = (std::string)MI_SetDrawingMark + std::to_string(markId);
+    std::string labelStr =
+        QT_TR_NOOP("Set Drawing Mark ") + std::to_string(markId);
+    QAction *action = createAction(cmdId.c_str(), labelStr.c_str(), "", "",
+                                   DrawingMarkCommandType);
+    action->setData(markId);
+  }
+
   // create cell mark actions
   for (int markId = 0; markId < 12; markId++) {
     std::string cmdId = (std::string)MI_SetCellMark + std::to_string(markId);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -506,6 +506,9 @@
 #define MI_ExportXsheetPDF "MI_ExportXsheetPDF"
 #define MI_ExportCameraTrack "MI_ExportCameraTrack"
 
+// mark id is added for each actual command (i.g. MI_SetDrawingMark1)
+#define MI_SetDrawingMark "MI_SetDrawingMark"
+
 // mark id is added for each actual command (i.g. MI_SetCellMark1)
 #define MI_SetCellMark "MI_SetCellMark"
 

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -85,7 +85,7 @@ public:
   int getSize() const override { return sizeof *this; }
 
   QString getHistoryString() override {
-    return QObject::tr("Edit Cell Mark #%1").arg(QString::number(m_id));
+    return QObject::tr("Edit Cell/Drawing Mark #%1").arg(QString::number(m_id));
   }
 };
 
@@ -168,7 +168,7 @@ QImage::Format_ARGB32);
 //-----------------------------------------------------------------------------
 
 CellMarksPopup::CellMarksPopup(QWidget *parent) : Dialog(parent) {
-  setWindowTitle(tr("Cell Marks Settings"));
+  setWindowTitle(tr("Marks Settings"));
 
   QList<TSceneProperties::CellMark> marks = TApp::instance()
                                                 ->getCurrentScene()
@@ -508,7 +508,7 @@ SceneSettingsPopup::SceneSettingsPopup()
       sprop->isColumnColorFilterOnRenderEnabled());
 
   QPushButton *editCellMarksButton =
-      new QPushButton(tr("Edit Cell Marks"), this);
+      new QPushButton(tr("Edit Marks"), this);
 
   QPushButton *editColorFiltersButton =
       new QPushButton(tr("Edit Column Color Filters"), this);
@@ -572,7 +572,7 @@ SceneSettingsPopup::SceneSettingsPopup()
                           Qt::AlignRight | Qt::AlignVCenter);
 
     // cell marks
-    mainLayout->addWidget(new QLabel(tr("Cell Marks:"), this), 7, 0,
+    mainLayout->addWidget(new QLabel(tr("Cell/Drawing Marks:"), this), 7, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
     mainLayout->addWidget(editCellMarksButton, 7, 1, 1, 4,
                           Qt::AlignLeft | Qt::AlignVCenter);

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -261,6 +261,7 @@ ShortcutTree::ShortcutTree(QWidget *parent) : QTreeWidget(parent) {
 
   addFolder(tr("Right-click Menu Commands"), RightClickMenuCommandType);
   QTreeWidgetItem *rcmSubFolder = m_folders.back();
+  addFolder(tr("Drawing Mark"), DrawingMarkCommandType, rcmSubFolder);
   addFolder(tr("Cell Mark"), CellMarkCommandType, rcmSubFolder);
 
   addFolder(tr("Tools"), ToolCommandType);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -639,7 +639,69 @@ QString SetCellMarkUndo::getHistoryString() {
       .arg(QString::number(m_row + 1))
       .arg(markName);
 }
+
 int SetCellMarkUndo::getHistoryType() { return HistoryType::Xsheet; }
+
+//=============================================================================
+// SetDrawingMarkUndo
+//-----------------------------------------------------------------------------
+
+SetDrawingMarkUndo::SetDrawingMarkUndo(std::vector<TXshCell> cells, int markId)
+    : m_cells(cells), m_newDrawingMark(markId) {
+  for (auto cell : m_cells) {
+    TXshSimpleLevel *level = cell.getSimpleLevel();
+    if (!level) {
+      m_oldDrawingMark.push_back(-1);
+      continue;
+    }
+    int oldMark = level->getDrawingMark(cell.getFrameId());
+    m_oldDrawingMark.push_back(oldMark);
+  }
+}
+
+void SetDrawingMarkUndo::undo() const {
+  for (int i = 0; i < m_cells.size(); i++) {
+    TXshSimpleLevel *level = m_cells[i].getSimpleLevel();
+    if (!level) continue;
+    level->setDrawingMark(m_cells[i].getFrameId(), m_oldDrawingMark[i]);
+  }
+  TApp::instance()->getCurrentLevel()->notifyLevelChange();
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+}
+
+void SetDrawingMarkUndo::redo() const {
+  for (int i = 0; i < m_cells.size(); i++) {
+    TXshSimpleLevel *level = m_cells[i].getSimpleLevel();
+    if (!level) continue;
+    level->setDrawingMark(m_cells[i].getFrameId(), m_newDrawingMark);
+  }
+  TApp::instance()->getCurrentLevel()->notifyLevelChange();
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+}
+
+int SetDrawingMarkUndo::getSize() const { return sizeof *this; }
+
+QString SetDrawingMarkUndo::getHistoryString() {
+  QString markName;
+  if (m_newDrawingMark < 0)
+    markName = QObject::tr("None", "Drawing Mark");
+  else
+    markName = TApp::instance()
+                   ->getCurrentScene()
+                   ->getScene()
+                   ->getProperties()
+                   ->getCellMark(m_newDrawingMark)
+                   .name;
+  if (m_cells.size() > 1)
+    return QObject::tr("Set Drawing Mark on multiple frames to %1")
+        .arg(markName);
+
+  return QObject::tr("Set Drawing Mark on Frame %1 to %2")
+      .arg(QString::number(m_cells.begin()->getFrameId().getNumber()))
+      .arg(markName);
+}
+int SetDrawingMarkUndo::getHistoryType() { return HistoryType::Xsheet; }
+
 
 //=============================================================================
 // RenameCellField
@@ -2114,6 +2176,40 @@ void CellArea::drawLoopFrameMarker(QPainter &p, int row, int col) {
 
 //-----------------------------------------------------------------------------
 
+void CellArea::drawDrawingMarker(QPainter &p, int markId, QRect rect,
+                                 TFrameId fid) {
+  if (markId < 0 || fid.getNumber() < 0) return;
+
+  int x0 = rect.left();
+  int y0 = rect.top();
+
+  QBrush origBrush = p.brush();
+  QPen origPen     = p.pen();
+
+  TPixel32 col = TApp::instance()
+                     ->getCurrentScene()
+                     ->getScene()
+                     ->getProperties()
+                     ->getCellMark(markId)
+                     .color;
+  QColor markColor   = QColor(col.r, col.g, col.b);
+  QColor borderColor = QColor(col.r + 50, col.g + 50, col.b + 50);
+
+  p.setBrush(markColor);
+  p.setPen(borderColor);
+
+  int w            = std::min(rect.height(), rect.width());
+  int h            = rect.height();
+  QPoint points[4] = {QPoint(x0, y0), QPoint(x0 + w, y0), QPoint(x0, y0 + h),
+                      QPoint(x0, y0)};
+  p.drawPolygon(points, 4);
+
+  p.setBrush(origBrush);
+  p.setPen(origPen);
+}
+
+//-----------------------------------------------------------------------------
+
 void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
                              bool showLevelName) {
   const Orientation *o = m_viewer->orientation();
@@ -2183,15 +2279,6 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
                  ? 2
                  : -1),
       (m_viewer->orientation()->isVerticalTimeline() ? -1 : 0));
-
-  QRect markRect =
-      o->rect(PredefinedRect::CELL_MARK_AREA)
-          .adjusted(0, -std::round(double(frameAdj.y()) * 0.1), -frameAdj.y(),
-                    -std::round(double(frameAdj.y()) * 0.9))
-          .translated(xy);
-  if (showLevelName && (!isSimpleView || !o->isVerticalTimeline()))
-    markRect.moveCenter(cellRect.center());
-  if (markRect.right() > rect.right()) markRect.setRight(rect.right());
 
   // get cell colors
   QColor cellColor, sideColor, dottedLineColor;
@@ -2334,12 +2421,33 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     drawCurrentTimeIndicator(p, xy);
 
   if (!isImplicitCell) {
-    bool isStart =
-        row > 0 && (prevCell.isEmpty() || prevIsImplicit ||
-                    prevCell.m_level.getPointer() != cell.m_level.getPointer());
+    bool isStart = row == 0 || prevCell.isEmpty() || prevIsImplicit ||
+                   prevCell.m_level.getPointer() != cell.m_level.getPointer() ||
+                   prevCell.getFrameId() != cell.getFrameId();
+    bool isLastRow =
+        nextCell.isEmpty() || isImplicitCellNext ||
+        cell.m_level.getPointer() != nextCell.m_level.getPointer() ||
+        cell.getFrameId() != nextCell.getFrameId();
 
-    bool isLastRow = nextCell.isEmpty() || isImplicitCellNext ||
-                     cell.m_level.getPointer() != nextCell.m_level.getPointer();
+    if (cell.m_level && cell.m_level->getSimpleLevel() &&
+        !cell.getFrameId().isStopFrame() && isStart) {
+      TFrameId fid      = cell.m_frameId;
+      int drawingMarkId = cell.m_level->getSimpleLevel()->getDrawingMark(fid);
+      if (drawingMarkId >= 0) {
+        QRect markRect = rect.adjusted(1, 1, 1, 0);
+        if (!m_viewer->orientation()->isVerticalTimeline())
+          markRect.adjust(
+              0, 0, (!nextCell.isEmpty() && !isImplicitCellNext ? -4 : -2), 0);
+        if (Preferences::instance()->isShowDragBarsEnabled()) {
+          if (m_viewer->orientation()->isVerticalTimeline())
+            markRect.adjust(7, 0, 7, 0);
+          else
+            markRect.adjust(0, 7, 0, 0);
+        }
+        drawDrawingMarker(p, drawingMarkId, markRect, fid);
+      }
+    }
+
     if (Preferences::instance()->isShowDragBarsEnabled()) {
       drawDragHandle(p, isStart, isLastRow, xy, sideColor);
       drawEndOfDragHandle(p, isLastRow, xy, cellColor);
@@ -4961,6 +5069,58 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
     else
       menu.addMenu(lipSyncMenu);
 
+    // Drawing Mark menu
+    if (selectionContainLevelImage(m_viewer->getCellSelection(),
+                                     m_viewer->getXsheet())) {
+      int markId = -2;
+      TCellSelection *cellSelection = m_viewer->getCellSelection();
+      int r0, r1, c0, c1;
+      cellSelection->getSelectedCells(r0, c0, r1, c1);
+      if (c0 < 0) c0 = 0;
+      for (int c = c0; c <= c1; c++) {
+        for (int r = r0; r <= r1; r++) {
+          TXshCell lcell = m_viewer->getXsheet()->getCell(r, c, true, false);
+          if (lcell.isEmpty() || lcell.getFrameId().isStopFrame() ||
+              !lcell.getSimpleLevel())
+            continue;
+          int lMarkId =
+              lcell.getSimpleLevel()->getDrawingMark(lcell.getFrameId());
+          if (markId == -2)
+            markId = lMarkId;
+          else if (lMarkId != markId) {
+            markId = -2;  // Multi selection, allow all values
+            c1     = c1 + 1;  // break out of both loops
+            break;
+          }
+        }
+      }
+
+      QMenu *marksMenu    = new QMenu(tr("Drawing Mark"), this);
+      QAction *markAction = marksMenu->addAction(tr("None"));
+      markAction->setCheckable(true);
+      markAction->setChecked(markId == -1);
+      markAction->setEnabled(markId != -1);
+      markAction->setData(-1);
+      connect(markAction, SIGNAL(triggered()), this, SLOT(onSetDrawingMark()));
+      QList<TSceneProperties::CellMark> marks = TApp::instance()
+                                                    ->getCurrentScene()
+                                                    ->getScene()
+                                                    ->getProperties()
+                                                    ->getCellMarks();
+      int curId = 0;
+      for (auto mark : marks) {
+        QString label = QString("%1: %2").arg(curId).arg(mark.name);
+        markAction = marksMenu->addAction(getColorChipIcon(mark.color), label);
+        markAction->setCheckable(true);
+        markAction->setChecked(markId == curId);
+        markAction->setEnabled(markId != curId);
+        markAction->setData(curId);
+        connect(markAction, SIGNAL(triggered()), this, SLOT(onSetDrawingMark()));
+        curId++;
+      }
+
+      menu.addMenu(marksMenu);
+    }
   } else {
     if (!folderCellsSelected && !pegbarCellsSelected) {
       menu.addAction(cmdManager->getAction(MI_CreateBlankDrawing));
@@ -5282,6 +5442,42 @@ void CellArea::onSetCellMark() {
   int col               = params[1].toInt();
   int id                = params[2].toInt();
   SetCellMarkUndo *undo = new SetCellMarkUndo(row, col, id);
+  undo->redo();
+  TUndoManager::manager()->add(undo);
+}
+
+//-----------------------------------------------------------------------------
+
+void CellArea::onSetDrawingMark() {
+  QAction *senderAction = qobject_cast<QAction *>(sender());
+  if (!senderAction) return;
+
+  int markId = senderAction->data().toInt();
+
+  TCellSelection *cellSelection = m_viewer->getCellSelection();
+  if (!cellSelection) return;
+
+  int r0, r1, c0, c1;
+  cellSelection->getSelectedCells(r0, c0, r1, c1);
+  if (c0 < 0) c0 = 0;
+
+  std::vector<TXshCell> cells;
+
+  // Find all unique cells with a drawing
+  for (int c = c0; c <= c1; c++) {
+    for (int r = r0; r <= r1; r++) {
+      TXshCell cell = m_viewer->getXsheet()->getCell(r, c, true, false);
+      if (cell.isEmpty() || cell.getFrameId().isStopFrame() ||
+          !cell.getSimpleLevel())
+        continue;
+      if (std::find(cells.begin(), cells.end(), cell) != cells.end()) continue;
+      cells.push_back(cell);
+    }
+  }
+
+  if (cells.empty()) return;
+
+  SetDrawingMarkUndo *undo = new SetDrawingMarkUndo(cells, markId);
   undo->redo();
   TUndoManager::manager()->add(undo);
 }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2177,8 +2177,9 @@ void CellArea::drawLoopFrameMarker(QPainter &p, int row, int col) {
 //-----------------------------------------------------------------------------
 
 void CellArea::drawDrawingMarker(QPainter &p, int markId, QRect rect,
-                                 TFrameId fid) {
-  if (markId < 0 || fid.getNumber() < 0) return;
+                                 TFrameId fid, bool hasFrame,
+                                 bool isLoopedCell) {
+  if (markId < 0 || fid.getNumber() < 0 || (!hasFrame && !isLoopedCell)) return;
 
   int x0 = rect.left();
   int y0 = rect.top();
@@ -2192,8 +2193,9 @@ void CellArea::drawDrawingMarker(QPainter &p, int markId, QRect rect,
                      ->getProperties()
                      ->getCellMark(markId)
                      .color;
-  QColor markColor   = QColor(col.r, col.g, col.b);
-  QColor borderColor = QColor(col.r + 50, col.g + 50, col.b + 50);
+  int opacity        = isLoopedCell ? 102 : 255;
+  QColor markColor   = QColor(col.r, col.g, col.b, opacity);
+  QColor borderColor = QColor(col.r + 50, col.g + 50, col.b + 50, opacity);
 
   p.setBrush(markColor);
   p.setPen(borderColor);
@@ -2420,7 +2422,6 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
       Preferences::instance()->isCurrentTimelineIndicatorEnabled())
     drawCurrentTimeIndicator(p, xy);
 
-  if (!isImplicitCell) {
     bool isStart = row == 0 || prevCell.isEmpty() || prevIsImplicit ||
                    prevCell.m_level.getPointer() != cell.m_level.getPointer() ||
                    prevCell.getFrameId() != cell.getFrameId();
@@ -2444,11 +2445,14 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
           else
             markRect.adjust(0, 7, 0, 0);
         }
-        drawDrawingMarker(p, drawingMarkId, markRect, fid);
+        drawDrawingMarker(
+            p, drawingMarkId, markRect, fid, !isImplicitCell,
+            (isLoopedCell && prevCell.m_frameId != cell.m_frameId));
       }
     }
 
-    if (Preferences::instance()->isShowDragBarsEnabled()) {
+  if (!isImplicitCell) {
+      if (Preferences::instance()->isShowDragBarsEnabled()) {
       drawDragHandle(p, isStart, isLastRow, xy, sideColor);
       drawEndOfDragHandle(p, isLastRow, xy, cellColor);
       dottedLineColor = cellColor;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -5097,6 +5097,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
 
       QMenu *marksMenu    = new QMenu(tr("Drawing Mark"), this);
       QAction *markAction = marksMenu->addAction(tr("None"));
+      markAction->setIconVisibleInMenu(true);
       markAction->setCheckable(true);
       markAction->setChecked(markId == -1);
       markAction->setEnabled(markId != -1);
@@ -5111,6 +5112,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
       for (auto mark : marks) {
         QString label = QString("%1: %2").arg(curId).arg(mark.name);
         markAction = marksMenu->addAction(getColorChipIcon(mark.color), label);
+        markAction->setIconVisibleInMenu(true);
         markAction->setCheckable(true);
         markAction->setChecked(markId == curId);
         markAction->setEnabled(markId != curId);
@@ -5145,6 +5147,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
     QMenu *marksMenu    = new QMenu(tr("Cell Mark"), this);
     int markId          = cellColumn->getCellMark(row);
     QAction *markAction = marksMenu->addAction(tr("None"));
+    markAction->setIconVisibleInMenu(true);
     markAction->setCheckable(true);
     markAction->setChecked(markId == -1);
     markAction->setEnabled(markId != -1);
@@ -5159,6 +5162,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
     for (auto mark : marks) {
       QString label = QString("%1: %2").arg(curId).arg(mark.name);
       markAction    = marksMenu->addAction(getColorChipIcon(mark.color), label);
+      markAction->setIconVisibleInMenu(true);
       markAction->setCheckable(true);
       markAction->setChecked(markId == curId);
       markAction->setEnabled(markId != curId);

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -34,6 +34,20 @@ public:
   int getHistoryType() override;
 };
 
+class SetDrawingMarkUndo final : public TUndo {
+  std::vector<TXshCell> m_cells;
+  std::vector<int> m_oldDrawingMark;
+  int m_newDrawingMark;
+
+public:
+  SetDrawingMarkUndo(std::vector<TXshCell> cells, int markId);
+  void undo() const override;
+  void redo() const override;
+  int getSize() const override;
+  QString getHistoryString() override;
+  int getHistoryType() override;
+};
+
 class NoteWidget;
 class DragTool;
 
@@ -148,6 +162,7 @@ class CellArea final : public QWidget {
   void drawCellMarker(QPainter &p, int markId, QRect rect,
                       bool hasFrame = false, bool isNextEmpty = true);
   void drawLoopFrameMarker(QPainter &p, int row, int col);
+  void drawDrawingMarker(QPainter &p, int markId, QRect rect, TFrameId fid);
 
   // Restistusce true
   bool getEaseHandles(int r0, int r1, double e0, double e1, int &rh0, int &rh1);
@@ -218,6 +233,7 @@ protected slots:
   // replace level with another level in the cast
   void onReplaceByCastedLevel(QAction *action);
   void onSetCellMark();
+  void onSetDrawingMark();
   void onDelayToolTip();
 };
 

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -162,7 +162,8 @@ class CellArea final : public QWidget {
   void drawCellMarker(QPainter &p, int markId, QRect rect,
                       bool hasFrame = false, bool isNextEmpty = true);
   void drawLoopFrameMarker(QPainter &p, int row, int col);
-  void drawDrawingMarker(QPainter &p, int markId, QRect rect, TFrameId fid);
+  void drawDrawingMarker(QPainter &p, int markId, QRect rect, TFrameId fid,
+                         bool hasFrame, bool isLoopedCell);
 
   // Restistusce true
   bool getEaseHandles(int r0, int r1, double e0, double e1, int &rh0, int &rh1);

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -48,6 +48,8 @@
 #include "toonz/txshpegbarcolumn.h"
 #include "toonz/tstageobjectcmd.h"
 
+#include "../toonz/filmstripselection.h"
+
 // TnzQt includes
 #include "toonzqt/tselectionhandle.h"
 #include "toonzqt/gutil.h"
@@ -2765,6 +2767,75 @@ public:
   }
 
 } ToggleXsheetOpenCloseFolderCommand;
+
+//-----------------------------------------------------------------------------
+
+class SetDrawingMarkCommand final : public MenuItemHandler {
+  int m_markId;
+
+public:
+  SetDrawingMarkCommand(int markId)
+      : MenuItemHandler(
+            ((std::string)MI_SetDrawingMark + std::to_string(markId)).c_str())
+      , m_markId(markId) {}
+
+  void execute() override {
+    TApp *app         = TApp::instance();
+    TXsheet *xsh      = app->getCurrentXsheet()->getXsheet();
+
+    TSelection *selection = app->getCurrentSelection()->getSelection();
+    if (!selection) return;
+
+    if (TApp::instance()->getCurrentFrame()->isEditingLevel()) {
+      TFilmstripSelection *filmstripSelection =
+          dynamic_cast<TFilmstripSelection *>(selection);
+      if (!filmstripSelection) return;
+
+      filmstripSelection->setDrawingMark(m_markId);
+      return;
+    }
+
+    TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(selection);
+    if (!cellSelection) return;
+
+    int r0, r1, c0, c1;
+    cellSelection->getSelectedCells(r0, c0, r1, c1);
+    if (c0 < 0) c0 = 0;
+
+    std::vector<TXshCell> cells;
+
+    // Find all unique cells with a drawing
+    for (int c = c0; c <= c1; c++) {
+      for (int r = r0; r <= r1; r++) {
+        TXshCell cell = xsh->getCell(r, c, true, false);
+        if (cell.isEmpty() || cell.getFrameId().isStopFrame() ||
+            !cell.getSimpleLevel())
+          continue;
+        if (std::find(cells.begin(), cells.end(), cell) != cells.end())
+          continue;
+        cells.push_back(cell);
+      }
+    }
+
+    if (cells.empty()) return;
+
+    XsheetGUI::SetDrawingMarkUndo *undo = new XsheetGUI::SetDrawingMarkUndo(cells, m_markId);
+    undo->redo();
+    TUndoManager::manager()->add(undo);
+  }
+};
+SetDrawingMarkCommand DrawingMarkCommand0(0);
+SetDrawingMarkCommand DrawingMarkCommand1(1);
+SetDrawingMarkCommand DrawingMarkCommand2(2);
+SetDrawingMarkCommand DrawingMarkCommand3(3);
+SetDrawingMarkCommand DrawingMarkCommand4(4);
+SetDrawingMarkCommand DrawingMarkCommand5(5);
+SetDrawingMarkCommand DrawingMarkCommand6(6);
+SetDrawingMarkCommand DrawingMarkCommand7(7);
+SetDrawingMarkCommand DrawingMarkCommand8(8);
+SetDrawingMarkCommand DrawingMarkCommand9(9);
+SetDrawingMarkCommand DrawingMarkCommand10(10);
+SetDrawingMarkCommand DrawingMarkCommand11(11);
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -869,6 +869,7 @@ void TXshSimpleLevel::eraseFrame(const TFrameId &fid) {
   }
 
   m_frames.erase(ft);
+  m_drawingMarks.erase(fid);
   getHookSet()->eraseFrame(fid);
 
   ImageManager *im = ImageManager::instance();
@@ -921,6 +922,7 @@ void TXshSimpleLevel::clearFrames() {
   m_editableRangeUserInfo.clear();
   m_renumberTable.clear();
   m_framesStatus.clear();
+  m_drawingMarks.clear();
 }
 
 //-----------------------------------------------------------------------------
@@ -1017,6 +1019,16 @@ void TXshSimpleLevel::loadData(TIStream &is) {
         m_properties->setColorSpaceGamma(colorSpaceGamma);
         m_properties->setVanishingPoints(vanishingPoints);
         if (isStopMotionLevel == 1) setIsReadOnly(true);
+      } else if (tagName == "drawingMarks") {
+        int markCount;
+        is >> markCount;
+        for (int i = 0; i < markCount; i++) {
+          int frameNumber, markId;
+          is >> frameNumber >> markId;
+          TFrameId fid(frameNumber);
+          setDrawingMark(fid, markId);
+        }
+        is.matchEndTag();
       } else
         throw TException("unexpected tag " + tagName);
     } else {
@@ -1518,6 +1530,15 @@ void TXshSimpleLevel::saveData(TOStream &os) {
   os.child("path") << m_path;  // fp;
   if (m_scannedPath != TFilePath())
     os.child("scannedPath") << m_scannedPath;  // fp;
+
+  if (m_drawingMarks.size()) {
+    os.openChild("drawingMarks");
+    os << (int)m_drawingMarks.size();
+    std::map<TFrameId, int>::const_iterator it;
+    for (it = m_drawingMarks.begin(); it != m_drawingMarks.end(); it++)
+      os << it->first.getNumber() << it->second;
+    os.closeChild();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -2249,6 +2270,16 @@ void TXshSimpleLevel::renumber(const std::vector<TFrameId> &fids) {
     m_frames.insert(fid);
   }
 
+  std::map<TFrameId, int> oldDrawingMarks = m_drawingMarks;
+  m_drawingMarks.clear();
+  for (std::map<TFrameId, int>::iterator it = oldDrawingMarks.begin();
+       it != oldDrawingMarks.end(); ++it) {
+    TFrameId oldFid = it->first;
+    TFrameId newFid = table[oldFid];
+
+    m_drawingMarks[newFid] = it->second;
+  }
+
   ImageManager *im = ImageManager::instance();
   TImageCache *ic  = TImageCache::instance();
 
@@ -2600,4 +2631,22 @@ void TXshSimpleLevel::convertSingleFileToSequence(TXsheet *xsh) {
       }
     }
   }
+}
+
+//-----------------------------------------------------------------------------
+
+int TXshSimpleLevel::getDrawingMark(const TFrameId &fid) const {
+  std::map<TFrameId, int>::const_iterator it = m_drawingMarks.find(fid);
+  return (it != m_drawingMarks.end()) ? it->second : -1;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshSimpleLevel::setDrawingMark(const TFrameId &fid, int markId) {
+  if (markId < 0) {
+    if (m_drawingMarks.find(fid) != m_drawingMarks.end())
+      m_drawingMarks.erase(fid);
+    return;
+  }
+  m_drawingMarks[fid] = markId;
 }

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -129,7 +129,8 @@ void CommandManager::define(CommandId id, CommandType type,
        (node->m_handler || node->m_qaction->actionGroup() != 0)) ||
       node->m_type == MiscCommandType ||
       node->m_type == ToolModifierCommandType ||
-      node->m_type == CellMarkCommandType);
+      node->m_type == CellMarkCommandType ||
+      node->m_type == DrawingMarkCommandType);
   node->m_iconSVGName = iconSVGName;
 
   m_qactionTable[qaction] = node;


### PR DESCRIPTION
This provides the ability to add a mark to drawings that is only visible in the Level Strip and Timeline/Xsheet.  The mark is shown in the upper left corner of the drawing icon or exposed cell.  This feature only applies to drawing levels.

<img width="70%" height="70%" alt="image" src="https://github.com/user-attachments/assets/3194110d-cee8-457d-845c-9e205d7832c2" />

This is an extension of the `Cell Mark` feature and uses the same mark list set in `Scene Properties`. `Drawing Mark` is applied to individual drawings and follows the drawing as it is moved around the timeline/xsheet.

Drawing marks can be set from either the Level Strip or Timeine/Xsheet. The option is found in the context menu.
<img width="40%" height="40%" alt="image" src="https://github.com/user-attachments/assets/6aaa1f69-f758-4f6e-a680-eeab2d0c3b7a" />

Similar to cell marks, the options can be added to command/quick/main toolbars as well as set shortcuts for them.