### PR TITLE
Fixes due to Drawing Mark changes

### DIFF
--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -2915,7 +2915,7 @@ public:
 
 void FilmstripCmd::setDrawingMark(TXshSimpleLevel *sl,
                                   std::set<TFrameId> &frames, int markId) {
-  if (!sl || sl->isSubsequence() || sl->isReadOnly() || !frames.size()) return;
+  if (!sl || sl->isSubsequence() || !frames.size()) return;
 
   SetDrawingMarkUndo *undo = new SetDrawingMarkUndo(sl, frames, markId);
   undo->redo();

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3478,6 +3478,12 @@ void MainWindow::defineActions() {
   createSpecialModifierAction(V_Scrub, QT_TR_NOOP("Viewer Scrub"), "#");
 
   // create drawing mark actions
+  std::string cmdId    = (std::string)MI_SetDrawingMark + "None";
+  std::string labelStr = QT_TR_NOOP("Remove Drawing Mark");
+  QAction *action      = createAction(cmdId.c_str(), labelStr.c_str(), "", "",
+                                      DrawingMarkCommandType);
+  action->setData(-1);
+
   for (int markId = 0; markId < 12; markId++) {
     std::string cmdId = (std::string)MI_SetDrawingMark + std::to_string(markId);
     std::string labelStr =
@@ -3488,6 +3494,11 @@ void MainWindow::defineActions() {
   }
 
   // create cell mark actions
+  cmdId    = (std::string)MI_SetCellMark + "None";
+  labelStr = QT_TR_NOOP("Remove Cell Mark");
+  action   = createAction(cmdId.c_str(), labelStr.c_str(), "", "",
+                          CellMarkCommandType);
+  action->setData(-1);
   for (int markId = 0; markId < 12; markId++) {
     std::string cmdId = (std::string)MI_SetCellMark + std::to_string(markId);
     std::string labelStr =

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2424,10 +2424,8 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     bool isStart = row == 0 || prevCell.isEmpty() || prevIsImplicit ||
                    prevCell.m_level.getPointer() != cell.m_level.getPointer() ||
                    prevCell.getFrameId() != cell.getFrameId();
-    bool isLastRow =
-        nextCell.isEmpty() || isImplicitCellNext ||
-        cell.m_level.getPointer() != nextCell.m_level.getPointer() ||
-        cell.getFrameId() != nextCell.getFrameId();
+  bool isLastRow = nextCell.isEmpty() || isImplicitCellNext ||
+                   cell.m_level.getPointer() != nextCell.m_level.getPointer();
 
     if (cell.m_level && cell.m_level->getSimpleLevel() &&
         !cell.getFrameId().isStopFrame() && isStart) {

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2775,8 +2775,9 @@ class SetDrawingMarkCommand final : public MenuItemHandler {
 
 public:
   SetDrawingMarkCommand(int markId)
-      : MenuItemHandler(
-            ((std::string)MI_SetDrawingMark + std::to_string(markId)).c_str())
+      : MenuItemHandler(((std::string)MI_SetDrawingMark +
+                         (markId < 0 ? "None" : std::to_string(markId)))
+                            .c_str())
       , m_markId(markId) {}
 
   void execute() override {
@@ -2824,6 +2825,7 @@ public:
     TUndoManager::manager()->add(undo);
   }
 };
+SetDrawingMarkCommand DrawingMarkCommandNone(-1);
 SetDrawingMarkCommand DrawingMarkCommand0(0);
 SetDrawingMarkCommand DrawingMarkCommand1(1);
 SetDrawingMarkCommand DrawingMarkCommand2(2);
@@ -2844,8 +2846,9 @@ class SetCellMarkCommand final : public MenuItemHandler {
 
 public:
   SetCellMarkCommand(int markId)
-      : MenuItemHandler(
-            ((std::string)MI_SetCellMark + std::to_string(markId)).c_str())
+      : MenuItemHandler(((std::string)MI_SetCellMark +
+                         (markId < 0 ? "None" : std::to_string(markId)))
+                            .c_str())
       , m_markId(markId) {}
 
   void execute() override {
@@ -2862,6 +2865,7 @@ public:
     TUndoManager::manager()->add(undo);
   }
 };
+SetCellMarkCommand CellMarkCommandNone(-1);
 SetCellMarkCommand CellMarkCommand0(0);
 SetCellMarkCommand CellMarkCommand1(1);
 SetCellMarkCommand CellMarkCommand2(2);


### PR DESCRIPTION
This fixes the following related to Drawing Mark changes (#2188)
- Allow Drawing Mark on Read-Only levels from Level Strip
- Fix broken continuous timeline/xsheet dragbars
- Add Remove Drawing/Cell Mark commands