### PR TITLE
Build macOS 15 ARM (Silicon) and Intel

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -4,7 +4,17 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   macOS:
-    runs-on: macos-15-intel
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Intel (x86_64) — Homebrew in /usr/local
+          - runner: macos-15-intel
+            suffix: intel
+          # Apple Silicon (arm64) — Homebrew in /opt/homebrew
+          - runner: macos-15
+            suffix: silicon
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup cmake
@@ -24,9 +34,9 @@ jobs:
         with:
           path: |
             /Users/runner/.ccache
-          key: ${{ runner.os }}-refs/heads/master
+          key: ${{ runner.os }}-${{ matrix.suffix }}-refs/heads/master
           restore-keys: |
-            ${{ runner.os }}-
+            ${{ runner.os }}-${{ matrix.suffix }}-
       - name: Get CanonSDK
         if: ${{ (github.repository_owner == 'tahoma2d' || github.repository_owner == 'manongjohn') && github.event_name == 'push' }}
         run: |
@@ -62,15 +72,18 @@ jobs:
           export PATH="/usr/local/opt/ccache/libexec:$PATH"
           ci-scripts/osx/tahoma-build.sh
       - name: Create Package
-        run: bash ./ci-scripts/osx/tahoma-buildpkg.sh
+        run: |
+          bash ./ci-scripts/osx/tahoma-buildpkg.sh
+          mv toonz/build/Tahoma2D-portable-osx.dmg toonz/build/Tahoma2D-portable-osx-${{ matrix.suffix }}.dmg
+          mv toonz/build/Tahoma2D-install-osx.pkg toonz/build/Tahoma2D-install-osx-${{ matrix.suffix }}.pkg
       - uses: actions/upload-artifact@v7
         with:
-          name: Tahoma2D-portable-osx.dmg
-          path: toonz/build/Tahoma2D-portable-osx.dmg
+          name: Tahoma2D-portable-osx-${{ matrix.suffix }}.dmg
+          path: toonz/build/Tahoma2D-portable-osx-${{ matrix.suffix }}.dmg
       - uses: actions/upload-artifact@v7
         with:
