### PR TITLE
Fix AppImage working directory

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -245,6 +245,20 @@ public:
       if (m_isPortable)
         m_workingDirectory = portableCheck.getParentDir().getQString();
     }
+#elif defined(LINUX) || defined(FREEBSD)
+    // Linux AppImages are mounted and run in a different location separating it
+    // from the tahomastuff folder. This will use the original location of the
+    // AppImage to look for it
+    if (!m_isPortable) {
+      char *value = getenv("APPIMAGE");
+      if (value) {
+        portableCheck  = TFilePath(value).getParentDir() + "/tahomastuff";
+        portableStatus = TFileStatus(portableCheck);
+        m_isPortable   = portableStatus.doesExist();
+        if (m_isPortable)
+          m_workingDirectory = portableCheck.getParentDir().getQString();
+      }
+    }
 #endif
   }
   QString getWorkingDirectory() { return m_workingDirectory; }


### PR DESCRIPTION
This fixes #1676.  Similar to macOS, when an AppImage is launched, it is basically translocated away from where the `tahomastuff` folder is.  The logic relied on the current working directory being set at the time of launch which required starting it from the same directory as the `tahomstuff` folder. However, the current working directory isn't set, or is set to a different location when the AppImage is launched from a shortcut or menu item.

I found an environment variable that is set at the time of launch that contains the original location of the AppImage.  Modified the logic to use this information to get to the `tahomastuff` folder so now the AppImage can be launched from anywhere.