### PR TITLE
Fix drawing sub key step change  crash

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -5253,6 +5253,7 @@ void CellArea::onStepChanged(QAction *act) {
     setParamStep(keyFrameIndex, step,
                  stageObject->getParam(TStageObject::T_ShearY));
   }
+  param         = stageObject->getParam(TStageObject::T_DrawingNumber);
   keyFrameIndex = param->getClosestKeyframe(frame);
   if (keyFrameIndex >= 0) {
     setParamStep(keyFrameIndex, step,


### PR DESCRIPTION
This fixes a crash that can occur when changing the interpolation step from the timeline/xsheet due to changes made for animating drawing substitution (#2117)