### PR TITLE
Fix shortcuts for toggling tool option checkboxes

### DIFF
--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -108,6 +108,7 @@ ToolOptionCheckbox::ToolOptionCheckbox(TTool *tool, TBoolProperty *property,
   // synchronize the state with the same widgets in other tool option bars
   if (toolHandle)
     connect(this, SIGNAL(clicked(bool)), toolHandle, SIGNAL(toolChanged()));
+  connect(this, SIGNAL(clicked(bool)), SLOT(onClicked(bool)));
 }
 
 //-----------------------------------------------------------------------------
@@ -118,6 +119,15 @@ void ToolOptionCheckbox::updateStatus() {
   if (isChecked() == check) return;
 
   setCheckState(check ? Qt::Checked : Qt::Unchecked);
+
+  onClicked(check);
+}
+
+void ToolOptionCheckbox::onClicked(bool check) {
+  // sync state of shortcut if there is one
+  std::string id = "A_ToolOption_" + m_property->getId();
+  QAction *ac    = CommandManager::instance()->getAction(id.c_str());
+  if (ac) ac->setChecked(check);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -106,6 +106,9 @@ public:
 
 protected:
   void nextCheckState() override;
+
+protected slots:
+  void onClicked(bool check);
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes an issue where shortcuts set on tool option checkboxes (i.e. `Auto Fill`, `Pressure`, etc.) may not always work the 1st time the shortcut is used or, in at least 1 or 2 cases, not at all.

This can happen when you change the setting from the tool option bar and then try to use the shortcut later and did not switch tools.  Doing this causes the internal state of the tool option bar checkbox and the shortcut to be out of sync.

In most cases repeating the shortcut again will get the states in sync and resume working normally. There is 1 or 2 shortcuts that only triggers if the internal status is in a certain state so it may not work until it syncs up after switching tools.

This corrects the problem by updating the internal status of the assigned shortcut every time the tool option bar checkbox is changed.