### PR TITLE
Fix delete Fx key crash

### DIFF
--- a/toonz/sources/toonzlib/stageobjectutil.cpp
+++ b/toonz/sources/toonzlib/stageobjectutil.cpp
@@ -426,7 +426,7 @@ void UndoChannelDelete::undo() const {
     TStageObjectId objId   = m_objectHandle->getObjectId();
     TStageObject *stageObj = m_xsheetHandle->getXsheet()->getStageObject(objId);
     int frame              = m_frameHandle->getFrameIndex();
-    stageObj->setCenterAndOffset(m_center, m_offset);
+    if (stageObj) stageObj->setCenterAndOffset(m_center, m_offset);
   }
 
   m_objectHandle->notifyObjectIdChanged(false);
@@ -443,9 +443,11 @@ void UndoChannelDelete::redo() const {
   TStageObject *stageObj = m_xsheetHandle->getXsheet()->getStageObject(objId);
   int frame              = m_frameHandle->getFrameIndex();
 
-  stageObj->getParam(m_actionId)->deleteKeyframe(frame);
-  if (m_center != TPointD() && !stageObj->isKeyframe(frame))
-    stageObj->setCenter(frame, m_center, true);
+  if (stageObj) {
+    stageObj->getParam(m_actionId)->deleteKeyframe(frame);
+    if (m_center != TPointD() && !stageObj->isKeyframe(frame))
+      stageObj->setCenter(frame, m_center, true);
+  }
 
   m_xsheetHandle->notifyXsheetChanged();
   m_objectHandle->notifyObjectIdChanged(false);

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -158,8 +158,9 @@ public:
            it != keyframes.end(); ++it) {
         m_columns[col].m_keyframes[*it] = param->getKeyframe(*it);
         TStageObject *stgObj            = m_sheet->getStageObject(col);
-        stgObj->getCenterAndOffset(m_columns[col].m_center,
-                                   m_columns[col].m_offset);
+        if (stgObj)
+          stgObj->getCenterAndOffset(m_columns[col].m_center,
+                                     m_columns[col].m_offset);
       }
     }
   }
@@ -180,7 +181,7 @@ public:
         m_columns[col].m_param->setKeyframe(it->second);
         double frame = it->second.m_frame;
         TStageObject *stgObj = m_sheet->getStageObject(col);
-        if (m_columns[col].m_center != TPointD())
+        if (stgObj && m_columns[col].m_center != TPointD())
           stgObj->setCenterAndOffset(m_columns[col].m_center,
                                      m_columns[col].m_offset);
       }
@@ -195,7 +196,8 @@ public:
         double frame = it->second.m_frame;
         m_columns[col].m_param->deleteKeyframe(frame);
         TStageObject *stgObj = m_sheet->getStageObject(col);
-        if (m_columns[col].m_center != TPointD() && !stgObj->isKeyframe(frame))
+        if (stgObj && m_columns[col].m_center != TPointD() &&
+            !stgObj->isKeyframe(frame))
           stgObj->setCenter(frame, m_columns[col].m_center, true);
       }
     }


### PR DESCRIPTION
This fixes #2214 a crash that happens when deleting an Fx Key from the function editor as it tries to fix the center offset which doesn't apply to fx keys.

Crash is caused by changes related to #2132 