### PR TITLE
Fix onion skin and column style support for some vector styles.

### DIFF
--- a/toonz/sources/colorfx/regionstyles.cpp
+++ b/toonz/sources/colorfx/regionstyles.cpp
@@ -1045,7 +1045,7 @@ double TPointShadowFillStyle::triangleArea(const TPointD &a, const TPointD &b,
 
 //------------------------------------------------------------
 
-void TPointShadowFillStyle::shadowOnEdge_parallel(const TPointD &p0,
+void TPointShadowFillStyle::shadowOnEdge_parallel(TPixel32 color, const TPointD &p0,
                                                   const TPointD &p1,
                                                   const TPointD &p2,
                                                   TRandom &rnd) const {
@@ -1069,8 +1069,8 @@ void TPointShadowFillStyle::shadowOnEdge_parallel(const TPointD &p0,
       TPointD u = p1 + (p2 - p1) * q;
       u         = u +
           r * (len1 * (1.0 - q) + len2 * q) * m_shadowDirection * m_shadowSize;
-      tglColor(TPixel32(m_shadowColor.r, m_shadowColor.g, m_shadowColor.b,
-                        (int)((1.0 - r) * (double)m_shadowColor.m)));
+      tglColor(TPixel32(color.r, color.g, color.b,
+                        (int)((1.0 - r) * (double)color.m)));
       tglVertex(u);
     }
   }
@@ -1154,7 +1154,7 @@ void TPointShadowFillStyle::drawRegion(const TColorFunction *cf,
       it0 = it1 == it_beg ? it_last : it1 - 1;
       it2 = it1 == it_last ? it_beg : it1 + 1;
 
-      shadowOnEdge_parallel(TPointD(it0->x, it0->y), TPointD(it1->x, it1->y),
+      shadowOnEdge_parallel(color, TPointD(it0->x, it0->y), TPointD(it1->x, it1->y),
                             TPointD(it2->x, it2->y), rnd);
     }
     glEnd();

--- a/toonz/sources/colorfx/regionstyles.h
+++ b/toonz/sources/colorfx/regionstyles.h
@@ -299,7 +299,7 @@ protected:
 private:
   double triangleArea(const TPointD &a, const TPointD &b,
                       const TPointD &c) const;
-  void shadowOnEdge_parallel(const TPointD &p0, const TPointD &p1,
+  void shadowOnEdge_parallel(TPixel32 color, const TPointD &p0, const TPointD &p1,
                              const TPointD &p2, TRandom &rnd) const;
 
   void deleteSameVerts(TRegionOutline::Boundary::iterator &rit,

--- a/toonz/sources/colorfx/strokestyles.cpp
+++ b/toonz/sources/colorfx/strokestyles.cpp
@@ -2145,10 +2145,10 @@ void TNormal2StrokeStyle::drawStroke(const TColorFunction *cf,
   glEnable(GL_LIGHT0);
   glEnable(GL_NORMALIZE);
   GLfloat mat_ambient[] = {(float)dcolor.r, (float)dcolor.g, (float)dcolor.b,
-                           1.0};
+                           (float)dcolor.m};
   GLfloat mat_specular[] = {(float)(m_metal * (1 - dcolor.r) + dcolor.r),
                             (float)(m_metal * (1 - dcolor.g) + dcolor.g),
-                            (float)(m_metal * (1 - dcolor.b) + dcolor.b), 1.0};
+                            (float)(m_metal * (1 - dcolor.b) + dcolor.b), (float)dcolor.m};
   GLfloat mat_shininess[] = {(float)m_shininess};
 
   glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, mat_specular);
@@ -3450,7 +3450,7 @@ void TZigzagStrokeStyle::drawStroke(const TColorFunction *cf, Points &points,
   else
     color = m_color;
 
-  tglColor(m_color);
+  tglColor(color);
 
   glEnableClientState(GL_VERTEX_ARRAY);
 

--- a/toonz/sources/common/tvrender/tvectorbrushstyle.cpp
+++ b/toonz/sources/common/tvrender/tvectorbrushstyle.cpp
@@ -141,7 +141,7 @@ void VectorBrushProp::draw(const TVectorRenderData &rd) {
 
         // Draw the outline
         colorStyle.setMainColor(brushStyle->getMainColor());
-        colorStyle.drawRegion(0, false, m_regionOutlines[r]);
+        colorStyle.drawRegion(rd.m_cf, false, m_regionOutlines[r]);
       }
     }
 
@@ -153,7 +153,7 @@ void VectorBrushProp::draw(const TVectorRenderData &rd) {
       if (!brushStyle) continue;
 
       colorStyle.setMainColor(brushStyle->getMainColor());
-      colorStyle.drawStroke(0, &m_strokeOutlines[t],
+      colorStyle.drawStroke(rd.m_cf, &m_strokeOutlines[t],
                             brushStroke);  // brushStroke unused but requested
     }
   }


### PR DESCRIPTION

<img width="1130" height="385" alt="image" src="https://github.com/user-attachments/assets/e7b152ab-cad3-48a2-acda-670badd8b47b" />


This fixes onion skin and column/layer style support for Zigzag, Bump, Vector Brush, Vector Pattern, and Sponge fill styles. All vector line and fill styles on the 'Vector' tab should work properly when visible in an onion skin and will be affected by column/layer styles. 

This does not fix the vector texture brush and fills (the Texture tab.) There was some issue with calling the color function there I couldn't figure out. The texture brushes need support for colorization added and some other bug fixes anyways. These should be addressed in another PR.