### PR TITLE
Fix Release v1.6.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,8 +40,9 @@ body:
       label: Software Version
       description: What version of the software are you running?
       options:
-        - 1.6.1
+        - 1.6.2
         - Nightly (Specify below)
+        - 1.6.1
         - 1.6.0
         - 1.5.4
         - 1.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-07-01
+
+### Fixed
+
+- Fix changing cell during playback [#2174, #2183]
+- Fix raster brush memory usage [#2178]
+- Fix Level Strip Insert & Swing undo/redo [#2190]
+- Fix copy-pasting first key as last key [#2201]
+- Fix shortcuts for toggling tool option checkboxes [#2206]
+- Fix delete Fx key crash [#2215]
+- Fix SVN check and File Browser listing [#2224, #2234]
+- Fix AppImage working directory [#2239]
+- Fix(t32birserv): Terminate the process when quiting or failing to init quickTime(OpenToonz port) [#2229[^10]]
+- Prevent crash by checking m_oldStyle before getPointer() (OpenToonz port) [#2229]
+- fix increase minimum size of buttons in insertfxpopup (OpenToonz port) [#2229]
+- Fix Random Wave FX on sub-xsheets with frame rounding (OpenToonz port) [#2229]
+- Fix: TCubic::getSpeed used an incorrect formula (OpenToonz port) [#2229]
+- Fix heap corruption in Iwa_TiledParticlesFx (OpenToonz port) [#2229]
+- Fix crash when reading empty and corrupted JPEG files (OpenToonz port) [#2229]
+- Fix JPG Reader crash on Windows (OpenToonz port) [#2229]
+- Fix long path issue in Ffmpeg by using hash (OpenToonz port) [#2229[^8]]
+- Revert References of Global Cleanup Parameters (OpenToonz port) [#2229]
+- Fix Output Settings > Linear Color Space Checkbox (OpenToonz port) [#2229]
+
+### Other
+
+- Add Wayland support [#2161, #2234]
+- Remove redundant appdata.xml [#2195]
+- Update to libfuse3-3 [#2218, #2231]
+- Build macOS 15 ARM (Silicon) and Intel [#2228, #2234, #2240]
+- Libgphoto2 2.5.34 [#2237]
+- Canon EDSDK 13.20.11 + macOS package fix [#2240]
+- fix: add braces to resolve dangling-else warnings (OpenToonz port) [#2229[^9]]
+- chore(thirdparty): update tinyexr.h to upstream release (OpenToonz port) [#2229]
+- chore(thirdparty): update kiss_fft to upstream release 131.2.0 (OpenToonz port) [#2229]
+- Fix typos in stuff/ and toonz/source/include subdirs (OpenToonz port) [#2229]
+- Fix compiler warnings and potential memory leaks in TIPC module (OpenToonz port) [#2229]
+
 ## [1.6.1] - 2026-05-01
 
 ### Fixed
@@ -128,7 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix(Scene Depth/Quicktoolbar): Invisible after startup (OpenToonz port) [#1942]
 - Fix: Add missing fclose calls for proper file handling (OpenToonz port) [#1946]
 - fix: handle MSVC warnings C4723 and C4552 (OpenToonz port) [#1946[^10]]
-- fix: initialize popup, firstW, and lastW (OpenToonz port) [#1946]
+- fix: initialize popup, firstW, and lastW (OpenToonz port) [#1946]
 - fix: ODR violations (# 241) by adding flipbooksettings.h for toggle vars (OpenToonz port) [#1946]
 - Fix: Premultiply background color for Export Level Commands (OpenToonz port) [#1946[^9] ]
 - fix: Preview not Updating for New Toonz Raster Levels editted with Fill Tool (OpenToonz port) [#1946]
@@ -182,7 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Relative Drawing Mode Tweening [#1819]
 - Percentage spacing on pattern brushes. [#1829]
 - Fix rasterization of vector [#1843]
-- Block shortcuts while tool is busy [#1844]
+- Block shortcuts while tool is busy [#1844, #1853]
 - Fix Implicit Clear Frames [#1845]
 - Fix Mesh Animate crash of SmartVector Level [#1784[^7]]
 - Remove rasterized vector pink box [#1806[^7]]
@@ -1067,6 +1105,7 @@ Some features, when used, are saved to the scene file and will prevent the scene
 [^10]: Partial. Changes not relevant to T2D were not applied
 [^11]: Partial. Similar changes already in T2D were not applied
 
+[1.6.2]: https://github.com/tahoma2d/tahoma2d/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/tahoma2d/tahoma2d/compare/v1.6...v1.6.1
 [1.6.0]: https://github.com/tahoma2d/tahoma2d/compare/v1.5.4...v1.6
 [1.5.4]: https://github.com/tahoma2d/tahoma2d/compare/v1.5.3...v1.5.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.6.1{build}
+version: 1.6.2{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export TAHOMA2DVERSION=1.6.1
+export TAHOMA2DVERSION=1.6.2
 #source /opt/qt515/bin/qt515-env.sh
 
 echo ">>> Temporary install of Tahoma2D"

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export TAHOMA2DVERSION=1.6.1
+export TAHOMA2DVERSION=1.6.2
 
 if [ -d /usr/local/Cellar/qt@5 ]
 then

--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.6.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.1</string>
+	<string>1.6.2</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>

--- a/toonz/installer/linux/deb-creator/deb-template/DEBIAN/control
+++ b/toonz/installer/linux/deb-creator/deb-template/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: tahoma2d
-Version: 1.6.1
+Version: 1.6.2
 Maintainer: Tahoma2D
 Section: graphics
 Installed-Size: 
@@ -7,7 +7,7 @@ Homepage: https://tahoma2d.org/
 Architecture: amd64
 Priority: optional
 Depends: gphoto2
-Description: Tahoma 2D Version 1.6.1
+Description: Tahoma 2D Version 1.6.2
  Tahoma2D is a 2D and stop motion animation software. 
  .
  It is a fork of OpenToonz which is based on Toonz Studio Ghibli Version, originally developed in Italy by Digital Video, Inc., and customized by Studio Ghibli over many years of production.

--- a/toonz/installer/windows/setup.iss
+++ b/toonz/installer/windows/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Tahoma2D"
-#define MyAppVersion "1.6.1"
+#define MyAppVersion "1.6.2"
 #define MyAppPublisher "Tahoma2D"
 #define MyAppURL "https://tahoma2d.org/"
 #define MyAppExeName "Tahoma2D.exe"

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -19,7 +19,7 @@ public:
 private:
   const char *applicationName     = "Tahoma2D";
   const float applicationVersion  = 1.6f;
-  const float applicationRevision = 1;
+  const float applicationRevision = 2;
   const char *applicationNote     = "";
 };
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(VERSION 1.6.1)
+set(VERSION 1.6.2)
 
 set(MOC_HEADERS
     aboutpopup.h

--- a/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
+++ b/toonz/sources/xdg-data/org.tahoma2d.Tahoma2D.metainfo.xml
@@ -20,6 +20,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.6.2" date="2026-07-01"/>
     <release version="1.6.1" date="2026-05-01"/>
     <release version="1.6.0" date="2026-03-01"/>
     <release version="1.5.4" date="2025-08-01"/>


### PR DESCRIPTION
This is to mark and update the nightly to fix release version v1.6.2 in the master.

Version 1.6.2 is being build in a separate branch containing primarily fix PRs which I will be releasing tomorrow (7/1)