### PR TITLE
Fix render range syncing with play markers

### DIFF
--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -1265,6 +1265,7 @@ void OutputSettingsPopup::updateField() {
     m_renderKeysOnly->setEnabled(prop->getMultimediaRendering());
     m_renderToFolders->setEnabled(prop->getMultimediaRendering());
 
+    prop->setSyncWithPlayRangeEnabled(SyncOutputWithPlayRange);
     prop->setAppendVersionFormat((TOutputProperties::AppendVersionFormat)(int)AppendVersionFormat);
   }
 
@@ -1314,8 +1315,17 @@ void OutputSettingsPopup::updateField() {
   int r0 = 0, r1 = -1, step;
   prop->getRange(r0, r1, step);
   if (r0 > r1) {
-    r0 = 0;
-    r1 = scene->getFrameCount() - 1;
+    if (!m_isPreviewSettings && prop->isSyncWithPlayRangeEnabled()) {
+      // First time opening Render properties. If sync play range is enabled,
+      // initialize range fields to whatever the preview range is
+      TOutputProperties *p = scene->getProperties()->getPreviewProperties();
+      int ignore;
+      p->getRange(r0, r1, ignore);
+    }
+    if (r0 > r1) {
+      r0 = 0;
+      r1 = scene->getFrameCount() - 1;
+    }
     if (r1 < 0) r1 = 0;
   }
   m_startFld->setValue(r0 + 1);

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -73,6 +73,7 @@ TOutputProperties::TOutputProperties(const TOutputProperties &src)
     , m_boardSettings(new BoardSettings(*src.m_boardSettings))
     , m_formatTemplateFId(src.m_formatTemplateFId)
     , m_syncColorSettings(src.m_syncColorSettings)
+    , m_syncWithPlayRange(src.m_syncWithPlayRange)
     , m_nonlinearBpp(src.m_nonlinearBpp)
     , m_appendVersionFormat(src.m_appendVersionFormat) {
   std::map<std::string, TPropertyGroup *>::iterator ft,
@@ -126,6 +127,8 @@ TOutputProperties &TOutputProperties::operator=(const TOutputProperties &src) {
   m_formatTemplateFId = src.m_formatTemplateFId;
 
   m_appendVersionFormat = src.m_appendVersionFormat;
+
+  m_syncWithPlayRange = src.m_syncWithPlayRange;
 
   return *this;
 }


### PR DESCRIPTION
Another fix for #2143 where the sync with frame range settings was being ignored.

Happens after switching scenes or going to a new scene without restarting T2D.  There may be other causes. Prior to this fix, I couldn't easily duplicate it until I found a reliable way to trigger it.  Hopefully this fixed those other potential causes I randomly found.