### PR TITLE
Fix SVN check and File Browser listing

### DIFF
--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -1321,32 +1321,6 @@ void DvDirTreeView::onRefreshStatusDone(const QString &text) {
 
   m_currentRefreshedNode->setExists(TFileStatus(nodePath).doesExist());
 
-  bool nodeChanged = false;
-
-  // If needed, transform the DvDirVersionControlNode "vcNode" to a
-  // DvDirVersionControlProjectNode
-  // And put it on the tree (removing the previous entry)
-  if (m_currentRefreshedNode->getNodeType() != "Project" &&
-      TProjectManager::instance()->isProject(nodePath)) {
-    DvDirModelNode *parentNode = m_currentRefreshedNode->getParent();
-    if (parentNode) {
-      std::wstring name = m_currentRefreshedNode->getName();
-
-      // Remove the old node (which is not a project node)
-      DvDirModel::instance()->removeRows(
-          m_currentRefreshedNode->getRow(), 1,
-          DvDirModel::instance()->getIndexByNode(parentNode));
-      // parentNode->removeChildren(vcNode->getRow(),1);
-
-      // Add a new project node instead of the old one
-      DvDirVersionControlProjectNode *newNode =
-          new DvDirVersionControlProjectNode(parentNode, name, nodePath);
-      parentNode->addChild(newNode);
-      nodeChanged            = true;
-      m_currentRefreshedNode = newNode;
-    }
-  }
-
   SVNStatusReader sr(text);
   QStringList checkPartialLockList =
       m_currentRefreshedNode->refreshVersionControl(sr.getStatus());
@@ -1354,9 +1328,6 @@ void DvDirTreeView::onRefreshStatusDone(const QString &text) {
   if (!checkPartialLockList.isEmpty())
     checkPartialLock(toQString(nodePath), checkPartialLockList);
   else {
-    // Refresh also the right side (thumbnails)
-    if (nodeChanged && m_currentRefreshedNode)
-      setCurrentNode(m_currentRefreshedNode);
     emit currentNodeChanged();
 
     QModelIndex index =

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -668,7 +668,7 @@ DvDirVersionControlRootNode::DvDirVersionControlRootNode(DvDirModelNode *parent,
                                                          std::wstring name,
                                                          const TFilePath &path)
     : DvDirVersionControlNode(parent, name, path) {
-  setPixmap(svgToPixmap(":Resources/vcroot.svg"));
+//  setPixmap(svgToPixmap(":Resources/vcroot.svg"));
   setIsUnderVersionControl(true);
 }
 
@@ -715,10 +715,13 @@ void DvDirVersionControlProjectNode::makeCurrent() {
 //-----------------------------------------------------------------------------
 
 QPixmap DvDirVersionControlProjectNode::getPixmap(bool isOpen) const {
-  static QPixmap openPixmap(
-      svgToPixmap(":Resources/browser_vcproject_open.svg"));
-  static QPixmap closePixmap(
-      svgToPixmap(":Resources/browser_vcproject_close.svg"));
+//  static QPixmap openPixmap(
+//      svgToPixmap(":Resources/browser_vcproject_open.svg"));
+//  static QPixmap closePixmap(
+//      svgToPixmap(":Resources/browser_vcproject_close.svg"));
+  static QPixmap openPixmap  = generateIconPixmap("folder_project_on");
+  static QPixmap closePixmap = generateIconPixmap("folder_project");
+
   static QPixmap openMissingPixmap(
       svgToPixmap(":Resources/vcfolder_mis_open.svg"));
   static QPixmap closeMissingPixmap(
@@ -1168,6 +1171,10 @@ void DvDirModelRootNode::refreshDefaultProjectPath() {
 
 void DvDirModelRootNode::refreshChildren() {
   m_childrenValid = true;
+
+  QList<SVNRepository> repositories =
+      VersionControl::instance()->getRepositories();
+
   if (m_children.empty()) {
     addChild(m_myComputerNode = new DvDirModelMyComputerNode(this));
 
@@ -1232,29 +1239,42 @@ void DvDirModelRootNode::refreshChildren() {
       }
     }
 
+    // SVN Repositories
+    int count = repositories.size();
+    // Add SVN Root repos
+    for (int i = 0; i < count; i++) {
+      SVNRepository repo = repositories.at(i);
+      TFilePath svnRoot(repo.m_localPath.toStdWString());
+      if (TProjectManager::instance()->isProject(svnRoot)) continue;
+      DvDirVersionControlRootNode *node = new DvDirVersionControlRootNode(
+          this, repo.m_name.toStdWString(), svnRoot);
+      node->setRepositoryPath(repo.m_repoPath.toStdWString());
+      node->setLocalPath(repo.m_localPath.toStdWString());
+      node->setUserName(repo.m_username.toStdWString());
+      node->setPassword(repo.m_password.toStdWString());
+      node->setPixmap(QPixmap(generateIconPixmap("projects_folder")));
+      m_versionControlNodes.push_back(node);
+      addChild(node);
+    }
+
+    // SVN Repo projects
+    for (int i = 0; i < count; i++) {
+      SVNRepository repo = repositories.at(i);
+      TFilePath svnProj(repo.m_localPath.toStdWString());
+      if (!TProjectManager::instance()->isProject(svnProj)) continue;
+      DvDirVersionControlProjectNode *node = new DvDirVersionControlProjectNode(
+          this, repo.m_name.toStdWString(), svnProj);
+      m_versionControlNodes.push_back(node);
+      addChild(node);
+      m_projectPaths.insert(svnProj);
+    }
+
     TProjectManager *pm          = TProjectManager::instance();
     TFilePath sandboxProjectPath = pm->getSandboxProjectFolder();
     m_projectPaths.insert(sandboxProjectPath);
     m_sandboxProjectNode = new DvDirModelProjectNode(this, sandboxProjectPath);
     addChild(m_sandboxProjectNode);
     m_projectNodes.push_back(m_sandboxProjectNode);
-
-    // SVN Repositories
-    QList<SVNRepository> repositories =
-        VersionControl::instance()->getRepositories();
-    int count = repositories.size();
-    for (int i = 0; i < count; i++) {
-      SVNRepository repo                = repositories.at(i);
-      DvDirVersionControlRootNode *node = new DvDirVersionControlRootNode(
-          this, repo.m_name.toStdWString(),
-          TFilePath(repo.m_localPath.toStdWString()));
-      node->setRepositoryPath(repo.m_repoPath.toStdWString());
-      node->setLocalPath(repo.m_localPath.toStdWString());
-      node->setUserName(repo.m_username.toStdWString());
-      node->setPassword(repo.m_password.toStdWString());
-      m_versionControlNodes.push_back(node);
-      addChild(node);
-    }
 
     // scenefolder node (access to the parent folder of the current scene file)
     m_sceneFolderNode =
@@ -1270,20 +1290,53 @@ void DvDirModelRootNode::refreshChildren() {
       if (TSystem::doesExistFileOrLevel(projectPath) &&
           m_projectPaths.find(projectPath) == m_projectPaths.end() &&
           pm->isProject(projectPath)) {
-        DvDirModelProjectNode *addedProjectNode =
-            new DvDirModelProjectNode(this, projectPath);
+        bool isSVN = false;
+        for (int i = 0; i < repositories.count(); i++) {
+          SVNRepository repo = repositories.at(i);
+          TFilePath svnPath(repo.m_localPath.toStdWString());
+          if (svnPath == projectPath || svnPath.isAncestorOf(projectPath)) {
+            isSVN = true;
+            break;
+          }
+        }
+
+        if (isSVN) {
+          DvDirVersionControlProjectNode *node =
+              new DvDirVersionControlProjectNode(
+                  this, projectPath.getWideName(), projectPath);
+          addChild(node);
+        } else {
+          DvDirModelProjectNode *addedProjectNode =
+              new DvDirModelProjectNode(this, projectPath);
+          addChild(addedProjectNode);
+          m_projectNodes.push_back(addedProjectNode);
+        }
         m_projectPaths.insert(projectPath);
-        addChild(addedProjectNode);
-        m_projectNodes.push_back(addedProjectNode);
       }
     }
 
     TFilePath projectPath = pm->getCurrentProjectPath().getParentDir();
     if (m_projectPaths.find(projectPath) == m_projectPaths.end()) {
-      std::string rootString = projectPath.getQString().toStdString();
-      m_currentProjectNode   = new DvDirModelProjectNode(this, projectPath);
+      bool isSVN = false;
+      for (int i = 0; i < repositories.count(); i++) {
+        SVNRepository repo = repositories.at(i);
+        TFilePath svnPath(repo.m_localPath.toStdWString());
+        if (svnPath == projectPath || svnPath.isAncestorOf(projectPath)) {
+          isSVN = true;
+          break;
+        }
+      }
+
+      if (isSVN) {
+        DvDirVersionControlProjectNode *node =
+            new DvDirVersionControlProjectNode(this, projectPath.getWideName(),
+                                               projectPath);
+        addChild(node);
+      } else {
+        m_currentProjectNode = new DvDirModelProjectNode(this, projectPath);
+        addChild(m_currentProjectNode);
+      }
       m_projectPaths.insert(projectPath);
-      addChild(m_currentProjectNode);
       updateSceneFolderNodeVisibility();
     }
   }

--- a/toonz/sources/toonz/versioncontrol.cpp
+++ b/toonz/sources/toonz/versioncontrol.cpp
@@ -611,10 +611,10 @@ bool VersionControl::testSetup() {
 
     if (!list.isEmpty()) {
       QString firstLine = list.first();
-      firstLine         = firstLine.remove("svn, version ");
-
-      double version = firstLine.left(3).toDouble();
-      if (version <= 1.5) {
+      QStringList wordList = firstLine.split(" ");
+      QStringList version =
+          wordList.size() >= 3 ? wordList[2].split(".") : QStringList();
+      if (!version.size() || (version[0] == 1 && version[1] < 5)) {
         DVGui::warning(
             tr("The version control client application installed on your "
                "computer needs to be updated, otherwise some features may not "


### PR DESCRIPTION
This fixes the following issues related to SVN

- Fixed #2219 by correcting the SVN detection logic
- Fixed an issue of duplicating SVN nodes in File Browser, when SVN node is clicked and refreshed
- Fixed it so recently visited SVN project nodes are listed in the File Browser as SVN nodes instead of regular project nodes
- Separated SVN root folder node from SVN individual project nodes
- Replaced the SVN Root folder node and SVN individual project node icons with existing root/individual project icons for a more uniform look.