### PR TITLE
Fix connect: incompatible arguments

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -1021,6 +1021,8 @@ public slots:
   void onToolSwitched();
   void onToolChanged();
   void onStageObjectChange(bool);
+  void onObjectSwitched();
+  void onXshLevelSwitched(TXshLevel *);
 
 signals:
   // used in ComboViewer to handle Tab focus

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -4717,7 +4717,7 @@ void ToolOptions::showEvent(QShowEvent *) {
   TObjectHandle *currObject = app->getCurrentObject();
   if (currObject) {
     onStageObjectChange(false);
-    connect(currObject, SIGNAL(objectSwitched()), SLOT(onStageObjectChange(bool)));
+    connect(currObject, SIGNAL(objectSwitched()), SLOT(onObjectSwitched()));
     connect(currObject, SIGNAL(objectChanged(bool)),
             SLOT(onStageObjectChange(bool)));
   }
@@ -4726,7 +4726,7 @@ void ToolOptions::showEvent(QShowEvent *) {
 
   if (currLevel)
     connect(currLevel, SIGNAL(xshLevelSwitched(TXshLevel *)), this,
-            SLOT(onStageObjectChange(bool)));
+            SLOT(onXshLevelSwitched(TXshLevel *)));
 }
 
 //-----------------------------------------------------------------------------
@@ -4870,6 +4870,15 @@ void ToolOptions::onStageObjectChange(bool isDragging) {
 
   ToolOptionsBox *panel = it->second;
   panel->onStageObjectChange(isDragging);
+}
+//-----------------------------------------------------------------------------
+
+void ToolOptions::onObjectSwitched() { onStageObjectChange(false); }
+
+//-----------------------------------------------------------------------------
+
+void ToolOptions::onXshLevelSwitched(TXshLevel *) {
+  onStageObjectChange(false);
 }
 
 //***********************************************************************************


### PR DESCRIPTION
This fixes the following errors thrown to console caused by changes made in #2157 addressing lag from #2061

```
QObject::connect: Incompatible sender/receiver arguments
        TObjectHandle::objectSwitched() --> ToolOptions::onStageObjectChange(bool)
QObject::connect: Incompatible sender/receiver arguments
        TXshLevelHandle::xshLevelSwitched(TXshLevel*) --> ToolOptions::onStageObjectChange(bool)
```

This was preventing some internal stuff from being triggered because the connection was failing.