### PR TITLE
Canon EDSDK 13.20.11 + macOS package fix

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get CanonSDK
         if: ${{ (github.repository_owner == 'tahoma2d' || github.repository_owner == 'manongjohn') && github.event_name == 'push' }}
         run: |
-          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Linux.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/223415219
+          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Linux.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/459223430
           unzip EDSDK_Linux.zip -d EDSDK_Linux
           mv EDSDK_Linux/EDSDK/* thirdparty/canon
           chmod 644 thirdparty/canon/Library/x86_64/lib*

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get CanonSDK
         if: ${{ (github.repository_owner == 'tahoma2d' || github.repository_owner == 'manongjohn') && github.event_name == 'push' }}
         run: |
-          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Macintosh.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/223415237
+          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Macintosh.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/459223333
           unzip EDSDK_Macintosh.zip -d EDSDK_Macintosh
           unzip EDSDK_Macintosh/Macintosh.dmg.zip -d EDSDK_Macintosh
           7z x EDSDK_Macintosh/Macintosh.dmg -oEDSDK_Macintosh

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get CanonSDK
         if: ${{ (github.repository_owner == 'tahoma2d' || github.repository_owner == 'manongjohn') && github.event_name == 'push' }}
         run: |
-          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Windows.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/223415203
+          curl -H "Authorization: token ${{ secrets.TAHOMA2D_TOKEN }}" -H "Accept:application/octet-stream" -fsSL -o EDSDK_Windows.zip https://api.github.com/repos/tahoma2d/CanonSDK/releases/assets/459223399
           7z x EDSDK_Windows.zip -oEDSDK_Windows
           move EDSDK_Windows\EDSDK\Header thirdparty\canon
           move EDSDK_Windows\EDSDK_64\Dll thirdparty\canon

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -178,11 +178,8 @@ function checkLibFile() {
             then
                local Y=`echo $DEPFILE | sed -e"s/^.*\/\.\.\///" -e"s/@rpath.//"`
             fi
-            if [ "$DEPFILE" != "@rpath/$Y" ]
-            then
-               echo "Fixing $DEPFILE in $LIBFILE"
-               install_name_tool -change $DEPFILE @rpath/$Y $LIBFILE
-            fi
+            echo "Fixing $DEPFILE in $LIBFILE"
+            install_name_tool -change $DEPFILE @executable_path/../Frameworks/$Y $LIBFILE
          fi
          FIXCHECK=`otool -D $LIBFILE | grep -v ":" | grep -e"\/usr\/local"`
          if [ "$FIXCHECK" == "$DEPFILE" ]


### PR DESCRIPTION
This updates the Canon EDSDK to the latest version.

Also corrects an issue with packaging macOS builds that prevents the Silicon builds from starting.  Fixes #2238