### PR TITLE
Fix saving global cleanup parameters

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1609,11 +1609,9 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   // autosave (would save to scene file) .
   CleanupParameters *cp = scene->getProperties()->getCleanupParameters();
   CleanupParameters keepCP(*cp);
-  if (!isAutosave) {
-    // In case of a .cln file be loaded into GlobalParemeters,
-    // we should also write these info into .tnz (scene file)
-    cp->assign(&CleanupParameters::GlobalParameters, false);
-  }
+  // In case of a .cln file be loaded into GlobalParemeters,
+  // we should also write these info into .tnz (scene file)
+  cp->assign(&CleanupParameters::GlobalParameters, false);
 
   // Must wait for current save to finish, just in case
   while (TApp::instance()->isSaveInProgress())
@@ -1631,7 +1629,7 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   }
   TApp::instance()->setSaveInProgress(false);
 
-  cp->assign(&keepCP);
+  cp->assign(&keepCP, false);
   // Make sure that the current cleanup palette is set to currentParams' palette
   TApp::instance()
       ->getPaletteController()


### PR DESCRIPTION
This fixes an issue where the current palette is switched to the Cleanup Palette when the scene is saved.

Due to a reversion of code released with 1.6.2 to reallow saving the global cleanup palette, an issue was uncovered where the temporary switching to the global cleanup palette caused a new palette to be cloned internally when switching back. This caused the Style Editor to update because a different palette was detected as it was updating it to the original parameters.

Modified it so it doesn't clone the palette on restoration and reuses the one that was temporarily moved aside.  Additionally, removed a condition so the global cleanup will now also save during autosave.