### PR TITLE
Enable Unified Preview/Camera Stand buttons and Disable drag-move cell OT ports

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -153,7 +153,9 @@ enum class PredefinedRect {
   TOGGLE_COLUMN_NUMBER_AREA,
   TOGGLE_COLUMN_NUMBER,
   TOGGLE_COLUMN_PARENT_AREA,
-  TOGGLE_COLUMN_PARENT
+  TOGGLE_COLUMN_PARENT,
+  TOGGLE_CAMERASTAND_BUTTON_AREA,
+  TOGGLE_CAMERASTAND_BUTTON
 };
 enum class PredefinedLine {
   LOCKED,              //! dotted vertical line when cell is locked

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -434,9 +434,7 @@ public:
     return getBoolValue(showColumnParents);
   }
   bool isUnifyColumnVisibilityTogglesEnabled() const {
-  // Disabled until OT officially releases it
-  //  return getBoolValue(unifyColumnVisibilityToggles);
-    return false;
+    return getBoolValue(unifyColumnVisibilityToggles);
   }
   bool isParentColorsInXsheetColumnEnabled() const {
     return getBoolValue(parentColorsInXsheetColumn);

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -705,7 +705,8 @@ void doUnifyColumnVisibilityToggles_Recursive(const TXsheet *xsh,
     if (colType == TXshColumn::ePaletteType ||
         colType == TXshColumn::eSoundType ||
         colType == TXshColumn::eSoundTextType ||
-        colType == TXshColumn::eFolderType)
+        colType == TXshColumn::eFolderType ||
+        colType == TXshColumn::ePegbarType)
       continue;
     // visibility check
     if (column->isPreviewVisible() != column->isCamstandVisible()) {

--- a/toonz/sources/toonz/icons/dark/actions/15/toggle_camerastand_button.svg
+++ b/toonz/sources/toonz/icons/dark/actions/15/toggle_camerastand_button.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="15px"
+   height="15px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg1"
+   sodipodi:docname="toggle_camerastand_button.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="59.8"
+   inkscape:cx="7.5083612"
+   inkscape:cy="7.5167224"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg1" />
+    
+<g
+   id="g1"
+   transform="matrix(0.95177114,0,0,0.95175882,0.34218133,0.34138637)"><path
+     d="m 7.5299272,1.02993 c 3.5870708,0 6.4999978,2.9129272 6.4999978,6.4999971 0,3.5870699 -2.912927,6.4999969 -6.4999978,6.4999969 -3.58707,0 -6.4999972,-2.912927 -6.4999972,-6.4999969 0,-3.5870699 2.9129272,-6.4999971 6.4999972,-6.4999971 z"
+     style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.19786px;stroke-linejoin:round;stroke-miterlimit:2"
+     id="path1-5" /><g
+     transform="translate(-1.47007,-1.470069)"
+     id="g3"
+     style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+        <rect
+   x="5"
+   y="6"
+   width="8"
+   height="6"
+   id="rect2" />
+    </g></g></svg>

--- a/toonz/sources/toonz/icons/dark/actions/15/toggle_camerastand_button_rollover.svg
+++ b/toonz/sources/toonz/icons/dark/actions/15/toggle_camerastand_button_rollover.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="15px"
+   height="15px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg2"
+   sodipodi:docname="toggle_camerastand_button_rollover.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs2" /><sodipodi:namedview
+   id="namedview2"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="59.8"
+   inkscape:cx="7.5083612"
+   inkscape:cy="7.5167224"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg2" />
+    <g
+   transform="matrix(0.833333,0,0,0.833333,0,0)"
+   id="g1">
+        <path
+   d="M18,2C18,0.896 17.104,0 16,0L2,0C0.896,0 0,0.896 0,2L0,16C0,17.104 0.896,18 2,18L16,18C17.104,18 18,17.104 18,16L18,2Z"
+   style="fill:black;fill-opacity:0.2;"
+   id="path1" />
+    </g><g
+   id="g2"
+   transform="matrix(0.95177309,0,0,0.95175892,0.34171765,0.34186007)"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"><path
+     d="m 7.5299272,1.02993 c 3.5870708,0 6.4999978,2.9129272 6.4999978,6.4999971 0,3.5870699 -2.912927,6.4999969 -6.4999978,6.4999969 -3.58707,0 -6.4999972,-2.912927 -6.4999972,-6.4999969 0,-3.5870699 2.9129272,-6.4999971 6.4999972,-6.4999971 z"
+     style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.19786px;stroke-linejoin:round;stroke-miterlimit:2"
+     id="path1-5" /><g
+     transform="translate(-1.47007,-1.470069)"
+     id="g3"
+     style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+        <rect
+   x="5"
+   y="6"
+   width="8"
+   height="6"
+   id="rect2" />
+    </g></g>
+    
+</svg>

--- a/toonz/sources/toonz/layerfooterpanel.cpp
+++ b/toonz/sources/toonz/layerfooterpanel.cpp
@@ -35,6 +35,10 @@ LayerFooterPanel::LayerFooterPanel(XsheetViewer *viewer, QWidget *parent,
   m_toggleColumnParent->setToolTip(tr("Toggle Column Parents"));
   m_toggleColumnParent->setIcon(createQIcon("toggle_col_parent"));
 
+  m_toggleCameraStandButton = new QToolButton(this);
+  m_toggleCameraStandButton->setToolTip(tr("Toggle Camera Stand Buttons"));
+  m_toggleCameraStandButton->setIcon(createQIcon("toggle_camerastand_button"));
+
   m_noteArea = new XsheetGUI::FooterNoteArea(this, m_viewer);
 
   Qt::Orientation ori =
@@ -62,6 +66,8 @@ LayerFooterPanel::LayerFooterPanel(XsheetViewer *viewer, QWidget *parent,
           SLOT(onToggleColumnNumbers()));
   connect(m_toggleColumnParent, SIGNAL(clicked()), this,
           SLOT(onToggleColumnParents()));
+  connect(m_toggleCameraStandButton, SIGNAL(clicked()), this,
+          SLOT(onToggleCameraStandButtons()));
 }
 
 LayerFooterPanel::~LayerFooterPanel() {}
@@ -118,6 +124,13 @@ void LayerFooterPanel::paintEvent(QPaintEvent *event) {
 
   QRect toggleColNumObjRect = o->rect(PredefinedRect::TOGGLE_COLUMN_NUMBER);
   m_toggleColumnNumber->setGeometry(toggleColNumObjRect);
+
+  QRect toggleCamStandButtonRect =
+      o->rect(PredefinedRect::TOGGLE_CAMERASTAND_BUTTON_AREA);
+  p.fillRect(toggleCamStandButtonRect, Qt::NoBrush);
+
+  QRect toggleCamStandButtonObjRect = o->rect(PredefinedRect::TOGGLE_CAMERASTAND_BUTTON);
+  m_toggleCameraStandButton->setGeometry(toggleCamStandButtonObjRect);
 
   static QPixmap zoomIn         = generateIconPixmap("zoom_in");
   static QPixmap zoomInRollover = generateIconPixmap("zoom_in_rollover");
@@ -312,6 +325,16 @@ void LayerFooterPanel::onToggleColumnParents() {
       showColumnParents,
       !Preferences::instance()->isShowColumnParentsEnabled());
   m_viewer->updateColumnArea();
+}
+
+//-----------------------------------------------------------------------------
+
+void LayerFooterPanel::onToggleCameraStandButtons() {
+  Preferences::instance()->setValue(
+      unifyColumnVisibilityToggles,
+      !Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled());
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
+      "unifyColumnVisibilityToggles");
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/layerfooterpanel.h
+++ b/toonz/sources/toonz/layerfooterpanel.h
@@ -25,7 +25,8 @@ class LayerFooterPanel final : public QWidget {
   QPoint m_pos;
 
   QSlider *m_frameZoomSlider;
-  QToolButton *m_toggleColumnNumber, *m_toggleColumnParent;
+  QToolButton *m_toggleColumnNumber, *m_toggleColumnParent,
+      *m_toggleCameraStandButton;
 
   bool isCtrlPressed        = false;
   bool m_zoomInHighlighted  = false;
@@ -67,6 +68,7 @@ public slots:
   void onFramesPerPageSelected();
   void onToggleColumnNumbers();
   void onToggleColumnParents();
+  void onToggleCameraStandButtons();
 };
 #endif
 #pragma once

--- a/toonz/sources/toonz/layerheaderpanel.cpp
+++ b/toonz/sources/toonz/layerheaderpanel.cpp
@@ -54,12 +54,19 @@ LayerHeaderPanel::LayerHeaderPanel(XsheetViewer *viewer, QWidget *parent,
   m_camstandButton->setIcon(createQIcon("table"));
   m_lockButton->setIcon(createQIcon("lock_on"));
 
+  m_camstandButton->setVisible(
+      !Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled());
+
   connect(m_previewButton, &QToolButton::clicked, this,
           &LayerHeaderPanel::onPreviewClicked);
   connect(m_camstandButton, &QToolButton::clicked, this,
           &LayerHeaderPanel::onCamstandClicked);
   connect(m_lockButton, &QToolButton::clicked, this,
           &LayerHeaderPanel::onLockClicked);
+
+  connect(TApp::instance()->getCurrentScene(),
+          SIGNAL(preferenceChanged(const QString &)), this,
+          SLOT(onPreferenceChanged(const QString &)));
 
   // Add widgets to the layout
   layout->addWidget(m_previewButton);
@@ -112,7 +119,12 @@ void LayerHeaderPanel::toggleColumnVisibility(int visibilityFlag) {
 //-----------------------------------------------------------------------------
 
 void LayerHeaderPanel::onPreviewClicked() {
-  toggleColumnVisibility(ToggleAllPreviewVisible);
+  // When unify visibility button is enabled, it follows the camstand status,
+  // not the preview status
+  toggleColumnVisibility(
+      Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled()
+          ? ToggleAllTransparency
+          : ToggleAllPreviewVisible);
 }
 
 void LayerHeaderPanel::onCamstandClicked() {
@@ -121,6 +133,12 @@ void LayerHeaderPanel::onCamstandClicked() {
 
 void LayerHeaderPanel::onLockClicked() {
   toggleColumnVisibility(ToggleAllLock);
+}
+
+void LayerHeaderPanel::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "unifyColumnVisibilityToggles")
+    m_camstandButton->setVisible(
+        !Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/layerheaderpanel.h
+++ b/toonz/sources/toonz/layerheaderpanel.h
@@ -40,6 +40,7 @@ public slots:
   void onPreviewClicked();
   void onCamstandClicked();
   void onLockClicked();
+  void onPreferenceChanged(const QString &prefName);
 };
 
 #endif

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1631,8 +1631,7 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
       {DragCellsBehaviour,
        {{tr("Cells Only"), 0},
         {tr("Cells and Column Data"), 1},
-// Disabled until OT officially releases it
-//        {tr("Disable Dragging Cells"), 2}
+        {tr("Disable Dragging Cells"), 2}
        }},
       {pasteCellsBehavior,
        {{tr("Insert Paste Whole Data"), 0},
@@ -2330,8 +2329,7 @@ QGridLayout* PreferencesPopup::createXsheetLayout() {
   }
   insertUI(showColumnNumbers, lay);
   insertUI(showColumnParents, lay);
-// Disabled until OT officially releases it
-//  insertUI(unifyColumnVisibilityToggles, lay);
+  insertUI(unifyColumnVisibilityToggles, lay);
   insertUI(parentColorsInXsheetColumn, lay);
   insertUI(highlightLineEverySecond, lay);
   if (Preferences::instance()->isShowAdvancedOptionsEnabled()) {

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -407,6 +407,8 @@
 		<file>icons/dark/actions/15/toggle_col_number_rollover.svg</file>
 		<file>icons/dark/actions/15/toggle_col_parent.svg</file>
 		<file>icons/dark/actions/15/toggle_col_parent_rollover.svg</file>
+		<file>icons/dark/actions/15/toggle_camerastand_button.svg</file>
+		<file>icons/dark/actions/15/toggle_camerastand_button_rollover.svg</file>
 
 		<file>icons/dark/actions/30/sound_header.svg</file>
 		<file>icons/dark/actions/30/sound_header_on.svg</file>

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1587,8 +1587,7 @@ void CellArea::drawExtenderHandles(QPainter &p) {
   if (cellSelection->isEmpty() || m_viewer->areSoundCellsSelected()) return;
 
   // if the drag move is disabled, the extender handles won't appear
-// Disabled until OT officially releases it
-//  if (Preferences::instance()->getDragCellsBehaviour() == 2) return;
+  if (Preferences::instance()->getDragCellsBehaviour() == 2) return;
 
   int selRow0, selCol0, selRow1, selCol1;
   cellSelection->getSelectedCells(selRow0, selCol0, selRow1, selCol1);
@@ -4259,7 +4258,7 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
         if (TCellKeyframeSelection *cellKeyframeSelection =
                 dynamic_cast<TCellKeyframeSelection *>(selection))
           setDragTool(XsheetGUI::DragTool::makeCellKeyframeMoverTool(m_viewer));
-        else //if (Preferences::instance()->getDragCellsBehaviour() != 2)    //Disabled until OT officially releases iteleas
+        else if (Preferences::instance()->getDragCellsBehaviour() != 2)
           setDragTool(XsheetGUI::DragTool::makeLevelMoverTool(m_viewer));
       } else {
         m_viewer->getKeyframeSelection()->selectNone();

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -956,18 +956,18 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
   QRect rect = o->rect((col < 0) ? PredefinedRect::CAMERA_LAYER_HEADER
                                  : PredefinedRect::LAYER_HEADER)
                    .translated(orig);
-  if (!o->isVerticalTimeline())
-    rect.adjust(isEmpty ? 0 : 73, 0, m_viewer->getTimelineBodyOffset() - 1, 0);
-  else
+  if (!o->isVerticalTimeline()) {
+    int shiftLeft = 0;
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    rect.adjust((isEmpty ? 0 : 80) - shiftLeft, 0,
+                m_viewer->getTimelineBodyOffset() - 1, 0);
+  } else
     rect.adjust(0, 0, 0, m_viewer->getXsheetBodyOffset());
   // Adjust for folder indicator
   QRect indicatorRect = o->rect(PredefinedRect::FOLDER_INDICATOR_AREA);
   int folderDepth     = 0;
-  if (column && column->folderDepth() && !o->isVerticalTimeline()) {
-    folderDepth = column->folderDepth();
-    rect.adjust(indicatorRect.width() * folderDepth, 0, 0, 0);
-  } else if (col >= 0 && o->isVerticalTimeline() &&
-             (!column || column->isEmpty()))
+  if (col >= 0 && o->isVerticalTimeline() && (!column || column->isEmpty()))
     rect.adjust(0, 0, 0, m_viewer->getXsheetBodyOffset());
 
   int x0 = rect.left();
@@ -988,8 +988,12 @@ void ColumnArea::DrawHeader::drawBaseFill(const QColor &columnColor,
         o->flag(PredefinedFlag::DRAG_LAYER_VISIBLE)) {
       // column handle
       QRect sideBar =
-          o->rect(PredefinedRect::DRAG_LAYER).translated(x0 - 73, y0);
+          o->rect(PredefinedRect::DRAG_LAYER).translated(x0 - 80, y0);
       if (!o->isVerticalTimeline()) {
+        if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled()) {
+          int shiftRight = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+          sideBar.adjust(0, 0, shiftRight, 0);
+        }
         if (Preferences::instance()->isShowColumnNumbersEnabled()) {
           int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
           sideBar.adjust(shiftRight, 0, 0, 0);
@@ -1185,8 +1189,7 @@ void ColumnArea::DrawHeader::drawUnifiedViewToggle(int opacity) const {
   else
     p.setPen(m_viewer->getTimelineIconLineColor());  // border color
 
-  if (col < 0 || column->getPaletteColumn() || column->getSoundTextColumn() ||
-      column->getPegbarColumn()) {
+  if (col < 0 || column->getSoundTextColumn() || column->getPegbarColumn()) {
     if (o->flag(PredefinedFlag::PREVIEW_LAYER_AREA_BORDER))
       p.drawRect(unifiedViewRect);
     return;
@@ -1229,6 +1232,14 @@ void ColumnArea::DrawHeader::drawLock() const {
                         m_viewer->getXsheetBodyOffset());
     lockModeImgRect.adjust(0, m_viewer->getXsheetBodyOffset(), 0,
                            m_viewer->getXsheetBodyOffset());
+  }
+
+  if (!o->isVerticalTimeline()) {
+    int shiftLeft = 0;
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    lockModeRect.adjust(-shiftLeft, 0, -shiftLeft, 0);
+    lockModeImgRect.adjust(-shiftLeft, 0, -shiftLeft, 0);
   }
 
   if (o->isVerticalTimeline() &&
@@ -1285,6 +1296,15 @@ void ColumnArea::DrawHeader::drawConfig() const {
     configImgRect.adjust(0, m_viewer->getXsheetBodyOffset(), 0,
                          m_viewer->getXsheetBodyOffset());
   }
+
+  if (!o->isVerticalTimeline()) {
+    int shiftLeft = 0;
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    configRect.adjust(-shiftLeft, 0, -shiftLeft, 0);
+    configImgRect.adjust(-shiftLeft, 0, -shiftLeft, 0);
+  }
+
   // config button
   if (o->isVerticalTimeline())
     p.setPen(m_viewer->getColumnIconLineColor());
@@ -1315,7 +1335,10 @@ void ColumnArea::DrawHeader::drawFolderIndicator() const {
 
   if (indicatorRect.isEmpty()) return;
 
+  int shiftLeft  = 0;
   int shiftRight = 0;
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
   if (Preferences::instance()->isShowColumnNumbersEnabled())
     shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
 
@@ -1325,9 +1348,9 @@ void ColumnArea::DrawHeader::drawFolderIndicator() const {
       indicatorRectAdj = indicatorRect.adjusted(0, indicatorRect.height() * i,
                                                 0, indicatorRect.height() * i);
     else
-      indicatorRectAdj =
-          indicatorRect.adjusted(shiftRight + (indicatorRect.width() * i), 0,
-                                 shiftRight + (indicatorRect.width() * i), 0);
+      indicatorRectAdj = indicatorRect.adjusted(
+          shiftRight - shiftLeft + (indicatorRect.width() * i), 0,
+          shiftRight - shiftLeft + (indicatorRect.width() * i), 0);
     p.setPen(Qt::NoPen);
     p.setBrush(m_viewer->getFolderColumnColor());
     p.drawRect(indicatorRectAdj);
@@ -1352,6 +1375,14 @@ void ColumnArea::DrawHeader::drawColumnNumber() const {
     return;
 
   QRect pos = o->rect(PredefinedRect::LAYER_NUMBER).translated(orig);
+
+  int shiftLeft = 0;
+  if (!o->isVerticalTimeline()) {
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+
+    pos.adjust(-shiftLeft, 0, -shiftLeft, 0);
+  }
 
   // Adjust for folder indicator
   QRect indicatorRect = o->rect(PredefinedRect::FOLDER_INDICATOR_AREA);
@@ -1406,11 +1437,16 @@ void ColumnArea::DrawHeader::drawColumnName() const {
   QRect columnName = o->rect((col < 0) ? PredefinedRect::CAMERA_LAYER_NAME
                                        : PredefinedRect::LAYER_NAME)
                          .translated(orig);
+  int shiftLeft  = 0;
+  int shiftRight = 0;
   if (!o->isVerticalTimeline()) {
-    if (Preferences::instance()->isShowColumnNumbersEnabled()) {
-      int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-      columnName.adjust(shiftRight, 0, shiftRight, 0);
-    }
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    if (Preferences::instance()->isShowColumnNumbersEnabled())
+      shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
+
+    columnName.adjust(shiftRight - shiftLeft, 0, shiftRight, 0);
+
     columnName.adjust(0, 0, m_viewer->getTimelineBodyOffset(), 0);
   }
 
@@ -1517,10 +1553,14 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
     thumbnailRect.adjust(0, m_viewer->getXsheetBodyOffset(), 0,
                          m_viewer->getXsheetBodyOffset());
 
-  if (!o->isVerticalTimeline() &&
-      Preferences::instance()->isShowColumnNumbersEnabled()) {
-    int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-    thumbnailRect.adjust(shiftRight, 0, shiftRight, 0);
+  int shiftLeft  = 0;
+  int shiftRight = 0;
+  if (!o->isVerticalTimeline()) {
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    if (Preferences::instance()->isShowColumnNumbersEnabled())
+      shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
+    thumbnailRect.adjust(shiftRight - shiftLeft, 0, shiftRight - shiftLeft, 0);
   }
 
   // Adjust for folder indicator
@@ -1565,16 +1605,15 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
     thumbnailImageRect.adjust(0, m_viewer->getXsheetBodyOffset(), 0,
                               m_viewer->getXsheetBodyOffset());
 
-  if (!o->isVerticalTimeline() &&
-           Preferences::instance()->isShowColumnNumbersEnabled()) {
-    int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-    thumbnailImageRect.adjust(shiftRight, 0, shiftRight, 0);
-  }
-
-  // Adjust for folder indicator
-  if (column && column->folderDepth() && !o->isVerticalTimeline()) {
-    thumbnailImageRect.adjust(indicatorRect.width() * column->folderDepth(), 0,
-                              indicatorRect.width() * column->folderDepth(), 0);
+  if (!o->isVerticalTimeline()) {
+    thumbnailImageRect.adjust(shiftRight - shiftLeft, 0, shiftRight - shiftLeft,
+                              0);
+    // Adjust for folder indicator
+    if (column && column->folderDepth()) {
+      thumbnailImageRect.adjust(
+          indicatorRect.width() * column->folderDepth(), 0,
+          indicatorRect.width() * column->folderDepth(), 0);
+    }
   }
 
   // palette thumbnail
@@ -1785,10 +1824,16 @@ void ColumnArea::DrawHeader::drawFilterColor() const {
     filterColorRect.adjust(0, m_viewer->getXsheetBodyOffset(), 0,
                            m_viewer->getXsheetBodyOffset());
   } else {
-    if (Preferences::instance()->isShowColumnNumbersEnabled()) {
-      int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-      filterColorRect.adjust(shiftRight, 0, shiftRight, 0);
-    }
+    int shiftLeft  = 0;
+    int shiftRight = 0;
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    if (Preferences::instance()->isShowColumnNumbersEnabled())
+      shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
+
+    filterColorRect.adjust(shiftRight - shiftLeft, 0, shiftRight - shiftLeft,
+                           0);
+
     if (column && column->folderDepth()) {
       filterColorRect.adjust(indicatorRect.width() * column->folderDepth(), 0,
                              indicatorRect.width() * column->folderDepth(), 0);
@@ -1860,10 +1905,15 @@ void ColumnArea::DrawHeader::drawSoundIcon(bool isPlaying) const {
     rect.adjust(0, m_viewer->getXsheetBodyOffset(), 0,
                 m_viewer->getXsheetBodyOffset());
   } else {
-    if (Preferences::instance()->isShowColumnNumbersEnabled()) {
-      int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-      rect.adjust(shiftRight, 0, shiftRight, 0);
-    }
+    int shiftLeft  = 0;
+    int shiftRight = 0;
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    if (Preferences::instance()->isShowColumnNumbersEnabled())
+      shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
+
+    rect.adjust(shiftRight - shiftLeft, 0, shiftRight - shiftLeft, 0);
+
     if (column && column->folderDepth()) {
       rect.adjust(indicatorRect.width() * column->folderDepth(), 0,
                   indicatorRect.width() * column->folderDepth(), 0);
@@ -1970,10 +2020,15 @@ void ColumnArea::DrawHeader::drawFolderStatusIcon(bool isOpen) const {
     rect.adjust(0, m_viewer->getXsheetBodyOffset(), 0,
                 m_viewer->getXsheetBodyOffset());
   } else {
-    if (Preferences::instance()->isShowColumnNumbersEnabled()) {
-      int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-      rect.adjust(shiftRight, 0, shiftRight, 0);
-    }
+    int shiftLeft  = 0;
+    int shiftRight = 0;
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    if (Preferences::instance()->isShowColumnNumbersEnabled())
+      shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
+
+    rect.adjust(shiftRight - shiftLeft, 0, shiftRight - shiftLeft, 0);
+
     if (column && column->folderDepth()) {
       rect.adjust(indicatorRect.width() * column->folderDepth(), 0,
                   indicatorRect.width() * column->folderDepth(), 0);
@@ -2041,6 +2096,11 @@ ColumnArea::ColumnArea(XsheetViewer *parent, Qt::WindowFlags flags)
           SLOT(onSubSampling(QAction *)));
   connect(xsheetHandle, SIGNAL(xsheetCameraChange(int)), this,
           SLOT(onXsheetCameraChange(int)));
+
+  connect(TApp::instance()->getCurrentScene(),
+          SIGNAL(preferenceChanged(const QString &)), this,
+          SLOT(onPreferenceChanged(const QString &)));
+
   setMouseTracking(true);
 }
 
@@ -2246,8 +2306,12 @@ void ColumnArea::drawPegbarColumnHead(QPainter &p, int col) {  // AREA
   QColor columnColor, dragColor;
   drawHeader.levelColors(columnColor, dragColor);
   drawHeader.drawBaseFill(columnColor, dragColor);
-  drawHeader.drawEye();
-  drawHeader.drawPreviewToggle(255);
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    drawHeader.drawUnifiedViewToggle(0);
+  else {
+    drawHeader.drawEye();
+    drawHeader.drawPreviewToggle(0);
+  }
   drawHeader.drawLock();
   drawHeader.drawConfig();
   drawHeader.drawFolderIndicator();
@@ -2272,15 +2336,20 @@ void ColumnArea::drawCurrentColumnFocus(QPainter &p, int col) {
                                  : PredefinedRect::LAYER_NAME)
                    .translated(orig);
   if (!o->isVerticalTimeline()) {
-    if (Preferences::instance()->isShowColumnNumbersEnabled()) {
-      int shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-      rect.adjust(shiftRight, 0, 0, 0);
-    }
+    int shiftLeft  = 0;
+    int shiftRight = 0;
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+    if (Preferences::instance()->isShowColumnNumbersEnabled())
+      shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
+
+    rect.adjust(shiftRight - shiftLeft, 0, 0, 0);
+
     if (Preferences::instance()->isShowColumnParentsEnabled() && column &&
         !column->isEmpty() && !column->getSoundColumn() &&
         !column->getSoundTextColumn() && !column->getFolderColumn()) {
-      int shiftLeft = o->rect(PredefinedRect::PEGBAR_NAME).width();
-      rect.adjust(0, 0, -shiftLeft, 0);
+      int shiftEnd = o->rect(PredefinedRect::PEGBAR_NAME).width();
+      rect.adjust(0, 0, -shiftEnd, 0);
     }
 
     rect.adjust(0, 0, m_viewer->getTimelineBodyOffset(), 0);
@@ -2323,8 +2392,13 @@ void ColumnArea::drawSoundColumnHead(QPainter &p, int col) {  // AREA
   //  drawHeader.soundColors(columnColor, dragColor);
   drawHeader.levelColors(columnColor, dragColor);
   drawHeader.drawBaseFill(columnColor, dragColor);
-  drawHeader.drawEye();
-  drawHeader.drawPreviewToggle(sc ? (troundp(255.0 * sc->getVolume())) : 0);
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    drawHeader.drawUnifiedViewToggle(sc ? (troundp(255.0 * sc->getVolume()))
+                                        : 255);
+  else {
+    drawHeader.drawEye();
+    drawHeader.drawPreviewToggle(sc ? (troundp(255.0 * sc->getVolume())) : 255);
+  }
   drawHeader.drawLock();
   drawHeader.drawConfig();
   drawHeader.drawFolderIndicator();
@@ -2347,8 +2421,12 @@ void ColumnArea::drawPaletteColumnHead(QPainter &p, int col) {  // AREA
   QColor columnColor, dragColor;
   drawHeader.paletteColors(columnColor, dragColor);
   drawHeader.drawBaseFill(columnColor, dragColor);
-  drawHeader.drawEye();
-  drawHeader.drawPreviewToggle(0);
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    drawHeader.drawUnifiedViewToggle(255);
+  else {
+    drawHeader.drawEye();
+    drawHeader.drawPreviewToggle(255);
+  }
   drawHeader.drawLock();
   drawHeader.drawConfig();
   drawHeader.drawFolderIndicator();
@@ -2404,8 +2482,12 @@ void ColumnArea::drawSoundTextColumnHead(QPainter &p, int col) {  // AREA
   QColor columnColor, dragColor;
   drawHeader.paletteColors(columnColor, dragColor);
   drawHeader.drawBaseFill(columnColor, dragColor);
-  drawHeader.drawEye();
-  drawHeader.drawPreviewToggle(255);
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    drawHeader.drawUnifiedViewToggle(0);
+  else {
+    drawHeader.drawEye();
+    drawHeader.drawPreviewToggle(0);
+  }
   drawHeader.drawLock();
   drawHeader.drawConfig();
   drawHeader.drawFolderIndicator();
@@ -3130,6 +3212,38 @@ void ColumnArea::autoOpenCloseFolder() {
   m_doOnRelease = 0;
 }
 
+void ColumnArea::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "unifyColumnVisibilityToggles") {
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled()) {
+      // We need to sync Preview with CamStand
+      bool isSoundColumn = false;
+      TXsheet *xsh       = m_viewer->getXsheet();
+      for (int col = 0; col < xsh->getColumnCount(); col++) {
+        if (xsh->isColumnEmpty(col)) continue;
+        TXshColumn *column = xsh->getColumn(col);
+        if (!column || column->getPegbarColumn() ||
+            column->getSoundTextColumn() || column->getPaletteColumn())
+          continue;
+
+        // Both on/off, don't do anything
+        if (column->isPreviewVisible() == column->isCamstandVisible()) continue;
+
+        column->setPreviewVisible(column->isCamstandVisible());
+        if (column->getSoundColumn()) isSoundColumn = true;
+      }
+
+      TApplication *app = TApp::instance();
+
+      if (isSoundColumn) app->getCurrentXsheet()->notifyXsheetSoundChanged();
+
+      app->getCurrentScene()->notifySceneChanged();
+      app->getCurrentXsheet()->notifyXsheetChanged();
+    }
+
+    update();
+  }
+}
+
 //----------------------------------------------------------------
 
 void ColumnArea::onXsheetCameraChange(int newIndex) {
@@ -3228,13 +3342,25 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
 
     bool hasDragBar = Preferences::instance()->isShowDragBarsEnabled();
 
+    int shiftLeft  = 0;
+    int shiftRight = 0;
+    if (!o->isVerticalTimeline()) {
+      if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+        shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+      if (Preferences::instance()->isShowColumnNumbersEnabled())
+        shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
+    }
+
     // clicking on the camera column
     if (m_col < 0) {
-      if (o->rect(PredefinedRect::CAMERA_LOCK_AREA).contains(mouseInCell)) {
+      if (o->rect(PredefinedRect::CAMERA_LOCK_AREA)
+              .adjusted(-shiftLeft, 0, -shiftLeft, 0)
+              .contains(mouseInCell)) {
         // lock button
         if (event->button() != Qt::LeftButton) return;
         m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
       } else if (o->rect(PredefinedRect::CAMERA_CONFIG_AREA)
+                     .adjusted(-shiftLeft, 0, -shiftLeft, 0)
                      .contains(mouseInCell)) {
         // config button
         if (event->button() != Qt::LeftButton) return;
@@ -3251,17 +3377,6 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     }
     // clicking on the normal columns
     else if (!isEmpty) {
-      int shiftRight = 0;
-      int shiftLeft  = 0;
-      if (!o->isVerticalTimeline()) {
-        if (Preferences::instance()->isShowColumnNumbersEnabled())
-          shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
-        if (Preferences::instance()->isShowColumnParentsEnabled() && column &&
-            !column->isEmpty() && !column->getSoundColumn() &&
-            !column->getSoundTextColumn() && !column->getFolderColumn())
-          shiftLeft = o->rect(PredefinedRect::PEGBAR_NAME).width();
-      }
-
       int xsheetBodyOffset =
           o->isVerticalTimeline() ? m_viewer->getXsheetBodyOffset() : 0;
       int timelineBodyOffset =
@@ -3278,7 +3393,8 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
       }
 
       if (o->rect(PredefinedRect::LOCK_AREA)
-              .adjusted(0, xsheetBodyOffset, 0, xsheetBodyOffset)
+              .adjusted(-shiftLeft, xsheetBodyOffset, -shiftLeft,
+                        xsheetBodyOffset)
               .contains(mouseInCell)) {
         // lock button
         if (event->button() != Qt::LeftButton) return;
@@ -3333,7 +3449,8 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
             startTransparencyPopupTimer(event);
         }
       } else if (o->rect(PredefinedRect::CONFIG_AREA)
-                     .adjusted(0, xsheetBodyOffset, 0, xsheetBodyOffset)
+                     .adjusted(-shiftLeft, xsheetBodyOffset, -shiftLeft,
+                               xsheetBodyOffset)
                      .contains(mouseInCell)) {
         // config button
         if (event->button() != Qt::LeftButton) return;
@@ -3351,8 +3468,9 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
           // sound column
           if (column->getSoundColumn()) {
             if (o->rect(PredefinedRect::SOUND_ICON)
-                    .adjusted(shiftRight + indicatorXAdj, xsheetBodyOffset,
-                              shiftRight + indicatorXAdj,
+                    .adjusted(shiftRight - shiftLeft + indicatorXAdj,
+                              xsheetBodyOffset,
+                              shiftRight - shiftLeft + indicatorXAdj,
                               xsheetBodyOffset)
                     .contains(mouseInCell)) {
               TXshSoundColumn *s = column->getSoundColumn();
@@ -3381,7 +3499,8 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
               return;
             } else if (!o->flag(PredefinedFlag::CONFIG_AREA_VISIBLE) &&
                        o->rect(PredefinedRect::VOLUME_AREA)
-                           .adjusted(shiftRight, xsheetBodyOffset, shiftRight,
+                           .adjusted(shiftRight - shiftLeft, xsheetBodyOffset,
+                                     shiftRight - shiftLeft,
                                      xsheetBodyOffset)
                            .contains(mouseInCell)) {
               setDragTool(XsheetGUI::DragTool::makeVolumeDragTool(m_viewer));
@@ -3390,8 +3509,9 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
           } else if (column->getFolderColumn()) {
             if (event->button() == Qt::LeftButton) {
               if (o->rect(PredefinedRect::FOLDER_TOGGLE_ICON)
-                      .adjusted(shiftRight + indicatorXAdj, xsheetBodyOffset,
-                                shiftRight + indicatorXAdj,
+                      .adjusted(shiftRight - shiftLeft + indicatorXAdj,
+                                xsheetBodyOffset,
+                                shiftRight - shiftLeft + indicatorXAdj,
                                 xsheetBodyOffset)
                       .contains(mouseInCell)) {
                 toggleFolderStatus(column);
@@ -3474,7 +3594,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
 
         bool isInDragArea =
             o->rect(PredefinedRect::DRAG_LAYER)
-                .adjusted(0, indicatorYAdj,
+                .adjusted(-shiftLeft, indicatorYAdj,
                           (!o->isVerticalTimeline()
                                ? m_viewer->getTimelineBodyOffset()
                                : 0),
@@ -3484,10 +3604,11 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
                                                            // layer name/number
                                                            // becomes dragbar
              && (o->rect(PredefinedRect::LAYER_NUMBER)
-                     .adjusted(0, indicatorYAdj, 0, indicatorYAdj)
+                     .adjusted(-shiftLeft, indicatorYAdj, -shiftLeft,
+                               indicatorYAdj)
                      .contains(mouseInCell) ||
                  o->rect(PredefinedRect::LAYER_NAME)
-                     .adjusted(0, indicatorYAdj, 0, indicatorYAdj)
+                     .adjusted(-shiftLeft, indicatorYAdj, 0, indicatorYAdj)
                      .contains(mouseInCell)));
 
         // When no drag bars..
@@ -3960,18 +4081,21 @@ void ColumnArea::mouseDoubleClickEvent(QMouseEvent *event) {
   QRect nameRect = o->rect((col < 0) ? PredefinedRect::CAMERA_LAYER_NAME
                                      : PredefinedRect::LAYER_NAME);
 
-  int shiftRight = 0;
   int shiftLeft  = 0;
+  int shiftRight = 0;
+  int shiftEnd   = 0;
   if (!o->isVerticalTimeline()) {
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
     if (Preferences::instance()->isShowColumnNumbersEnabled())
       shiftRight = o->rect(PredefinedRect::LAYER_NUMBER).width();
     if (Preferences::instance()->isShowColumnParentsEnabled() && column &&
         !column->isEmpty() && !column->getSoundColumn() &&
         !column->getSoundTextColumn() && !column->getFolderColumn())
-      shiftLeft = o->rect(PredefinedRect::PEGBAR_NAME).width();
+      shiftEnd = o->rect(PredefinedRect::PEGBAR_NAME).width();
 
-    nameRect.adjust(shiftRight, 0,
-                    m_viewer->getTimelineBodyOffset() - shiftLeft, 0);
+    nameRect.adjust(shiftRight, 0, m_viewer->getTimelineBodyOffset() - shiftEnd,
+                    0);
   }
 
   // Adjust for folder indicator
@@ -3994,8 +4118,8 @@ void ColumnArea::mouseDoubleClickEvent(QMouseEvent *event) {
   QRect renameRect =
       o->rect(PredefinedRect::RENAME_COLUMN).translated(fieldPos);
   if (!o->isVerticalTimeline())
-    renameRect.adjust(shiftRight, 0,
-                      m_viewer->getTimelineBodyOffset() - shiftLeft, 0);
+    renameRect.adjust(shiftRight - shiftLeft, 0,
+                      m_viewer->getTimelineBodyOffset() - shiftEnd, 0);
 
   if (column && column->folderDepth()) {
     if (!o->isVerticalTimeline())
@@ -4042,6 +4166,11 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
   connect(&menu, SIGNAL(aboutToHide()), this, SLOT(onMenuAboutToHide()));
 
   CommandManager *cmdManager = CommandManager::instance();
+
+  int shiftLeft = 0;
+  if (!o->isVerticalTimeline() &&
+      Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
 
   int xsheetBodyOffset = o->isVerticalTimeline() && !isCamera
                              ? m_viewer->getXsheetBodyOffset()
@@ -4112,7 +4241,8 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
   else if ((isCamera || !xsh->isColumnEmpty(m_menuCol)) &&
            o->rect((isCamera) ? PredefinedRect::CAMERA_LOCK_AREA
                               : PredefinedRect::LOCK_AREA)
-               .adjusted(0, xsheetBodyOffset, 0, xsheetBodyOffset)
+               .adjusted(-shiftLeft, xsheetBodyOffset, -shiftLeft,
+                         xsheetBodyOffset)
                .contains(mouseInCell)) {
     menu.setObjectName("xsheetColumnAreaMenu_Lock");
 

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -437,6 +437,7 @@ protected slots:
   void onMenuAboutToHide();
   void onResetContextMenuTarget();
   void autoOpenCloseFolder();
+  void onPreferenceChanged(const QString &prefName);
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -2254,8 +2254,12 @@ public:
         o->rect(PredefinedRect::FOLDER_INDICATOR_AREA).translated(orig);
     if (o->isVerticalTimeline())
       rect.adjust(0, indicatorRect.height() * columnDepth, 0, 0);
-    else
-      rect.adjust(indicatorRect.width() * columnDepth, 0, 0, 0);
+    else {
+      int shiftLeft = 0;
+      if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+        shiftLeft = o->rect(PredefinedRect::PREVIEW_LAYER_AREA).width();
+      rect.adjust((indicatorRect.width() * columnDepth) - shiftLeft, 0, 0, 0);
+    }
 
     p.setPen(QColor(190, 220, 255));
     p.setBrush(Qt::NoBrush);

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -1017,9 +1017,11 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::TOGGLE_COLUMN_NUMBER,
             toggleColNum.adjusted(0, 1, 0, 0));
 
-
   addRect(PredefinedRect::TOGGLE_COLUMN_PARENT_AREA, QRect(0, 0, -1, -1));
   addRect(PredefinedRect::TOGGLE_COLUMN_PARENT, QRect(0, 0, -1, -1));
+
+  addRect(PredefinedRect::TOGGLE_CAMERASTAND_BUTTON_AREA, QRect(0, 0, -1, -1));
+  addRect(PredefinedRect::TOGGLE_CAMERASTAND_BUTTON, QRect(0, 0, -1, -1));
 
   zoomSlider = QRect(0, toggleColNum.bottom() + 17, LAYER_FOOTER_PANEL_WIDTH,
                      use_header_height - 51);
@@ -1541,7 +1543,8 @@ LeftToRightOrientation::LeftToRightOrientation(QString layout) {
       QRect(0, 0, LAYER_HEADER_WIDTH + 2, LAYER_FOOTER_PANEL_HEIGHT));
   addRect(PredefinedRect::LAYER_FOOTER_PANEL, layerFooterPanel);
 
-  QRect toggleColNum, toggleColParent, zoomSlider, zoomIn, zoomOut, noteArea;  // addLevel,
+  QRect toggleColNum, toggleColParent, toggleCamStandButton, zoomSlider, zoomIn,
+      zoomOut, noteArea;  // addLevel,
 
   zoomSlider =
       QRect(layerFooterPanel.width() - 100, 0, 81, LAYER_FOOTER_PANEL_HEIGHT);
@@ -1575,6 +1578,13 @@ LeftToRightOrientation::LeftToRightOrientation(QString layout) {
   addRect(PredefinedRect::TOGGLE_COLUMN_NUMBER_AREA, toggleColNum);
   addRect(PredefinedRect::TOGGLE_COLUMN_NUMBER,
           toggleColNum.adjusted(1, 1, 0, 0));
+
+  toggleCamStandButton =
+      QRect(toggleColNum.left() - 20, 0, LAYER_FOOTER_PANEL_HEIGHT,
+            LAYER_FOOTER_PANEL_HEIGHT);
+  addRect(PredefinedRect::TOGGLE_CAMERASTAND_BUTTON_AREA, toggleCamStandButton);
+  addRect(PredefinedRect::TOGGLE_CAMERASTAND_BUTTON,
+          toggleCamStandButton.adjusted(1, 1, 0, 0));
 
   // Flags
   addFlag(PredefinedFlag::DRAG_LAYER_BORDER, false);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -608,7 +608,7 @@ void Preferences::definePreferenceItems() {
   define(showColumnNumbers, "showColumnNumbers", QMetaType::Bool, false);
   define(showColumnParents, "showColumnParents", QMetaType::Bool, false);
   define(unifyColumnVisibilityToggles, "unifyColumnVisibilityToggles",
-         QMetaType::Bool, false);
+         QMetaType::Bool, true);
   define(parentColorsInXsheetColumn, "parentColorsInXsheetColumn",
          QMetaType::Bool, true);
   define(highlightLineEverySecond, "highlightLineEverySecond", QMetaType::Bool,


### PR DESCRIPTION
With OT publishing 1.8 RC, their official release is right around the corner.  I can now safely enable some OT ports that I had done almost 1.5 years ago for T2D v1.5 but disabled due to OT's delayed release.

opentoonz/opentoonz/#4843 - Unify preview and camstand visibility toggles option by Contrail Co., Ltd.  by @shun-iwasawa[^1]
opentoonz/opentoonz/#4874 - Disable drag-moving cells option by Contrail Co.,Ltd. by @shun-iwasawa

I've further fixed the Preview/Camera Stand Visibility toggles implementation as follows:
- Unified toggle is now defaulted `On` in keeping with most other software only having 1 visibility toggle.
- A new button at the bottom of the Timeline layer panel can be used to toggle the Unified toggle mode on/off as desired.
- Modified the Timeline so that all layer information is shifted left when toggle buttons are unified
- Fixed Xsheet columns where unused preview/camera stand buttons were not being combined for a more uniformed look.

[^1]: Modified some commits for T2D changes