-          name: Tahoma2D-install-osx.pkg
-          path: toonz/build/Tahoma2D-install-osx.pkg
+          name: Tahoma2D-install-osx-${{ matrix.suffix }}.pkg
+          path: toonz/build/Tahoma2D-install-osx-${{ matrix.suffix }}.pkg
       - name: Get Nightly Release Date
         if: ${{ github.repository_owner == 'tahoma2d' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
@@ -82,7 +95,7 @@ jobs:
         with:
           allowUpdates: true
           artifactErrorsFailBuild: false
-          artifacts: toonz/build/Tahoma2D-portable-osx.dmg,toonz/build/Tahoma2D-install-osx.pkg
+          artifacts: toonz/build/Tahoma2D-portable-osx-${{ matrix.suffix }}.dmg,toonz/build/Tahoma2D-install-osx-${{ matrix.suffix }}.pkg
           artifactContentType: "raw"
           body: ${{ github.event.head_commit.message }}
           name: Latest Nightly ${{ env.NIGHTLYDATE }}
@@ -108,7 +121,7 @@ jobs:
         with:
           allowUpdates: true
           artifactErrorsFailBuild: false
-          artifacts: toonz/build/Tahoma2D-portable-osx.dmg,toonz/build/Tahoma2D-install-osx.pkg
+          artifacts: toonz/build/Tahoma2D-portable-osx-${{ matrix.suffix }}.dmg,toonz/build/Tahoma2D-install-osx-${{ matrix.suffix }}.pkg
           artifactContentType: "raw"
           body: ${{ github.event.head_commit.message }}
           name: ${{ env.NIGHTLYDATETIME }}
@@ -122,7 +135,7 @@ jobs:
           token: ${{ secrets.TAHOMA2D_TOKEN }}
       - name: Remove existing master cache
         if: ${{ steps.restore-cache.outputs.cache-hit == 'true' && github.ref == 'refs/heads/master' }}
-        run: gh cache delete ${{ runner.os }}-refs/heads/master
+        run: gh cache delete ${{ runner.os }}-${{ matrix.suffix }}-refs/heads/master
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Save cache
@@ -131,4 +144,4 @@ jobs:
         with:
           path: |
             /Users/runner/.ccache
-          key: ${{ runner.os }}-${{ github.ref }}
+          key: ${{ runner.os }}-${{ matrix.suffix }}-${{ github.ref }}

--- a/ci-scripts/osx/tahoma-build.sh
+++ b/ci-scripts/osx/tahoma-build.sh
@@ -37,6 +37,6 @@ cmake ../sources  $CANON_FLAG \
       -DWITH_GPHOTO2=ON \
       -DQT_PATH=$USEQTLIB \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.2.0/libtiff/ \
-      -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
+      -DWITH_SYSTEM_SUPERLU=ON
 
 make -j7 # runs 7 jobs in parallel

--- a/ci-scripts/osx/tahoma-buildopencv.sh
+++ b/ci-scripts/osx/tahoma-buildopencv.sh
@@ -15,6 +15,7 @@ cd build
 
 echo ">>> Cmaking opencv"
 cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
       -DBUILD_JASPER=OFF \
       -DBUILD_JPEG=OFF \
       -DBUILD_OPENEXR=OFF \

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -18,36 +18,36 @@ then
    export TOONZDIR=$TOONZDIR/Release
 fi
 
-if [ -d $TOONZDIR/Tahoma2D.app/tahomastuff ]
+if [ -d $TOONZDIR/Tahoma2D.app/Contents/Resources/tahomastuff ]
 then
    # In case of prior builds, replace stuff folder
-   rm -rf $TOONZDIR/Tahoma2D.app/tahomastuff
+   rm -rf $TOONZDIR/Tahoma2D.app/Contents/Resources/tahomastuff
 fi
 
 if [ -d thirdparty/apps/ffmpeg/bin ]
 then
-   echo ">>> Copying FFmpeg to Tahoma2D.app/ffmpeg"
-   if [ -d $TOONZDIR/Tahoma2D.app/ffmpeg ]
+   echo ">>> Copying FFmpeg to Tahoma2D.app/Contents/Resources/ffmpeg"
+   if [ -d $TOONZDIR/Tahoma2D.app/Contents/Resources/ffmpeg ]
    then
       # In case of prior builds, replace ffmpeg folder
-      rm -rf $TOONZDIR/Tahoma2D.app/ffmpeg
+      rm -rf $TOONZDIR/Tahoma2D.app/Contents/Resources/ffmpeg
    fi
-   mkdir $TOONZDIR/Tahoma2D.app/ffmpeg
-   cp -R thirdparty/apps/ffmpeg/bin/ffmpeg thirdparty/apps/ffmpeg/bin/ffprobe $TOONZDIR/Tahoma2D.app/ffmpeg
-   chmod -R 755 $TOONZDIR/Tahoma2D.app/ffmpeg
+   mkdir $TOONZDIR/Tahoma2D.app/Contents/Resources/ffmpeg
+   cp -R thirdparty/apps/ffmpeg/bin/ffmpeg thirdparty/apps/ffmpeg/bin/ffprobe $TOONZDIR/Tahoma2D.app/Contents/Resources/ffmpeg
+   chmod -R 755 $TOONZDIR/Tahoma2D.app/Contents/Resources/ffmpeg
 fi
 
 if [ -d thirdparty/apps/rhubarb ]
 then
-   echo ">>> Copying Rhubarb Lip Sync to Tahoma2D.app/rhubarb"
-   if [ -d $TOONZDIR/Tahoma2D.app/rhubarb ]
+   echo ">>> Copying Rhubarb Lip Sync to Tahoma2D.app/Contents/Resources/rhubarb"
+   if [ -d $TOONZDIR/Tahoma2D.app/Contents/Resources/rhubarb ]
    then
       # In case of prior builds, replace rhubarb folder
-      rm -rf $TOONZDIR/Tahoma2D.app/rhubarb
+      rm -rf $TOONZDIR/Tahoma2D.app/Contents/Resources/rhubarb
    fi
-   mkdir $TOONZDIR/Tahoma2D.app/rhubarb
-   cp -R thirdparty/apps/rhubarb/rhubarb thirdparty/apps/rhubarb/res $TOONZDIR/Tahoma2D.app/rhubarb
-   chmod -R 755 $TOONZDIR/Tahoma2D.app/rhubarb
+   mkdir $TOONZDIR/Tahoma2D.app/Contents/Resources/rhubarb
+   cp -R thirdparty/apps/rhubarb/rhubarb thirdparty/apps/rhubarb/res $TOONZDIR/Tahoma2D.app/Contents/Resources/rhubarb
+   chmod -R 755 $TOONZDIR/Tahoma2D.app/Contents/Resources/rhubarb
 fi
 
 if [ ! -d $TOONZDIR/Tahoma2D.app/Contents/Frameworks ]
@@ -67,12 +67,12 @@ fi
 
 if [ ! -d $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2 ]
 then
-   echo ">>> Copying libghoto2 supporting directories to Tahoma2D.app/Contents/Frameworks"
-   cp -R /usr/local/lib/libgphoto2 $TOONZDIR/Tahoma2D.app/Contents/Frameworks
-   cp -R /usr/local/lib/libgphoto2_port $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+   echo ">>> Copying libghoto2 supporting directories to Tahoma2D.app/Contents/Resources"
+   cp -R /usr/local/lib/libgphoto2 $TOONZDIR/Tahoma2D.app/Contents/Resources
+   cp -R /usr/local/lib/libgphoto2_port $TOONZDIR/Tahoma2D.app/Contents/Resources
 
-   rm $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2/print-camera-list
-   find $TOONZDIR/Tahoma2D.app/Contents/Frameworks/libgphoto2* -name *.la -exec rm -f {} \;
+   rm $TOONZDIR/Tahoma2D.app/Contents/Resources/libgphoto2/print-camera-list
+   find $TOONZDIR/Tahoma2D.app/Contents/Resources/libgphoto2* -name *.la -exec rm -f {} \;
 fi
 
 echo ">>> Creating DSYM files"
@@ -87,9 +87,9 @@ do
    strip -S $X
 done
 
-if [ -d $TOONZDIR/Tahoma2D.app/DSYM ]
+if [ -d $TOONZDIR/Tahoma2D.app/Contents/Resources/DWARF ]
 then
-   rm -rf $TOONZDIR/Tahoma2D.app/DSYM
+   rm -rf $TOONZDIR/Tahoma2D.app/Contents/Resources/DWARF
 fi
 
 echo ">>> Configuring Tahoma2D.app for deployment"
@@ -142,6 +142,22 @@ function checkLibFile() {
             then
                 local SRC=/usr/local/lib/$Y
             fi
+            echo ">>>Checking for $SRC"
+            if [ ! -f $SRC ]
+            then
+               echo ">>>NOT Found...Searching /usr"
+               local SRC=`find /usr -name $Y | head -1`
+               if [ "$SRC" = "" ]
+               then
+                  echo ">>>NOT Found...Searching /opt"
+                  local SRC=`find /opt -name $Y | head -1`
+                  if [ "$SRC" = "" ]
+                  then
+                     echo "Error: Unable to find dependency $Y"
+                     exit 1
+                  fi
+               fi
+            fi
             echo "Copying $SRC to Frameworks"
             cp $SRC $TOONZDIR/Tahoma2D.app/Contents/Frameworks
             chmod 644 $TOONZDIR/Tahoma2D.app/Contents/Frameworks/$Y
@@ -175,8 +191,17 @@ do
    checkLibFile $FILE
 done
 
-echo ">>> Moving DYSM to Tahoma2D.app"
-mv $TOONZDIR/DSYM $TOONZDIR/Tahoma2D.app
+echo ">>> Moving DSYM/Contents/Resources to Tahoma2D.app/Contents/Resources"
+mv $TOONZDIR/DSYM/Contents/Resources/* $TOONZDIR/Tahoma2D.app/Contents/Resources
+
+find $TOONZDIR/Tahoma2D.app -name .DS_Store -exec rm {} \;
+
+mv $TOONZDIR/Tahoma2D.app/Contents/MacOS/Tahoma2D $TOONZDIR/Tahoma2D.app/Contents/MacOS/Tahoma2D.real
+cp toonz/sources/scripts/AppRun_macos $TOONZDIR/Tahoma2D.app/Contents/MacOS/Tahoma2D
+chmod 755 $TOONZDIR/Tahoma2D.app/Contents/MacOS/Tahoma2D
+
+echo ">>> Codesign Tahoma2D.app (installed)"
+codesign --deep --force --sign - $TOONZDIR/Tahoma2D.app
 
 echo ">>> Creating Tahoma2D-install-osx.pkg"
 
@@ -186,10 +211,13 @@ mv $TOONZDIR/Tahoma2D-install-osx.pkg $TOONZDIR/..
 
 echo ">>> Creating Tahoma2D-portable-osx.dmg"
 
-cp -R stuff $TOONZDIR/Tahoma2D.app/tahomastuff
-chmod -R 777 $TOONZDIR/Tahoma2D.app/tahomastuff
+cp -R stuff $TOONZDIR/Tahoma2D.app/Contents/Resources/tahomastuff
+chmod -R 777 $TOONZDIR/Tahoma2D.app/Contents/Resources/tahomastuff
 
-find $TOONZDIR/Tahoma2D.app/tahomastuff -name .gitkeep -exec rm -f {} \;
+find $TOONZDIR/Tahoma2D.app/Contents/Resources/tahomastuff -name .gitkeep -exec rm -f {} \;
+
+echo ">>> Codesign Tahoma2D.app (portable)"
+codesign --deep --force --sign - $TOONZDIR/Tahoma2D.app
 
 cd $TOONZDIR
 

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -17,3 +17,4 @@ brew install openjpeg libresample protobuf boost qt@5 clang-format glew lz4 lzo 
 #brew install dav1d
 brew install meson ninja
 brew install automake autoconf gettext pkg-config libtool libusb-compat gd libexif libdeflate
+brew install superlu

--- a/toonz/cmake/FindSuperLU.cmake
+++ b/toonz/cmake/FindSuperLU.cmake
@@ -40,6 +40,7 @@ find_library(
         libsuperlu.so
         libsuperlu.a
         libsuperlu_4.1.a
+        libsuperlu.dylib
     HINTS
         ${_lib_hints}
     PATH_SUFFIXES

--- a/toonz/installer/osx/app.rb
+++ b/toonz/installer/osx/app.rb
@@ -40,6 +40,8 @@ exec_with_assert "cp -r #{APP_BUNDLE} #{VIRTUAL_ROOT}/#{APP}"
 PKG_PLIST = "#{BUILD_DIR}/app.plist"
 unless File.exist? PKG_PLIST then
     exec_with_assert "pkgbuild --root #{VIRTUAL_ROOT} --analyze #{PKG_PLIST}"
+    exec_with_assert "gsed -i -e \"14i <key>BundleIsRelocatable</key>\" #{PKG_PLIST}"
+    exec_with_assert "gsed -i -e \"15i <false/>\" #{PKG_PLIST}"
     exec_with_assert "gsed -i -e \"14i <key>BundlePreInstallScriptPath</key>\" #{PKG_PLIST}"
     exec_with_assert "gsed -i -e \"15i <string>preinstall-script.sh</string>\" #{PKG_PLIST}"
     exec_with_assert "gsed -i -e \"14i <key>BundlePostInstallScriptPath</key>\" #{PKG_PLIST}"

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -199,6 +199,8 @@ elseif(BUILD_ENV_APPLE)
     else()
         message(FATAL_ERROR "Invalid PLATFORM:" ${PLATFORM} ". 'PLATFORM' must be 32 or 64.")
     endif()
+
+    set(CMAKE_CXX_STANDARD 17)
 elseif(BUILD_ENV_UNIXLIKE)
     # Needed for correct Qt detection
     cmake_minimum_required(VERSION 2.8.12)
@@ -646,7 +648,7 @@ if(BUILD_ENV_MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1")
 elseif(BUILD_ENV_APPLE)
-    # pass
+    include_directories(SYSTEM "/usr/local/include/")
 elseif(BUILD_ENV_UNIXLIKE)
     set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 

--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -239,7 +239,7 @@ public:
     // everything together when it translocates.
     if (!m_isPortable) {
       portableCheck =
-          TFilePath(m_workingDirectory) + "tahomastuff";
+          TFilePath(m_workingDirectory) + "Contents/Resources/tahomastuff";
       portableStatus = TFileStatus(portableCheck);
       m_isPortable   = portableStatus.doesExist();
       if (m_isPortable)

--- a/toonz/sources/scripts/AppRun_macos
+++ b/toonz/sources/scripts/AppRun_macos
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DIR="`dirname \"$0\"`" 
+DIR="`( cd \"$DIR\" && readlink -f $(pwd) )`"
+echo "DIR: $DIR"
+export APPDIR=$DIR
+
+export CAMLIBS=`find $APPDIR/../Resources/libgphoto2 -mindepth 1 -type d`
+echo "CAMLIBS: $CAMLIBS"
+
+export IOLIBS=`find $APPDIR/../Resources/libgphoto2_port -mindepth 1 -type d`
+echo "IOLIBS: $IOLIBS"
+
+exec $APPDIR/Tahoma2D.real "$@"

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -569,7 +569,7 @@ int main(int argc, char *argv[]) {
   QOpenGLFramebufferObjectFormat fmt;
   fmt.setAttachment(QOpenGLFramebufferObject::Attachment::CombinedDepthStencil);
 
-#ifndef __HAIKU__
+#if !defined(__HAIKU__) && !defined(MACOSX)
   glutInit(&argc, argv);
 #endif
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2724,8 +2724,13 @@ void PreferencesPopup::onImport() {
     return;
   }
 
+#ifdef MACOSX
+  TFilePath oldStuffPath = TFilePath(m_importPrefpath->getPath() +
+                                     "/Contents/Resources/tahomastuff");
+#else
   TFilePath oldStuffPath =
       TFilePath(m_importPrefpath->getPath() + "/tahomastuff");
+#endif
   if (!TFileStatus(oldStuffPath).doesExist()) {
     DVGui::error("Unable to find the 'tahomastuff' folder in " +
                  m_importPrefpath->getPath() +


### PR DESCRIPTION
This PR allows building both ARM (Silicon) and Intel based versions of T2D.

Due to needing to "codesign" (not App sign) the application for ARM builds, I had to move some things around in the bundle which applies to both build types.

Requires some testing but I plan on including this with 1.6.2, still primarily promoting the Intel based version for now.  Will likely switch to just ARM builds with 1.7.
