### PR TITLE
Fix AppImage Creation

### DIFF
--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -19,20 +19,20 @@ pip3 install numpy
 cd ..
 
 ##### This is temporary because linuxdeploy won't work on Ubuntu 22.04 until May 1st 2025
-
-sudo apt-get -y install git g++ libgl1-mesa-dev
-git clone https://github.com/tahoma2d/linuxdeployqt.git
-# Then build in Qt Creator, or use
-export PATH=$(readlink -f /tmp/.mount_QtCreator-*-x86_64/*/gcc_64/bin/):$PATH
-cd linuxdeployqt
-git checkout tahoma2d_version
-qmake
-make
-sudo make install
-
-#wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
-#tar xf patchelf-0.9.tar.bz2
-#( cd patchelf-0.9/ && ./configure  && make && sudo make install )
-
-sudo wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O /usr/local/bin/appimagetool
-sudo chmod a+x /usr/local/bin/appimagetool
+#
+#sudo apt-get -y install git g++ libgl1-mesa-dev
+#git clone https://github.com/tahoma2d/linuxdeployqt.git
+## Then build in Qt Creator, or use
+#export PATH=$(readlink -f /tmp/.mount_QtCreator-*-x86_64/*/gcc_64/bin/):$PATH
+#cd linuxdeployqt
+#git checkout tahoma2d_version
+#qmake
+#make
+#sudo make install
+#
+##wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
+##tar xf patchelf-0.9.tar.bz2
+##( cd patchelf-0.9/ && ./configure  && make && sudo make install )
+#
+#sudo wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O /usr/local/bin/appimagetool
+#sudo chmod a+x /usr/local/bin/appimagetool


### PR DESCRIPTION
Due to the libfuse version change made in #2218, the temporary local build of linuxdeployqt doesnt work because it requires libfuse2.

Rather than updating it to the latest, this restores the original step of downloading and using the latest linuxdeployqt which has the update.

Fixes #2230 