### PR TITLE
Separate Auto Close from Auto Group + new shortcuts

### DIFF
--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -2289,26 +2289,17 @@ bool ToonzVectorBrushTool::onPropertyChanged(std::string propertyName) {
   }
 
   if (propertyName == m_autoClose.getName() && !m_autoClose.getValue()) {
+    // We need autofill off if off.
     m_autoFill.setValue(false);
-    m_autoGroup.setValue(false);
-    V_VectorBrushAutoFill  = m_autoFill.getValue();
-    V_VectorBrushAutoGroup = m_autoGroup.getValue();
-    notifyTool             = true;
+    V_VectorBrushAutoFill = m_autoFill.getValue();
+    notifyTool            = true;
   }
 
-  if (propertyName == m_autoGroup.getName()) {
-    // We need close turned on if on,
+  if (propertyName == m_autoGroup.getName() && !m_autoGroup.getValue()) {
     // We need autofill off if off.
-    if (m_autoGroup.getValue()) {
-      m_autoClose.setValue(true);
-      V_VectorBrushAutoClose = m_autoClose.getValue();
-      notifyTool             = true;
-    }
-    if (!m_autoGroup.getValue() && m_autoFill.getValue()) {
-      m_autoFill.setValue(false);
-      V_VectorBrushAutoFill = m_autoFill.getValue();
-      notifyTool            = true;
-    }
+    m_autoFill.setValue(false);
+    V_VectorBrushAutoFill = m_autoFill.getValue();
+    notifyTool            = true;
   }
 
   // we need close and group on
@@ -2472,11 +2463,6 @@ void ToonzVectorBrushTool::loadLastBrush() {
       m_autoGroup.setValue(true);
       V_VectorBrushAutoGroup = 1;
     }
-  }
-
-  if (m_autoGroup.getValue() && !m_autoClose.getValue()) {
-    m_autoClose.setValue(true);
-    V_VectorBrushAutoClose = 1;
   }
 
   switch (V_VectorBrushSnapSensitivity) {

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -433,11 +433,11 @@ static void addStroke(TTool::Application *application, const TVectorImageP &vi,
                        autoGroup, autoFill, sendToBack));
   }
 
