### PR TITLE
Fix macOS libghoto2 build

### DIFF
--- a/ci-scripts/osx/tahoma-buildlibgphoto2.sh
+++ b/ci-scripts/osx/tahoma-buildlibgphoto2.sh
@@ -8,13 +8,27 @@ cd libgphoto2_src
 
 git checkout tahoma2d-version-2.5.34
 
+export GETTEXT_PATH=`brew --prefix gettext`
+
 echo ">>> Configuring libgphoto2"
 autoreconf --install --symlink
 
-./configure --prefix=/usr/local
+./configure --prefix=/usr/local \
+  CPPFLAGS="-I$GETTEXT_PATH/include" \
+  LDFLAGS="-L$GETTEXT_PATH/lib -lintl"
+
+if [ $? != 0 ]
+then
+   exit 1
+fi
 
 echo ">>> Making libgphoto2"
 make
+
+if [ $? != 0 ]
+then
+   exit 1
+fi
 
 echo ">>> Installing libgphoto2"
 sudo make install


### PR DESCRIPTION
This fixes an issue with macOS builds failing due to libghoto2 failing to compile.

Something, in a brew'd dependency most-likely, has changed and is causing a linking issue when building libgphoto2.  Doesn't seem to know where `gettext` is and link it properly.  Updated the configuration parameters for building it to fix it.

Will merge as soon as all builds complete successfully.