-  if (autoGroup && stroke->isSelfLoop()) {
+  if (autoGroup) {
     int index             = vi->getStrokeCount() - 1;
     if (sendToBack) index = addedStrokeIndex;
     vi->group(index, 1);
-    if (autoFill) {
+    if (autoFill && stroke->isSelfLoop()) {
       // to avoid filling other strokes, I enter into the new stroke group
       int currentGroup = vi->exitGroup();
       vi->enterGroup(index);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2950,8 +2950,14 @@ void MainWindow::defineActions() {
   /*-- Brush tool + mode switching shortcuts --*/
   createAction(MI_BrushAutoFillOn, QT_TR_NOOP("Brush Tool - Auto Fill On"), "",
                "", ToolCommandType);
-  createAction(MI_BrushAutoFillOff, QT_TR_NOOP("Brush Tool - Auto Fill Off"),
-               "", "", ToolCommandType);
+  createAction(MI_BrushAutoFillOff,
+               QT_TR_NOOP("Brush Tool - Auto Close/Group/Fill Off"), "", "",
+               ToolCommandType);
+  createAction(MI_BrushAutoCloseOn, QT_TR_NOOP("Brush Tool - Auto Close On"), "",
+               "", ToolCommandType);
+  createAction(MI_BrushAutoGroupOn,
+               QT_TR_NOOP("Brush Tool - Auto Group On"), "", "",
+               ToolCommandType);
 
   /*-- Geometric tool + shape switching shortcuts --*/
   createAction(MI_GeometricNextShape, QT_TR_NOOP("Geometric Tool - Next Shape"),

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -449,6 +449,8 @@
 
 #define MI_BrushAutoFillOn "MI_BrushAutoFillOn"
 #define MI_BrushAutoFillOff "MI_BrushAutoFillOff"
+#define MI_BrushAutoCloseOn "MI_BrushAutoCloseOn"
+#define MI_BrushAutoGroupOn "MI_BrushAutoGroupOn"
 
 #define MI_DeactivateUpperColumns "MI_DeactivateUpperColumns"
 #define MI_CompareToSnapshot "MI_CompareToSnapshot"

--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
@@ -593,6 +593,10 @@ void ToolOptionsShortcutInvoker::initialize() {
                     &ToolOptionsShortcutInvoker::ToggleBrushAutoFillOff);
   setCommandHandler(MI_BrushAutoFillOn, this,
                     &ToolOptionsShortcutInvoker::ToggleBrushAutoFillOn);
+  setCommandHandler(MI_BrushAutoCloseOn, this,
+                    &ToolOptionsShortcutInvoker::ToggleBrushAutoCloseOn);
+  setCommandHandler(MI_BrushAutoGroupOn, this,
+                    &ToolOptionsShortcutInvoker::ToggleBrushAutoGroupOn);
 }
 
 //-----------------------------------------------------------------------------
@@ -1158,7 +1162,15 @@ void ToolOptionsShortcutInvoker::TogglePlasticAnimate() {
 /*-- Brush tool + mode switching shortcuts --*/
 void ToolOptionsShortcutInvoker::ToggleBrushAutoFillOff() {
   CommandManager::instance()->getAction(T_Brush)->trigger();
-  QAction *ac = CommandManager::instance()->getAction("A_ToolOption_AutoClose");
+  QAction* ac = CommandManager::instance()->getAction("A_ToolOption_Autofill");
+  if (ac->isChecked()) {
+    ac->trigger();
+  }
+  ac = CommandManager::instance()->getAction("A_ToolOption_AutoGroup");
+  if (ac->isChecked()) {
+    ac->trigger();
+  }
+  ac = CommandManager::instance()->getAction("A_ToolOption_AutoClose");
   if (ac->isChecked()) {
     ac->trigger();
   }
@@ -1167,6 +1179,22 @@ void ToolOptionsShortcutInvoker::ToggleBrushAutoFillOff() {
 void ToolOptionsShortcutInvoker::ToggleBrushAutoFillOn() {
   CommandManager::instance()->getAction(T_Brush)->trigger();
   QAction *ac = CommandManager::instance()->getAction("A_ToolOption_Autofill");
+  if (!ac->isChecked()) {
+    ac->trigger();
+  }
+}
+
+void ToolOptionsShortcutInvoker::ToggleBrushAutoCloseOn() {
+  CommandManager::instance()->getAction(T_Brush)->trigger();
+  QAction* ac = CommandManager::instance()->getAction("A_ToolOption_AutoClose");
+  if (!ac->isChecked()) {
+    ac->trigger();
+  }
+}
+
+void ToolOptionsShortcutInvoker::ToggleBrushAutoGroupOn() {
+  CommandManager::instance()->getAction(T_Brush)->trigger();
+  QAction* ac = CommandManager::instance()->getAction("A_ToolOption_AutoGroup");
   if (!ac->isChecked()) {
     ac->trigger();
   }

--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.h
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.h
@@ -257,6 +257,8 @@ protected slots:
   /*-- Brush Tool + mode switching shortcuts --*/
   void ToggleBrushAutoFillOff();
   void ToggleBrushAutoFillOn();
+  void ToggleBrushAutoCloseOn();
+  void ToggleBrushAutoGroupOn();
 };
 
 #endif


### PR DESCRIPTION
This fixes #2198.  

`Auto Close` is now an independent setting in relation to `Auto Group`.

Note: `Auto Close` is still required, along with `Auto Group` when `Auto Fill` is enabled.

Additional changes
- Renames `Brush Tool - Auto Fill Off` shortcut -> `Brush Tool - Auto Close/Group/Fill Off`
- Adds `Brush Tool - Auto Close On` shortcut
- Adds `Brush Tool - Auto Group On` shortcut